### PR TITLE
Implement WorkQueue metric stats and periodic logging

### DIFF
--- a/lib/base/workqueue.hpp
+++ b/lib/base/workqueue.hpp
@@ -22,6 +22,7 @@
 
 #include "base/i2-base.hpp"
 #include "base/timer.hpp"
+#include "base/ringbuffer.hpp"
 #include <boost/function.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
@@ -93,12 +94,16 @@ public:
 	bool IsWorkerThread(void) const;
 
 	size_t GetLength(void) const;
+	int GetTaskCount(RingBuffer::SizeType span) const;
 
 	void SetExceptionCallback(const ExceptionCallback& callback);
 
 	bool HasExceptions(void) const;
 	std::vector<boost::exception_ptr> GetExceptions(void) const;
 	void ReportExceptions(const String& facility) const;
+
+protected:
+	void IncreaseTaskCount(void);
 
 private:
 	int m_ID;
@@ -120,6 +125,12 @@ private:
 	ExceptionCallback m_ExceptionCallback;
 	std::vector<boost::exception_ptr> m_Exceptions;
 	Timer::Ptr m_StatusTimer;
+	double m_StatusTimerTimeout;
+
+	mutable boost::mutex m_StatsMutex;
+	RingBuffer m_TaskStats;
+	int m_PendingTasks;
+	double m_PendingTasksTimestamp;
 
 	void WorkerThreadProc(void);
 	void StatusTimerHandler(void);


### PR DESCRIPTION
This will only log an entry if

- there are pending tasks inside the work queue
- 5 min interval after startup

There's also the current rate calculation and "queue empty" estimation as you know from the IDO feature already.

This PR also solves the problem of spamming the log with empty queues every 10 seconds.

Any feature which uses a work queue in the future will get those metrics and logs "for free".

Bonus: Rate calculation is available to any work queue owner, so it can be used for API and built-in performance data metrics too in #5266 and #5133.

```
# icinga2 daemon | grep WorkQueue
[2017-05-23 15:56:26 +0200] information/WorkQueue: #7 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2017-05-23 15:56:26 +0200] information/WorkQueue: #5 (InfluxdbWriter, influxdb) items: 5, rate:  0/s (0/min 0/5min 0/15min); empty in 17309 days, 13 hours, 56 minutes and 26 seconds
[2017-05-23 15:56:26 +0200] information/WorkQueue: #6 (ApiListener, RelayQueue) items: 0, rate: 158.95/s (9537/min 9537/5min 9537/15min);
[2017-05-23 15:56:26 +0200] information/WorkQueue: #8 (IdoMysqlConnection, ido-mysql) items: 0, rate: 3.81667/s (229/min 229/5min 229/15min);
[2017-05-23 15:56:36 +0200] information/WorkQueue: #5 (InfluxdbWriter, influxdb) items: 18, rate:  0/s (0/min 0/5min 0/15min); empty in 13 seconds
[2017-05-23 15:56:46 +0200] information/WorkQueue: #5 (InfluxdbWriter, influxdb) items: 31, rate:  0/s (0/min 0/5min 0/15min); empty in 23 seconds
[2017-05-23 15:56:56 +0200] information/WorkQueue: #5 (InfluxdbWriter, influxdb) items: 940, rate:  0/s (0/min 0/5min 0/15min); empty in 10 seconds
[2017-05-23 15:57:06 +0200] information/WorkQueue: #5 (InfluxdbWriter, influxdb) items: 952, rate:  0/s (0/min 0/5min 0/15min); empty in 13 minutes and 13 seconds
[2017-05-23 15:57:16 +0200] information/WorkQueue: #5 (InfluxdbWriter, influxdb) items: 965, rate:  0/s (0/min 0/5min 0/15min); empty in 12 minutes and 22 seconds

```