### PR TITLE
Windows Plugins: Add new parameter to check_disk to show used space

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1440,8 +1440,8 @@ Threshold    | Meaning
 ### disk-windows <a id="windows-plugins-disk-windows"></a>
 
 Check command object for the `check_disk.exe` plugin.
-Aggregates the free disk space of all volumes and mount points it can find, or the ones defined in `disk_win_path`. Ignores removable storage like fash drives and discs (CD, DVD etc.).
-The data collection is instant and free disk space is used for threshold computation.
+Aggregates the disk space of all volumes and mount points it can find, or the ones defined in `disk_win_path`. Ignores removable storage like fash drives and discs (CD, DVD etc.).
+The data collection is instant and free disk space (default, see `disk_win_show_used`) is used for threshold computation.
 
 > **Note**
 >
@@ -1450,13 +1450,14 @@ The data collection is instant and free disk space is used for threshold computa
 
 Custom attributes:
 
-Name                | Description
-:-------------------|:------------
-disk\_win\_warn     | **Optional**. The warning threshold.
-disk\_win\_crit     | **Optional**. The critical threshold.
-disk\_win\_path     | **Optional**. Check only these paths, default checks all.
-disk\_win\_unit     | **Optional**. Use this unit to display disk space, thresholds are interpreted in this unit. Defaults to "mb", possible values are: b, kb, mb, gb and tb.
-disk\_win\_exclude  | **Optional**. Exclude these drives from check.
+Name                  | Description
+:---------------------|:------------
+disk\_win\_warn       | **Optional**. The warning threshold.
+disk\_win\_crit       | **Optional**. The critical threshold.
+disk\_win\_path       | **Optional**. Check only these paths, default checks all.
+disk\_win\_unit       | **Optional**. Use this unit to display disk space, thresholds are interpreted in this unit. Defaults to "mb", possible values are: b, kb, mb, gb and tb.
+disk\_win\_exclude    | **Optional**. Exclude these drives from check.
+disk\_win\_show\_used | **Optional**. Use used instead of free space.
 
 ### load-windows <a id="windows-plugins-load-windows"></a>
 
@@ -5057,4 +5058,3 @@ webinject_no_output     | **Optional.** Suppresses all output to STDOUT except t
 webinject_timeout       | **Optional.** The value [given in seconds] will be compared to the global time elapsed to run all the tests. If the tests have all been successful, but have taken more time than the 'globaltimeout' value, a warning message is sent back to Icinga.
 webinject_report_type   | **Optional.** This setting is used to enable output formatting that is compatible for use with specific external programs. The available values you can set this to are: nagios, mrtg, external and standard.
 webinject_testcase_file | **Optional.** When you launch WebInject in console mode, you can optionally supply an argument for a testcase file to run. It will look for this file in the directory that webinject.pl resides in. If no filename is passed from the command line, it will look in config.xml for testcasefile declarations. If no files are specified, it will look for a default file named 'testcases.xml' in the current [webinject] directory. If none of these are found, the engine will stop and give you an error.
-

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -42,8 +42,11 @@ object CheckCommand "disk-windows" {
 			value = "$disk_win_exclude$"
 			description = "Exclude these drives from check"
 		}
+		"-U" = {
+			set_if = "$disk_win_show_used$"
+			description = "Work with used instead of free space"
+		}
 	}
-
 	vars.disk_win_unit = "mb"
 	//The default
 }

