### PR TITLE
Update 10-icinga2-client.md regarding update-config

### DIFF
--- a/doc/10-icinga2-client.md
+++ b/doc/10-icinga2-client.md
@@ -512,7 +512,7 @@ Using systemd:
 
 
 The `update-config` CLI command will fail, if there are uncommitted changes for the
-configuration repository.
+configuration repository or if your master is part of a HA setup (see https://dev.icinga.org/issues/8292 for details).
 Please review these changes manually, or clear the commit and try again. This is a
 safety hook to prevent unwanted manual changes to be committed by a updating the
 client discovered objects only.


### PR DESCRIPTION
Added a hint regarding update-config. At the moment, this command doesn't work if your configuration master is part of a HA setup.
Many folks, including me, stumbled accross this fact. See https://dev.icinga.org/issues/8292 and http://www.monitoring-portal.org/wbb/index.php?page=Thread&postID=212236&highlight=#post212236 for details.

Adding this hint to the documentation will be realy helpful.