### PR TITLE
Fix for stats min operator

### DIFF
--- a/lib/livestatus/minaggregator.cpp
+++ b/lib/livestatus/minaggregator.cpp
@@ -27,12 +27,12 @@ MinAggregator::MinAggregator(const String& attr)
 
 void MinAggregator::Apply(const Table::Ptr& table, const Value& row)
 {
-	Column column = table->GetColumn(m_MinAttr);
+    Column column = table->GetColumn(m_MinAttr);
 
-	Value value = column.ExtractValue(row);
+    Value value = column.ExtractValue(row);
 
-	if (value < m_Min)
-		m_Min = value;
+    if (value < m_Min)
+        m_Min = value;
 }
 
 double MinAggregator::GetResult(void) const

--- a/lib/livestatus/minaggregator.cpp
+++ b/lib/livestatus/minaggregator.cpp
@@ -22,7 +22,7 @@
 using namespace icinga;
 
 MinAggregator::MinAggregator(const String& attr)
-    : m_Min(9999999999), m_MinAttr(attr)
+    : m_Min(0), m_MinAttr(attr)
 { }
 
 void MinAggregator::Apply(const Table::Ptr& table, const Value& row)
@@ -31,7 +31,7 @@ void MinAggregator::Apply(const Table::Ptr& table, const Value& row)
 
 	Value value = column.ExtractValue(row);
 
-	if (value < m_Min)
+	if ((m_Min == 0) || (value < m_Min))
 		m_Min = value;
 }
 

--- a/lib/livestatus/minaggregator.cpp
+++ b/lib/livestatus/minaggregator.cpp
@@ -22,7 +22,7 @@
 using namespace icinga;
 
 MinAggregator::MinAggregator(const String& attr)
-    : m_Min(0), m_MinAttr(attr)
+    : m_Min(9999999999), m_MinAttr(attr)
 { }
 
 void MinAggregator::Apply(const Table::Ptr& table, const Value& row)

--- a/lib/livestatus/minaggregator.cpp
+++ b/lib/livestatus/minaggregator.cpp
@@ -22,20 +22,23 @@
 using namespace icinga;
 
 MinAggregator::MinAggregator(const String& attr)
-    : m_Min(0), m_MinAttr(attr)
+    : m_Min(DBL_MAX), m_MinAttr(attr)
 { }
 
 void MinAggregator::Apply(const Table::Ptr& table, const Value& row)
 {
-	Column column = table->GetColumn(m_MinAttr);
+        Column column = table->GetColumn(m_MinAttr);
 
-	Value value = column.ExtractValue(row);
+        Value value = column.ExtractValue(row);
 
-	if ((m_Min == 0) || (value < m_Min))
-		m_Min = value;
+        if (value < m_Min)
+                m_Min = value;
 }
 
 double MinAggregator::GetResult(void) const
 {
-	return m_Min;
+        if (m_Min == DBL_MAX)
+                return 0;
+        else
+                return m_Min;
 }

--- a/lib/livestatus/minaggregator.cpp
+++ b/lib/livestatus/minaggregator.cpp
@@ -27,18 +27,18 @@ MinAggregator::MinAggregator(const String& attr)
 
 void MinAggregator::Apply(const Table::Ptr& table, const Value& row)
 {
-        Column column = table->GetColumn(m_MinAttr);
+	Column column = table->GetColumn(m_MinAttr);
 
-        Value value = column.ExtractValue(row);
+	Value value = column.ExtractValue(row);
 
-        if (value < m_Min)
-                m_Min = value;
+	if (value < m_Min)
+		m_Min = value;
 }
 
 double MinAggregator::GetResult(void) const
 {
-        if (m_Min == DBL_MAX)
-                return 0;
-        else
-                return m_Min;
+    if (m_Min == DBL_MAX)
+		return 0;
+    else
+		return m_Min;
 }


### PR DESCRIPTION
`m_Min` was initialzed with a value of 0.
As 0 is the lowest possible value the if clause is true and m_Min will be set to 0 => MinAggregator::GetRestult always returns 0.
```
	if (value < m_Min)
		m_Min = value;
```
Changed initial value to 9999999999 (20.11.2286 - 18:46:39)
Fix for bug #3410