### PR TITLE
Add vars for all check_swap args

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1256,8 +1256,20 @@ object CheckCommand "swap" {
 	command = [ PluginDir + "/check_swap" ]
 
 	arguments = {
-		"-w" = "$swap_wfree$"
-		"-c" = "$swap_cfree$"
+		"-w" = {{
+			if (macro("$swap_integer$") {
+				return macro("$swap_wfree$");
+			} else {
+				return macro("$swap_wfree$%")
+			}
+		}}
+		"-c" = {{
+			if (macro("$swap_integer$") {
+				return macro("$swap_cfree$");
+			} else {
+				return macro("$swap_cfree$%")
+			}
+		}}
 		"-a" = {
 			set_if = "$swap_allswaps$"
 		}
@@ -1266,6 +1278,7 @@ object CheckCommand "swap" {
 
 	vars.swap_wfree = "50%"
 	vars.swap_cfree = "25%"
+	vars.swap_integer = false
 	vars.swap_allswaps = false
 	vars.swap_noswap = "critical"
 }

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1256,12 +1256,18 @@ object CheckCommand "swap" {
 	command = [ PluginDir + "/check_swap" ]
 
 	arguments = {
-		"-w" = "$swap_wfree$%"
-		"-c" = "$swap_cfree$%"
+		"-w" = "$swap_wfree$"
+		"-c" = "$swap_cfree$"
+		"-a" = {
+			set_if = "$swap_allswaps$"
+		}
+		"-n" = "$swap_noswap$"
 	}
 
-	vars.swap_wfree = 50
-	vars.swap_cfree = 25
+	vars.swap_wfree = "50%"
+	vars.swap_cfree = "25%"
+	vars.swap_allswaps = false
+	vars.swap_noswap = "critical"
 }
 
 object CheckCommand "load" {


### PR DESCRIPTION
The check_swap has support for some additional arguments.
This diff adds support for them.

Also the % was moved from the checkcommand args to the default values.
This way you could define a static value instead of a percentage.