### PR TITLE
Update 22-appendix.md

### DIFF
--- a/doc/22-appendix.md
+++ b/doc/22-appendix.md
@@ -420,9 +420,10 @@ Not supported: `initial_state`, `pending_flex_downtime`, `check_flapping_recover
   no_more_notifications | int       | notification_interval == 0 && volatile == false.
   last_check            | int       | .
   last_state_change     | int       | .
-  last_time_up          | int       | .
-  last_time_down        | int       | .
-  last_time_unreachable | int       | .
+  last_time_ok          | int       | .
+  last_time_warning     | int       | .
+  last_time_critical    | int       | .
+  last_time_unknown     | int       | .
   is_flapping           | int       | .
   scheduled_downtime_depth | int    | .
   active_checks_enabled | int       | .


### PR DESCRIPTION
Hi, I was trying to get a last time timestamp when a service was ok, using livestatus. But that fail because there is no "last_time_up" column in the services table.
The column is actually named "last_time_ok" (looking at the source code https://github.com/Icinga/icinga2/blob/master/lib/livestatus/servicestable.cpp), also a few others "last_time_*" are named diffently than in the hosts table.
Maybe the naming should be consistent, don't know, but here is update of the doc anyway :)