### PR TITLE
Add sudo option on check_mailq

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -718,6 +718,7 @@ mailq_domain_warning	| **Optional.** Min. number of messages for same domain in 
 mailq_domain_critical	| **Optional.** Min. number of messages for same domain in queue to generate critical alert ( W < C ).
 mailq_timeout		| **Optional.** Plugin timeout in seconds (default = 15).
 mailq_servertype	| **Optional.** [ sendmail \| qmail \| postfix \| exim \| nullmailer ] (default = autodetect).
+mailq_sudo		| **Optional.** Use sudo to execute the mailq command.
 
 ### <a id="plugin-check-command-mysql"></a> mysql
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1984,6 +1984,10 @@ object CheckCommand "mailq" {
 			value = "$mailq_servertype$"
 			description = "[ sendmail | qmail | postfix | exim | nullmailer ] (default = autodetect)"
 		}
+		"-s" = {
+			set_if = "$mailq_sudo$"
+			description = "Use sudo for mailq command"
+		}
 	}
 }
 


### PR DESCRIPTION
The new version of check_mailq has support for sudo execution of mailq command.
Please include :)
