### PR TITLE
Update documentation, change http:// links to https:// links where a website exists

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -799,7 +799,7 @@ negate_arguments	| **Optional.** Arguments for the negated command.
 
 ### <a id="plugin-check-command-nrpe"></a> nrpe
 
-The `check_nrpe` plugin can be used to query an [NRPE](http://docs.icinga.com/latest/en/nrpe.html)
+The `check_nrpe` plugin can be used to query an [NRPE](https://docs.icinga.com/latest/en/nrpe.html)
 server or [NSClient++](https://www.nsclient.org). **Note**: This plugin
 is considered insecure/deprecated.
 
@@ -2145,7 +2145,7 @@ postgres_unixsocket  | **Optional.** If "postgres_unixsocket" is set to true, th
 postgres_query       | **Optional.** Query for "custom_query" action.
 postgres_valtype     | **Optional.** Value type of query result for "custom_query".
 postgres_reverse     | **Optional.** If "postgres_reverse" is set, warning and critical values are reversed for "custom_query" action.
-postgres_tempdir     | **Optional.** Specify directory for temporary files. The default directory is dependent on the OS. More details [here](http://perldoc.perl.org/File/Spec.html).
+postgres_tempdir     | **Optional.** Specify directory for temporary files. The default directory is dependent on the OS. More details [here](https://perldoc.perl.org/File/Spec.html).
 
 #### <a id="plugin-contrib-command-mongodb"></a> mongodb
 
@@ -2753,8 +2753,8 @@ This category includes all plugins for various virtualization technologies.
 
 #### <a id="plugin-contrib-command-esxi-hardware"></a> esxi_hardware
 
-The [check_esxi_hardware.py](http://www.claudiokuenzler.com/nagios-plugins/check_esxi_hardware.php) plugin
-uses the [pywbem](http://pywbem.github.io/pywbem/) Python library to monitor the hardware of ESXi servers
+The [check_esxi_hardware.py](https://www.claudiokuenzler.com/nagios-plugins/check_esxi_hardware.php) plugin
+uses the [pywbem](https://pywbem.github.io/pywbem/) Python library to monitor the hardware of ESXi servers
 through the [VMWare API](https://www.vmware.com/support/pubs/sdk_pubs.html) and CIM service.
 
 Custom attributes passed as [command parameters](3-monitoring-basics.md#command-passing-parameters):
@@ -4777,7 +4777,7 @@ This category includes all plugins for web-based checks.
 #### <a id="plugin-contrib-command-webinject"></a> webinject
 
 The [check_webinject](https://labs.consol.de/de/nagios/check_webinject/index.html) plugin
-uses [WebInject](http://www.webinject.org/manual.html) to test web applications
+uses [WebInject](https://www.webinject.org/manual.html) to test web applications
 and web services in an automated fashion.
 It can be used to test individual system components that have HTTP interfaces
 (JSP, ASP, CGI, PHP, AJAX, Servlets, HTML Forms, XML/SOAP Web Services, REST, etc),

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -38,7 +38,7 @@ make calls to
 ### <a id="icinga2-api-requests"></a> Requests
 
 Any tool capable of making HTTP requests can communicate with
-the API, for example [curl](http://curl.haxx.se).
+the API, for example [curl](https://curl.haxx.se/).
 
 Requests are only allowed to use the HTTPS protocol so that
 traffic remains encrypted.
@@ -1668,7 +1668,7 @@ similar fashion when pressing TAB inside the [console CLI command](11-cli-comman
 
 There are a couple of existing clients which can be used with the Icinga 2 API:
 
-* [curl](http://curl.haxx.se) or any other HTTP client really
+* [curl](https://curl.haxx.se/) or any other HTTP client really
 * [Icinga 2 console (CLI command)](12-icinga2-api.md#icinga2-api-clients-cli-console)
 * [Icinga Studio](12-icinga2-api.md#icinga2-api-clients-icinga-studio)
 * [Icinga Web 2 Director](https://www.icinga.com/products/icinga-web-2-modules/)

--- a/doc/13-addons.md
+++ b/doc/13-addons.md
@@ -4,15 +4,15 @@
 
 ### <a id="addons-graphing-pnp"></a> PNP
 
-[PNP](http://www.pnp4nagios.org) is a graphing addon.
+[PNP](https://www.pnp4nagios.org) is a graphing addon.
 
-[PNP](http://www.pnp4nagios.org) is an addon which adds a graphical representation of the performance data collected
+[PNP](https://www.pnp4nagios.org) is an addon which adds a graphical representation of the performance data collected
 by the monitoring plugins. The data is stored as rrd (round robin database) files.
 
 Use your distribution's package manager to install the `pnp4nagios` package.
 
 If you're planning to use it, configure it to use the
-[bulk mode with npcd and npcdmod](http://docs.pnp4nagios.org/pnp-0.6/modes#bulk_mode_with_npcd_and_npcdmod)
+[bulk mode with npcd and npcdmod](https://docs.pnp4nagios.org/pnp-0.6/modes#bulk_mode_with_npcd_and_npcdmod)
 in combination with Icinga 2's [PerfdataWriter](14-features.md#performance-data). NPCD collects the performance
 data files which Icinga 2 generates.
 
@@ -35,7 +35,7 @@ and [graph template names](13-addons.md#addons-graphing-pnp-custom-templates).
 
 ### <a id="addons-graphing-graphite"></a> Graphite
 
-[Graphite](http://graphite.readthedocs.org/en/latest/) is a time-series database
+[Graphite](https://graphite.readthedocs.org/en/latest/) is a time-series database
 storing collected metrics and making them available through restful apis
 and web interfaces.
 
@@ -52,7 +52,7 @@ for sending real-time metrics from Icinga 2 to Graphite.
 
 There are Graphite addons available for collecting the performance data files too (e.g. `Graphios`).
 
-A popular alternative frontend for Graphite is for example [Grafana](http://grafana.org).
+A popular alternative frontend for Graphite is for example [Grafana](https://grafana.org).
 
 ### <a id="addons-graphing-influxdb"></a> InfluxDB
 
@@ -64,7 +64,7 @@ for sending real-time metrics from Icinga 2 to InfluxDB.
 
     # icinga2 feature enable influxdb
 
-A popular frontend for InfluxDB is for example [Grafana](http://grafana.org).
+A popular frontend for InfluxDB is for example [Grafana](https://grafana.org).
 
 ## <a id="addons-visualization"></a> Visualization
 
@@ -77,7 +77,7 @@ By enabling the [DB IDO](14-features.md#db-ido) feature you can use the
 
 By using either [Livestatus](14-features.md#setting-up-livestatus) or
 [DB IDO](14-features.md#db-ido) as a backend you can create your own network maps
-based on your monitoring configuration and status data using [NagVis](http://www.nagvis.org).
+based on your monitoring configuration and status data using [NagVis](https://www.nagvis.org).
 
 The configuration in nagvis.ini.php should look like this for Livestatus for example:
 
@@ -89,7 +89,7 @@ If you are planning an integration into Icinga Web 2, look at [this module](http
 
 ### <a id="addons-visualization-thruk"></a> Thruk
 
-[Thruk](http://www.thruk.org) is an alternative web interface which can be used with Icinga 2
+[Thruk](https://www.thruk.org) is an alternative web interface which can be used with Icinga 2
 and the [Livestatus](14-features.md#setting-up-livestatus) feature.
 
 ## <a id="log-monitoring"></a> Log Monitoring

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -109,7 +109,7 @@ a forced service check:
 A list of currently supported external commands can be found [here](23-appendix.md#external-commands-list-detail).
 
 Detailed information on the commands and their required parameters can be found
-on the [Icinga 1.x documentation](http://docs.icinga.com/latest/en/extcommands2.html).
+on the [Icinga 1.x documentation](https://docs.icinga.com/latest/en/extcommands2.html).
 
 ## <a id="performance-data"></a> Performance Data
 
@@ -512,7 +512,7 @@ with the following tags
 
 ## <a id="setting-up-livestatus"></a> Livestatus
 
-The [MK Livestatus](http://mathias-kettner.de/checkmk_livestatus.html) project
+The [MK Livestatus](https://mathias-kettner.de/checkmk_livestatus.html) project
 implements a query protocol that lets users query their Icinga instance for
 status information. It can also be used to send commands.
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -50,7 +50,7 @@ Install tools which help you to do so. Opinions differ, let us know if you have 
 
 ### <a id="troubleshooting-analyze-environment-linux"></a> Analyse your Linux/Unix Environment
 
-[htop](http://hisham.hm/htop/) is a better replacement for `top` and helps to analyze processes
+[htop](https://hisham.hm/htop/) is a better replacement for `top` and helps to analyze processes
 interactively.
 
 ```

--- a/doc/2-getting-started.md
+++ b/doc/2-getting-started.md
@@ -12,13 +12,13 @@ and distribution you are running.
 
   Distribution            | Repository
   ------------------------|---------------------------
-  Debian                  | [Icinga Repository](http://packages.icinga.com/debian/), [debmon](https://debmon.org/packages/debmon-jessie/icinga2)
-  Ubuntu                  | [Icinga Repository](http://packages.icinga.com/ubuntu/), [Icinga PPA](https://launchpad.net/~formorer/+archive/ubuntu/icinga)
-  RHEL/CentOS             | [Icinga Repository](http://packages.icinga.com/epel/)
-  openSUSE                | [Icinga Repository](http://packages.icinga.com/openSUSE/), [Server Monitoring Repository](https://build.opensuse.org/package/show/server:monitoring/icinga2)
-  SLES                    | [Icinga Repository](http://packages.icinga.com/SUSE/)
-  Gentoo                  | [Upstream](http://packages.gentoo.org/package/net-analyzer/icinga2)
-  FreeBSD                 | [Upstream](http://www.freshports.org/net-mgmt/icinga2)
+  Debian                  | [Icinga Repository](https://packages.icinga.com/debian/), [debmon](https://debmon.org/packages/debmon-jessie/icinga2)
+  Ubuntu                  | [Icinga Repository](https://packages.icinga.com/ubuntu/), [Icinga PPA](https://launchpad.net/~formorer/+archive/ubuntu/icinga)
+  RHEL/CentOS             | [Icinga Repository](https://packages.icinga.com/epel/)
+  openSUSE                | [Icinga Repository](https://packages.icinga.com/openSUSE/), [Server Monitoring Repository](https://build.opensuse.org/package/show/server:monitoring/icinga2)
+  SLES                    | [Icinga Repository](https://packages.icinga.com/SUSE/)
+  Gentoo                  | [Upstream](https://packages.gentoo.org/package/net-analyzer/icinga2)
+  FreeBSD                 | [Upstream](https://www.freshports.org/net-mgmt/icinga2)
   OpenBSD                 | [Upstream](http://ports.su/net/icinga/core2,-main)
   ArchLinux               | [Upstream](https://aur.archlinux.org/packages/icinga2)
   AlpineLinux             | [Upstream](https://pkgs.alpinelinux.org/package/edge/community/x86_64/icinga2)
@@ -33,19 +33,19 @@ Below is a list with examples for the various distributions.
 
 Debian:
 
-    # wget -O - http://packages.icinga.com/icinga.key | apt-key add -
-    # echo 'deb http://packages.icinga.com/debian icinga-jessie main' >/etc/apt/sources.list.d/icinga.list
+    # wget -O - https://packages.icinga.com/icinga.key | apt-key add -
+    # echo 'deb https://packages.icinga.com/debian icinga-jessie main' >/etc/apt/sources.list.d/icinga.list
     # apt-get update
 
 Ubuntu:
 
-    # wget -O - http://packages.icinga.com/icinga.key | apt-key add -
-    # echo 'deb http://packages.icinga.com/ubuntu icinga-xenial main' >/etc/apt/sources.list.d/icinga.list
+    # wget -O - https://packages.icinga.com/icinga.key | apt-key add -
+    # echo 'deb https://packages.icinga.com/ubuntu icinga-xenial main' >/etc/apt/sources.list.d/icinga.list
     # apt-get update
 
 RHEL/CentOS 7:
 
-    yum install https://packages.icinga.com/epel/7/release/noarch/icinga-rpm-release-7-1.el7.centos.noarch.rpm
+    yum install httpss://packages.icinga.com/epel/7/release/noarch/icinga-rpm-release-7-1.el7.centos.noarch.rpm
 
 RHEL/CentOS 6:
 
@@ -53,7 +53,7 @@ RHEL/CentOS 6:
 
 RHEL/CentOS 5:
 
-    rpm -i http://packages.icinga.com/epel/5/release/noarch/icinga-rpm-release-5-1.el5.centos.noarch.rpm
+    rpm -i https://packages.icinga.com/epel/5/release/noarch/icinga-rpm-release-5-1.el5.centos.noarch.rpm
 
 Fedora 25:
 
@@ -69,31 +69,31 @@ Fedora 23:
 
 SLES 11:
 
-    # zypper ar http://packages.icinga.com/SUSE/ICINGA-release-11.repo
+    # zypper ar https://packages.icinga.com/SUSE/ICINGA-release-11.repo
     # zypper ref
 
 SLES 12:
 
-    # zypper ar http://packages.icinga.com/SUSE/ICINGA-release.repo
+    # zypper ar https://packages.icinga.com/SUSE/ICINGA-release.repo
     # zypper ref
 
 openSUSE:
 
-    # zypper ar http://packages.icinga.com/openSUSE/ICINGA-release.repo
+    # zypper ar https://packages.icinga.com/openSUSE/ICINGA-release.repo
     # zypper ref
 
 
 #### <a id="package-repositories-rhel-epel"></a> RHEL/CentOS EPEL Repository
 
 The packages for RHEL/CentOS depend on other packages which are distributed
-as part of the [EPEL repository](http://fedoraproject.org/wiki/EPEL).
+as part of the [EPEL repository](https://fedoraproject.org/wiki/EPEL).
 
 CentOS 7/6/5:
 
     yum install epel-release
 
 If you are using RHEL you need enable the `optional` repository and then install
-the [EPEL rpm package](http://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F).
+the [EPEL rpm package](https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F).
 
 #### <a id="package-repositories-sles-security"></a> SLES Security Repository
 
@@ -206,11 +206,11 @@ popular operating systems/distributions:
 
 OS/Distribution        | Package Name       | Repository                | Installation Path
 -----------------------|--------------------|---------------------------|----------------------------
-RHEL/CentOS            | nagios-plugins-all | [EPEL](http://fedoraproject.org/wiki/EPEL) | /usr/lib/nagios/plugins or /usr/lib64/nagios/plugins
+RHEL/CentOS            | nagios-plugins-all | [EPEL](https://fedoraproject.org/wiki/EPEL) | /usr/lib/nagios/plugins or /usr/lib64/nagios/plugins
 SLES/OpenSUSE          | monitoring-plugins | [server:monitoring](https://build.opensuse.org/project/repositories/server:monitoring) | /usr/lib/nagios/plugins
 Debian/Ubuntu          | nagios-plugins     | -                         | /usr/lib/nagios/plugins
 FreeBSD                | monitoring-plugins | -                         | /usr/local/libexec/nagios
-OS X                   | nagios-plugins     | [MacPorts](http://www.macports.org), [Homebrew](http://brew.sh) | /opt/local/libexec or /usr/local/sbin
+OS X                   | nagios-plugins     | [MacPorts](https://www.macports.org), [Homebrew](https://brew.sh) | /opt/local/libexec or /usr/local/sbin
 
 The recommended way of installing these standard plugins is to use your
 distribution's package manager.
@@ -224,9 +224,9 @@ RHEL/CentOS:
     # yum install nagios-plugins-all
 
 The packages for RHEL/CentOS depend on other packages which are distributed
-as part of the [EPEL repository](http://fedoraproject.org/wiki/EPEL). Please
+as part of the [EPEL repository](https://fedoraproject.org/wiki/EPEL). Please
 make sure to enable this repository by following
-[these instructions](http://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F).
+[these instructions](https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F).
 
 Fedora:
 

--- a/doc/21-selinux.md
+++ b/doc/21-selinux.md
@@ -4,7 +4,7 @@
 
 SELinux is a mandatory access control (MAC) system on Linux which adds a fine-grained permission system for access to all system resources such as files, devices, networks and inter-process communication.
 
-The most important questions are answered briefly in the [FAQ of the SELinux Project](http://selinuxproject.org/page/FAQ). For more details on SELinux and how to actually use and administrate it on your system have a look at [Red Hat Enterprise Linux 7 - SELinux User's and Administrator's Guide](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide/index.html). For a simplified (and funny) introduction download the [SELinux Coloring Book](https://github.com/mairin/selinux-coloring-book).
+The most important questions are answered briefly in the [FAQ of the SELinux Project](https://selinuxproject.org/page/FAQ). For more details on SELinux and how to actually use and administrate it on your system have a look at [Red Hat Enterprise Linux 7 - SELinux User's and Administrator's Guide](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide/index.html). For a simplified (and funny) introduction download the [SELinux Coloring Book](https://github.com/mairin/selinux-coloring-book).
 
 This documentation will use a format similar to the SELinux User's and Administrator's Guide.
 
@@ -126,7 +126,7 @@ Make sure to report the bugs in the policy afterwards.
 
 Download and install a plugin, for example check_mysql_health.
 
-    # wget http://labs.consol.de/download/shinken-nagios-plugins/check_mysql_health-2.1.9.2.tar.gz
+    # wget https://labs.consol.de/download/shinken-nagios-plugins/check_mysql_health-2.1.9.2.tar.gz
     # tar xvzf check_mysql_health-2.1.9.2.tar.gz
     # cd check_mysql_health-2.1.9.2/
     # ./configure --libexecdir /usr/lib64/nagios/plugins

--- a/doc/22-migrating-from-icinga-1x.md
+++ b/doc/22-migrating-from-icinga-1x.md
@@ -1168,7 +1168,7 @@ Icinga 2 does not make a difference between `output` (first line) and
 provided separately.
 
 There is no output length restriction as known from Icinga 1.x using an
-[8KB static buffer](http://docs.icinga.com/latest/en/pluginapi.html#outputlengthrestrictions).
+[8KB static buffer](https://docs.icinga.com/latest/en/pluginapi.html#outputlengthrestrictions).
 
 The `StatusDataWriter`, `IdoMysqlConnection` and `LivestatusListener` types
 split the raw output into `output` (first line) and `long_output` (remaining

--- a/doc/23-appendix.md
+++ b/doc/23-appendix.md
@@ -2,7 +2,7 @@
 
 ## <a id="external-commands-list-detail"></a> External Commands List
 
-Additional details can be found in the [Icinga 1.x Documentation](http://docs.icinga.com/latest/en/extcommands2.html)
+Additional details can be found in the [Icinga 1.x Documentation](https://docs.icinga.com/latest/en/extcommands2.html)
 
   Command name                              | Parameters                        | Description
   ------------------------------------------|-----------------------------------|--------------------------
@@ -152,7 +152,7 @@ is set as additional custom variable in `objects.cache`.
 ### <a id="schema-db-ido"></a> DB IDO Schema
 
 There is a detailed documentation for the Icinga IDOUtils 1.x
-database schema available on [http://docs.icinga.com/latest/en/db_model.html]
+database schema available on [https://docs.icinga.com/latest/en/db_model.html]
 
 #### <a id="schema-db-ido-extensions"></a> DB IDO Schema Extensions
 

--- a/doc/3-monitoring-basics.md
+++ b/doc/3-monitoring-basics.md
@@ -784,7 +784,7 @@ The other way around you can override specific custom attributes inherited from 
 
       /* Calculate some additional object attributes after populating the `vars` dictionary */
       notes = "Interface check for " + interface_name + " (units: '" + interface_config.iftraffic_units + "') in VLAN '" + vars.vlan + "' with ' QoS '" + vars.qos + "'"
-      notes_url = "http://foreman.company.com/hosts/" + host.name
+      notes_url = "https://foreman.company.com/hosts/" + host.name
       action_url = "http://snmp.checker.company.com/" + host.name + "/if-" + interface_name
     }
 
@@ -895,7 +895,7 @@ values for any object attribute specified in that apply rule.
 
       notes = "Support contract: " + vars.support_contract + " for Customer " + vars.customer_name + " (" + vars.customer_id + ")."
 
-      notes_url = "http://foreman.company.com/hosts/" + host.name
+      notes_url = "https://foreman.company.com/hosts/" + host.name
       action_url = "http://snmp.checker.company.com/" + host.name + "/" + vars.customer_id
     }
 

--- a/doc/5-service-monitoring.md
+++ b/doc/5-service-monitoring.md
@@ -259,7 +259,7 @@ Instead, choose a plugin and configure its parameters and thresholds. The follow
 * [VMware](10-icinga-template-library.md#plugin-contrib-vmware)
 
 **Tip**: If you are encountering timeouts using the VMware Perl SDK,
-check [this blog entry](http://www.claudiokuenzler.com/blog/650/slow-vmware-perl-sdk-soap-request-error-libwww-version).
+check [this blog entry](https://www.claudiokuenzler.com/blog/650/slow-vmware-perl-sdk-soap-request-error-libwww-version).
 
 ### <a id="service-monitoring-sap"></a> SAP Monitoring
 

--- a/doc/6-distributed-monitoring.md
+++ b/doc/6-distributed-monitoring.md
@@ -414,14 +414,14 @@ the [configuration modes](6-distributed-monitoring.md#distributed-monitoring-con
 
 ### <a id="distributed-monitoring-setup-client-windows"></a> Client/Satellite Windows Setup
 
-Download the MSI-Installer package from [http://packages.icinga.com/windows/](http://packages.icinga.com/windows/).
+Download the MSI-Installer package from [https://packages.icinga.com/windows/](https://packages.icinga.com/windows/).
 
 Requirements:
 
 * Windows Vista/Server 2008 or higher
-* [Microsoft .NET Framework 2.0](http://www.microsoft.com/de-de/download/details.aspx?id=1639)
+* [Microsoft .NET Framework 2.0](https://www.microsoft.com/de-de/download/details.aspx?id=1639)
 
-The installer package includes the [NSClient++](http://www.nsclient.org/) package
+The installer package includes the [NSClient++](https://www.nsclient.org/) package
 so that Icinga 2 can use its built-in plugins. You can find more details in
 [this chapter](6-distributed-monitoring.md#distributed-monitoring-windows-nscp).
 The Windows package also installs native [monitoring plugin binaries](6-distributed-monitoring.md#distributed-monitoring-windows-plugins)

--- a/doc/7-agent-based-monitoring.md
+++ b/doc/7-agent-based-monitoring.md
@@ -57,7 +57,7 @@ requires the `check_by_ssh` check plugin which is available in the [Monitoring P
 
 ## <a id="agent-based-checks-nsclient"></a> NSClient++
 
-[NSClient++](http://nsclient.org) works on both Windows and Linux platforms and is well
+[NSClient++](https://nsclient.org/) works on both Windows and Linux platforms and is well
 known for its magnificent Windows support. There are alternatives like the WMI interface,
 but using `NSClient++` will allow you to run local scripts similar to check plugins fetching
 the required output and performance counters.
@@ -95,7 +95,7 @@ feature.
 
 ## <a id="agent-based-checks-nrpe"></a> NRPE
 
-[NRPE](http://docs.icinga.com/latest/en/nrpe.html) runs as daemon on the remote client including
+[NRPE](https://docs.icinga.com/latest/en/nrpe.html) runs as daemon on the remote client including
 the required plugins and command definitions.
 Icinga 2 calls the `check_nrpe` plugin binary in order to query the configured command on the
 remote client.


### PR DESCRIPTION
The following websites do not provide a website which is secured by https:

* http://my-plugin.de/
* http://www.logstash.net/
* http://search.cpan.org/
* http://ports.su/
* http://www.networkupstools.org/
* http://nagios.manubulon.com/
* http://www.freetds.org/
* http://www.tontonitch.com/
* http://sysadminsjourney.com/
* http://www.squid-cache.org/
* http://nagiosplug.sourceforge.net/
* http://opentsdb.net/
* http://www.nsca-ng.org/
* http://seclists.org/
* http://snmptt.sourceforge.net/
* http://www.edcint.co.nz/
* http://snmp.checker.company.com/

This may affect multiple links in the documentation.

The following website is currently not available, and can't be checked:

* http://www.activesw.com/
