### PR TITLE
fix ssl cert check when SNI is used

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1275,6 +1275,7 @@ ssl_port                      | **Required.** The port that should be checked.
 ssl_timeout                   | **Optional.** Timeout in seconds for the connect and handshake. The plugin default is 10 seconds.
 ssl_cert_valid_days_warn      | **Optional.** Warning threshold for days before the certificate will expire. When used, ssl_cert_valid_days_critical must also be set.
 ssl_cert_valid_days_critical  | **Optional.** Critical threshold for days before the certificate will expire. When used, ssl_cert_valid_days_warn must also be set.
+ssl_sni                       | **Optional.** The `server_name` that is send to select the SSL certificate to check. Important if SNI is used. Defaults to "$ssl_address$".
 
 
 ### <a id="plugin-check-command-ssmtp"></a> ssmtp

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -269,9 +269,11 @@ object CheckCommand "ssl" {
 		"--ssl" = { }
 		"--timeout" = "$ssl_timeout$"
 		"-D" = "$ssl_cert_valid_days_warn$,$ssl_cert_valid_days_critical$"
+		"-N" = "$ssl_sni$"
 	}
 
 	vars.ssl_address = "$check_address$"
+	vars.ssl_sni = "$ssl_address$"
 }
 
 object CheckCommand "udp" {


### PR DESCRIPTION
Without this, we check the wrong cert when SNI is used:

```
./check_tcp -H git.netsandbox.de -p 443 -D 30,10
OK - Certificate 'netsandbox.de' will expire on 2017-04-19 12:01 +0200/CEST.

./check_tcp -H git.netsandbox.de -p 443 -D 30,10 -N git.netsandbox.de
OK - Certificate 'git.netsandbox.de' will expire on 2017-04-15 14:06 +0200/CEST.
```