### PR TITLE
Add macro "check_source" for hosts and services to use them in notification mails

### DIFF
--- a/doc/3-monitoring-basics.md
+++ b/doc/3-monitoring-basics.md
@@ -2045,6 +2045,7 @@ hosts or services:
   host.output                  | The last check's output.
   host.perfdata                | The last check's performance data.
   host.last_check              | The timestamp when the last check was executed.
+  host.check_source            | The monitoring instance that performed the last check.
   host.num_services            | Number of services associated with the host.
   host.num_services_ok         | Number of services associated with the host which are in an `OK` state.
   host.num_services_warning    | Number of services associated with the host which are in a `WARNING` state.
@@ -2076,6 +2077,7 @@ services:
   service.output             | The last check's output.
   service.perfdata           | The last check's performance data.
   service.last_check         | The timestamp when the last check was executed.
+  service.check_source       | The monitoring instance that performed the last check.
 
 ### <a id="command-runtime-macros"></a> Command Runtime Macros
 

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -280,6 +280,9 @@ bool Host::ResolveMacro(const String& macro, const CheckResult::Ptr&, Value *res
 		} else if (macro == "last_check") {
 			*result = Convert::ToString((long)cr->GetScheduleStart());
 			return true;
+		} else if (macro == "check_source") {
+			*result = cr->GetCheckSource();
+			return true;
 		}
 	}
 

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -178,6 +178,9 @@ bool Service::ResolveMacro(const String& macro, const CheckResult::Ptr& cr, Valu
 		} else if (macro == "last_check") {
 			*result = Convert::ToString((long)cr->GetExecutionEnd());
 			return true;
+		} else if (macro == "check_source") {
+			*result = cr->GetCheckSource();
+			return true;
 		}
 	}
 


### PR DESCRIPTION
This commit adds macros "$host.check_source$" and "$service.check_source$" in order to add the check_source to notification mails in a cluster setup.