### PR TITLE
Added CheckCommand definitions for SMART, RAID controller and IPMI ping check

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2225,6 +2225,24 @@ hpasm_privprotocol		| **Optional.** The private protocol for SNMPv3 (des\|aes\|a
 hpasm_servertype		| **Optional.** The type of the server: proliant (default) or bladesystem.
 hpasm_eval-nics			| **Optional.** Check network interfaces (and groups). Try it and report me whyt you think about it. I need to build up some know how on this subject. If you get an error and think, it is not justified for your configuration, please tell me about it. (alwasy send the output of "snmpwalk -On .... 1.3.6.1.4.1.232" and a description how you setup your nics and why it is correct opposed to the plugins error message.
 
+#### <a id="plugin-contrib-command-adaptec-raid"></a> adaptec-raid
+
+The plugin [check_adaptec_raid](https://github.com/thomas-krenn/check_adaptec_raid) is a plugin to monitor Adaptec RAID controller through arcconf.
+
+Name                            | Description
+--------------------------------|-----------------------------------------------------------------------
+adaptec_controller_number       | **Required.** Insert the controller number to monitor.
+arcconf_path                    | **Required.** Insert the path to the arcconf binary, e.g. "/sbin/arcconf".
+
+#### <a id="plugin-contrib-command-lsi-raid"></a> lsi-raid
+
+The plugin [check_lsi_raid](https://github.com/thomas-krenn/check_lsi_raid) is a plugin to monitor MegaRAID RAID controller through storcli.
+
+Name                            | Description
+--------------------------------|-----------------------------------------------------------------------
+lsi_controller_number           | **Required.** Insert the controller number to monitor.
+storcli_path                    | **Required.** Insert the path to the storcli binary, e.g. "/usr/sbin/storcli".
+
 #### <a id="plugin-contrib-command-smart-attributes"></a> smart-attributes
 
 The plugin [check_smart_attributes](https://github.com/thomas-krenn/check_smart_attributes) is a plugin to monitor the SMART values of SSDs and HDDs.

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2274,7 +2274,13 @@ ipmi_no_sel_checking             | **Optional.** Turn off system event log check
 ipmi_verbose                     | **Optional.** Be Verbose multi line output, also with additional details for warnings.
 ipmi_debug                       | **Optional.** Be Verbose debugging output, followed by normal multi line output.
 
+#### <a id="plugin-contrib-command-ipmi-alive"></a> ipmi-alive
 
+With the plugin `ipmi-alive` you can assign a PING check for the IPMI Interface.
+
+Name                             | Description
+---------------------------------|-----------------------------------------------------------------------------------------------------
+ipmi_address                     | **Required.** Specifies the remote host (IPMI device) to check.
 
 
 ### <a id="plugins-contrib-log-management"></a> Log Management

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2294,7 +2294,7 @@ ipmi_exclude_sensor_id           | **Optional.** Exclude sensor matching ipmi_se
 ipmi_exclude_sensor              | **Optional.** Exclude sensor based on IPMI sensor type. (Comma-separated)
 ipmi_exclude_sel                 | **Optional.** Exclude SEL entries of specific sensor types. (comma-separated list).
 ipmi_sensor_id                   | **Optional.** Include sensor matching ipmi_sensor_id.
-ipmi_protocal_lan_version        | **Optional.** Change the protocol LAN version. Defaults to "LAN_2_0".
+ipmi_protocol_lan_version        | **Optional.** Change the protocol LAN version. Defaults to "LAN_2_0".
 ipmi_number_of_active_fans       | **Optional.** Number of fans that should be active. Otherwise a WARNING state is returned.
 ipmi_show_fru                    | **Optional.** Print the product serial number if it is available in the IPMI FRU data.
 ipmi_no_sel_checking             | **Optional.** Turn off system event log checking via ipmi-sel.

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2225,6 +2225,15 @@ hpasm_privprotocol		| **Optional.** The private protocol for SNMPv3 (des\|aes\|a
 hpasm_servertype		| **Optional.** The type of the server: proliant (default) or bladesystem.
 hpasm_eval-nics			| **Optional.** Check network interfaces (and groups). Try it and report me whyt you think about it. I need to build up some know how on this subject. If you get an error and think, it is not justified for your configuration, please tell me about it. (alwasy send the output of "snmpwalk -On .... 1.3.6.1.4.1.232" and a description how you setup your nics and why it is correct opposed to the plugins error message.
 
+#### <a id="plugin-contrib-command-smart-attributes"></a> smart-attributes
+
+The plugin [check_smart_attributes](https://github.com/thomas-krenn/check_smart_attributes) is a plugin to monitor the SMART values of SSDs and HDDs.
+
+Name                            | Description
+--------------------------------|-----------------------------------------------------------------------
+smart_attributes_config_path    | **Required.** Path to the smart attributes config file (e.g. check_smartdb.json).
+smart_attributes_device         | **Required.** Insert the device name (e.g. /dev/sda) to monitor.
+
 
 ### <a id="plugin-contrib-icingacli"></a> IcingaCLI
 

--- a/itl/plugins-contrib.d/ipmi.conf
+++ b/itl/plugins-contrib.d/ipmi.conf
@@ -104,3 +104,20 @@ object CheckCommand "ipmi-sensor" {
 	vars.ipmi_address = "$check_address$"
 	vars.ipmi_protocal_lan_version = "LAN_2_0"
 }
+
+/*
+ * Icinga2 CheckCommand definition for an IPMI interface ping check
+*/
+
+object CheckCommand "ipmi-alive" {
+	import "plugin-check-command"
+
+	command = [ PluginDir + "/check_ping" ]
+
+	arguments = {
+		"-H" = "$ipmi_address$"
+		"-w" = "5000,100%"
+		"-c" = "5000,100%"
+		"-p" = "1"
+	}
+}

--- a/itl/plugins-contrib.d/ipmi.conf
+++ b/itl/plugins-contrib.d/ipmi.conf
@@ -76,7 +76,7 @@ object CheckCommand "ipmi-sensor" {
 			description = "Turn off system event log checking via ipmi-sel"
 		}
 		"-D" = {
-			value = "$ipmi_protocal_lan_version$"
+			value = "$ipmi_protocol_lan_version$"
 			description = "Change the protocol LAN version (default: LAN_2_0)"
 		}
 		"-fc" = {
@@ -102,7 +102,7 @@ object CheckCommand "ipmi-sensor" {
 	}
 
 	vars.ipmi_address = "$check_address$"
-	vars.ipmi_protocal_lan_version = "LAN_2_0"
+	vars.ipmi_protocol_lan_version = "LAN_2_0"
 }
 
 /*

--- a/itl/plugins-contrib.d/raid-controller.conf
+++ b/itl/plugins-contrib.d/raid-controller.conf
@@ -1,0 +1,44 @@
+/*
+ * Icinga2 CheckCommand definitions to monitor RAID controller from Adaptec and Broadcom using
+ * the Adaptec RAID Monitoring Plugin and the LSI RAID Monitoring Plugin
+ */
+
+object CheckCommand "adaptec-raid" {
+	import "plugin-check-command"
+
+	command = [ PluginDir + "/check_adaptec_raid" ]
+
+	arguments = {
+		"-C" = {
+			required = true
+			value = "$adaptec_controller_number$"
+			description = "Insert the controller number to be checked."
+		}
+		"-p" = {
+			required = true
+			value = "$arcconf_path$"
+			description = "Insert the path to arcconf (e.g. /sbin/arcconf)."
+	}
+
+	vars.arcconf_path = "/sbin/arcconf"
+}
+
+object CheckCommand "lsi-raid" {
+	import "plugin-check-command"
+
+	command = [ PluginDir + "/check_lsi_raid" ]
+
+	arguments = {
+		"-C" = {
+			required = true
+			value = "$lsi_controller_number$"
+			description = "Insert the controller number to be checked."
+		}
+		"-p" = {
+			required = true
+			value = "$storcli_path$"
+			description = "Insert the path to storcli (e.g. /usr/sbin/storcli)."
+	}
+
+	vars.storcli_path = "/usr/sbin/storcli"
+}

--- a/itl/plugins-contrib.d/smart-attributes.conf
+++ b/itl/plugins-contrib.d/smart-attributes.conf
@@ -1,0 +1,24 @@
+/* 
+ * Icinga2 CheckCommand definition for the SMART Attributes Monitoring Plugin
+ */
+
+object CheckCommand "smart-attributes" {
+	import "plugin-check-command"
+
+	command = [ PluginDir + "/check_smart_attributes" ]
+
+	arguments = {
+		"-dbj" = {
+			required = true
+			value = "$smart_attributes_config_path$"
+			description = "Path to the smart attributes config file (e.g. check_smartdb.json)"
+		}
+		"-d" = {
+			required = true
+			value = "$smart_attributes_device$"
+			description = "Insert the device name (e.g. /dev/sda) to monitor"
+		}
+	}
+
+	vars.smart_attributes_config_path = SysconfDir + "/icinga2/plugins-config/check_smartdb.json"
+}


### PR DESCRIPTION
I'm sorry I had to reopen the pull request, I messed up my first fork completely. This pull request is a successor to #4990 and will add a bunch of CheckCommand definitions. An IPMI interface ping check, RAID controller checks for MegaRAID and Adaptec controller and a SMART attributes check. I already applied all your hints and request. Thanks for your valuable help @dnsmichi @gunnarbeutner and @dgoetz. I also found and corrected a spelling mistake in the existing ipmi-sensor CheckCommand.