### PR TITLE
Making the disk check only run on icinga node.

### DIFF
--- a/etc/icinga2/conf.d/services.conf
+++ b/etc/icinga2/conf.d/services.conf
@@ -68,6 +68,8 @@ apply Service for (disk => config in host.vars.disks) {
   check_command = "disk"
 
   vars += config
+  assign where host.name == NodeName
+
 }
 
 apply Service "icinga" {


### PR DESCRIPTION
   If you don't do this the local disk check runs on all your hosts with host.vars.disks set