### PR TITLE
Add report mode to db2_health

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2017,6 +2017,7 @@ db2_health_units              | **Optional.** This is used for a better output o
 db2_health_maxinactivity      | **Optional.** Used for the maximum amount of time a certain event has not happened.
 db2_health_mitigation         | **Optional.** Classifies the severity of an offline tablespace.
 db2_health_lookback           | **Optional.** How many days in the past db2_health check should look back to calculate exitcode.
+db2_health_report             | **Optional.** Report can be used to output only the bad news. Possible values are "short", "long", "html". Defaults to `short`.
 db2_health_env_db2_home       | **Required.** Specifies the location of the db2 client libraries as environment variable `DB2_HOME`. Defaults to "/opt/ibm/db2/V10.5".
 db2_health_env_db2_version    | **Optional.** Specifies the DB2 version as environment variable `DB2_VERSION`.
 

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -335,7 +335,10 @@ object CheckCommand "db2_health" {
                         value = "$db2_health_lookback$"
                         description = "How many days iin the past db2_health check should look back to calculate exitcode."
                 }
-
+                "--report" = {
+                        value = "$db2_health_report$"
+                        description = "Report can be used to output only the bad news (short,long,html)"
+                }
         }
 
         env = {
@@ -345,6 +348,7 @@ object CheckCommand "db2_health" {
 
         vars.db2_health_regexp = false
         vars.db2_health_hostname = "$check_address$"
+        vars.db2_health_report = "short"
 
         vars.db2_health_env_db2_home = "/opt/ibm/db2/V10.5"
         vars.db2_health_env_db2_version = "10.5"


### PR DESCRIPTION
The standard long output slows down Icingaweb2, so i added the report option and set "short" as default.
It will display now only the things that are not ok.