### PR TITLE
fix the formatting of `systemctl reload icinga2`

### DIFF
--- a/doc/11-icinga2-client.md
+++ b/doc/11-icinga2-client.md
@@ -588,6 +588,7 @@ After updating the configuration repository, make sure to reload Icinga 2.
     # service icinga2 reload
 
 Using systemd:
+
     # systemctl reload icinga2
 
 


### PR DESCRIPTION
without the empty line markdown will not render the block properly