### PR TITLE
Travis: Run config validation at the end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_script:
   - cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/tmp/icinga2
 
 script:
-  - make && make test && make install && /tmp/icinga2/sbin/icinga2 --version
+  - make && make test && make install && /tmp/icinga2/sbin/icinga2 --version && /tmp/icinga2/sbin/icinga2 daemon -C -DRunAsUser=$(id -u -n) -DRunAsGroup=$(id -g -n)


### PR DESCRIPTION
This will help detect faulty contributed CheckCommand definitions (enabled by default since 2.5).