### PR TITLE
Fix for API crashing when stressing it (racecondition/deadlock)?

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1231,13 +1231,13 @@ std::set<JsonRpcConnection::Ptr> ApiListener::GetAnonymousClients(void) const
 
 void ApiListener::AddHttpClient(const HttpServerConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpLock);
 	m_HttpClients.insert(aclient);
 }
 
 void ApiListener::RemoveHttpClient(const HttpServerConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpLock);
 	m_HttpClients.erase(aclient);
 }
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -134,6 +134,7 @@ private:
 	WorkQueue m_RelayQueue;
 	WorkQueue m_SyncQueue;
 
+	boost::mutex m_HttpLock;
 	boost::mutex m_LogLock;
 	Stream::Ptr m_LogFile;
 	size_t m_LogMessageCount;


### PR DESCRIPTION
Just for people who want to test / have trouble with the API crashing.
Some Threaded lock expert need to put his focus on the locks around m_HttpClients in ApiListener

Solves my problem, my poller (when bugged) updates all 10 passive services and doing so via the API crashed the API (20 hosts + check now would crash the API in a deadlock and because all API calls hang, the OS would kill Icinga when threads go higher then 1500)

Tested with the bugged poller and 52 hosts, check-now and no crash. 99 threads for a few seconds and back to 38.

ps.
`curl -k -s -u user:pass -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/events?queue=debugchecks&types=CheckResult'` still ++'s the thread counter.