### PR TITLE
Handle mis-detection with clang on RHEL/CentOS 7

### DIFF
--- a/lib/base/i2-base.hpp
+++ b/lib/base/i2-base.hpp
@@ -52,6 +52,12 @@
  * event handling for sockets and timers.
  */
 
+#include <boost/config.hpp>
+
+#if defined(__clang__) && __cplusplus >= 201103L
+#	undef BOOST_NO_CXX11_HDR_TUPLE
+#endif
+
 #ifdef _MSC_VER
 #	pragma warning(disable:4251)
 #	pragma warning(disable:4275)


### PR DESCRIPTION
C++11 features available: BOOST_NO_CXX11_HDR_TUPLE

https://access.redhat.com/solutions/3037411

Refs: #5257