### PR TITLE
Add feature stats to 'icinga' check as performance data metrics

### DIFF
--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -43,7 +43,10 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& service, const CheckResul
 	if (interval > 60)
 		interval = 60;
 
-	Array::Ptr perfdata = new Array();
+	/* use feature stats perfdata */
+	std::pair<Dictionary::Ptr, Array::Ptr> feature_stats = CIB::GetFeatureStats();
+
+	Array::Ptr perfdata = feature_stats.second;
 
 	perfdata->Add(new PerfdataValue("active_host_checks", CIB::GetActiveHostChecksStatistics(interval) / interval));
 	perfdata->Add(new PerfdataValue("passive_host_checks", CIB::GetPassiveHostChecksStatistics(interval) / interval));


### PR DESCRIPTION
This was previously only exposed via `cluster` check command. Modern Icinga 2 systems should at least have the `icinga` check enabled (see updated docs for "monitoring icinga 2").

I'm pushing this as separate PR since there is a change in metrics for backends (this must not be backported to 2.6.x).

refs #5133