### PR TITLE
Add the ability to disable the conf.d inclusion through the node wizard

### DIFF
--- a/agent/windows-setup-agent/SetupWizard.Designer.cs
+++ b/agent/windows-setup-agent/SetupWizard.Designer.cs
@@ -87,6 +87,7 @@
 			this.txtError = new System.Windows.Forms.TextBox();
 			this.lblError = new System.Windows.Forms.Label();
 			this.picBanner = new System.Windows.Forms.PictureBox();
+			this.chkDisableConf = new System.Windows.Forms.CheckBox();
 			this.tabFinish.SuspendLayout();
 			this.tabConfigure.SuspendLayout();
 			this.tabParameters.SuspendLayout();
@@ -105,7 +106,7 @@
 			// btnBack
 			// 
 			this.btnBack.Enabled = false;
-			this.btnBack.Location = new System.Drawing.Point(376, 556);
+			this.btnBack.Location = new System.Drawing.Point(376, 587);
 			this.btnBack.Name = "btnBack";
 			this.btnBack.Size = new System.Drawing.Size(75, 23);
 			this.btnBack.TabIndex = 1;
@@ -115,7 +116,7 @@
 			// 
 			// btnNext
 			// 
-			this.btnNext.Location = new System.Drawing.Point(457, 556);
+			this.btnNext.Location = new System.Drawing.Point(457, 587);
 			this.btnNext.Name = "btnNext";
 			this.btnNext.Size = new System.Drawing.Size(75, 23);
 			this.btnNext.TabIndex = 2;
@@ -126,7 +127,7 @@
 			// btnCancel
 			// 
 			this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.btnCancel.Location = new System.Drawing.Point(538, 556);
+			this.btnCancel.Location = new System.Drawing.Point(538, 587);
 			this.btnCancel.Name = "btnCancel";
 			this.btnCancel.Size = new System.Drawing.Size(75, 23);
 			this.btnCancel.TabIndex = 3;
@@ -196,7 +197,7 @@
 			this.tabParameters.Location = new System.Drawing.Point(4, 5);
 			this.tabParameters.Name = "tabParameters";
 			this.tabParameters.Padding = new System.Windows.Forms.Padding(3);
-			this.tabParameters.Size = new System.Drawing.Size(617, 471);
+			this.tabParameters.Size = new System.Drawing.Size(617, 495);
 			this.tabParameters.TabIndex = 3;
 			this.tabParameters.Text = "Agent Parameters";
 			this.tabParameters.UseVisualStyleBackColor = true;
@@ -275,6 +276,7 @@
 			// 
 			// groupBox3
 			// 
+			this.groupBox3.Controls.Add(this.chkDisableConf);
 			this.groupBox3.Controls.Add(this.txtUser);
 			this.groupBox3.Controls.Add(this.chkRunServiceAsThisUser);
 			this.groupBox3.Controls.Add(this.chkInstallNSCP);
@@ -282,7 +284,7 @@
 			this.groupBox3.Controls.Add(this.chkAcceptCommands);
 			this.groupBox3.Location = new System.Drawing.Point(308, 326);
 			this.groupBox3.Name = "groupBox3";
-			this.groupBox3.Size = new System.Drawing.Size(301, 139);
+			this.groupBox3.Size = new System.Drawing.Size(301, 163);
 			this.groupBox3.TabIndex = 5;
 			this.groupBox3.TabStop = false;
 			this.groupBox3.Text = "Advanced Options";
@@ -377,7 +379,7 @@
 			this.groupBox2.Controls.Add(this.rdoListener);
 			this.groupBox2.Location = new System.Drawing.Point(8, 326);
 			this.groupBox2.Name = "groupBox2";
-			this.groupBox2.Size = new System.Drawing.Size(298, 139);
+			this.groupBox2.Size = new System.Drawing.Size(298, 163);
 			this.groupBox2.TabIndex = 2;
 			this.groupBox2.TabStop = false;
 			this.groupBox2.Text = "TCP Listener";
@@ -513,7 +515,7 @@
 			this.tbcPages.Margin = new System.Windows.Forms.Padding(0);
 			this.tbcPages.Name = "tbcPages";
 			this.tbcPages.SelectedIndex = 0;
-			this.tbcPages.Size = new System.Drawing.Size(625, 480);
+			this.tbcPages.Size = new System.Drawing.Size(625, 504);
 			this.tbcPages.SizeMode = System.Windows.Forms.TabSizeMode.Fixed;
 			this.tbcPages.TabIndex = 0;
 			this.tbcPages.SelectedIndexChanged += new System.EventHandler(this.tbcPages_SelectedIndexChanged);
@@ -691,13 +693,26 @@
 			this.picBanner.TabIndex = 1;
 			this.picBanner.TabStop = false;
 			// 
