### PR TITLE
Allow overwriting expected answer of dns check

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1519,7 +1519,10 @@ object CheckCommand "dns" {
 		}
 		"-a_old" = {
 			key = "-a"
-			value ="$dns_expected_answer$"
+			set_if = {{
+				return bool(macro("$dns_expected_answer$"))
+			}}
+			value = "$dns_expected_answer$"
 		}
 		"-A" = {
 			set_if = "$dns_authoritative$"


### PR DESCRIPTION
I usually only test whether DNS works using a random online service as the checked host (e.g. `google.com`). I do not care what the actual results are, but since it's impossible to overwrite a var with null (correct me if I'm wrong), I cannot reset the expected answer so the parameter isn't set. That's why I removed it from the default variables.
