### PR TITLE
Remove inode default values

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1086,8 +1086,6 @@ object CheckCommand "disk" {
 
 	vars.disk_wfree = "20%"
 	vars.disk_cfree = "10%"
-	vars.disk_inode_wfree = "20%"
-	vars.disk_inode_cfree = "10%"
 	vars.disk_megabytes = true
 	vars.disk_exclude_type = [ "none", "tmpfs", "sysfs", "proc", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse" ]
 }


### PR DESCRIPTION
Free inode check is a an optional argument and does make sense in most
cases, yet not in every case. Eg, XFS and filesystems alike dynamically
allocate inodes; prompting failures. Because they are definded by
default, inode crit and warn cannot be unset any more.

refs #12588