### PR TITLE
Fix missing apostrophe in notification log

### DIFF
--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -414,7 +414,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		Log(LogInformation, "Notification")
 		    << "Sending " << (reminder ? "reminder " : "") << "'" << NotificationTypeToStringInternal(type) << "' notification '"
-		    << GetName() << " for user '" << userName << "'";
+		    << GetName() << "' for user '" << userName << "'";
 
 		Utility::QueueAsyncCallback(boost::bind(&Notification::ExecuteNotificationHelper, this, type, user, cr, force, author, text));
 


### PR DESCRIPTION
Added the missing apostrophe in notification log.

fix #5294 