### PR TITLE
Added query option to check_postgres

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -1739,6 +1739,9 @@ postgres_standby     | **Optional.** Assume that the server is in continious WAL
 postgres_production  | **Optional.** Assume that the server is in production mode if set to true. Defaults to false.
 postgres_action      | **Required.** Determines the test executed.
 postgres_unixsocket  | **Optional.** If "postgres_unixsocket" is set to true the unix socket is used instead of an address. Defaults to false.
+postgres_query       | **Optional.** Query for "custom_query" action.
+postgres_valtype     | **Optional.** Value type of query result for "custom_query".
+postgres_reverse     | **Optional.** If "postgres_reverse" is set, warning and critical values are reversed for "custom_query" action.
 
 #### <a id="plugins-contrib-command-mongodb"></a> mongodb
 

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -296,6 +296,18 @@ object CheckCommand "postgres" {
 			value = "$postgres_action$"
 			description = "determines the test executed"
 		}
+		"--query" = {
+			value = "$postgres_query$"
+			description = "query for custom_query action"
+		}
+		"--valtype" = {
+			value = "$postgres_valtype$"
+			description = "determines the result type for custom_query action"
+		}
+		"--reverse" = {
+			set_if = "$postgres_reverse$"
+			description = "reverses warning and critical for custom_query action"
+		}
 	}
 
 	vars.postgres_host = "$check_address$"


### PR DESCRIPTION
There were "query", "valtype" and "reverse" options missing
for "custom_query" action type in check_postgres plugin.

refs #11205