### PR TITLE
Remove deprecated "DbCat1 | DbCat2" notation for DB IDO categories

### DIFF
--- a/doc/9-object-types.md
+++ b/doc/9-object-types.md
@@ -779,12 +779,6 @@ by Icinga Web 2 in the table above.
 In addition to the category flags listed above the `DbCatEverything`
 flag may be used as a shortcut for listing all flags.
 
-> **Note**
->
-> The previous way of defining the `categories` attribute e.g.
-> `DbCatProgramStatus | DbCatState` was deprecated in 2.5 and will
-> be removed in future versions.
-
 ## <a id="objecttype-idopgsqlconnection"></a> IdoPgSqlConnection
 
 IDO database adapter for PostgreSQL.
@@ -867,13 +861,6 @@ by Icinga Web 2 in the table above.
 
 In addition to the category flags listed above the `DbCatEverything`
 flag may be used as a shortcut for listing all flags.
-
-> **Note**
->
-> The previous way of defining the `categories` attribute e.g.
-> `DbCatProgramStatus | DbCatState` was deprecated in 2.5 and will
-> be removed in future versions.
-
 
 ## <a id="objecttype-influxdbwriter"></a> InfluxdbWriter
 

--- a/lib/db_ido/dbconnection.hpp
+++ b/lib/db_ido/dbconnection.hpp
@@ -77,6 +77,7 @@ public:
 	virtual int GetPendingQueryCount(void) const = 0;
 
 	virtual void ValidateFailoverTimeout(double value, const ValidationUtils& utils) override;
+	virtual void ValidateCategories(const Array::Ptr& value, const ValidationUtils& utils) override;
 
 protected:
 	virtual void OnConfigLoaded(void) override;

--- a/lib/db_ido/dbconnection.ti
+++ b/lib/db_ido/dbconnection.ti
@@ -35,7 +35,7 @@ abstract class DbConnection : ConfigObject
 		default {{{ return new Dictionary(); }}}
 	};
 
-	[config] Value categories {
+	[config] Array::Ptr categories {
 		default {{{
 			Array::Ptr cat = new Array();
 			cat->Add("DbCatConfig");
@@ -90,10 +90,8 @@ validator DbConnection {
 		Number systemcommands_age;
 	};
 
-	Number categories;
 	Array categories {
 		String "*";
-		Number "*";
 	};
 };
 


### PR DESCRIPTION
This allows for a specific config validation function.