### PR TITLE
Enhance event command docs with more examples on remote clients

### DIFF
--- a/doc/9-object-types.md
+++ b/doc/9-object-types.md
@@ -466,6 +466,7 @@ Configuration Attributes:
 
 Command arguments can be used the same way as for [CheckCommand objects](9-object-types.md#objecttype-checkcommand-arguments).
 
+More advanced examples for event command usage can be found [here](3-monitoring-basics.md#event-commands).
 
 ## <a id="objecttype-externalcommandlistener"></a> ExternalCommandListener
 


### PR DESCRIPTION
Like discussed in #5090 this pull request expands the documentation for EventCommand.

It adds an example usage for sending events from the master to an external system (it is a bit constructed, but real world examples would be to complicated I think), an example for executing a service restart locally on Linux via Icinga2 agent and thanks to @LordHepipud one for Windows.

Furthermore it adds a note about execution location to the object description.