### PR TITLE
Fixed return code check in CRL loading (#5040).

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -231,7 +231,7 @@ void AddCRLToSSLContext(const boost::shared_ptr<SSL_CTX>& context, const String&
 		    << errinfo_openssl_error(ERR_peek_error()));
 	}
 
-	if (X509_LOOKUP_load_file(lookup, crlPath.CStr(), X509_FILETYPE_PEM) != 0) {
+	if (X509_LOOKUP_load_file(lookup, crlPath.CStr(), X509_FILETYPE_PEM) != 1) {
 		Log(LogCritical, "SSL")
 		    << "Error loading crl file '" << crlPath << "': " << ERR_peek_error() << ", \"" << ERR_error_string(ERR_peek_error(), errbuf) << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()


### PR DESCRIPTION
The code for loading CRLs was incorrectly assuming that OpenSSL's
X509_LOOKUP_load_file function returns zero on success, but actually it
returns one on success. This commit fixes this return code check so
that a CRL can be loaded.

This patch applies to the master branch, but issue #5040 is actually also present in older releases (at least down to 2.4), so it should be backported to all releases that are still supported.