### PR TITLE
Fix IDO MySQL "command out of sync" error with lots of comments/downtimes upsert queries

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -481,6 +481,9 @@ void IdoMysqlConnection::AsyncQuery(const String& query, const boost::function<v
 
 	IdoAsyncQuery aq;
 	aq.Query = query;
+	/* XXX: Important: The callback must not immediately execute a query, but enqueue it!
+	 * See https://github.com/Icinga/icinga2/issues/4603 for details.
+	 */
 	aq.Callback = callback;
 	m_AsyncQueries.push_back(aq);
 
@@ -1094,7 +1097,13 @@ void IdoMysqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 void IdoMysqlConnection::FinishExecuteQuery(const DbQuery& query, int type, bool upsert)
 {
 	if (upsert && GetAffectedRows() == 0) {
-		InternalExecuteQuery(query, DbQueryDelete | DbQueryInsert);
+
+#ifdef I2_DEBUG /* I2_DEBUG */
+		Log(LogDebug, "IdoMysqlConnection")
+		    << "Rescheduling DELETE/INSERT query: Upsert UPDATE did not affect rows, type " << type << ", table '" << query.Table << "'.";
+#endif /* I2_DEBUG */
+
+		m_QueryQueue.Enqueue(boost::bind(&IdoMysqlConnection::InternalExecuteQuery, this, query, DbQueryDelete | DbQueryInsert), query.Priority);
 
 		return;
 	}


### PR DESCRIPTION
This only happens when the comments/downtines are not already inserted
thus causing the UPDATE statement not to match any rows.

The callback within the result set fetch loop was trying to immediately
fire such queries; right now it is just enqueuing the query again.

This patch also adds plenty of debug log entries which are only
available in debug builds.

fixes #4603