### PR TITLE
#10975 - Add the exclude drive parameter for CheckCommand "disk-windows"

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -1170,12 +1170,13 @@ Aggregates the free disk space of all volumes and mount points it can find, or t
 
 Custom attributes:
 
-Name            | Description
-:---------------|:------------
-disk\_win\_warn | **Optional**. The warning threshold.
-disk\_win\_crit | **Optional**. The critical threshold.
-disk\_win\_path | **Optional**. Check only these paths, default checks all.
-disk\_win\_unit | **Optional**. Use this unit to display disk space, thresholds are interpreted in this unit. Defaults to "mb", possible values are: b, kb, mb, gb and tb.
+Name               | Description
+:------------------|:------------
+disk\_win\_warn    | **Optional**. The warning threshold.
+disk\_win\_crit    | **Optional**. The critical threshold.
+disk\_win\_path    | **Optional**. Check only these paths, default checks all.
+disk\_win\_unit    | **Optional**. Use this unit to display disk space, thresholds are interpreted in this unit. Defaults to "mb", possible values are: b, kb, mb, gb and tb.
+disk\_win\_exclude | **Optional**. Exclude these drives from check.
 
 
 ### <a id="windows-plugins-load-windows"></a> load-windows

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -40,6 +40,10 @@ object CheckCommand "disk-windows" {
 			value = "$disk_win_unit$"
 			description = "Use this unit to display disk space"
 		}
+		"-x" = {
+            value = "$disk_win_exclude$"
+        	description = "Exclude these drives from check"
+        }
 	}
 	
 	vars.disk_win_unit = "mb"


### PR DESCRIPTION
Added the missing, but useful parameter to "disk-windows" CheckCommand

refs #10975