### PR TITLE
Fix that host downtimes might be triggered even if their state is Up

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -134,7 +134,7 @@ void Downtime::Start(bool runtimeCreated)
 	 * this downtime now *after* it has been added (important
 	 * for DB IDO, etc.)
 	 */
-	if (checkable->GetStateRaw() != ServiceOK) {
+	if (!checkable->IsStateOK(checkable->GetStateRaw())) {
 		Log(LogNotice, "Downtime")
 		    << "Checkable '" << checkable->GetName() << "' already in a NOT-OK state."
 		    << " Triggering downtime now.";


### PR DESCRIPTION
If the checkresult's state is 1, this is internally mapped to Up.
The added downtime will check for triggers and might cause a wrong
downtime start event.

refs #5202