### PR TITLE
Update logrotate conf to supress stderr output

### DIFF
--- a/etc/logrotate.d/icinga2.cmake
+++ b/etc/logrotate.d/icinga2.cmake
@@ -7,7 +7,7 @@
 	notifempty
 	create 644 @ICINGA2_USER@ @ICINGA2_GROUP@
 	postrotate
-		if service icinga2 status > /dev/null; then
+		if service icinga2 status &> /dev/null; then
 			if [ -e @ICINGA2_RUNDIR@/icinga2/icinga2.pid ]; then
 				kill -USR1 $(cat @ICINGA2_RUNDIR@/icinga2/icinga2.pid)
 			fi


### PR DESCRIPTION
Relates to: https://dev.icinga.org/issues/10935#change-46706

In the logrotate config there is a check using "service icinga2 status". On a systemd based distro this generates a message to stderr (since service gets redirected to systemctl) and this can result in mails to root with the output.

It would be nice to handle this in an elegant manner where a non systemd distro uses service and a systemd distro uses systemctl but for now redirecting stderr to /dev/null will suffice.