### PR TITLE
Added "-r" parameter to the check_load command for dividing the load averages by the number of CPUs.

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -485,6 +485,7 @@ load_wload15    | **Optional.** The 15-minute warning threshold. Defaults to 3.
 load_cload1     | **Optional.** The 1-minute critical threshold. Defaults to 10.
 load_cload5     | **Optional.** The 5-minute critical threshold. Defaults to 6.
 load_cload15    | **Optional.** The 15-minute critical threshold. Defaults to 4.
+load_percpu     | **Optional.** Divide the load averages by the number of CPUs (when possible). Defaults to false.
 
 
 ## <a id="plugin-check-command-nrpe"></a> nrpe

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -975,8 +975,18 @@ object CheckCommand "load" {
 	command = [ PluginDir + "/check_load" ]
 
 	arguments = {
-		"-w" = "$load_wload1$,$load_wload5$,$load_wload15$"
-		"-c" = "$load_cload1$,$load_cload5$,$load_cload15$"
+		"-w" = {
+			value = "$load_wload1$,$load_wload5$,$load_wload15$"
+			description = "Exit with WARNING status if load average exceeds WLOADn"
+		}
+		"-c" = {
+			value = "$load_cload1$,$load_cload5$,$load_cload15$"
+			description = "Exit with CRITICAL status if load average exceed CLOADn the load average format is the same used by 'uptime' and 'w'"
+		}
+		"-r" = {
+			set_if = "$load_percpu$"
+			description = "Divide the load averages by the number of CPUs (when possible)"
+		}
 	}
 
 	vars.load_wload1 = 5.0
@@ -986,6 +996,8 @@ object CheckCommand "load" {
 	vars.load_cload1 = 10.0
 	vars.load_cload5 = 6.0
 	vars.load_cload15 = 4.0
+
+	vars.load_percpu = false
 }
 
 object CheckCommand "snmp" {


### PR DESCRIPTION
Hello.

I added "-r" parameter to the check_load command for dividing the load averages by the number of CPUs.
It's handy if you are monitoring the servers with different number of CPUs.
I also added new variable "load_percpu" to use this and write descriptions to the "check_load command section".

Regards

PetrR