### PR TITLE
Improve systemd service file

### DIFF
--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -1,6 +1,6 @@
 [Unit]
 Description=Icinga host/service/network monitoring system
-After=syslog.target network.target postgresql.service mariadb.service carbon-cache.service
+After=syslog.target network-online.target postgresql.service mariadb.service carbon-cache.service carbon-relay.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
This pull request improves the systemd file by changing the target network to network-online according to https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/ and as @widhalmt suggested which allows to bind the API to a specific interface and by adding carbon-relay as service to start after for scenarios you want to run the relay on the master and have the cache on another system.