### PR TITLE
Add API & Cluster metric stats to /v1/status & icinga check incl. performance data

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -53,13 +53,15 @@ void IdoMysqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 	Dictionary::Ptr nodes = new Dictionary();
 
 	for (const IdoMysqlConnection::Ptr& idomysqlconnection : ConfigType::GetObjectsByType<IdoMysqlConnection>()) {
-		size_t items = idomysqlconnection->m_QueryQueue.GetLength();
+		size_t queryQueueItems = idomysqlconnection->m_QueryQueue.GetLength();
+		double queryQueueItemRate = idomysqlconnection->m_QueryQueue.GetTaskCount(60) / 60.0;
 
 		Dictionary::Ptr stats = new Dictionary();
 		stats->Set("version", idomysqlconnection->GetSchemaVersion());
 		stats->Set("instance_name", idomysqlconnection->GetInstanceName());
 		stats->Set("connected", idomysqlconnection->GetConnected());
-		stats->Set("query_queue_items", items);
+		stats->Set("query_queue_items", queryQueueItems);
+		stats->Set("query_queue_item_rate", queryQueueItemRate);
 
 		nodes->Set(idomysqlconnection->GetName(), stats);
 
@@ -67,7 +69,8 @@ void IdoMysqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 		perfdata->Add(new PerfdataValue("idomysqlconnection_" + idomysqlconnection->GetName() + "_queries_1min", idomysqlconnection->GetQueryCount(60)));
 		perfdata->Add(new PerfdataValue("idomysqlconnection_" + idomysqlconnection->GetName() + "_queries_5mins", idomysqlconnection->GetQueryCount(5 * 60)));
 		perfdata->Add(new PerfdataValue("idomysqlconnection_" + idomysqlconnection->GetName() + "_queries_15mins", idomysqlconnection->GetQueryCount(15 * 60)));
-		perfdata->Add(new PerfdataValue("idomysqlconnection_" + idomysqlconnection->GetName() + "_query_queue_items", items));
+		perfdata->Add(new PerfdataValue("idomysqlconnection_" + idomysqlconnection->GetName() + "_query_queue_items", queryQueueItems));
+		perfdata->Add(new PerfdataValue("idomysqlconnection_" + idomysqlconnection->GetName() + "_query_queue_item_rate", queryQueueItemRate));
 	}
 
 	status->Set("idomysqlconnection", nodes);

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -57,13 +57,15 @@ void IdoPgsqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 	Dictionary::Ptr nodes = new Dictionary();
 
 	for (const IdoPgsqlConnection::Ptr& idopgsqlconnection : ConfigType::GetObjectsByType<IdoPgsqlConnection>()) {
-		size_t items = idopgsqlconnection->m_QueryQueue.GetLength();
+		size_t queryQueueItems = idopgsqlconnection->m_QueryQueue.GetLength();
+		double queryQueueItemRate = idopgsqlconnection->m_QueryQueue.GetTaskCount(60) / 60.0;
 
 		Dictionary::Ptr stats = new Dictionary();
 		stats->Set("version", idopgsqlconnection->GetSchemaVersion());
-		stats->Set("connected", idopgsqlconnection->GetConnected());
 		stats->Set("instance_name", idopgsqlconnection->GetInstanceName());
-		stats->Set("query_queue_items", items);
+		stats->Set("connected", idopgsqlconnection->GetConnected());
+		stats->Set("query_queue_items", queryQueueItems);
+		stats->Set("query_queue_item_rate", queryQueueItemRate);
 
 		nodes->Set(idopgsqlconnection->GetName(), stats);
 
@@ -71,7 +73,8 @@ void IdoPgsqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 		perfdata->Add(new PerfdataValue("idopgsqlconnection_" + idopgsqlconnection->GetName() + "_queries_1min", idopgsqlconnection->GetQueryCount(60)));
 		perfdata->Add(new PerfdataValue("idopgsqlconnection_" + idopgsqlconnection->GetName() + "_queries_5mins", idopgsqlconnection->GetQueryCount(5 * 60)));
 		perfdata->Add(new PerfdataValue("idopgsqlconnection_" + idopgsqlconnection->GetName() + "_queries_15mins", idopgsqlconnection->GetQueryCount(15 * 60)));
-		perfdata->Add(new PerfdataValue("idopgsqlconnection_" + idopgsqlconnection->GetName() + "_query_queue_items", items));
+		perfdata->Add(new PerfdataValue("idopgsqlconnection_" + idopgsqlconnection->GetName() + "_query_queue_items", queryQueueItems));
+		perfdata->Add(new PerfdataValue("idopgsqlconnection_" + idopgsqlconnection->GetName() + "_query_queue_item_rate", queryQueueItemRate));
 	}
 
 	status->Set("idopgsqlconnection", nodes);

