### PR TITLE
Removed seemingly unnecessary paths in spec

### DIFF
--- a/icinga2.spec
+++ b/icinga2.spec
@@ -458,8 +458,6 @@ exit 0
 %exclude %{_libdir}/%{name}/libdb_ido_pgsql*
 %dir %{_libdir}/%{name}
 %{_libdir}/%{name}/*.so*
-%dir %{_libdir}/%{name}/sbin
-%{_libdir}/%{name}/sbin/%{name}
 %{_datadir}/%{name}
 %exclude %{_datadir}/%{name}/include
 %{_mandir}/man8/%{name}.8.gz


### PR DESCRIPTION
At least on Red Hat/CentOS, %{_libdir}/%{name}/sbin expands to /usr/lib64/icinga2/sbin - which nothing is installed to (including the explicit binary listed below of (/usr/lib64/icinga2/sbin/icinga2). The icinga2 binary is correctly listed above as %{_sbindir}/%{name}, expanding to /usr/sbin/icinga2.