### PR TITLE
Add link to upgrade documentation to log message

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -303,7 +303,8 @@ void IdoMysqlConnection::Reconnect(void)
 
 		Log(LogCritical, "IdoMysqlConnection")
 		    << "Schema version '" << version << "' does not match the required version '"
-		    << IDO_COMPAT_SCHEMA_VERSION << "' (or newer)! Please check the upgrade documentation.";
+		    << IDO_COMPAT_SCHEMA_VERSION << "' (or newer)! Please check the upgrade documentation at "
+		    << "https://docs.icinga.com/icinga2/latest/doc/module/icinga2/chapter/upgrading-icinga-2#upgrading-mysql-db";
 
 		Application::Exit(EXIT_FAILURE);
 	}

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -264,7 +264,8 @@ void IdoPgsqlConnection::Reconnect(void)
 
 		Log(LogCritical, "IdoPgsqlConnection")
 		    << "Schema version '" << version << "' does not match the required version '"
-		    << IDO_COMPAT_SCHEMA_VERSION << "' (or newer)! Please check the upgrade documentation.";
+		    << IDO_COMPAT_SCHEMA_VERSION << "' (or newer)! Please check the upgrade documentation at "
+		    << "https://docs.icinga.com/icinga2/latest/doc/module/icinga2/chapter/upgrading-icinga-2#upgrading-postgresql-db";
 
 		Application::Exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
When there's a schema version mismatch after an upgrade, the following
message is logged:

```
Schema version 'x.y.z' does not match the required version 'x.y.z' (or
newer)! Please check the upgrade documentation.
```

After reading this log message, users have to search for the upgrade
section in the docs in order to perform the necessary steps.

I added the URL for the relevant sections to the log message, so users
can simply click/copy it.