### PR TITLE
Add fuse.gvfs-fuse-daemon to disk_exclude_type

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -288,7 +288,7 @@ disk\_ignore\_eregi\_path | **Optional.** Regular expression to ignore selected 
 disk\_ignore\_ereg\_path  | **Optional.** Regular expression to ignore selected path or partition. Multiple regular expression strings must be defined as array.
 disk\_timeout             | **Optional.** Seconds before connection times out (default: 10).
 disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB (default: MB).
-disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array.
+disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs".
 
 ### <a id="plugin-check-command-disk-smb"></a> disk_smb
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1110,7 +1110,7 @@ object CheckCommand "disk" {
 	vars.disk_wfree = "20%"
 	vars.disk_cfree = "10%"
 	vars.disk_megabytes = true
-	vars.disk_exclude_type = [ "none", "tmpfs", "sysfs", "proc", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fdescfs" ]
+	vars.disk_exclude_type = [ "none", "tmpfs", "sysfs", "proc", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs" ]
 }
 
 object CheckCommand "disk_smb" {


### PR DESCRIPTION
This pull request adds fuse.gvfs-fuse-daemon to disk_exclude_type and documentation of disk_exclude_type defaults.