### PR TITLE
Fix rpmspec build for el7-like machines

### DIFF
--- a/icinga2.spec
+++ b/icinga2.spec
@@ -245,6 +245,9 @@ make %{?_smp_mflags}
 make install \
 	DESTDIR="%{buildroot}"
 
+# install crash dir
+install -d %{buildroot}%{_localstatedir}/log/%{name}/crash
+
 # install classicui config
 install -D -m 0644 etc/icinga/icinga-classic.htpasswd %{buildroot}%{icingaclassicconfdir}/passwd
 install -D -m 0644 etc/icinga/cgi.cfg %{buildroot}%{icingaclassicconfdir}/cgi.cfg


### PR DESCRIPTION
Builds were failing because the log/crash directory was not created during the %install directive.