### PR TITLE
add concurrent_checks in CheckerComponent example config so it shows …

### DIFF
--- a/doc/9-object-types.md
+++ b/doc/9-object-types.md
@@ -195,7 +195,9 @@ Example:
 
     library "checker"
 
-    object CheckerComponent "checker" { }
+    object CheckerComponent "checker" {
+      concurrent_checks = 512
+    }
 
 Configuration Attributes:
 


### PR DESCRIPTION
add concurrent_checks in CheckerComponent example config so it shows when searching for "concurrent_checks" in the documentation search field
