### PR TITLE
Make reload timeout configurable via command-line arg

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -343,6 +343,7 @@ int Main(void)
 		("errorlog,e", po::value<std::string>(), "log fatal errors to the specified log file (only works in combination with --daemonize)")
 #ifndef _WIN32
 		("reload-internal", po::value<int>(), "used internally to implement config reload: do not call manually, send SIGHUP instead")
+		("reload-timeout", po::value<int>()->default_value(300), "seconds to wait for the child to finish during a reload. defaults to 300.")
 		("daemonize,d", "detach from the controlling terminal")
 		("user,u", po::value<std::string>(), "user to run Icinga as")
 		("group,g", po::value<std::string>(), "group to run Icinga as")
@@ -385,6 +386,7 @@ int Main(void)
 	Application::DeclareStatePath(Application::GetLocalStateDir() + "/lib/icinga2/icinga2.state");
 	Application::DeclareObjectsPath(Application::GetLocalStateDir() + "/cache/icinga2/icinga2.debug");
 	Application::DeclarePidPath(Application::GetRunDir() + "/icinga2/icinga2.pid");
+	Application::SetReloadTimeout(g_AppParams["reload-timeout"].as<int>());
 
 #ifndef _WIN32
 	if (g_AppParams.count("group")) {

--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -54,6 +54,7 @@ static bool l_InExceptionHandler = false;
 int Application::m_ArgC;
 char **Application::m_ArgV;
 double Application::m_StartTime;
+int Application::m_ReloadTimeout;
 
 /**
  * Constructor for the Application class.
@@ -353,7 +354,7 @@ pid_t Application::StartReloadProcess(void)
 	args->Add(Convert::ToString(Utility::GetPid()));
 
 	Process::Ptr process = make_shared<Process>(Process::PrepareCommand(args));
-	process->SetTimeout(300);
+	process->SetTimeout(Application::GetReloadTimeout());
 	process->Run(&ReloadProcessCallback);
 
 	return process->GetPID();
@@ -1086,4 +1087,14 @@ double Application::GetStartTime(void)
 void Application::SetStartTime(double ts)
 {
 	m_StartTime = ts;
+}
+
+int Application::GetReloadTimeout(void)
+{
+	return m_ReloadTimeout;
+}
+
+void Application::SetReloadTimeout(int timeout_seconds)
+{
+	m_ReloadTimeout = timeout_seconds;
 }

--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -122,6 +122,9 @@ public:
 	static double GetStartTime(void);
 	static void SetStartTime(double ts);
 
+    static int GetReloadTimeout(void);
+    static void SetReloadTimeout(int timeout_seconds);
+
 	static void DisplayInfoMessage(bool skipVersion = false);
 
 protected:
@@ -150,6 +153,7 @@ private:
 	static bool m_Debugging; /**< Whether debugging is enabled. */
 	static LogSeverity m_DebuggingSeverity; /**< Whether debugging severity is set. */
 	static double m_StartTime;
+	static int m_ReloadTimeout;
 
 #ifndef _WIN32
 	static void SigIntTermHandler(int signum);


### PR DESCRIPTION
Our configuration is pretty big, and it takes significantly longer than 300 seconds to load.