### PR TITLE
Added CheckCommand definitions for SMART, RAID controller and IPMI ping check

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2235,6 +2235,14 @@ Name                            | Description
 --------------------------------|-----------------------------------------------------------------------
 lsi_controller_number		| **Required.** Insert the controller number to monitor.
 
+#### <a id="plugin-contrib-command-smart-attributes"></a> smart-attributes
+
+The plugin [check_smart_attributes](https://github.com/thomas-krenn/check_smart_attributes) is a plugin to monitor the SMART values of SSDs and HDDs.
+
+Name                            | Description
+--------------------------------|-----------------------------------------------------------------------
+device				| **Required.** Insert the device name (e.g. /dev/sda) to monitor.
+
 
 ### <a id="plugin-contrib-icingacli"></a> IcingaCLI
 

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2241,7 +2241,9 @@ The plugin [check_smart_attributes](https://github.com/thomas-krenn/check_smart_
 
 Name                            | Description
 --------------------------------|-----------------------------------------------------------------------
-device				| **Required.** Insert the device name (e.g. /dev/sda) to monitor.
+smart_attributes_config_path	| **Required.** Path to the smart attributes config file (e.g. check_smartdb.json).
+smart_attributes_device		| **Required.** Insert the device name (e.g. /dev/sda) to monitor.
+
 
 
 ### <a id="plugin-contrib-icingacli"></a> IcingaCLI

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2269,6 +2269,14 @@ ipmi_verbose                     | **Optional.** Be Verbose multi line output, a
 ipmi_debug                       | **Optional.** Be Verbose debugging output, followed by normal multi line output.
 
 
+#### <a id="plugin-contrib-command-ipmi-alive"></a> ipmi-alive
+
+With the plugin `ipmi-alive` you can assign a PING check for the IPMI Interface.
+
+Name                             | Description
+---------------------------------|-----------------------------------------------------------------------------------------------------
+ipmi_address                     | **Required.** Specifies the remote host (IPMI device) to check.
+
 
 
 ### <a id="plugins-contrib-log-management"></a> Log Management

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2219,6 +2219,22 @@ hpasm_privprotocol		| **Optional.** The private protocol for SNMPv3 (des\|aes\|a
 hpasm_servertype		| **Optional.** The type of the server: proliant (default) or bladesystem.
 hpasm_eval-nics			| **Optional.** Check network interfaces (and groups). Try it and report me whyt you think about it. I need to build up some know how on this subject. If you get an error and think, it is not justified for your configuration, please tell me about it. (alwasy send the output of "snmpwalk -On .... 1.3.6.1.4.1.232" and a description how you setup your nics and why it is correct opposed to the plugins error message.
 
+#### <a id="plugin-contrib-command-adaptec-raid"></a> adaptec-raid
+
+The plugin [check_adaptec_raid](https://github.com/thomas-krenn/check_adaptec_raid) is a plugin to monitor Adaptec RAID controller through arcconf.
+
+Name                            | Description
+--------------------------------|-----------------------------------------------------------------------
+adaptec_controller_number	| **Required.** Insert the controller number to monitor.
+
+#### <a id="plugin-contrib-command-lsi-raid"></a> lsi-raid
+
+The plugin [check_lsi_raid](https://github.com/thomas-krenn/check_lsi_raid) is a plugin to monitor MegaRAID RAID controller through storcli.
+
+Name                            | Description
+--------------------------------|-----------------------------------------------------------------------
+lsi_controller_number		| **Required.** Insert the controller number to monitor.
+
 
 ### <a id="plugin-contrib-icingacli"></a> IcingaCLI
 

--- a/itl/plugins-contrib.d/ipmi.conf
+++ b/itl/plugins-contrib.d/ipmi.conf
@@ -104,3 +104,18 @@ object CheckCommand "ipmi-sensor" {
 	vars.ipmi_address = "$check_address$"
 	vars.ipmi_protocal_lan_version = "LAN_2_0"
 }
+
+/*
+ * Icinga2 CheckCommand definition for an IPMI interface ping check
+*/
+
+object CheckCommand "ipmi-alive" {
+        import "plugin-check-command"
+        command = [ PluginContribDir + "/check_ping" ]
+        arguments = {
+                "-H" = "$ipmi_address$"
+                "-w" = "5000,100%"
+                "-c" = "5000,100%"
+                "-p" = "1"
+        }
+}

--- a/itl/plugins-contrib.d/ipmi.conf
+++ b/itl/plugins-contrib.d/ipmi.conf
@@ -111,7 +111,7 @@ object CheckCommand "ipmi-sensor" {
 
 object CheckCommand "ipmi-alive" {
         import "plugin-check-command"
-        command = [ PluginContribDir + "/check_ping" ]
+        command = [ PluginDir + "/check_ping" ]
         arguments = {
                 "-H" = "$ipmi_address$"
                 "-w" = "5000,100%"

--- a/itl/plugins-contrib.d/raid-controller.conf
+++ b/itl/plugins-contrib.d/raid-controller.conf
@@ -1,0 +1,30 @@
+/*
+ * Icinga2 CheckCommand definitions to monitor RAID controller from Adaptec and Broadcom using
+ * the Adaptec RAID Monitoring Plugin and the LSI RAID Monitoring Plugin
+ */
+
+object CheckCommand "adaptec-raid" {
+        import "plugin-check-command"
+        command = [ PluginDir + "/check_adaptec_raid" ]
+        arguments = {
+                "-C" = {
+                        required = true
+                        value = "$adaptec_controller_number$"
+                        description = "The controller number to be checked."
+                }
+                "-p" = "/sbin/arcconf"
+        }
+}
+
+object CheckCommand "lsi-raid" {
+        import "plugin-check-command"
+        command = [ PluginDir + "/check_lsi_raid" ]
+        arguments = {
+                "-C" = {
+                        required = true
+                        value = "$lsi_controller_number$"
+                        description = "The controller number to be checked."
+                }
+                "-p" = "/usr/sbin/storcli"
+        }
+}

--- a/itl/plugins-contrib.d/smart-attributes.conf
+++ b/itl/plugins-contrib.d/smart-attributes.conf
@@ -6,10 +6,15 @@ object CheckCommand "smart-attributes" {
    import "plugin-check-command"
    command = [ PluginDir + "/check_smart_attributes" ]
    arguments = {
-   "-dbj" = "/etc/nagios-plugins/config/check_smartdb.json"
+   "-dbj" = {
+	required = true
+	value = "$smart_attributes_config_path$"
+	description = "Path to the smart attributes config file (e.g. check_smartdb.json)"
+	}
    "-d" = {
-         required = true
-         value = "$device$"
-      }
+	required = true
+	value = "$smart_attributes_device$"
+	description = "Insert the device name (e.g. /dev/sda) to monitor"
+	}
    }
 }

--- a/itl/plugins-contrib.d/smart-attributes.conf
+++ b/itl/plugins-contrib.d/smart-attributes.conf
@@ -1,0 +1,15 @@
+/* 
+ * Icinga2 CheckCommand definition for the SMART Attributes Monitoring Plugin
+ */
+
+object CheckCommand "smart-attributes" {
+   import "plugin-check-command"
+   command = [ PluginDir + "/check_smart_attributes" ]
+   arguments = {
+   "-dbj" = "/etc/nagios-plugins/config/check_smartdb.json"
+   "-d" = {
+         required = true
+         value = "$device$"
+      }
+   }
+}


### PR DESCRIPTION
I created a bunch of CheckCommand definitions. An IPMI interface ping check, RAID controller checks for MegaRAID and Adaptec controller and a SMART attributes check.
I'm not sure, if the file path for the variable "-dbj" in the SMART attributes check is suitable in this way, it works, but maybe something like "-dbj" = [PluginConfigDir + "/check_smartdb.json" would be better.
Therefore, I think a line for this new directory has to be added into the constants.conf, e.g. "const PluginConfigDir = "/etc/nagios-plugins/config/".