### PR TITLE
Make check apt command timeout configurable

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -94,7 +94,11 @@ which contains the path of the plugins from the Monitoring Plugins project.
 
 Check command for the `check_apt` plugin.
 
-The `apt` check command does not support any vars.
+Custom attributes passed as [command parameters](3-monitoring-basics.md#command-passing-parameters):
+
+Name            | Description
+----------------|--------------
+apt_timeout  | **Optional.** The timeout in seconds.
 
 
 ## <a id="plugin-check-command-by-ssh"></a> by_ssh

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1148,6 +1148,14 @@ object CheckCommand "apt" {
 	import "plugin-check-command"
 
 	command = [ PluginDir + "/check_apt" ]
+
+	arguments = {
+		"-t" = {
+			value = "$apt_timeout$"
+			description = "Seconds before connection times out"
+		}
+	}
+
 }
 
 object CheckCommand "dhcp" {


### PR DESCRIPTION
check_apt has a default timeout of 10sec. The service is flagged as CRITICAL in case the timeout is hit.
On slow internet connections, slow sources and just a vast number of sources 10sec might not be enough. I therefore added a timeout variable to make the timeout configurable.