### PR TITLE
Add option to let parent downtimes suppress child notifications

### DIFF
--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -135,6 +135,19 @@ bool Dependency::IsAvailable(DependencyType dt) const
 		return true;
 	}
 
+  /* fail if parent is in downtime  */
+  if (!GetIgnoreDowntime() && parent->IsInDowntime()) {
+      if (dt == DependencyCheckExecution && GetDisableChecks()) {
+          Log(LogNotice, "Dependency")
+            << "Dependency '" << GetName() << "' failed: Parent " << (parentService ? "service" : "host") << " '" << parent->GetName() << "' is in Downtime: Checks are disabled.";
+          return false;
+      } else if (dt == DependencyNotification && GetDisableNotifications()) {
+          Log(LogNotice, "Dependency")
+            << "Dependency '" << GetName() << "' failed: Parent " << (parentService ? "service" : "host") << " '" << parent->GetName() << "' is in Downtime: Notifications are disabled.";
+          return false;
+      }
+  }
+
 	/* ignore pending  */
 	if (!parent->GetLastCheckResult()) {
 		Log(LogNotice, "Dependency")

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -111,6 +111,9 @@ class Dependency : CustomVarObject < DependencyNameComposer
 	[config] bool disable_notifications {
 		default {{{ return true; }}}
 	};
+	[config] bool ignore_downtime {
+		default {{{ return true; }}}
+	};
 };
 
 }


### PR DESCRIPTION
Old Nagios supported just setting downtimes on the host and service
notifications would not get sent anymore.

Add the option `ignore_downtime` to the dependencies to also check
whether the parent is in downtime. Hence we can not only consider state
changes for reachability, but also the downtime status.

This can be used to downtime the host only, but suppress notifications
for both host and services and make it unnecessary to downtime all
services _also_.

Whenever a host is downtimed we have the expectation to not receive
any notifications for the services.

Defaults to `ignore_downtime = true` to keep the old behaviour.

Fixes https://github.com/Icinga/icinga2/issues/3935