### PR TITLE
RPM: Disable SELinux policy hardlink

### DIFF
--- a/icinga2.spec
+++ b/icinga2.spec
@@ -397,7 +397,8 @@ do
 done
 cd -
 
-/usr/sbin/hardlink -cv %{buildroot}%{_datadir}/selinux
+# TODO: Fix build problems on Icinga, see https://github.com/Icinga/puppet-icinga_build/issues/11
+#/usr/sbin/hardlink -cv %{buildroot}%{_datadir}/selinux
 %endif
 
 %if 0%{?fedora}


### PR DESCRIPTION
This is a nice2have extension to keep the package size clean,
but unfortunately breaks builds with Docker and overlayfs
where hardlinks don't work.

Details: Icinga/puppet-icinga_build#11