### PR TITLE
Issue 9858: Gelf module: exposed 'perfdata' fields and 'reachable' field for 'CHECK_RESULT' events

### DIFF
--- a/etc/icinga2/features-available/gelf.conf
+++ b/etc/icinga2/features-available/gelf.conf
@@ -9,4 +9,5 @@ library "perfdata"
 object GelfWriter "gelf" {
   //host = "127.0.0.1"
   //port = 12201
+  //include_perfdata_fields = false
 }

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -33,6 +33,8 @@
 #include "base/networkstream.hpp"
 #include "base/json.hpp"
 #include "base/context.hpp"
+#include <boost/foreach.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 using namespace icinga;
 
@@ -107,11 +109,48 @@ void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const Check
 	fields->Set("_current_check_attempt", checkable->GetCheckAttempt());
 	fields->Set("_max_check_attempts", checkable->GetMaxCheckAttempts());
 
+	fields->Set("_latency", Service::CalculateLatency(cr));
+	fields->Set("_execution_time", Service::CalculateExecutionTime(cr));
+	fields->Set("_reachable",  checkable->IsReachable());
+
 	if (cr) {
 		fields->Set("short_message", CompatUtility::GetCheckResultOutput(cr));
 		fields->Set("full_message", CompatUtility::GetCheckResultLongOutput(cr));
 		fields->Set("_check_source", cr->GetCheckSource());
 	}
+
+	if (GetIncludePerfdataFields()) {
+		Array::Ptr perfdata = cr->GetPerformanceData();
+		if (perfdata) {
+			ObjectLock olock(perfdata);
+			BOOST_FOREACH(const Value& val, perfdata) {
+				PerfdataValue::Ptr pdv;
+
+				if (val.IsObjectType<PerfdataValue>())
+					pdv = val;
+				else {
+					try {
+						pdv = PerfdataValue::Parse(val);
+
+						String escaped_key = pdv->GetLabel();
+						boost::replace_all(escaped_key, " ", "_");
+						boost::replace_all(escaped_key, ".", "_");
+						boost::replace_all(escaped_key, "\\", "_");
+						boost::algorithm::replace_all(escaped_key, "::", ".");
+
+						fields->Set("_" + escaped_key, pdv->GetValue());
+
+						if (pdv->GetMin()) fields->Set("_" + escaped_key + "_min", pdv->GetMin());
+						if (pdv->GetMax()) fields->Set("_" + escaped_key + "_max", pdv->GetMax());
+						if (pdv->GetWarn())	fields->Set("_" + escaped_key + "_warn", pdv->GetWarn());
+						if (pdv->GetCrit()) fields->Set("_" + escaped_key + "_crit", pdv->GetCrit());
+					} catch (const std::exception&) {
+						Log(LogWarning, "GelfWriter") << "Ignoring invalid perfdata value: " << val;
+					}
+				}
+			}
+		}
+    }
 
 	SendLogMessage(ComposeGelfMessage(fields, GetSource()));
 }

--- a/lib/perfdata/gelfwriter.ti
+++ b/lib/perfdata/gelfwriter.ti
@@ -35,6 +35,9 @@ class GelfWriter : ConfigObject
 	[config] String source {
 		default {{{ return "icinga2"; }}}
 	};
+	[config] bool include_perfdata_fields {
+		default {{{ return false; }}}
+	};
 };
 
 }


### PR DESCRIPTION
This adds https://dev.icinga.org/issues/9858 feature

Current GELF Icinga plugin output doesn't include any 'perfdata' fields for check results. Instead GELF output includes human-readable, but not highly parseable strings like 'shortmessage' which contains only a part of check result data. Most oftenly, this part is not enough for graphing and analysing Icinga check results somewhere else outside the Icinga. E.g., at popular Elasticsearch + Logstash + Kibana stack. This is very inconvenient from the point of Logstash (or any other monitoring data parsing tools coming with a Gelf input) to parse numbers from human-readable messages like '*short_message: Ram : 33%, Swap : 0% : : OK *'_.

Also there is a bunch of Icinga internal variables which, I think, are good to be exposed in GELF plugin CHECK RESULT events. E.g., 'checkable->IsReachable()' field could be useful at GELF receiver side for alerting purposes.

What this PR actually does:
- Exposed all 'perfdata' fields at GELF plugin 'CHECK RESULT' events
- Exposed 'checkable->IsReachable()' field at GELF plugin 'CHECK RESULT' events

Example:
Currently Icinga GELF plugin output for simple SNMP 'memory' check looks like below:

```json
{
  "_index": "monitoring-X.Y.Z",
  "_type": "CHECK_RESULT",
  "_id": "AU8DBUezYa1p4CWRhXHN",
  "_score": null,
  "_source": {
    "host": "icinga2",
    "short_message": "Ram : 33%, Swap : 0% : : OK ",
    "@version": "1",
    "@timestamp": "2015-08-06T12:38:41.143Z",
    "source_host": "10.194.36.21",
    "message": "<msg>",
    "execution_time": 0.08232688903808594,
    "hostname": "MongoDB1",
    "latency": 0,
    "service_name": "check_snmp_memory",
    "service_state": "OK",
    "state": "OK",
    "type": "CHECK_RESULT",
  }
}
```

After this code update it looks like:
```json
{
  "_index": "monitoring-X.Y.Z",
  "_type": "CHECK_RESULT",
  "_id": "AU8DBUezYa1p4CWRhXHN",
  "_score": null,
  "_source": {
    "host": "icinga2",
    "short_message": "Ram : 33%, Swap : 0% : : OK ",
    "@version": "1",
    "@timestamp": "2015-08-06T12:38:41.143Z",
    "source_host": "10.194.36.21",
    "message": "<msg>",
    "execution_time": 0.08232688903808594,
    "hostname": "MongoDB1",
    "latency": 0,
    "ram_used": 338608,
    "ram_used_crit": 965477,
    "ram_used_max": 1016292,
    "ram_used_warn": 914663,
    "reachable": true,
    "service_name": "check_snmp_memory",
    "service_state": "OK",
    "state": "OK",
    "swap_used": 560,
    "swap_used_crit": 314572,
    "swap_used_max": 1048572,
    "swap_used_warn": 104857,
    "type": "CHECK_RESULT",
  }
}
```
Note the new fields: "ram_used",  "ram_used_crit", "ram_used_max", "ram_used_warn" fields (and also "swap_used*" fields).
As the result, GELF output data is ready for graphing or farther analysing. You could start showing it in Kibana / Graphite / etc. without any additional parsing and format conversion.