### PR TITLE
Fix failures for ido-mysql upgrades

### DIFF
--- a/lib/db_ido_mysql/schema/upgrade/2.1.0.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.1.0.sql
@@ -7,11 +7,10 @@
 -- Please check http://docs.icinga.org for upgrading information!
 -- -----------------------------------------
 
-ALTER TABLE `icinga_programstatus` ADD COLUMN `endpoint_name` varchar(255) character set latin1 collate latin1_general_cs default NULL;
+ALTER TABLE `icinga_programstatus` MODIFY COLUMN `endpoint_name` varchar(255) character set latin1 collate latin1_general_cs default NULL;
 
 -- -----------------------------------------
 -- update dbversion
 -- -----------------------------------------
 
 INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.11.7', NOW(), NOW()) ON DUPLICATE KEY UPDATE version='1.11.7', modify_time=NOW();
-

--- a/lib/db_ido_mysql/schema/upgrade/2.2.0.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.2.0.sql
@@ -7,17 +7,16 @@
 -- Please check http://docs.icinga.org for upgrading information!
 -- -----------------------------------------
 
-ALTER TABLE `icinga_programstatus` ADD COLUMN `program_version` varchar(64) character set latin1 collate latin1_general_cs default NULL;
+ALTER TABLE `icinga_programstatus` MODIFY COLUMN `program_version` varchar(64) character set latin1 collate latin1_general_cs default NULL;
 
 ALTER TABLE icinga_contacts MODIFY alias TEXT character set latin1  default '';
 ALTER TABLE icinga_hosts MODIFY alias TEXT character set latin1  default '';
 
-ALTER TABLE icinga_customvariables ADD COLUMN is_json smallint default 0;
-ALTER TABLE icinga_customvariablestatus ADD COLUMN is_json smallint default 0;
+ALTER TABLE icinga_customvariables MODIFY COLUMN is_json smallint default 0;
+ALTER TABLE icinga_customvariablestatus MODIFY COLUMN is_json smallint default 0;
 
 -- -----------------------------------------
 -- update dbversion
 -- -----------------------------------------
 
 INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.12.0', NOW(), NOW()) ON DUPLICATE KEY UPDATE version='1.12.0', modify_time=NOW();
-


### PR DESCRIPTION
fix duplicate column name errors by switching to MODIFY

There are multiple failures with the upgrade patches due to the column already existing when running the commands that have the pattern:

```sql
ALTER TABLE <table> ADD COLUMN ...
```

Looks as though the columns already exist and should instead be MODIFY requests.