### PR TITLE
Support --only-critical for check_apt

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -140,6 +140,7 @@ apt_include             | **Optional.** Include only packages matching REGEXP. C
 apt_exclude             | **Optional.** Exclude packages matching REGEXP from the list of packages that would otherwise be included. Can be specified multiple times.
 apt_critical            | **Optional.** If the full package information of any of the upgradable packages match this REGEXP, the plugin will return CRITICAL status. Can be specified multiple times.
 apt_timeout             | **Optional.** Seconds before plugin times out (default: 10).
+apt_only_critical       | **Optional.** Only warn about critical upgrades.
 
 
 ### <a id="plugin-check-command-breeze"></a> breeze

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1474,6 +1474,10 @@ object CheckCommand "apt" {
 			value = "$apt_timeout$"
 			description = "Seconds before plugin times out (default: 10)."
 		}
+		"--only-critical" = {
+			set_if = "$apt_only_critical$"
+			description = "Only warn about critical upgrades."
+		}
 	}
 
 	timeout = 5m


### PR DESCRIPTION
This PR adds support for the new `--only-critical` switch for `check_apt` added in https://github.com/monitoring-plugins/monitoring-plugins/pull/1457 (commited today, not yet released, will be included in release 2.3 AFAICT).

FWIW I submitted an identical PR for the *nagios-plugins* project (before I knew about *monitoring-plugins*  and the forking issue), but so far there has been no response: https://github.com/nagios-plugins/nagios-plugins/pull/210