### PR TITLE
livestatus/minaggregator: Buildfix for Debian wheezy

### DIFF
--- a/lib/livestatus/minaggregator.hpp
+++ b/lib/livestatus/minaggregator.hpp
@@ -22,6 +22,7 @@
 
 #include "livestatus/table.hpp"
 #include "livestatus/aggregator.hpp"
+#include <cfloat>
 
 namespace icinga
 {


### PR DESCRIPTION
Depending on either boost or glibc the build fails only on wheezy:

```
cd /home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/obj-x86_64-linux-gnu/lib/livestatus && /usr/bin/c++   -DI2_LIVESTATUS_BUILD -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2  -g -pthread -fvisibility=hidden -std=c++0x -O3 -DNDEBUG -fPIC -I/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2 -I/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/lib -I/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/obj-x86_64-linux-gnu -I/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/obj-x86_64-linux-gnu/lib    -o CMakeFiles/livestatus.dir/livestatus_unity.cpp.o -c /home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/obj-x86_64-linux-gnu/lib/livestatus/livestatus_unity.cpp
In file included from /home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/obj-x86_64-linux-gnu/lib/livestatus/livestatus_unity.cpp:25:0:
/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/lib/livestatus/minaggregator.cpp: In constructor 'icinga::MinAggregator::MinAggregator(const icinga::String&)':
/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/lib/livestatus/minaggregator.cpp:25:13: error: 'DBL_MAX' was not declared in this scope
/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/lib/livestatus/minaggregator.cpp: In member function 'virtual double icinga::MinAggregator::GetResult() const':
/home/jenkins/workspace/icinga2-snapshot/deb-debian-wheezy-1binary/arch/x86_64/icinga2/lib/livestatus/minaggregator.cpp:40:15: error: 'DBL_MAX' was not declared in this scope
```