### PR TITLE
Fixed wrong node in documentation chapter Client/Satellite Linux Setup

### DIFF
--- a/doc/6-distributed-monitoring.md
+++ b/doc/6-distributed-monitoring.md
@@ -405,7 +405,7 @@ is configured to accept configuration and commands from the master:
 
     Now restart your Icinga 2 daemon to finish the installation!
 
-    [root@icinga2-master1.localdomain /]# systemctl restart icinga2
+    [root@icinga2-client1.localdomain /]# systemctl restart icinga2
 
 As you can see, the certificate files are stored in the `/etc/icinga2/pki` directory.
 


### PR DESCRIPTION
The restart command at the end of chapter 6.8.2. Client/Satellite Linux Setup in the documentation points to a master-node. Since we are configuring a client/satellite-node I think this should point to the client1-node. 