### PR TITLE
Implement exclude and include ability for timeranges

### DIFF
--- a/doc/6-object-types.md
+++ b/doc/6-object-types.md
@@ -1322,7 +1322,9 @@ Configuration Attributes:
   display_name    |**Optional.** A short description of the time period.
   update          |**Required.** The "update" script method takes care of updating the internal representation of the time period. In virtually all cases you should import the "legacy-timeperiod" template to take care of this setting.
   ranges          |**Required.** A dictionary containing information which days and durations apply to this timeperiod.
-
+  prefer_includes |**Optional.** Boolean for prefer include or exclude timeperiods. Default to true.
+  excludes        |**Optional.** An array of timeperiods, which should exclude from your timerange.
+  includes        |**Optional.** An array of timeperiods, which should include into your timerange
 The `/etc/icinga2/conf.d/timeperiods.conf` file is usually used to define
 timeperiods including this one.
 

--- a/lib/icinga/timeperiod.ti
+++ b/lib/icinga/timeperiod.ti
@@ -37,6 +37,15 @@ class TimePeriod : CustomVarObject
 	};
 	[config] Dictionary::Ptr ranges;
 	[config, required] Function::Ptr update;
+	[config] bool prefer_includes {
+		default {{{ return true; }}}
+	};
+	[config] array(name(TimePeriod)) excludes {
+		default {{{ return new Array(); }}}
+	};
+	[config] array(name(TimePeriod)) includes {
+		default {{{ return new Array(); }}}
+	};
 	[state, no_user_modify] Value valid_begin;
 	[state, no_user_modify] Value valid_end;
 	[state, no_user_modify] Array::Ptr segments;


### PR DESCRIPTION
With this change we can include and exclude timeranges in timeranges. I think we need this feature to support holidays and so on

refs #7355

Thx to @gunnarbeutner for his comment. https://dev.icinga.org/issues/7355#note-16

My last c++ adventures are a long time ago, so please help me to improve my code, if this is not good enough.

Greetings Reamer

@dnsmichi I am glad to see you at icinga-camp-berlin