### PR TITLE
Add new parameter for check_http: -L: Wrap output in HTML link

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -601,7 +601,8 @@ http_pagesize                    | **Optional.** Minimum page size required:Maxi
 http_timeout                     | **Optional.** Seconds before connection times out.
 http_ipv4                        | **Optional.** Use IPv4 connection. Defaults to false.
 http_ipv6                        | **Optional.** Use IPv6 connection. Defaults to false.
-http_verbose			 | **Optional.** Show details for command-line debugging. Defaults to false.
+http_link                        | **Optional.** Wrap output in HTML link. Defaults to false.
+http_verbose                     | **Optional.** Show details for command-line debugging. Defaults to false.
 
 
 ### <a id="plugin-check-command-icmp"></a> icmp

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -455,6 +455,10 @@ object CheckCommand "http" {
 			set_if = "$http_ipv6$"
 			description = "Use IPv6 connection"
 		}
+		"-L" = {
+			set_if = "$http_link$"
+			description = "Wrap output in HTML link"
+		}
 		"-v" = {
 			set_if = "$http_verbose$"
 			description = "Show details for command-line debugging"
@@ -468,6 +472,7 @@ object CheckCommand "http" {
 	vars.http_invertregex = false
 	vars.check_ipv4 = "$http_ipv4$"
 	vars.check_ipv6 = "$http_ipv6$"
+	vars.http_link = false
 	vars.http_verbose = false
 }
 


### PR DESCRIPTION
It seems Icinga 2 is missing the possibility to pass -L parameter that Wrap output in HTML link. This patch adds this feature.
https://www.monitoring-plugins.org/doc/man/check_http.html
-L, --link
    Wrap output in HTML link (obsoleted by urlize)