### PR TITLE
Re-add the 'su' directive to logrotate if supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,22 @@ if(WIN32)
   add_definitions(-DBOOST_ALL_NO_LIB)
 endif()
 
+if(NOT DEFINED LOGROTATE_HAS_SU)
+  set(LOGROTATE_HAS_SU OFF)
+  execute_process(COMMAND "/usr/sbin/logrotate" ERROR_VARIABLE LOGROTATE_OUTPUT)
+  if(LOGROTATE_OUTPUT)
+    string(REGEX REPLACE "^logrotate ([0-9.]*).*" "\\1" LOGROTATE_VERSION
+      ${LOGROTATE_OUTPUT})
+    message(STATUS "Found logrotate (found version \"${LOGROTATE_VERSION}\")")
+    if("${LOGROTATE_VERSION}" VERSION_GREATER "3.7.9")
+      set(LOGROTATE_HAS_SU ON)
+    endif()
+  endif()
+endif()
+if(LOGROTATE_HAS_SU)
+  set(LOGROTATE_USE_SU "\n\tsu ${ICINGA2_USER} ${ICINGA2_GROUP}")
+endif()
+
 find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS thread system program_options regex REQUIRED)
 
 link_directories(${Boost_LIBRARY_DIRS})

--- a/etc/logrotate.d/icinga2.cmake
+++ b/etc/logrotate.d/icinga2.cmake
@@ -1,6 +1,6 @@
 @CMAKE_INSTALL_FULL_LOCALSTATEDIR@/log/icinga2/icinga2.log @CMAKE_INSTALL_FULL_LOCALSTATEDIR@/log/icinga2/debug.log {
 	daily
-	rotate 7
+	rotate 7@LOGROTATE_USE_SU@
 	compress
 	delaycompress
 	missingok
@@ -13,7 +13,7 @@
 
 @CMAKE_INSTALL_FULL_LOCALSTATEDIR@/log/icinga2/error.log {
 	daily
-	rotate 90
+	rotate 90@LOGROTATE_USE_SU@
 	compress
 	delaycompress
 	missingok


### PR DESCRIPTION
- try to detect a recent logrotate version which supports the 'su'
directive (added in 3.8.0, see
https://github.com/logrotate/logrotate/commit/5be96cf1822496f80227e9a446281c3fa42e7b67#diff-e4eb329834da3d36278b1b7d943b3bc9R6)
- if logrotate can't be found, assume an old version is used
- allow the parameter to be forced by the user

Closes: https://dev.icinga.org/issues/9249

I am not familiar with cmake so there are a couple of things of which I'm unsure, please let me know if I should change anything:
- is calling an external command frowned upon? I couldn't find a better way to detect logrotate version
- should the `LOGROTATE_HAS_SU` variable be prefixed with `ICINGA2_`?
- should the code be placed further down in `CMakeLists.txt`? Or should itmaybe go to `etc/CMakeLists.txt`?
