### PR TITLE
Added possibility to set securityLevel, e.g. if using snmpv3 without enc...

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -640,7 +640,8 @@ Name              | Description
 snmpv3_address    | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
 snmpv3_user       | **Required.** The username to log in with.
 snmpv3_auth_alg   | **Optional.** The authentication algorithm. Defaults to SHA.
-snmpv3_auth_key   | **Required.** The authentication key.
+snmpv3_seclevel   | **Optional.** The securityLevel. Defaults to authPriv.
+snmpv3_auth_key   | **Required,** if snmpv3_seclevel is set to authPriv. The authentication key.
 snmpv3_priv_alg   | **Optional.** The encryption algorithm. Defaults to AES.
 snmpv3_priv_key   | **Required.** The encryption key.
 snmpv3_oid        | **Required.** The SNMP OID.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -789,7 +789,7 @@ object CheckCommand "snmpv3" {
 	arguments = {
 		"-H" = "$snmpv3_address$"
 		"-P" = 3
-		"--seclevel" = "authPriv"
+		"--seclevel" = "$snmpv3_seclevel$"
 		"-U" = "$snmpv3_user$"
 		"-a" = "$snmpv3_auth_alg$"
 		"-A" = "$snmpv3_auth_key$"
@@ -804,6 +804,7 @@ object CheckCommand "snmpv3" {
 	vars.snmpv3_address = "$check_address$"
 	vars.snmpv3_auth_alg = "SHA"
 	vars.snmpv3_priv_alg = "AES"
+	vars.snmpv3_seclevel = "authPriv"
 }
 
 object CheckCommand "snmp-uptime" {


### PR DESCRIPTION
...ryption. Defaults set to privAuth to stay compatible to older versions. I had the problem, that i am using snmpv3 with user authentication, but without DES encryption. The hard coded security level can now be set from outer configuration files. This solved my problem. Hopefully it will be merged :-)

best regards.

/legacycode