### PR TITLE
Add ip4-or-ipv6 import to logstash ITL command

### DIFF
--- a/itl/plugins-contrib.d/logmanagement.conf
+++ b/itl/plugins-contrib.d/logmanagement.conf
@@ -19,6 +19,7 @@
 
 object CheckCommand "logstash" {
 	import "ipv4-or-ipv6"
+
 	command = [ PluginContribDir + "/check_logstash" ]
 
 	arguments = {
@@ -62,8 +63,8 @@ object CheckCommand "logstash" {
 			value = "$logstash_cpu_crit$"
 			description = "Critical threshold for cpu usage in percent"
 		}
-
 	}
+
 	vars.logstash_hostname = "$check_address$"
 	vars.logstash_port = 9600
 	vars.logstash_filedesc_warn = 85

--- a/itl/plugins-contrib.d/logmanagement.conf
+++ b/itl/plugins-contrib.d/logmanagement.conf
@@ -18,6 +18,7 @@
  ******************************************************************************/
 
 object CheckCommand "logstash" {
+	import "ipv4-or-ipv6"
 	command = [ PluginContribDir + "/check_logstash" ]
 
 	arguments = {


### PR DESCRIPTION
This adds the import ipv4-or-ipv6 the command needs for its default values.

fixes #5343 