### PR TITLE
Added support to NRPE v2 in NRPE CheckCommand

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -816,6 +816,7 @@ nrpe_timeout    | **Optional.** The timeout in seconds.
 nrpe_arguments	| **Optional.** Arguments that should be passed to the command. Multiple arguments must be defined as array.
 nrpe_ipv4       | **Optional.** Use IPv4 connection. Defaults to false.
 nrpe_ipv6       | **Optional.** Use IPv6 connection. Defaults to false.
+nrpe_version_2	| **Optional.** Use this if you want to connect using NRPE v2 protocol. Defaults to false.
 
 
 ### <a id="plugin-check-command-nscp"></a> nscp

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1755,6 +1755,10 @@ object CheckCommand "nrpe" {
 			set_if = "$nrpe_ipv6$"
 			description = "Use IPv6 connection"
 		}
+		"-2" = {
+			set_if = "$nrpe_version_2$"
+			description = "Use this if you want to connect to NRPE v2"
+		}
 	}
 
 	vars.nrpe_address = "$check_address$"
@@ -1762,7 +1766,7 @@ object CheckCommand "nrpe" {
 	vars.nrpe_timeout_unknown = false
 	vars.check_ipv4 = "$nrpe_ipv4$"
 	vars.check_ipv6 = "$nrpe_ipv6$"
-
+	vars.nrpe_version_2 = false
 	timeout = 5m
 }
 


### PR DESCRIPTION
Added support for NRPE v2 version by adding argument nrpe_version_2 CheckCommand nrpe.
Based on issue: [https://github.com/Icinga/icinga2/issues/5113](https://github.com/Icinga/icinga2/issues/5113)