### PR TITLE
Don't violate POSIX by ensuring that the argument to usleep(3) is less than 1000000

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -421,7 +421,11 @@ pid_t Utility::GetPid(void)
 void Utility::Sleep(double timeout)
 {
 #ifndef _WIN32
-	usleep(timeout * 1000 * 1000);
+	unsigned long micros = timeout * 1000000u;
+	if (timeout >= 1.0)
+		sleep((unsigned)timeout);
+
+	usleep(micros % 1000000u);
 #else /* _WIN32 */
 	::Sleep(timeout * 1000);
 #endif /* _WIN32 */


### PR DESCRIPTION
[POSIX](http://pubs.opengroup.org/onlinepubs/009695399/functions/usleep.html) says about usleep(3): "The useconds argument shall be less than one million."

Violating this in utility.cpp causes icinga2 to excessively use the CPU on (at least) NetBSD, since a call to usleep with an argument >= 1000000 has no effect whatsoever.  As a result, icinga2's main loop runs unthrottled, using as much CPU as available.

This PR avoids the issue by calling sleep(3) on the integer part of the timeout, then follows up with usleep(3) for the fractional part (i.e. the microseconds that don't add up to a whole second).