### PR TITLE
Update command-plugins.conf

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -870,7 +870,10 @@ object CheckCommand "ntp_time" {
 	arguments = {
 		"-H" = "$ntp_address$"
 		"-p" = "$ntp_port$"
-		"-q" = "$ntp_quit$"
+		"-q" = {
+			set_if = "$ntp_quiet$"
+			description = "Returns UNKNOWN instead of CRITICAL if offset cannot be found"
+			}
 		"-w" = "$ntp_warning$"
 		"-c" = "$ntp_critical$"
 		"-o" = "$ntp_timeoffset$"


### PR DESCRIPTION
-q is not for "quit", but for quiet: Returns UNKNOWN instead of CRITICAL if offset cannot be found