### PR TITLE
Feature check ldap

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -673,22 +673,24 @@ This can be ensured by enabling `ldap_starttls` or `ldap_ssl`.
 
 Custom attributes passed as [command parameters](3-monitoring-basics.md#command-passing-parameters):
 
-Name            | Description
-----------------|--------------
-ldap_address    | **Optional.** Host name, IP Address, or unix socket (must be an absolute path). Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-ldap_port       | **Optional.** Port number. Defaults to 389.
-ldap_attr	| **Optional.** LDAP attribute to search for (default: "(objectclass=*)"
-ldap_base       | **Required.** LDAP base (eg. ou=myunit,o=myorg,c=at).
-ldap_bind       | **Optional.** LDAP bind DN (if required).
-ldap_pass       | **Optional.** LDAP password (if required).
-ldap_starttls   | **Optional.** Use STARTSSL mechanism introduced in protocol version 3.
-ldap_ssl        | **Optional.** Use LDAPS (LDAP v2 SSL method). This also sets the default port to 636.
-ldap_v2         | **Optional.** Use LDAP protocol version 2 (enabled by default).
-ldap_v3         | **Optional.** Use LDAP protocol version 3 (disabled by default)
-ldap_warning	| **Optional.** Response time to result in warning status (seconds).
-ldap_critical	| **Optional.** Response time to result in critical status (seconds).
-ldap_timeout	| **Optional.** Seconds before connection times out (default: 10).
-ldap_verbose	| **Optional.** Show details for command-line debugging (disabled by default)
+Name            	| Description
+------------------------|--------------
+ldap_address    	| **Optional.** Host name, IP Address, or unix socket (must be an absolute path). Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+ldap_port       	| **Optional.** Port number. Defaults to 389.
+ldap_attr		| **Optional.** LDAP attribute to search for (default: "(objectclass=*)"
+ldap_base       	| **Required.** LDAP base (eg. ou=myunit,o=myorg,c=at).
+ldap_bind       	| **Optional.** LDAP bind DN (if required).
+ldap_pass       	| **Optional.** LDAP password (if required).
+ldap_starttls   	| **Optional.** Use STARTSSL mechanism introduced in protocol version 3.
+ldap_ssl        	| **Optional.** Use LDAPS (LDAP v2 SSL method). This also sets the default port to 636.
+ldap_v2         	| **Optional.** Use LDAP protocol version 2 (enabled by default).
+ldap_v3         	| **Optional.** Use LDAP protocol version 3 (disabled by default)
+ldap_warning		| **Optional.** Response time to result in warning status (seconds).
+ldap_critical		| **Optional.** Response time to result in critical status (seconds).
+ldap_warning_entries	| **Optional.** Number of found entries to result in warning status.
+ldap_critical_entries	| **Optional.** Number of found entries to result in critical status.
+ldap_timeout		| **Optional.** Seconds before connection times out (default: 10).
+ldap_verbose		| **Optional.** Show details for command-line debugging (disabled by default)
 
 ### <a id="plugin-check-command-load"></a> load
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1863,7 +1863,6 @@ object CheckCommand "ldap" {
 			value = "$ldap_critical$"
 			description = "Response time to result in critical status (seconds)"
 		}
-		
 		"-W" = {
 			value = "$ldap_warning_entries$"
 			description = "Number of found entries to result in warning status (optional)"

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1863,6 +1863,15 @@ object CheckCommand "ldap" {
 			value = "$ldap_critical$"
 			description = "Response time to result in critical status (seconds)"
 		}
+		
+		"-W" = {
+			value = "$ldap_warning_entries$"
+			description = "Number of found entries to result in warning status (optional)"
+		}
+		"-C" = {
+			value = "$ldap_critical_entries$"
+			description = "Number of found entries to result in critical status (optional)"
+		}
 		"-t" = {
 			value = "$ldap_timeout$"
 			description = "Seconds before connection times out (default: 10)"


### PR DESCRIPTION
Hi there !

I'm trying to use the check_ldap plugin with Icinga and I discover that there is no support for two options in the check_ldap plugin (the one available at monitoring-plugins project : https://github.com/monitoring-plugins/monitoring-plugins/blob/master/plugins/check_ldap.c )

It's -W and -C (--warning-entries and --critical-entries)

I tested the modifications I made, its working fine on my installation.
