### PR TITLE
Notification Scripts: notification_type is always required

### DIFF
--- a/etc/icinga2/conf.d/commands.conf
+++ b/etc/icinga2/conf.d/commands.conf
@@ -100,7 +100,10 @@ object NotificationCommand "mail-service-notification" {
       required = true
       value = "$notification_servicestate$"
     }
-    "-t" = "$notification_type$"
+    "-t" = {
+      required = true
+      value = "$notification_type$"
+    }
     "-u" = {
       required = true
       value = "$notification_servicedisplayname$"


### PR DESCRIPTION
Make $notification_type$ mandatory in mail-service-notification, too (as it is in mail-host-notification).