### PR TITLE
Add report mode to mssql_health

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2051,6 +2051,7 @@ mssql_health_commit              | **Optional.** Set this to true to turn on aut
 mssql_health_notemp              | **Optional.** Set this to true to ignore temporary databases/tablespaces. Defaults to false.
 mssql_health_nooffline           | **Optional.** Set this to true to ignore offline databases. Defaults to false.
 mssql_health_lookback            | **Optional.** The amount of time you want to look back when calculating average rates.
+mssql_health_report              | **Optional.** Report can be used to output only the bad news. Possible values are "short", "long", "html". Defaults to `short`.
 
 #### <a id="plugin-contrib-command-mysql_health"></a> mysql_health
 

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -97,6 +97,10 @@ object CheckCommand "mssql_health" {
 			value = "$mssql_health_lookback$"
 			description = "The amount of time you want to look back when calculating average rates"
 		}
+		"--report" = {
+			value = "$mssql_health_report$"
+			description = "Report can be used to output only the bad news (short,long,html)"
+		}
 	}
 
 	vars.mssql_health_regexp = false
@@ -104,6 +108,7 @@ object CheckCommand "mssql_health" {
 	vars.mssql_health_commit = false
 	vars.mssql_health_notemp = false
 	vars.mssql_health_nooffline = false
+	vars.mssql_health_report = "short"
 }
 
 object CheckCommand "mysql_health" {


### PR DESCRIPTION
The  standard long output slows down Icingaweb2, so i added the report option and set "sort" as default. 
It will display now only the things that are not ok.