### PR TITLE
change `dummy` CheckCommand. fixes #4987

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -138,11 +138,22 @@ object CheckCommand "fping6" {
 }
 
 object CheckCommand "dummy" {
-	command = [
-		PluginDir + "/check_dummy",
-		"$dummy_state$",
-		"$dummy_text$"
-	]
+	command = [ PluginDir + "/check_dummy" ]
+
+	arguments = {
+		"state" = {
+			value = "$dummy_state$"
+			skip_key = true
+			order = 1
+			description = "The state. Can be one of 0 (ok), 1 (warning), 2 (critical) and 3 (unknown). Defaults to 0."
+		}
+		"text" = {
+			value = "$dummy_text$"
+			skip_key = true
+			order = 2
+			description = "Plugin output. Defaults to Check was successful."
+		}
+	}
 
 	vars.dummy_state = 0
 	vars.dummy_text = "Check was successful."


### PR DESCRIPTION
This changes the `dummy` CheckCommand so tools like Icinga Director can more easily identify the variables to set.