### PR TITLE
Fix parsing of YYYY-MM-DD in LegacyTimePeriod::ParseTimeSpec

### DIFF
--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -144,10 +144,15 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 		int month = Convert::ToLong(timespec.SubStr(5, 2));
 		int day = Convert::ToLong(timespec.SubStr(8, 2));
 
+		if (month < 1 || month > 12)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid month in time specification: " + timespec));
+		if (day < 1 || day > 31)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid day in time specification: " + timespec));
+
 		if (begin) {
 			begin->tm_year = year - 1900;
-			begin->tm_mon = month;
-			begin->tm_mday = day + 1;
+			begin->tm_mon = month - 1;
+			begin->tm_mday = day;
 			begin->tm_hour = 0;
 			begin->tm_min = 0;
 			begin->tm_sec = 0;
@@ -155,8 +160,8 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 
 		if (end) {
 			end->tm_year = year - 1900;
-			end->tm_mon = month;
-			end->tm_mday = day + 1;
+			end->tm_mon = month - 1;
+			end->tm_mday = day;
 			end->tm_hour = 24;
 			end->tm_min = 0;
 			end->tm_sec = 0;


### PR DESCRIPTION
This commit fixes the issue reported in [this mailing list post](https://www.mail-archive.com/icinga-users@lists.icinga.org/msg02942.html).

The parsed month and day values were being assigned to the time struct incorrectly, as `tm_mday` is the day of the month and `tm_mon` is the number of months since January.

To confirm this fix was correct I wrote a unit test for `LegacyTimePeriod`, is this something you would be interested in merging? There doesn't seem to be any testing of time periods currently, which I know from experience is often a rich source of bugs.