+			// chkDisableConf
+			// 
+			this.chkDisableConf.AutoSize = true;
+			this.chkDisableConf.Checked = true;
+			this.chkDisableConf.CheckState = System.Windows.Forms.CheckState.Checked;
+			this.chkDisableConf.Location = new System.Drawing.Point(9, 137);
+			this.chkDisableConf.Name = "chkDisableConf";
+			this.chkDisableConf.Size = new System.Drawing.Size(138, 17);
+			this.chkDisableConf.TabIndex = 9;
+			this.chkDisableConf.Text = "Disable conf.d inclusion";
+			this.chkDisableConf.UseVisualStyleBackColor = true;
+			this.chkDisableConf.CheckedChanged += new System.EventHandler(this.checkBox1_CheckedChanged);
+			// 
 			// SetupWizard
 			// 
 			this.AcceptButton = this.btnNext;
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.btnCancel;
-			this.ClientSize = new System.Drawing.Size(625, 587);
+			this.ClientSize = new System.Drawing.Size(625, 622);
 			this.Controls.Add(this.btnCancel);
 			this.Controls.Add(this.btnNext);
 			this.Controls.Add(this.btnBack);
@@ -794,6 +809,7 @@
 		private System.Windows.Forms.Button btnAddGlobalZone;
 		private System.Windows.Forms.ListView lvwGlobalZones;
 		private System.Windows.Forms.ColumnHeader colGlobalZoneName;
+		private System.Windows.Forms.CheckBox chkDisableConf;
 	}
 }
 

--- a/agent/windows-setup-agent/SetupWizard.cs
+++ b/agent/windows-setup-agent/SetupWizard.cs
@@ -229,6 +229,9 @@ namespace Icinga
 				args += " --global_zones " + lvi.SubItems[0].Text.Trim();
 			}
 
+			if (chkDisableConf.Checked)
+				args += " --disable-confd";
+
 			if (!RunProcess(Program.Icinga2InstallDir + "\\sbin\\icinga2.exe",
 				"node setup" + args,
 				out output)) {
@@ -567,6 +570,11 @@ namespace Icinga
 			lvi2.Text = gzib.txtGlobalZoneName.Text;
 			
 			lvwGlobalZones.Items.Add(lvi2);
+		}
+
+		private void checkBox1_CheckedChanged(object sender, EventArgs e)
+		{
+
 		}
 	}
 }

--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -236,7 +236,9 @@ Enabling feature api. Make sure to restart Icinga 2 for these changes to take ef
 
 Master zone name [master]:
 
+Default global zones: global-templates director-global
 Do you want to specify additional global zones? [y/N]: N
+
 Please specify the API bind host/port (optional):
 Bind Host []:
 Bind Port []:
@@ -548,6 +550,7 @@ Press `Enter` or choose `n`, if you don't want to add any additional.
 ```
 Reconfiguring Icinga...
 
+Default global zones: global-templates director-global
 Do you want to specify additional global zones? [y/N]: N
 ```
 

--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -205,6 +205,7 @@ ensure to collect the required information:
   Global zones        | **Optional.** Allows to specify more global zones in addition to `global-templates` and `director-global`. Defaults to `n`.
   API bind host       | **Optional.** Allows to specify the address the ApiListener is bound to. For advanced usage only.
   API bind port       | **Optional.** Allows to specify the port the ApiListener is bound to. For advanced usage only (requires changing the default port 5665 everywhere).
+  Disable conf.d      | **Optional.** Allows to disable the `include_recursive "conf.d"` directive except for the `api-users.conf` file in the `icinga2.conf` file. Defaults to `y`. Configuration on the master is discussed below.
 
 The setup wizard will ensure that the following steps are taken:
 
