### PR TITLE
Don't crash on large IPC control messages

### DIFF
--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -249,14 +249,14 @@ static void ProcessHandler(void)
 	}
 
 	for (;;) {
-		SizeType length;
+		size_t length;
 
 		struct msghdr msg;
 		memset(&msg, 0, sizeof(msg));
 
 		struct iovec io;
 		io.iov_base = &length;
-		io.iov_len = sizeof(SizeType);
+		io.iov_len = sizeof(size_t);
 
 		msg.msg_iov = &io;
 		msg.msg_iovlen = 1;
@@ -282,7 +282,7 @@ static void ProcessHandler(void)
 
 		char *mbuf = new char[length];
 
-		SizeType count = 0;
+		size_t count = 0;
 		while (count < length) {
 			rc = recv(l_ProcessControlFD, mbuf + count, length - count, 0);
 
@@ -382,7 +382,7 @@ static pid_t ProcessSpawn(const std::vector<String>& arguments, const Dictionary
 	request->Set("extraEnvironment", extraEnvironment);
 
 	String jrequest = JsonEncode(request);
-	SizeType length = jrequest.GetLength();
+	size_t length = jrequest.GetLength();
 
 	boost::mutex::scoped_lock lock(l_ProcessControlMutex);
 
@@ -391,7 +391,7 @@ static pid_t ProcessSpawn(const std::vector<String>& arguments, const Dictionary
 
 	struct iovec io;
 	io.iov_base = &length;
-	io.iov_len = sizeof(SizeType);
+	io.iov_len = sizeof(size_t);
 
 	msg.msg_iov = &io;
 	msg.msg_iovlen = 1;
@@ -439,11 +439,11 @@ static int ProcessKill(pid_t pid, int signum)
 	request->Set("signum", signum);
 
 	String jrequest = JsonEncode(request);
-	SizeType length = jrequest.GetLength();
+	size_t length = jrequest.GetLength();
 
 	boost::mutex::scoped_lock lock(l_ProcessControlMutex);
 
-	while (send(l_ProcessControlFD, &length, sizeof(SizeType), 0) < 0)
+	while (send(l_ProcessControlFD, &length, sizeof(size_t), 0) < 0)
 		StartSpawnProcessHelper();
 
 	if (send(l_ProcessControlFD, jrequest.CStr(), jrequest.GetLength(), 0) < 0) {
@@ -472,11 +472,11 @@ static int ProcessWaitPID(pid_t pid, int *status)
 	request->Set("pid", pid);
 
 	String jrequest = JsonEncode(request);
-	SizeType length = jrequest.GetLength();
+	size_t length = jrequest.GetLength();
 
 	boost::mutex::scoped_lock lock(l_ProcessControlMutex);
 
-	while (send(l_ProcessControlFD, &length, sizeof(SizeType), 0) < 0)
+	while (send(l_ProcessControlFD, &length, sizeof(size_t), 0) < 0)
 		StartSpawnProcessHelper();
 
 	if (send(l_ProcessControlFD, jrequest.CStr(), jrequest.GetLength(), 0) < 0) {

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -303,7 +303,7 @@ static void ProcessHandler(void)
 				break;
 		}
 
-		String jrequest = String(mbuf, length);
+		String jrequest = String(mbuf, mbuf + count);
 
 		delete [] mbuf;
 


### PR DESCRIPTION
This addresses https://dev.icinga.com/issues/13655

The issue is that IPC is done using JSON documents. When spawning an external process, the buffer containing this information (including parameters and environment variables) is limited to 4096 bytes and any further data is truncated. When the JSON is truncated, it fails to properly parse which leads to an assertion failure.

This solves the issue by sending the length of the document first, allowing the client to allocate a proper buffer and to fully read the buffer.

_I was not able to test this_ as we rolled back our system to a previous version, but I can verify it compiles. This PR should stand as a suggestion as to how to do it. I haven't programmed in C/C++ in ~6 years so please be gentle.