### PR TITLE
get agent checks working inside an ha zone

### DIFF
--- a/lib/icinga/apievents.cpp
+++ b/lib/icinga/apievents.cpp
@@ -1510,9 +1510,9 @@ Value ApiEvents::AcknowledgementClearedAPIHandler(const MessageOrigin& origin, c
 
 Value ApiEvents::ExecuteCommandAPIHandler(const MessageOrigin& origin, const Dictionary::Ptr& params)
 {
-	Endpoint::Ptr endpoint = origin.FromClient->GetEndpoint();
+	Endpoint::Ptr sourceEndpoint = origin.FromClient->GetEndpoint();
 
-	if (!endpoint || (origin.FromZone && !Zone::GetLocalZone()->IsChildOf(origin.FromZone)))
+	if (!sourceEndpoint || (origin.FromZone && !Zone::GetLocalZone()->IsChildOf(origin.FromZone)))
 		return Empty;
 
 	ApiListener::Ptr listener = ApiListener::GetInstance();
@@ -1543,7 +1543,7 @@ Value ApiEvents::ExecuteCommandAPIHandler(const MessageOrigin& origin, const Dic
 			cr->SetState(ServiceUnknown);
 			cr->SetOutput("Check command '" + command + "' does not exist.");
 			Dictionary::Ptr message = MakeCheckResultMessage(host, cr);
-			listener->SyncSendMessage(endpoint, message);
+			listener->SyncSendMessage(sourceEndpoint, message);
 			return Empty;
 		}
 	} else if (command_type == "event_command") {
@@ -1553,7 +1553,7 @@ Value ApiEvents::ExecuteCommandAPIHandler(const MessageOrigin& origin, const Dic
 		return Empty;
 
 	attrs->Set(command_type, params->Get("command"));
-	attrs->Set("command_endpoint", endpoint->GetName());
+	attrs->Set("command_endpoint", sourceEndpoint->GetName());
 
 	Deserialize(host, attrs, false, FAConfig);
 
@@ -1569,7 +1569,7 @@ Value ApiEvents::ExecuteCommandAPIHandler(const MessageOrigin& origin, const Dic
 	Dictionary::Ptr macros = params->Get("macros");
 
 	if (command_type == "check_command")
-		host->ExecuteCheck(macros, true);
+		host->ExecuteRemoteCheck(macros);
 	else if (command_type == "event_command")
 		host->ExecuteEventHandler(macros, true);
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -135,8 +135,8 @@ public:
 
 	static void UpdateStatistics(const CheckResult::Ptr& cr, CheckableType type);
 
-	void ExecuteCheck(const Dictionary::Ptr& resolvedMacros = Dictionary::Ptr(),
-	    bool useResolvedMacros = false);
+	void ExecuteRemoteCheck(const Dictionary::Ptr& resolvedMacros = Dictionary::Ptr());
+	void ExecuteCheck();
 	void ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrigin& origin = MessageOrigin());
 
 	int GetModifiedAttributes(void) const;


### PR DESCRIPTION
https://lists.icinga.org/pipermail/icinga-users/2014-December/008952.html

This is an attempt to fix my own problem. Icinga2 clusters don't work properly for checks with a command_endpoint which is part of their own HA zone. There were two general problems to fix here:

(1) Checkable::ExecuteCheck() was handling remote checks as well as local ones, but lots of the logic was not appropriate to remote checks. I've created a much simpler ExecuteRemoteCheck() method which simply performs a check and now use this for handling agent checks which come in via the API.

(2) Checkable::ProcessCheckResult() sends agent checks back to the source, but we never got to process them locally. Since agent checks are performed in a dummy environment, we can't simply run process the check in "this". Instead I've more-or-less duplicated the logic which handles incoming check result messages in order to route these to the appropriate checkable object, if any.

I've probably missed a lot, but this seems to fix my main problems.