### PR TITLE
Inverse Interface Switch for snmp-interface

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1892,6 +1892,7 @@ snmp_privpass               | **Required.** SNMP version 3 priv password. No val
 snmp_warn                   | **Optional.** The warning threshold.
 snmp_crit                   | **Optional.** The critical threshold.
 snmp_interface              | **Optional.** Network interface name. Default to regex "eth0".
+snmp_interface_inverse      | **Optional.** Inverse Interface check, down is ok. Defaults to false as it is missing.
 snmp_interface_perf         | **Optional.** Check the input/ouput bandwidth of the interface. Defaults to true.
 snmp_interface_label        | **Optional.** Add label before speed in output: in=, out=, errors-out=, etc.
 snmp_interface_bits_bytes   | **Optional.** Output performance data in bits/s or Bytes/s. **Depends** on snmp_interface_kbits set to true. Defaults to true.

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -183,6 +183,10 @@ object CheckCommand "snmp-interface" {
 		"-e" = {
 			set_if = "$snmp_interface_errors$"
 		}
+		"-i" = {
+			set_if = "$snmp_interface_inverse$"
+		}
+		"-r" = {
 		"-r" = {
 			set_if = "$snmp_interface_noregexp$"
 		}

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -187,7 +187,6 @@ object CheckCommand "snmp-interface" {
 			set_if = "$snmp_interface_inverse$"
 		}
 		"-r" = {
-		"-r" = {
 			set_if = "$snmp_interface_noregexp$"
 		}
 		"-d" = "$snmp_interface_delta$"


### PR DESCRIPTION
Implemented -i switch to snmp-interface command configuration. As for Interface Monitoring it is sometime needed to inverse the status (down-> OK, up -> NOT OK).

Can be configured via snmp_interface_inverse variable (boolean). Add documentation, too.