### PR TITLE
Extend http CheckCommand to accept --expected http status return codes

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -193,6 +193,7 @@ object CheckCommand "http" {
 		"--no-body" = {
 			set_if = "$http_ignore_body$"
 		}
+		"-e" = "$http_expected_status_codes$"
 		"-r" = "$http_expect_body_regex$"
 		"-w" = "$http_warn_time$"
 		"-c" = "$http_critical_time$"
@@ -200,6 +201,7 @@ object CheckCommand "http" {
 
 	vars.http_address = "$address$"
 	vars.http_ssl = false
+	vars.http_expected_status_codes = "200"
 }
 
 object CheckCommand "ftp" {


### PR DESCRIPTION
HTTP status code 200 (everything is OK) is often expected.

There are use cases when another status code is acceptable like 401 (Unauthorized) when a webpage must require some form of authentication method.

Signed-off-by: Christophe Vanlancker christophe.vanlancker@inuits.eu
