### PR TITLE
Fix Check Output Parsing

### DIFF
--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -118,22 +118,32 @@ std::pair<String, String> PluginUtility::ParseCheckOutput(const String& output)
 	std::vector<String> lines;
 	boost::algorithm::split(lines, output, boost::is_any_of("\r\n"));
 
-	for (const String& line : lines) {
-		size_t delim = line.FindFirstOf("|");
+	// We only need extract performance data from the first and second last lines
+	// See: https://www.monitoring-plugins.org/doc/guidelines.html#AEN201
+
+	std::vector<String>::size_type second_last;
+	if (lines.size() > 2)
+		second_last = lines.size() - 2;
+
+	for (std::vector<String>::size_type i = 0; i < lines.size(); i++) {
+		const String& line = lines[i];
 
 		if (!text.IsEmpty())
 			text += "\n";
 
-		if (delim != String::NPos) {
+		if (i == 0 || i == second_last) {
+			size_t delim = line.FindFirstOf("|");
+
+			if (delim != String::NPos) {
+				if (!perfdata.IsEmpty())
+					perfdata += " ";
+
+				perfdata += line.SubStr(delim + 1, line.GetLength());
+			}
+
 			text += line.SubStr(0, delim);
-
-			if (!perfdata.IsEmpty())
-				perfdata += " ";
-
-			perfdata += line.SubStr(delim + 1, line.GetLength());
-		} else {
+		} else
 			text += line;
-		}
 	}
 
 	boost::algorithm::trim(perfdata);

--- a/lib/methods/pluginchecktask.cpp
+++ b/lib/methods/pluginchecktask.cpp
@@ -71,9 +71,7 @@ void PluginCheckTask::ProcessFinishedHandler(const Checkable::Ptr& checkable, co
 		    << pr.ExitStatus << ", output: " << pr.Output;
 	}
 
-	String output = pr.Output.Trim();
-
-	std::pair<String, String> co = PluginUtility::ParseCheckOutput(output);
+	std::pair<String, String> co = PluginUtility::ParseCheckOutput(pr.Output);
 	cr->SetCommand(commandLine);
 	cr->SetOutput(co.first);
 	cr->SetPerformanceData(PluginUtility::SplitPerfdata(co.second));


### PR DESCRIPTION
The parser which chops up check output and separates performance data from actual
human readable output is a little too aggressive, matching all lines containing a
`|` as having performance data rather than the first and second last, as per the
specification.  As a result, checks with pretty table output end up being consumed
as (invalid) performance data.  I also had to remove a trim which would have removed
trailling white space from the performance data before parsing.  Any white space
added seems to disappear in icingaweb2 so isn't detrimental to the prettiness.