### PR TITLE
feature/itl-vmware-esx-storage-path-standbyok

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -4183,6 +4183,7 @@ vmware_exclude          | **Optional.** Blacklist paths. No value defined as def
 vmware_include          | **Optional.** Whitelist paths. No value defined as default.
 vmware_isregexp         | **Optional.** Treat blacklist and whitelist expressions as regexp.
 vmware_multiline        | **Optional.** Multiline output in overview. This mean technically that a multiline output uses a HTML **\<br\>** for the GUI. No value defined as default.
+vmware_standbyok        | **Optional.** For storage systems where a standby multipath is ok and not a warning.
 
 
 **vmware-esx-soap-vm-cpu**

--- a/itl/plugins-contrib.d/vmware.conf
+++ b/itl/plugins-contrib.d/vmware.conf
@@ -887,6 +887,9 @@ object CheckCommand "vmware-esx-soap-host-storage-path" {
 		"--multiline" = {
 			set_if = "$vmware_multiline$"
 		}
+    "--standbyok" = {
+      set_if = "$vmware_standbyok$"
+    }
 	}
 }
 

--- a/itl/plugins-contrib.d/vmware.conf
+++ b/itl/plugins-contrib.d/vmware.conf
@@ -887,9 +887,9 @@ object CheckCommand "vmware-esx-soap-host-storage-path" {
 		"--multiline" = {
 			set_if = "$vmware_multiline$"
 		}
-    "--standbyok" = {
-      set_if = "$vmware_standbyok$"
-    }
+		"--standbyok" = {
+			set_if = "$vmware_standbyok$"
+		}
 	}
 }
 


### PR DESCRIPTION
Add ITL --standbyok argument to the vmware-esx-soap-host-storage-path CheckCommand

needed if it is ok to have standby paths in your storage multipath environment.