### PR TITLE
PerfData: Server Timeouts for InfluxDB Writer

### DIFF
--- a/doc/9-object-types.md
+++ b/doc/9-object-types.md
@@ -933,6 +933,7 @@ Configuration Attributes:
   enable_send_metadata   | **Optional.** Whether to send check metadata e.g. states, execution time, latency etc.
   flush_interval         | **Optional.** How long to buffer data points before transfering to InfluxDB. Defaults to `10s`.
   flush_threshold        | **Optional.** How many data points to buffer before forcing a transfer to InfluxDB.  Defaults to `1024`.
+  socket_timeout         | **Optional.** How long to wait for InfluxDB to respond.  Defaults to `5s`.
 
 ### <a id="objecttype-influxdbwriter-instance-tags"></a> Instance Tagging
 

--- a/lib/perfdata/influxdbwriter.hpp
+++ b/lib/perfdata/influxdbwriter.hpp
@@ -65,7 +65,7 @@ private:
 	static String EscapeKey(const String& str);
 	static String EscapeField(const String& str);
 
-	Stream::Ptr Connect(void);
+	Stream::Ptr Connect(TcpSocket::Ptr& socket);
 };
 
 }

--- a/lib/perfdata/influxdbwriter.ti
+++ b/lib/perfdata/influxdbwriter.ti
@@ -90,6 +90,9 @@ class InfluxdbWriter : ConfigObject
 	[config] int flush_threshold {
 		default {{{ return 1024; }}}
 	};
+	[config] int socket_timeout {
+		default {{{ return 5; }}}
+	};
 };
 
 validator InfluxdbWriter {


### PR DESCRIPTION
Exposes the TCP socket used to communicate with the InfluxDB server.  When we are
expecing a response we can now call poll() on the socket to wait for data to become
available.  If it doesn't in a user configurable timeout period we abort the request.

Refs #4927