### PR TITLE
Fix absolute include paths for windows

### DIFF
--- a/lib/config/configcompiler.cpp
+++ b/lib/config/configcompiler.cpp
@@ -26,6 +26,10 @@
 #include "base/exception.hpp"
 #include <fstream>
 
+#ifdef _WIN32
+#include "Shlwapi.h"
+#endif /* _WIN32 */
+
 using namespace icinga;
 
 std::vector<String> ConfigCompiler::m_IncludeSearchDirs;
@@ -135,7 +139,7 @@ Expression *ConfigCompiler::HandleInclude(const String& relativeBase, const Stri
 {
 	String upath;
 
-	if (search || (path.GetLength() > 0 && path[0] == '/'))
+	if (search || (IsAbsolutePath(path)))
 		upath = path;
 	else
 		upath = relativeBase + "/" + path;
@@ -179,7 +183,7 @@ Expression *ConfigCompiler::HandleIncludeRecursive(const String& relativeBase, c
 {
 	String ppath;
 
-	if (path.GetLength() > 0 && path[0] == '/')
+	if (IsAbsolutePath(path))
 		ppath = path;
 	else
 		ppath = relativeBase + "/" + path;
@@ -198,7 +202,7 @@ void ConfigCompiler::HandleIncludeZone(const String& relativeBase, const String&
 
 	String ppath;
 
-	if (path.GetLength() > 0 && path[0] == '/')
+	if (IsAbsolutePath(path))
 		ppath = path;
 	else
 		ppath = relativeBase + "/" + path;
@@ -223,7 +227,7 @@ Expression *ConfigCompiler::HandleIncludeZones(const String& relativeBase, const
 	String ppath;
 	String newRelativeBase = relativeBase;
 
-	if (path.GetLength() > 0 && path[0] == '/')
+	if (IsAbsolutePath(path))
 		ppath = path;
 	else {
 		ppath = relativeBase + "/" + path;
@@ -350,4 +354,3 @@ bool ConfigCompiler::HasZoneConfigAuthority(const String& zoneName)
 
 	return !empty;
 }
-

--- a/lib/config/configcompiler.hpp
+++ b/lib/config/configcompiler.hpp
@@ -127,6 +127,14 @@ public:
 
 	static bool HasZoneConfigAuthority(const String& zoneName);
 
+	static inline bool IsAbsolutePath(const String& path) {
+#ifndef _WIN32
+		return (path.GetLength() > 0 && path[0] == '/');
+#else
+		return !PathIsRelative(path.CStr());
+#endif /* _WIN32 */
+	}
+
 private:
 	boost::promise<boost::shared_ptr<Expression> > m_Promise;
 


### PR DESCRIPTION
Adds a new helper to correctly recognize absolute paths on both Windows and Linux.

fixes #5168 