### PR TITLE
Adding option to access ifName.

### DIFF
--- a/doc/7-icinga-template-library.md
+++ b/doc/7-icinga-template-library.md
@@ -1604,6 +1604,7 @@ snmp_interface_errors       | **Optional.** Add error & discard to Perfparse out
 snmp_interface_noregexp     | **Optional.** Do not use regexp to match interface name in description OID. Defaults to false.
 snmp_interface_delta        | **Optional.** Delta time of perfcheck. Defaults to "300" (5 min).
 snmp_warncrit_percent       | **Optional.** Make the warning and critical levels in % of reported interface speed. If set, **snmp_interface_megabytes** needs to be set to false. Defaults to false.
+snmp_interface_ifname       | **Optional.** Switch from IF-MIB::ifDescr to IF-MIB::ifName when looking up the interface's name
 snmp_perf                   | **Optional.** Enable perfdata values. Defaults to true.
 snmp_timeout                | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -187,6 +187,9 @@ object CheckCommand "snmp-interface" {
 		"-u" = {
 			set_if = "$snmp_interface_warncrit_percent$"
 		}
+		"-N" = {
+			set_if = "$snmp_interface_ifname$"
+		}
 		"-f" = {
 			set_if = "$snmp_perf$"
 		}
@@ -203,6 +206,7 @@ object CheckCommand "snmp-interface" {
 	vars.snmp_interface_noregexp = false
 	vars.snmp_interface_delta = 300
 	vars.snmp_interface_warncrit_percent = false
+	vars.snmp_interface_ifname = false
 	vars.snmp_warn = "300,400"
 	vars.snmp_crit = "0,600"
 	vars.snmp_perf = true


### PR DESCRIPTION
Recent Net-SNMP's snmpd daemon has changed behavior returning detailed
information about the network interfaces in the IF-MIB::ifDescr MIB.

There is a patch out there that is working around the issue (see also
https://bugs.debian.org/812837) by providing the behaviour via '-N'.

This path provides a way to make use of this workaround.