### PR TITLE
Changed dependency of selinux subpackage

### DIFF
--- a/icinga2.spec
+++ b/icinga2.spec
@@ -230,8 +230,8 @@ BuildRequires:  checkpolicy, selinux-policy-devel, /usr/share/selinux/devel/poli
 Requires:       selinux-policy >= %{_selinux_policy_version}
 %endif
 Requires:       %{name} = %{version}-%{release}
-Requires(post):   /usr/sbin/semodule, /sbin/restorecon
-Requires(postun): /usr/sbin/semodule, /sbin/restorecon
+Requires(post):   policycoreutils-python
+Requires(postun): policycoreutils-python
 
 %description selinux
 SELinux policy module supporting icinga2


### PR DESCRIPTION
I had to change the dependency as semanage (required for labeling the port) is not install as dependency, so it could fail to set the label of the port and so not allowing connections to the API.