### PR TITLE
Add timeout to snmpv3 check

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -885,6 +885,7 @@ snmpv3_ereg          | **Optional.** Return OK state (for that OID) if extended 
 snmpv3_eregi         | **Optional.** Return OK state (for that OID) if case-insensitive extended REGEX matches.
 snmpv3_invert_search | **Optional.** Invert search result and return CRITICAL if found
 snmpv3_label         | **Optional.** Prefix label for output value.
+snmpv3_timeout       | **Optional.** The command timeout in seconds. Defaults to 10 seconds.
 
 ### <a id="plugin-check-command-snmp-uptime"></a> snmp-uptime
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1163,12 +1163,14 @@ object CheckCommand "snmpv3" {
 				value = "$snmpv3_label$"
 				description = "Prefix label for output from plugin"
 		}
+		"-t" = "$snmpv3_timeout$"
 	}
 
 	vars.snmpv3_address = "$check_address$"
 	vars.snmpv3_auth_alg = "SHA"
 	vars.snmpv3_priv_alg = "AES"
 	vars.snmpv3_seclevel = "authPriv"
+	vars.snmpv3_timeout = "10"
 }
 
 object CheckCommand "snmp-uptime" {


### PR DESCRIPTION
The snmp check already supports the timeout parameter, now the snmpv3 check supports it, too.