### PR TITLE
Docs: Replace nagios-plugins by monitoring-plugins for Debian/Ubuntu

### DIFF
--- a/doc/2-getting-started.md
+++ b/doc/2-getting-started.md
@@ -200,7 +200,7 @@ OS/Distribution        | Package Name       | Repository                | Instal
 -----------------------|--------------------|---------------------------|----------------------------
 RHEL/CentOS            | nagios-plugins-all | [EPEL](https://fedoraproject.org/wiki/EPEL) | /usr/lib/nagios/plugins or /usr/lib64/nagios/plugins
 SLES/OpenSUSE          | monitoring-plugins | [server:monitoring](https://build.opensuse.org/project/repositories/server:monitoring) | /usr/lib/nagios/plugins
-Debian/Ubuntu          | nagios-plugins     | -                         | /usr/lib/nagios/plugins
+Debian/Ubuntu          | monitoring-plugins | -                         | /usr/lib/nagios/plugins
 FreeBSD                | monitoring-plugins | -                         | /usr/local/libexec/nagios
 OS X                   | nagios-plugins     | [MacPorts](https://www.macports.org), [Homebrew](https://brew.sh) | /opt/local/libexec or /usr/local/sbin
 
@@ -209,7 +209,7 @@ distribution's package manager.
 
 Debian/Ubuntu:
 
-    # apt-get install nagios-plugins
+    # apt-get install monitoring-plugins
 
 RHEL/CentOS:
 


### PR DESCRIPTION
Updated the Documentation to use monitoring-plugins instead of nagios-plugins for debian/ubuntu based installations.

["This dummy package is provided to support the transition from nagios-plugins to monitoring-plugins and should be removed afterwards."](https://packages.debian.org/en/jessie/nagios-plugins)
 