### PR TITLE
Don't call mysql_error() after a failure of mysql_init()

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -248,7 +248,7 @@ void IdoMysqlConnection::Reconnect(void)
 	/* connection */
 	if (!mysql_init(&m_Connection)) {
 		Log(LogCritical, "IdoMysqlConnection")
-		    << "mysql_init() failed: \"" << mysql_error(&m_Connection) << "\"";
+		    << "mysql_init() failed: out of memory";
 
 		BOOST_THROW_EXCEPTION(std::bad_alloc());
 	}


### PR DESCRIPTION
fixes #3664