### PR TITLE
add --if-names option to check_interfaces

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2468,6 +2468,7 @@ interfaces_aliases        | **Optional.** Retrieves the interface description.
 interfaces_match_aliases  | **Optional.** Also match against aliases (Option --aliases automatically enabled).
 interfaces_timeout        | **Optional.** Sets the SNMP timeout (in ms).
 interfaces_sleep          | **Optional.** Sleep between every SNMP query (in ms).
+interfaces_names          | **Optional.** If set to true, use ifName instead of ifDescr.
 
 #### <a id="plugin-contrib-command-nwc_health"></a> nwc_health
 

--- a/itl/plugins-contrib.d/network-components.conf
+++ b/itl/plugins-contrib.d/network-components.conf
@@ -489,6 +489,10 @@ object CheckCommand "interfaces" {
 			value = "$interfaces_sleep$"
 			description = "Sleep between every SNMP query (in ms)."
 		}
+                "--if-names" = {
+                        set_if = "$interfaces_names$"
+                        description = "Use ifName instead of ifDescr."
+                }
 	}
 
 	vars.interfaces_address = "$check_address$"


### PR DESCRIPTION
check_interfaces supports since version 1.3 the option to query ifName instead of ifDescr, which is helpful eg. FortiOS 5.4 devices.