### PR TITLE
update perf data host macros

### DIFF
--- a/doc/4-advanced-topics.md
+++ b/doc/4-advanced-topics.md
@@ -424,7 +424,7 @@ Therefore the Icinga 2 `PerfdataWriter` object allows you to define
 the output template format for host and services backed with Icinga 2
 runtime vars.
 
-    host_format_template = "DATATYPE::HOSTPERFDATA\tTIMET::$icinga.timet$\tHOSTNAME::$host.name$\tHOSTPERFDATA::$host.perfdata$\tHOSTCHECKCOMMAND::$host.checkcommand$\tHOSTSTATE::$host.state$\tHOSTSTATETYPE::$host.statetype$"
+    host_format_template = "DATATYPE::HOSTPERFDATA\tTIMET::$icinga.timet$\tHOSTNAME::$host.name$\tHOSTPERFDATA::$host.perfdata$\tHOSTCHECKCOMMAND::$host.check_command$\tHOSTSTATE::$host.state$\tHOSTSTATETYPE::$host.state_type$"
     service_format_template = "DATATYPE::SERVICEPERFDATA\tTIMET::$icinga.timet$\tHOSTNAME::$host.name$\tSERVICEDESC::$service.name$\tSERVICEPERFDATA::$service.perfdata$\tSERVICECHECKCOMMAND::$service.checkcommand$\tHOSTSTATE::$host.state$\tHOSTSTATETYPE::$host.statetype$\tSERVICESTATE::$service.state$\tSERVICESTATETYPE::$service.statetype$"
 
 The default templates are already provided with the Icinga 2 feature configuration


### PR DESCRIPTION
Kept receiving the warning message (warning/MacroProcessor: Macro 'host.checkcommand' is not defined.) from icinga2 using `host.checkcommand`. Small documentation update.