### PR TITLE
Add port configuration to snap checks (Feature #10423)

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -726,6 +726,7 @@ Name                | Description
 snmp_address        | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
 snmp_oid            | **Required.** The SNMP OID.
 snmp_community      | **Optional.** The SNMP community. Defaults to "public".
+snmp_port           | **Optional.** The SNMP port. Defaults to "161".
 snmp_warn           | **Optional.** The warning threshold.
 snmp_crit           | **Optional.** The critical threshold.
 snmp_string         | **Optional.** Return OK state if the string matches exactly with the output value

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1021,6 +1021,7 @@ object CheckCommand "snmp" {
 		"-l" = "$snmp_label$"
 		"-u" = "$snmp_units$"
 		"-t" = "$snmp_timeout$"
+		"-p" = "$snmp_port$"
 		"--invert-search" = {
 			set_if = "$snmp_invert_search$"
 			description = "Invert search result and return CRITICAL if found"


### PR DESCRIPTION
The check_snmp check has the "-p" flag allow a non standard SNMP port to be set. This should be settable through the ITL for all SNMP checks

https://dev.icinga.org/issues/10423