### PR TITLE
indent accept_config and accept_commands

### DIFF
--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -463,15 +463,18 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 		if (tokens.size() > 1)
 			fp << "  bind_port = " << tokens[1] << "\n";
 	}
+
+	fp << "\n";
+
 	if (vm.count("accept-config"))
-		fp << "accept_config = true\n";
+		fp << "  accept_config = true\n";
 	else
-		fp << "accept_config = false\n";
+		fp << "  accept_config = false\n";
 
 	if (vm.count("accept-commands"))
-		fp << "accept_commands = true\n";
+		fp << "  accept_commands = true\n";
 	else
-		fp << "accept_commands = false\n";
+		fp << "  accept_commands = false\n";
 
 	fp << "\n"
 	    << "  ticket_salt = TicketSalt\n"

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -394,6 +394,7 @@ wizard_ticket:
 		    << "  cert_path = SysconfDir + \"/icinga2/pki/\" + NodeName + \".crt\"\n"
 		    << "  key_path = SysconfDir + \"/icinga2/pki/\" + NodeName + \".key\"\n"
 		    << "  ca_path = SysconfDir + \"/icinga2/pki/ca.crt\"\n"
+		    << "\n"
 		    << "  accept_config = " << accept_config << "\n"
 		    << "  accept_commands = " << accept_commands << "\n";
 


### PR DESCRIPTION
Indent the accept_config and accept_commands during creation and separate them with a newline.

Reconstructing the behavior from the code, this bug only appeared, when you have used `node setup`.