--- a/lib/perfdata/influxdbwriter.cpp
+++ b/lib/perfdata/influxdbwriter.cpp
@@ -70,11 +70,13 @@ void InfluxdbWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 
 	for (const InfluxdbWriter::Ptr& influxdbwriter : ConfigType::GetObjectsByType<InfluxdbWriter>()) {
 		size_t workQueueItems = influxdbwriter->m_WorkQueue.GetLength();
+		double workQueueItemRate = influxdbwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
 		size_t dataBufferItems = influxdbwriter->m_DataBuffer.size();
 
 		//TODO: Collect more stats
 		Dictionary::Ptr stats = new Dictionary();
 		stats->Set("work_queue_items", workQueueItems);
+		stats->Set("work_queue_item_rate", workQueueItemRate);
 		stats->Set("data_buffer_items", dataBufferItems);
 
 		nodes->Set(influxdbwriter->GetName(), stats);

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -340,3 +340,30 @@ void JsonRpcConnection::TimeoutTimerHandler(void)
 	}
 }
 
+int JsonRpcConnection::GetWorkQueueCount(void)
+{
+	return l_JsonRpcConnectionWorkQueueCount;
+}
+
+int JsonRpcConnection::GetWorkQueueLength(void)
+{
+	size_t itemCount = 0;
+
+	for (size_t i = 0; i < l_JsonRpcConnectionWorkQueueCount; i++) {
+		itemCount += l_JsonRpcConnectionWorkQueues[i].GetLength();
+	}
+
+	return itemCount;
+}
+
+double JsonRpcConnection::GetWorkQueueRate(void)
+{
+	double rate = 0.0;
+
+	for (size_t i = 0; i < l_JsonRpcConnectionWorkQueueCount; i++) {
+		rate += l_JsonRpcConnectionWorkQueues[i].GetTaskCount(60) / 60.0;
+	}
+
+	return rate / l_JsonRpcConnectionWorkQueueCount;
+}
+

--- a/lib/remote/jsonrpcconnection.hpp
+++ b/lib/remote/jsonrpcconnection.hpp
@@ -71,6 +71,10 @@ public:
 	static void HeartbeatTimerHandler(void);
 	static Value HeartbeatAPIHandler(const intrusive_ptr<MessageOrigin>& origin, const Dictionary::Ptr& params);
 
+	static int GetWorkQueueCount(void);
+	static int GetWorkQueueLength(void);
+	static double GetWorkQueueRate(void);
+
 private:
 	int m_ID;
 	String m_Identity;


### PR DESCRIPTION
This PR implements the following changes based on changes in #5284, #5280 and #5265:

- fix ApiListener performance data (depends on #5265)
- expose cluster ("json-rpc") work queue stats for the REST API and embedded checks as performance data
- expose api ("http") client stats for REST API and checks
- add query items rate based on #5280 
- additional metrics are available inside the `icinga` check in #5284

Examples:

- ApiListener

![screen shot 2017-05-23 at 16 45 56](https://cloud.githubusercontent.com/assets/382049/26360909/a8622924-3fd9-11e7-8413-f7b903bfbb29.png)

- IdoMysqlConnection

![screen shot 2017-05-23 at 16 45 40](https://cloud.githubusercontent.com/assets/382049/26360911/a87df32a-3fd9-11e7-8a42-4af29dcfa79d.png)


refs #5133 
