### PR TITLE
Parents who are non-active should not be rescheduled

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -249,8 +249,13 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 			if (parent.get() == this)
 				continue;
 
-			ObjectLock olock(parent);
-			parent->SetNextCheck(Utility::GetTime());
+			if (!parent->GetEnableActiveChecks())
+				continue;
+
+			if (parent->GetNextCheck() >= now + parent->GetRetryInterval()) {
+				ObjectLock olock(parent);
+				parent->SetNextCheck(now);
+			}
 		}
 	}
 


### PR DESCRIPTION
Parents who are non-active should not be rescheduled.

This fix also prevents reschedule storms when there are lots of children for a parent. The parent will now only reschedule when its next check is too far in the future, this is determined by the retry interval of the parent.

fixes #5022 