@@ -213,6 +214,7 @@ The setup wizard will ensure that the following steps are taken:
 * Create a certificate for this node signed by the CA key.
 * Update the [zones.conf](04-configuring-icinga-2.md#zones-conf) file with the new zone hierarchy.
 * Update the [ApiListener](06-distributed-monitoring.md#distributed-monitoring-apilistener) and [constants](04-configuring-icinga-2.md#constants-conf) configuration.
+* Update the [icinga2.conf](04-configuring-icinga-2.md#icinga2-conf) to disable the `conf.d` inclusion, and add the `api-users.conf` file inclusion.
 
 Here is an example of a master setup for the `icinga2-master1.localdomain` node on CentOS 7:
 
@@ -242,6 +244,10 @@ Do you want to specify additional global zones? [y/N]: N
 Please specify the API bind host/port (optional):
 Bind Host []:
 Bind Port []:
+
+Do you want to disable the inclusion of the conf.d directory [Y/n]:
+Disabling the inclusion of the conf.d directory...
+Checking if the api-users.conf file exists...
 
 Done.
 
@@ -337,7 +343,7 @@ object with at least the `actions/generate-ticket` permission.
 Retrieve the ticket on the master node `icinga2-master1.localdomain` with `curl`, for example:
 
      [root@icinga2-master1.localdomain /]# curl -k -s -u client-pki-ticket:bea11beb7b810ea9ce6ea -H 'Accept: application/json' \
-     -X POST 'https://icinga2-master1.localdomain:5665/v1/actions/generate-ticket' -d '{ "cn": "icinga2-client1.localdomain" }'
+     -X POST 'https://localhost:5665/v1/actions/generate-ticket' -d '{ "cn": "icinga2-client1.localdomain" }'
 
 Store that ticket number for the satellite/client setup below.
 
@@ -554,6 +560,16 @@ Default global zones: global-templates director-global
 Do you want to specify additional global zones? [y/N]: N
 ```
 
+Last but not least the wizard asks you whether you want to disable the inclusion of the local configuration
+directory in `conf.d`, or not. Defaults to disabled, as clients either are checked via command endpoint, or
+they receive configuration synced from the parent zone.
+
+```
+Do you want to disable the inclusion of the conf.d directory [Y/n]: Y
+Disabling the inclusion of the conf.d directory...
+```
+
+
 The wizard proceeds and you are good to go.
 
 ```
@@ -595,6 +611,7 @@ Here is an overview of all parameters in detail:
   Local zone name     | **Optional.** Allows to specify the name for the local zone. This comes in handy when this instance is a satellite, not a client. Defaults to the FQDN.
   Parent zone name    | **Optional.** Allows to specify the name for the parent zone. This is important if the client has a satellite instance as parent, not the master. Defaults to `master`.
   Global zones        | **Optional.** Allows to specify more global zones in addition to `global-templates` and `director-global`. Defaults to `n`.
+  Disable conf.d      | **Optional.** Allows to disable the inclusion of the `conf.d` directory which holds local example configuration. Clients should retrieve their configuration from the parent node, or act as command endpoint execution bridge. Defaults to `y`.
 
 The setup wizard will ensure that the following steps are taken:
 
@@ -605,7 +622,7 @@ The setup wizard will ensure that the following steps are taken:
 * Store the signed client certificate and ca.crt in `/var/lib/icinga2/certs`.
 * Update the `zones.conf` file with the new zone hierarchy.
 * Update `/etc/icinga2/features-enabled/api.conf` (`accept_config`, `accept_commands`) and `constants.conf`.
-
+* Update `/etc/icinga2/icinga2.conf` and comment out `include_recursive "conf.d"`.
 
 You can verify that the certificate files are stored in the `/var/lib/icinga2/certs` directory.
 
@@ -782,11 +799,15 @@ Add a [global zone](06-distributed-monitoring.md#distributed-monitoring-global-z
 for syncing check commands later. Navigate to `C:\ProgramData\icinga2\etc\icinga2` and open
 the `zones.conf` file in your preferred editor. Add the following lines if not existing already:
 
-    object Zone "global-templates" {
-      global = true
-    }
+```
+object Zone "global-templates" {
+  global = true
+}
+```
 
-Note: Packages >= 2.8 provide this configuration by default.
+> **Note:**
+>
+> Packages >= 2.8 provide this configuration by default.
 
 You don't need any local configuration on the client except for
 CheckCommand definitions which can be synced using the global zone
@@ -796,14 +817,23 @@ Navigate to `C:\ProgramData\icinga2\etc\icinga2` and open
 the `icinga2.conf` file in your preferred editor. Remove or comment (`//`)
 the following line:
 
-    // Commented out, not required on a client with top down mode
-    //include_recursive "conf.d"
+```
+// Commented out, not required on a client with top down mode
+//include_recursive "conf.d"
+```
+
+> **Note**
+>
+> Packages >= 2.9 provide an option in the setup wizard to disable this.
+> Defaults to disabled.
 
 Validate the configuration on Windows open an administrator terminal
 and run the following command:
 
-    C:\WINDOWS\system32>cd "C:\Program Files\ICINGA2\sbin"
-    C:\Program Files\ICINGA2\sbin>icinga2.exe daemon -C
+```
+C:\WINDOWS\system32>cd "C:\Program Files\ICINGA2\sbin"
+C:\Program Files\ICINGA2\sbin>icinga2.exe daemon -C
+```
 
 **Note**: You have to run this command in a shell with `administrator` privileges.
 
@@ -921,23 +951,34 @@ The `master` zone is a parent of the `icinga2-client1.localdomain` zone:
 In addition, add a [global zone](06-distributed-monitoring.md#distributed-monitoring-global-zone-config-sync)
 for syncing check commands later:
 
-    [root@icinga2-client1.localdomain /]# vim /etc/icinga2/zones.conf
+```
+[root@icinga2-client1.localdomain /]# vim /etc/icinga2/zones.conf
 
-    object Zone "global-templates" {
-      global = true
-    }
+object Zone "global-templates" {
+  global = true
+}
+```
 
-Note: Packages >= 2.8 provide this configuration by default.
+> **Note:**
+>
+> Packages >= 2.8 provide this configuration by default.
 
 You don't need any local configuration on the client except for
 CheckCommand definitions which can be synced using the global zone
 above. Therefore disable the inclusion of the `conf.d` directory
 in `/etc/icinga2/icinga2.conf`.
 
-    [root@icinga2-client1.localdomain /]# vim /etc/icinga2/icinga2.conf
+```
+[root@icinga2-client1.localdomain /]# vim /etc/icinga2/icinga2.conf
 
-    // Commented out, not required on a client as command endpoint
-    //include_recursive "conf.d"
+// Commented out, not required on a client as command endpoint
+//include_recursive "conf.d"
+```
+
+> **Note**
+>
+> Packages >= 2.9 provide an option in the setup wizard to disable this.
+> Defaults to disabled.
 
 Edit the `api` feature on the client `icinga2-client1.localdomain` in
 the `/etc/icinga2/features-enabled/api.conf` file and make sure to set
@@ -2560,15 +2601,24 @@ be passed (defaults to the FQDN).
   Common name (CN)    | **Optional.** Specified with the `--cn` parameter. By convention this should be the host's FQDN. Defaults to the FQDN.
   Zone name           | **Optional.** Specified with the `--zone` parameter. Defaults to `master`.
   Listen on           | **Optional.** Specified with the `--listen` parameter. Syntax is `host,port`.
+  Disable conf.d      | **Optional.** Specified with the `disable-confd` parameter. If provided, this disables the `include_recursive "conf.d"` directive and adds the `api-users.conf` file inclusion to `icinga2.conf`. Available since v2.9+. Not set by default for compatibility reasons with Puppet, Ansible, Chef, etc.
 
 Example:
 
-    [root@icinga2-master1.localdomain /]# icinga2 node setup --master
+```
+[root@icinga2-master1.localdomain /]# icinga2 node setup --master
+```
 
 In case you want to bind the `ApiListener` object to a specific
 host/port you can specify it like this:
 
     --listen 192.68.56.101,5665
+
+In case you don't need anything in `conf.d`, use the following command line:
+
+```
+[root@icinga2-master1.localdomain /]# icinga2 node setup --master --disable-confd
+```
 
 
 #### Node Setup with Satellites/Clients <a id="distributed-monitoring-automation-cli-node-setup-satellite-client"></a>
@@ -2634,6 +2684,7 @@ Pass the following details to the `node setup` CLI command:
   Accept config       | **Optional.** Whether this node accepts configuration sync from the master node (required for [config sync mode](06-distributed-monitoring.md#distributed-monitoring-top-down-config-sync)).
   Accept commands     | **Optional.** Whether this node accepts command execution messages from the master node (required for [command endpoint mode](06-distributed-monitoring.md#distributed-monitoring-top-down-command-endpoint)).
   Global zones        | **Optional.** Allows to specify more global zones in addition to `global-templates` and `director-global`.
+  Disable conf.d      | **Optional.** Specified with the `disable-confd` parameter. If provided, this disables the `include_recursive "conf.d"` directive in `icinga2.conf`. Available since v2.9+. Not set by default for compatibility reasons with Puppet, Ansible, Chef, etc.
 
 > **Note**
 >
@@ -2641,14 +2692,17 @@ Pass the following details to the `node setup` CLI command:
 
 Example for Icinga 2 v2.9:
 
-    [root@icinga2-client1.localdomain /]# icinga2 node setup --ticket ead2d570e18c78abf285d6b85524970a0f69c22d \
-    --cn icinga2-client1.localdomain \
-    --endpoint icinga2-master1.localdomain \
-    --zone icinga2-client1.localdomain \
-    --parent_zone master \
-    --parent_host icinga2-master1.localdomain \
-    --trustedcert /var/lib/icinga2/certs/trusted-parent.crt \
-    --accept-commands --accept-config
+```
+[root@icinga2-client1.localdomain /]# icinga2 node setup --ticket ead2d570e18c78abf285d6b85524970a0f69c22d \
+--cn icinga2-client1.localdomain \
+--endpoint icinga2-master1.localdomain \
+--zone icinga2-client1.localdomain \
+--parent_zone master \
+--parent_host icinga2-master1.localdomain \
+--trustedcert /var/lib/icinga2/certs/trusted-parent.crt \
+--accept-commands --accept-config \
+--disable-confd
+```
 
 In case the client should connect to the master node, you'll
 need to modify the `--endpoint` parameter using the format `cn,host,port`:

--- a/lib/cli/apisetuputility.cpp
+++ b/lib/cli/apisetuputility.cpp
@@ -40,7 +40,12 @@ using namespace icinga;
 
 String ApiSetupUtility::GetConfdPath()
 {
-		return Application::GetSysconfDir() + "/icinga2/conf.d";
+	return Application::GetSysconfDir() + "/icinga2/conf.d";
+}
+
+String ApiSetupUtility::GetApiUsersConfPath()
+{
+	return ApiSetupUtility::GetConfdPath() + "/api-users.conf";
 }
 
 bool ApiSetupUtility::SetupMaster(const String& cn, bool prompt_restart)

--- a/lib/cli/apisetuputility.hpp
+++ b/lib/cli/apisetuputility.hpp
@@ -45,6 +45,7 @@ public:
 	static bool SetupMasterUpdateConstants(const String& cn);
 
 	static String GetConfdPath();
+	static String GetApiUsersConfPath();
 
 private:
 	ApiSetupUtility();

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -66,7 +66,8 @@ void NodeSetupCommand::InitParameters(boost::program_options::options_descriptio
 		("accept-config", "Accept config from master")
 		("accept-commands", "Accept commands from master")
 		("master", "Use setup for a master instance")
-		("global_zones", po::value<std::vector<std::string> >(), "The names of the additional global zones.");
+		("global_zones", po::value<std::vector<std::string> >(), "The names of the additional global zones.")
+		("dont-disable-confd", "Disables the conf.d directory during the setup");
 
 	hiddenDesc.add_options()
 		("master_zone", po::value<std::string>(), "DEPRECATED: The name of the master zone")
@@ -244,8 +245,22 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 	Log(LogInformation, "cli")
 		<< "Edit the api feature config file '" << apipath << "' and set a secure 'ticket_salt' attribute.";
 
-	/* tell the user to reload icinga2 */
+	if (!vm.count("dont-disable-confd")) {
+		/* Disable conf.d inclusion */
+		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);
 
+		String apiUsersFilePath = Application::GetSysconfDir() + "/icinga2/conf.d/api-users.conf";
+		std::ifstream apiUsersFile(apiUsersFilePath);
+
+		/* Include api-users.conf */
+		if(apiUsersFile)
+			NodeUtility::UpdateConfiguration("\"conf.d/api-users.conf\"", true, false);
+		else
+			Log(LogWarning, "cli")
+				<< "Included file dosen't exist " << apiUsersFilePath;
+	}
+
+	/* tell the user to reload icinga2 */
 	Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
 
 	return 0;
@@ -554,6 +569,23 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 	} else {
 		Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
 	}
+
+	if (!vm.count("dont-disable-confd")) {
+
+		/* Disable conf.d inclusion */
+		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);
+
+		String apiUsersFilePath = Application::GetSysconfDir() + "/icinga2/conf.d/api-users.conf";
+		std::ifstream apiUsersFile(apiUsersFilePath);
+
+		if(apiUsersFile)
+			NodeUtility::UpdateConfiguration("\"conf.d/api-users.conf\"", true, false);
+		else
+			Log(LogWarning, "cli", "Included file dosen't exist " + apiUsersFilePath);
+	}
+
+	/* tell the user to reload icinga2 */
+	Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
 
 	return 0;
 }

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -247,7 +247,12 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 
 	if (vm.count("disable-confd")) {
 		/* Disable conf.d inclusion */
-		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);
+		if (NodeUtility::UpdateConfiguration("\"conf.d\"", false, true))
+			Log(LogInformation, "cli")
+				<< "Disabled conf.d inclusion";
+		else
+			Log(LogWarning, "cli")
+				<< "Tried to disable conf.d inclusion but failed, possibly it's already disabled.";
 
 		String apiUsersFilePath = Application::GetSysconfDir() + "/icinga2/conf.d/api-users.conf";
 		std::ifstream apiUsersFile(apiUsersFilePath);

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -67,7 +67,7 @@ void NodeSetupCommand::InitParameters(boost::program_options::options_descriptio
 		("accept-commands", "Accept commands from master")
 		("master", "Use setup for a master instance")
 		("global_zones", po::value<std::vector<std::string> >(), "The names of the additional global zones.")
-		("dont-disable-confd", "Disables the conf.d directory during the setup");
+		("disable-confd", "Disables the conf.d directory during the setup");
 
 	hiddenDesc.add_options()
 		("master_zone", po::value<std::string>(), "DEPRECATED: The name of the master zone")
@@ -245,7 +245,7 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 	Log(LogInformation, "cli")
 		<< "Edit the api feature config file '" << apipath << "' and set a secure 'ticket_salt' attribute.";
 
-	if (!vm.count("dont-disable-confd")) {
+	if (vm.count("disable-confd")) {
 		/* Disable conf.d inclusion */
 		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);
 
@@ -570,7 +570,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 		Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
 	}
 
-	if (!vm.count("dont-disable-confd")) {
+	if (vm.count("disable-confd")) {
 
 		/* Disable conf.d inclusion */
 		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -270,8 +270,9 @@ void NodeUtility::SerializeObject(std::ostream& fp, const Dictionary::Ptr& objec
  * include = true, will add an include statement or uncomment a statement if one is existing
  * resursive = false, will search for a non-resursive include statement
  * recursive = true, will search for a resursive include statement
+ * Returns true on success, false if option was not found
  */
-void NodeUtility::UpdateConfiguration(const String& value, const bool& include, const bool& recursive)
+bool NodeUtility::UpdateConfiguration(const String& value, const bool& include, const bool& recursive)
 {
 	String configurationFile = Application::GetSysconfDir() + "/icinga2/icinga2.conf";
 
@@ -331,6 +332,8 @@ void NodeUtility::UpdateConfiguration(const String& value, const bool& include, 
 			<< boost::errinfo_errno(errno)
 			<< boost::errinfo_file_name(configurationFile));
 	}
+
+	return (found || include);
 }
 
 void NodeUtility::UpdateConstant(const String& name, const String& value)

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -265,6 +265,74 @@ void NodeUtility::SerializeObject(std::ostream& fp, const Dictionary::Ptr& objec
 	fp << "}\n\n";
 }
 
+/*
+ * include = false, will comment out the include statement
+ * include = true, will add an include statement or uncomment a statement if one is existing
+ * resursive = false, will search for a non-resursive include statement
+ * recursive = true, will search for a resursive include statement
+ */
+void NodeUtility::UpdateConfiguration(const String& value, const bool& include, const bool& recursive)
+{
+	String configurationFile = Application::GetSysconfDir() + "/icinga2/icinga2.conf";
+
+	Log(LogInformation, "cli")
+		<< "Updating' " << value << "' include in '" << configurationFile << "'.";
+
+	NodeUtility::CreateBackupFile(configurationFile);
+
+	std::ifstream ifp(configurationFile.CStr());
+	std::fstream ofp;
+	String tempFile = Utility::CreateTempFile(configurationFile + ".XXXXXX", 0644, ofp);
+
+	String affectedInclude = value;
+
+	recursive ? affectedInclude = "include_recursive " + affectedInclude : affectedInclude = "include " + affectedInclude;
+
+	bool found = false;
+
+	std::string line;
+
+	while (std::getline(ifp, line)) {
+		if(include) {
+			if (line.find("//" + affectedInclude) != std::string::npos || line.find("// " + affectedInclude) != std::string::npos) {
+				found = true;
+				ofp << affectedInclude + "\n";
+			} else if (line.find(affectedInclude) != std::string::npos) {
+				found = true;
+				
+				Log(LogInformation, "cli")
+					<< "Include statement '" + affectedInclude + "' already set.";
+					
+				ofp << line << "\n";
+			} else
+				ofp << line << "\n";
+		} else {
+			if (line.find(affectedInclude) != std::string::npos) {
+				found = true;
+				ofp << "// " + affectedInclude + "\n";
+			} else
+				ofp << line << "\n";
+		}
+	}
+
+	if (include && !found)
+		ofp << affectedInclude + "\n";
+
+	ifp.close();
+	ofp.close();
+
+#ifdef _WIN32
+	_unlink(configurationFile.CStr());
+#endif /* _WIN32 */
+
+	if (rename(tempFile.CStr(), configurationFile.CStr()) < 0) {
+		BOOST_THROW_EXCEPTION(posix_error()
+			<< boost::errinfo_api_function("rename")
+			<< boost::errinfo_errno(errno)
+			<< boost::errinfo_file_name(configurationFile));
+	}
+}
+
 void NodeUtility::UpdateConstant(const String& name, const String& value)
 {
 	String constantsConfPath = NodeUtility::GetConstantsConfPath();

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -44,7 +44,7 @@ public:
 
 	static bool WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects);
 
-	static bool UpdateConfiguration(const String& value, const bool& include, const bool& recursive);
+	static bool UpdateConfiguration(const String& value, bool include, bool recursive);
 	static void UpdateConstant(const String& name, const String& value);
 
 	/* node setup helpers */

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -44,6 +44,7 @@ public:
 
 	static bool WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects);
 
+	static void UpdateConfiguration(const String& value, const bool& include, const bool& recursive);
 	static void UpdateConstant(const String& name, const String& value);
 
 	/* node setup helpers */

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -44,7 +44,7 @@ public:
 
 	static bool WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects);
 
-	static void UpdateConfiguration(const String& value, const bool& include, const bool& recursive);
+	static bool UpdateConfiguration(const String& value, const bool& include, const bool& recursive);
 	static void UpdateConstant(const String& name, const String& value);
 
 	/* node setup helpers */

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -633,7 +633,7 @@ wizard_global_zone_loop_start:
 
 		if(!NodeUtility::UpdateConfiguration("\"conf.d\"", false, true)) {
 			std::cout << ConsoleColorTag(Console_Bold | Console_ForegroundRed)
-				<< "Failed to disable conf.d inclusion, it may already be disabled."
+				<< "Failed to disable conf.d inclusion, it may already be disabled.\n"
 				<< ConsoleColorTag(Console_Normal);
 		}
 
@@ -840,7 +840,11 @@ wizard_global_zone_loop_start:
 			<< "Disable the inclusion of the conf.d directory...\n"
 			<< ConsoleColorTag(Console_Normal);
 
-		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);
+		if (!NodeUtility::UpdateConfiguration("\"conf.d\"", false, true)) {
+			std::cout << ConsoleColorTag(Console_Bold | Console_ForegroundRed)
+				<< "Failed to disable conf.d inclusion, it may already be disabled.\n"
+				<< ConsoleColorTag(Console_Normal);
+		}
 
 		/* Include api-users.conf */
 		String apiUsersFilePath = Application::GetSysconfDir() + "/icinga2/conf.d/api-users.conf";

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -628,7 +628,7 @@ wizard_global_zone_loop_start:
 			<< "The deactivation of the conf.d directory was skipped.";
 	else {
 		std::cout << ConsoleColorTag(Console_Bold | Console_ForegroundGreen)
-			<< "Disable the inclusion of the conf.d directory...\n"
+			<< "Disabling the inclusion of the conf.d directory...\n"
 			<< ConsoleColorTag(Console_Normal);
 
 		if(!NodeUtility::UpdateConfiguration("\"conf.d\"", false, true)) {
@@ -814,9 +814,7 @@ wizard_global_zone_loop_start:
 
 	Log(LogInformation, "cli", "Updating constants.conf.");
 	
-	String constants_file = Application::GetSysconfDir() + "/icinga2/constants.conf";
-
-	NodeUtility::CreateBackupFile(constants_file);
+	NodeUtility::CreateBackupFile(NodeUtility::GetConstantsConfPath());
 
 	NodeUtility::UpdateConstant("NodeName", cn);
 	NodeUtility::UpdateConstant("ZoneName", cn);

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -631,7 +631,12 @@ wizard_global_zone_loop_start:
 			<< "Disable the inclusion of the conf.d directory...\n"
 			<< ConsoleColorTag(Console_Normal);
 
-		NodeUtility::UpdateConfiguration("\"conf.d\"", false, true);
+		if(!NodeUtility::UpdateConfiguration("\"conf.d\"", false, true)) {
+			std::cout << ConsoleColorTag(Console_Bold | Console_ForegroundRed)
+				<< "Failed to disable conf.d inclusion, it may already be disabled."
+				<< ConsoleColorTag(Console_Normal);
+		}
+
 	}
 
 	return 0;


### PR DESCRIPTION
This PR add the ability to disable the conf.d inclusion through running node wizard. This PR also adds a new function to NodeUtility to update the Icinga 2 configuraton file (`icinga2.conf`). 

```
# /tmp/icinga2/sbin/icinga2 daemon -C -DRunAsUser=$(id -u -n) -DRunAsGroup=$(id -g -n)

information/cli: Icinga application loader (version: v2.6.3-404-ge50a823)
information/cli: Loading configuration file(s).
information/ConfigItem: Committing config item(s).
warning/ApplyRule: Apply rule 'satellite-host' (in /tmp/icinga2/etc/icinga2/conf.d/satellite.conf: 29:1-29:41) for type 'Dependency' does not match anywhere!
information/ConfigItem: Instantiated 3 Zones.
information/ConfigItem: Instantiated 1 FileLogger.
information/ConfigItem: Instantiated 1 Endpoint.
information/ConfigItem: Instantiated 2 NotificationCommands.
information/ConfigItem: Instantiated 12 Notifications.
information/ConfigItem: Instantiated 207 CheckCommands.
information/ConfigItem: Instantiated 1 Host.
information/ConfigItem: Instantiated 1 IcingaApplication.
information/ConfigItem: Instantiated 2 HostGroups.
information/ConfigItem: Instantiated 1 UserGroup.
information/ConfigItem: Instantiated 3 TimePeriods.
information/ConfigItem: Instantiated 1 User.
information/ConfigItem: Instantiated 11 Services.
information/ConfigItem: Instantiated 3 ServiceGroups.
information/ConfigItem: Instantiated 1 ScheduledDowntime.
information/ConfigItem: Instantiated 1 NotificationComponent.
information/ConfigItem: Instantiated 1 CheckerComponent.
information/ScriptGlobal: Dumping variables to file '/tmp/icinga2/var/cache/icinga2/icinga2.vars'
information/cli: Finished validating the configuration file(s).

# /tmp/icinga2/sbin/icinga2 node wizard -DRunAsUser=$(id -u -n) -DRunAsGroup=$(id -g -n)

Welcome to the Icinga 2 Setup Wizard!

We'll guide you through all required configuration details.



Please specify if this is a satellite setup ('n' installs a master setup) [Y/n]: n
Starting the Master setup routine...
Please specify the common name (CN) [ganymed]: 
Do you want do disable the inclusion of the conf.d directory [Y/n]: 
Checking for existing certificates for common name 'ganymed'...
Certificates not yet generated. Running 'api setup' now.
information/cli: Generating new CA.
information/base: Writing private key to '/tmp/icinga2/var/lib/icinga2/ca/ca.key'.
information/base: Writing X509 certificate to '/tmp/icinga2/var/lib/icinga2/ca/ca.crt'.
information/cli: Generating new CSR in '/tmp/icinga2/etc/icinga2/pki/ganymed.csr'.
information/base: Writing private key to '/tmp/icinga2/etc/icinga2/pki/ganymed.key'.
information/base: Writing certificate signing request to '/tmp/icinga2/etc/icinga2/pki/ganymed.csr'.
information/cli: Signing CSR with CA and writing certificate to '/tmp/icinga2/etc/icinga2/pki/ganymed.crt'.
information/pki: Writing certificate to file '/tmp/icinga2/etc/icinga2/pki/ganymed.crt'.
information/cli: Copying CA certificate to '/tmp/icinga2/etc/icinga2/pki/ca.crt'.
Generating master configuration for Icinga 2.
information/cli: Adding new ApiUser 'root' in '/tmp/icinga2/etc/icinga2/conf.d/api-users.conf'.
information/cli: Enabling the 'api' feature.
Enabling feature api. Make sure to restart Icinga 2 for these changes to take effect.
information/cli: Dumping config items to file '/tmp/icinga2/etc/icinga2/zones.conf'.
information/cli: Created backup file '/tmp/icinga2/etc/icinga2/zones.conf.orig'.
Please specify the API bind host/port (optional):
Bind Host []: 
Bind Port []: 
information/cli: Created backup file '/tmp/icinga2/etc/icinga2/features-available/api.conf.orig'.
information/cli: Updating constants.conf.
information/cli: Created backup file '/tmp/icinga2/etc/icinga2/constants.conf.orig'.
information/cli: Updating constants file '/tmp/icinga2/etc/icinga2/constants.conf'.
information/cli: Updating constants file '/tmp/icinga2/etc/icinga2/constants.conf'.
information/cli: Updating constants file '/tmp/icinga2/etc/icinga2/constants.conf'.
information/cli: Updating configuration file '/tmp/icinga2/etc/icinga2/icinga2.conf'.
information/cli: Updating configuration file '/tmp/icinga2/etc/icinga2/icinga2.conf'.
Done.

Now restart your Icinga 2 daemon to finish the installation!

# /tmp/icinga2/sbin/icinga2 daemon -C -DRunAsUser=$(id -u -n) -DRunAsGroup=$(id -g -n)

information/cli: Icinga application loader (version: v2.6.3-404-ge50a823)
information/cli: Loading configuration file(s).
information/ConfigItem: Committing config item(s).
information/ApiListener: My API identity: ganymed
information/ConfigItem: Instantiated 1 ApiUser.
information/ConfigItem: Instantiated 1 ApiListener.
information/ConfigItem: Instantiated 1 Zone.
information/ConfigItem: Instantiated 1 FileLogger.
information/ConfigItem: Instantiated 1 Endpoint.
information/ConfigItem: Instantiated 207 CheckCommands.
information/ConfigItem: Instantiated 1 IcingaApplication.
information/ConfigItem: Instantiated 1 NotificationComponent.
information/ConfigItem: Instantiated 1 CheckerComponent.
information/ScriptGlobal: Dumping variables to file '/tmp/icinga2/var/cache/icinga2/icinga2.vars'
information/cli: Finished validating the configuration file(s).
```

This is still WIP and works so far only while setting up a master instance. Please provide me some feedback if the patch is okay (so far). 

I am trying to add the missing parts within the coming week, so the PR should leave WIP towards the end of coming week.

fixes #4508