--- a/plugins/check_disk.cpp
+++ b/plugins/check_disk.cpp
@@ -108,7 +108,7 @@ static INT parseArguments(INT ac, WCHAR **av, po::variables_map& vm, printInfoSt
 	if (vm.count("help")) {
 		std::wcout << progName << " Help\n\tVersion: " << VERSION << '\n';
 		wprintf(
-			L"%s is a simple program to check a machines free disk space.\n"
+			L"%s is a simple program to check a machines disk space usage.\n"
 			L"You can use the following options to define its behaviour:\n\n", progName);
 		std::cout << desc;
 		wprintf(

--- a/plugins/check_disk.cpp
+++ b/plugins/check_disk.cpp
@@ -185,10 +185,7 @@ static INT parseArguments(INT ac, WCHAR **av, po::variables_map& vm, printInfoSt
 			printInfo.unit = BunitB;
 	}
 
-	if (vm.count("show-used"))
-		printInfo.showUsed = true;
-	else
-		printInfo.showUsed = false;
+	printInfo.showUsed = vm.count("show-used");
 
 	if (vm.count("debug"))
 		debug = TRUE;
@@ -208,9 +205,8 @@ static INT printOutput(printInfoStruct& printInfo, std::vector<drive>& vDrives)
 
 	std::wstring output = L"DISK OK - free space:";
 
-	if (printInfo.showUsed) {
+	if (printInfo.showUsed)
 		output = L"DISK OK - used space:";
-	}
 	
 	double tCap = 0, tFree = 0, tUsed = 0;
 
@@ -267,14 +263,15 @@ static INT printOutput(printInfoStruct& printInfo, std::vector<drive>& vDrives)
 	std::wcout << output;
 
 	if (vDrives.size() > 1) {
-		if (printInfo.showUsed)
-			std::wcout << "Total " << tUsed << unit << " (" << removeZero(std::round(tUsed / tCap * 100.0)) << "%); ";
-
-		std::wcout << "Total " << tFree << unit << " (" << removeZero(std::round(tFree / tCap * 100.0)) << "%); ";
+		if (printInfo.showUsed) {
+			std::wcout << "Total " << (printInfo.showUsed ? tUsed : tFree) << unit
+			    << " (" << removeZero(std::round(tUsed / tCap * 100.0)) << "%); ";
+		}
 	}
 
 	for (std::vector<std::wstring>::const_iterator it = wsDrives.begin(); it != wsDrives.end(); it++)
 		std::wcout << *it;
+
 	std::wcout << "|";
 
 	for (std::vector<std::wstring>::const_iterator it = wsPerf.begin(); it != wsPerf.end(); it++)
@@ -433,7 +430,7 @@ static BOOL getDriveSpaceValues(drive& drive, const Bunit& unit)
 
 	if (debug)
 		std::wcout << "\tAfter conversion: " << drive.free << '\n' 
-		<< "\tused: " << tempUsed.QuadPart << '\n';
+		    << "\tused: " << tempUsed.QuadPart << '\n';
 
 	drive.used = round((tempUsed.QuadPart / pow(1024.0, unit)));
 

--- a/plugins/check_disk.cpp
+++ b/plugins/check_disk.cpp
@@ -55,7 +55,7 @@ INT wmain(INT argc, WCHAR **argv)
 		return ret;
 
 	for (std::vector<drive>::iterator it = vDrives.begin(); it != vDrives.end(); ++it) {
-		if (!getFreeAndCap(*it, printInfo.unit)) {
+		if (!getDriveSpaceValues(*it, printInfo.unit)) {
 			std::wcout << "Failed to access drive at " << it->name << '\n';
 			return 3;
 		}
@@ -83,7 +83,8 @@ static INT parseArguments(INT ac, WCHAR **av, po::variables_map& vm, printInfoSt
 		("exclude-type,X", po::wvalue<std::vector<std::wstring>>()->multitoken(), "Exclude partition types (ignored)")
 		("iwarning,W", po::wvalue<std::wstring>(), "Warning threshold for inodes (ignored)")
 		("icritical,K", po::wvalue<std::wstring>(), "Critical threshold for inodes (ignored)")
-		("unit,u", po::wvalue<std::wstring>(), "Assign unit possible are: B, kB, MB, GB, TB")\
+		("unit,u", po::wvalue<std::wstring>(), "Assign unit possible are: B, kB, MB, GB, TB")
+		("show-used,U", "Show used space instead of the free space")
 		("megabytes,m", "use megabytes, overridden by -unit")
 		;
 
@@ -184,6 +185,11 @@ static INT parseArguments(INT ac, WCHAR **av, po::variables_map& vm, printInfoSt
 			printInfo.unit = BunitB;
 	}
 
+	if (vm.count("show-used"))
+		printInfo.showUsed = true;
+	else
+		printInfo.showUsed = false;
+
 	if (vm.count("debug"))
 		debug = TRUE;
 
@@ -199,32 +205,73 @@ static INT printOutput(printInfoStruct& printInfo, std::vector<drive>& vDrives)
 	std::wstring unit = BunitStr(printInfo.unit);
 
 	state state = OK;
+
 	std::wstring output = L"DISK OK - free space:";
 
-	double tCap = 0, tFree = 0;
+	if (printInfo.showUsed) {
+		output = L"DISK OK - used space:";
+	}
+	
+	double tCap = 0, tFree = 0, tUsed = 0;
+
 	for (std::vector<drive>::iterator it = vDrives.begin(); it != vDrives.end(); it++) {
 		tCap += it->cap;
 		tFree += it->free;
-		wsDrives.push_back(it->name + L" " + removeZero(it->free) + L" " + unit + L" (" + 
-						   removeZero(std::round(it->free/it->cap * 100.0)) + L"%); ");
-		wsPerf.push_back(L" " + it->name + L"=" + removeZero(it->free) + unit + L";" + 
-						 printInfo.warn.pString(it->cap) + L";" + printInfo.crit.pString(it->cap) + L";0;"
-						 + removeZero(it->cap));
-		if (printInfo.crit.rend(it->free, it->cap))
-			state = CRITICAL;
-		if (state == OK && printInfo.warn.rend(it->free, it->cap))
-			state = WARNING;
+		tUsed += it->used;
+
+		if (printInfo.showUsed)
+		{
+			wsDrives.push_back(it->name + L" " + removeZero(it->used) + L" " + unit + L" (" +
+				removeZero(std::round(it->used / it->cap * 100.0)) + L"%); ");
+
+			wsPerf.push_back(L" " + it->name + L"=" + removeZero(it->used) + unit + L";" +
+				printInfo.warn.pString(it->cap) + L";" + printInfo.crit.pString(it->cap) + L";0;"
+				+ removeZero(it->cap));
+
+			if (printInfo.crit.set && !printInfo.crit.rend(it->used, it->cap))
+				state = CRITICAL;
+
+			if (state == OK && printInfo.warn.set && !printInfo.warn.rend(it->used, it->cap))
+				state = WARNING;
+		}
+		else {
+			wsDrives.push_back(it->name + L" " + removeZero(it->free) + L" " + unit + L" (" +
+				removeZero(std::round(it->free / it->cap * 100.0)) + L"%); ");
+
+			wsPerf.push_back(L" " + it->name + L"=" + removeZero(it->free) + unit + L";" +
+				printInfo.warn.pString(it->cap) + L";" + printInfo.crit.pString(it->cap) + L";0;"
+				+ removeZero(it->cap));
+
+			if ( printInfo.crit.rend(it->free, it->cap))
+				state = CRITICAL;
+
+			if (state == OK && printInfo.warn.rend(it->free, it->cap))
+				state = WARNING;
+		}
 	}
 
-	if (state == WARNING)
+	if (state == WARNING) {
 		output = L"DISK WARNING - free space:";
+		
+		if (printInfo.showUsed)
+			output = L"DISK WARNING - used space:";
+	}
 
-	if (state == CRITICAL)
+	if (state == CRITICAL) {
 		output = L"DISK CRITICAL - free space:";
 
+		if (printInfo.showUsed)
+			output = L"DISK CRITICAL - used space:";
+	}
+
 	std::wcout << output;
-	if (vDrives.size() > 1)
-		std::wcout << "Total " << tFree << unit << " (" << removeZero(std::round(tFree/tCap * 100.0)) << "%); ";
+
+	if (vDrives.size() > 1) {
+		if (printInfo.showUsed)
+			std::wcout << "Total " << tUsed << unit << " (" << removeZero(std::round(tUsed / tCap * 100.0)) << "%); ";
+
+		std::wcout << "Total " << tFree << unit << " (" << removeZero(std::round(tFree / tCap * 100.0)) << "%); ";
+	}
 
 	for (std::vector<std::wstring>::const_iterator it = wsDrives.begin(); it != wsDrives.end(); it++)
 		std::wcout << *it;
@@ -330,8 +377,6 @@ die:
 	return 3;
 }
 
-
-
 static INT check_drives(std::vector<drive>& vDrives, printInfoStruct& printInfo) 
 {
 	if (!printInfo.exclude_drives.empty()) {
@@ -362,23 +407,38 @@ static INT check_drives(std::vector<drive>& vDrives, printInfoStruct& printInfo)
 	return -1;
 }
 
-static BOOL getFreeAndCap(drive& drive, const Bunit& unit) 
+static BOOL getDriveSpaceValues(drive& drive, const Bunit& unit)
 {
 	if (debug)
-		std::wcout << "Getting free disk space for drive " << drive.name << '\n';
-	ULARGE_INTEGER tempFree, tempTotal;
+		std::wcout << "Getting free and used disk space for drive " << drive.name << '\n';
+
+	ULARGE_INTEGER tempFree, tempTotal, tempUsed;
+
 	if (!GetDiskFreeSpaceEx(drive.name.c_str(), NULL, &tempTotal, &tempFree)) {
 		return FALSE;
 	}
+
+	tempUsed.QuadPart = tempTotal.QuadPart - tempFree.QuadPart;
+
 	if (debug)
 		std::wcout << "\tcap: " << tempFree.QuadPart << '\n';
+
 	drive.cap = round((tempTotal.QuadPart / pow(1024.0, unit)));
+
 	if (debug)
 		std::wcout << "\tAfter conversion: " << drive.cap << '\n'
-		    << "\tfree: " << tempFree.QuadPart << '\n';
+		<< "\tfree: " << tempFree.QuadPart << '\n';
+
 	drive.free = round((tempFree.QuadPart / pow(1024.0, unit)));
+
 	if (debug)
-		std::wcout << "\tAfter conversion: " << drive.free << '\n' << '\n';
+		std::wcout << "\tAfter conversion: " << drive.free << '\n' 
+		<< "\tused: " << tempUsed.QuadPart << '\n';
+
+	drive.used = round((tempUsed.QuadPart / pow(1024.0, unit)));
+
+	if (debug)
+		std::wcout << "\tAfter conversion: " << drive.used << '\n' << '\n';
 
 	return TRUE;
 }

--- a/plugins/check_disk.h
+++ b/plugins/check_disk.h
@@ -29,7 +29,7 @@
 struct drive
 {
 	std::wstring name;
-	double cap, free;
+	double cap, free, used;
 	drive(std::wstring p)
 		: name(p)
 	{
@@ -41,12 +41,13 @@ struct printInfoStruct
 	threshold warn, crit;
 	std::vector<std::wstring> drives, exclude_drives;
 	Bunit unit;
+	BOOL showUsed;
 };
 
 static INT parseArguments(int, wchar_t **, boost::program_options::variables_map&, printInfoStruct&);
 static INT printOutput(printInfoStruct&, std::vector<drive>&);
 static INT check_drives(std::vector<drive>&, std::vector<std::wstring>&);
 static INT check_drives(std::vector<drive>&, printInfoStruct&);
-static BOOL getFreeAndCap(drive&, const Bunit&);
+static BOOL getDriveSpaceValues(drive&, const Bunit&);
 static bool checkName(const drive& d, const std::wstring& s);
 #endif /*CHECK_DISK_H*/


### PR DESCRIPTION
### Feature
The Linux `disk` check returns the used space from a given or all disks. I thought it would be a good feature to have the possibility on windows also. 

This adds a new parameter to the check_disk windows plugin. With `--show-used` or `-U` this plugin will output the used space instead of the free space. 

To get the used space the plugin calculate the total space minus the free space of a disk.

### Test environment:
Windows 10 Pro x64
Disk G:
* capacity 5,65 GB
* used space 1,03 GB
* free space 4,62 GB

#### Testing the free space output:

```
check_disk.exe -u gb -p G:
DISK OK - free space:G:\ 5 GB (83%); | G:\=5GB;;;0;6

check_disk.exe -u gb -p G: -w 10% -c 5%
DISK OK - free space:G:\ 5 GB (83%); | G:\=5GB;0.60000000000000009;0.30000000000000004;0;6

check_disk.exe -u gb -p G: -w 90% -c 5%
DISK WARNING - free space:G:\ 5 GB (83%); | G:\=5GB;5.4000000000000004;0.30000000000000004;0;6

check_disk.exe -u gb -p G: -w 90% -c 95%
DISK CRITICAL - free space:G:\ 5 GB (83%); | G:\=5GB;5.4000000000000004;5.6999999999999993;0;6

```
#### Testing the used space output:
```

check_disk.exe -u gb -p G: -U
DISK CRITICAL - used space:G:\ 1 GB (17%); | G:\=1GB;;;0;6

check_disk.exe -u gb -p G: -U -w 90% -c 95%
DISK OK - used space:G:\ 1 GB (17%); | G:\=1GB;5.4000000000000004;5.6999999999999993;0;6

check_disk.exe -u gb -p G: -U -w 10% -c 95%
DISK WARNING - used space:G:\ 1 GB (17%); | G:\=1GB;0.60000000000000009;5.6999999999999993;0;6

check_disk.exe -u gb -p G: -U -w 10% -c 11%
DISK CRITICAL - used space:G:\ 1 GB (17%); | G:\=1GB;0.60000000000000009;0.66000000000000003;0;6
```

As far as I can tell, this should not break any things of previous versions.   