### PR TITLE
Refined documentation for the "update-windows" check plugin

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1593,9 +1593,16 @@ Custom attributes:
 
 Name                | Description
 :-------------------|:------------
-update\_win\_warn   | If set, returns warning when important updates are available
-update\_win\_crit   | If set, return critical when important updates that require a reboot are available.
-update\_win\_reboot | Set to treat 'may need update' as 'definitely needs update'
+update\_win\_warn   | **Optional**. If set, returns warning when important updates are available.
+update\_win\_crit   | **Optional**. If set, return critical when important updates that require a reboot are available.
+update\_win\_reboot | **Optional**. Set to treat 'may need update' as 'definitely needs update'. Please Note that this is true for almost every update and is therefore not recommended.
+
+
+In contrast to most other plugins, the values of check_update's custom attributes do not set thresholds, but just enable/disable the behaviour described in the table above.  
+It can be enabled/disabled for example by setting them to "true" or "false", "1" or "0" would also work.  
+Thresholds will always be "1".  
+**Hint**: If they are enabled, performance data will be shown in the webinterface.  
+If run without the optional parameters, the plugin will output critical if any important updates are available.  
 
 
 ### <a id="windows-plugins-uptime-windows"></a> uptime-windows

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1600,9 +1600,12 @@ update\_win\_reboot | **Optional**. Set to treat 'may need update' as 'definitel
 
 In contrast to most other plugins, the values of check_update's custom attributes do not set thresholds, but just enable/disable the behaviour described in the table above.  
 It can be enabled/disabled for example by setting them to "true" or "false", "1" or "0" would also work.  
-Thresholds will always be "1".  
-**Hint**: If they are enabled, performance data will be shown in the webinterface.  
-If run without the optional parameters, the plugin will output critical if any important updates are available.  
+Thresholds will always be "1".
+
+> **Note**
+>
+> If they are enabled, performance data will be shown in the webinterface.  
+> If run without the optional parameters, the plugin will output critical if any important updates are available.  
 
 
 ### <a id="windows-plugins-uptime-windows"></a> uptime-windows


### PR DESCRIPTION
- Marked optional custom attributes as optional
- Added information on the behaviour of the plugin regarding the custom attributes being booleans instead of -as usual- setting thresholds.
- refs #5178