### PR TITLE
Removed mail_from from check_ssmtp command.

### DIFF
--- a/doc/7-configuring-icinga-2.md
+++ b/doc/7-configuring-icinga-2.md
@@ -2141,7 +2141,6 @@ Name            | Description
 ----------------|--------------
 ssmtp_address   | **Required.** The host's address. Defaults to "$address$".
 ssmtp_port      | **Optional.** The port that should be checked. Defaults to 465.
-ssmtp_mail_from | **Optional.** Test a MAIL FROM command with the given email address.
 
 #### <a id="plugin-check-command-imap"></a> imap
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -316,7 +316,6 @@ object CheckCommand "ssmtp" {
 	arguments = {
 		"-H" = "$ssmtp_address$"
 		"-p" = "$ssmtp_port$"
-		"-f" = "$ssmtp_mail_from$"
 	}
 
 	vars.ssmtp_address = "$address$"


### PR DESCRIPTION
Monitoring Plugin ssmtp has no "-f" switch. Command and documentation changed.

refs #8245