### PR TITLE
Un-Bashify mail-{host,service}-notification.sh

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-template=$(cat <<TEMPLATE
+#!/bin/sh
+template=`cat <<TEMPLATE
 ***** Icinga  *****
 
 Notification Type: $NOTIFICATIONTYPE
@@ -14,7 +14,7 @@ Additional Info: $HOSTOUTPUT
 
 Comment: [$NOTIFICATIONAUTHORNAME] $NOTIFICATIONCOMMENT
 TEMPLATE
-)
+`
 
 /usr/bin/printf "%b" "$template" | mail -s "$NOTIFICATIONTYPE - $HOSTDISPLAYNAME is $HOSTSTATE" $USEREMAIL
 

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-template=$(cat <<TEMPLATE
+#!/bin/sh
+template=`cat <<TEMPLATE
 ***** Icinga  *****
 
 Notification Type: $NOTIFICATIONTYPE
@@ -15,7 +15,7 @@ Additional Info: $SERVICEOUTPUT
 
 Comment: [$NOTIFICATIONAUTHORNAME] $NOTIFICATIONCOMMENT
 TEMPLATE
-)
+`
 
 /usr/bin/printf "%b" "$template" | mail -s "$NOTIFICATIONTYPE - $HOSTDISPLAYNAME - $SERVICEDISPLAYNAME is $SERVICESTATE" $USEREMAIL
 


### PR DESCRIPTION
In the two scripts there's no need to use bash, switch from bash to /bin/sh and $() to `` which allows the scripts to work also with Solaris' broken /bin/sh.
