### PR TITLE
Updated command definition and documentation for check_esxi_hardware

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -2260,6 +2260,7 @@ Name                    | Description
 esxi_hardware_host      | **Required.** Specifies the host to monitor. Defaults to "$address$".
 esxi_hardware_user      | **Required.** Specifies the user for polling. Must be a local user of the root group on the system. Can also be provided as a file path file:/path/to/.passwdfile, then first string of file is used.
 esxi_hardware_pass      | **Required.** Password of the user. Can also be provided as a file path file:/path/to/.passwdfile, then second string of file is used.
+esxi_hardware_port      | **Optional.** Specifies the CIM port to connect to. Defaults to "5989".
 esxi_hardware_vendor    | **Optional.** Defines the vendor of the server: "auto", "dell", "hp", "ibm", "intel", "unknown" (default).
 esxi_hardware_html      | **Optional.** Add web-links to hardware manuals for Dell servers (use your country extension). Only useful with **esxi_hardware_vendor** = dell.
 esxi_hardware_ignore    | **Optional.** Comma separated list of elements to ignore.

--- a/itl/plugins-contrib.d/virtualization.conf
+++ b/itl/plugins-contrib.d/virtualization.conf
@@ -35,6 +35,10 @@ object CheckCommand "esxi_hardware" {
 			value = "$esxi_hardware_pass$"
 			description = "password"
 		}
+		"-C" = {
+			value = "$esxi_hardware_port$"
+			description = "cim port"
+		}
 		"-V" = {
 			value = "$esxi_hardware_vendor$"
 			description = "Vendor code: auto, dell, hp, ibm, intel, or unknown"
@@ -74,6 +78,7 @@ object CheckCommand "esxi_hardware" {
 	}
 
 	vars.esxi_hardware_host = "$address$"
+	vars.esxi_hardware_port = "5989"
 	vars.esxi_hardware_perfdata = false
 	vars.esxi_hardware_nopower = false
 	vars.esxi_hardware_novolts = false


### PR DESCRIPTION
Added CIM port parameter. See http://www.claudiokuenzler.com/blog/644/check_esxi_hardware-different-cim-ports-behind-nat for more details.