### PR TITLE
Fixed missing closing bracket in CLI command pki new-cert.

### DIFF
--- a/lib/cli/pkinewcertcommand.cpp
+++ b/lib/cli/pkinewcertcommand.cpp
@@ -41,7 +41,7 @@ void PKINewCertCommand::InitParameters(boost::program_options::options_descripti
 {
 	visibleDesc.add_options()
 		("cn", po::value<std::string>(), "Common Name")
-		("key", po::value<std::string>(), "Key file path (output")
+		("key", po::value<std::string>(), "Key file path (output)")
 		("csr", po::value<std::string>(), "CSR file path (optional, output)")
 		("cert", po::value<std::string>(), "Certificate file path (optional, output)");
 }


### PR DESCRIPTION
Added missing closing bracket in CLI command pki new-cert.

`icinga2 pki new-cert --help`

```
[...]
Command options:
  --cn arg              Common Name
  --key arg             Key file path (output
  --csr arg             CSR file path (optional, output)
  --cert arg            Certificate file path (optional, output)
[...]
```
Missing bracket:
`  --key arg             Key file path (output`