### PR TITLE
Add -d option to check_service

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1561,10 +1561,11 @@ This checks thresholds work different since the binary decision whether a servic
 
 Custom attributes:
 
-Name                  | Description
-:---------------------|:------------
-service\_win\_warn    | **Optional**. Warn when service is not running.
-service\_win\_service | **Required**. The critical threshold.
+Name                      | Description
+:-------------------------|:------------
+service\_win\_warn        | **Optional**. Warn when service is not running.
+service\_win\_description | **Optional**. If this is set, `service\_win\_service` looks at the service description.
+service\_win\_service     | **Required**. Name of the service to check.
 
 
 ### swap-windows <a id="windows-plugins-swap-windows"></a>

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -226,6 +226,10 @@ object CheckCommand "service-windows" {
 			required = true
 			description = "Service to check"
 		}
+		"-d" = {
+			set_if = "$service_win_description$"
+			description = "Use service description instead of name"
+		}
 	}
 }
 

--- a/plugins/check_service.h
+++ b/plugins/check_service.h
@@ -31,6 +31,7 @@ struct printInfoStruct
 
 INT parseArguments(INT, WCHAR **, boost::program_options::variables_map&, printInfoStruct&);
 INT printOutput(CONST printInfoStruct&);
+std::wstring GetServiceByDescription(CONST std::wstring&);
 DWORD ServiceStatus(CONST printInfoStruct&);
 
 #endif // !CHECK_SERVICE_H


### PR DESCRIPTION
Adds a new option (-d/--description) to make check_service able to search a service description for a string. In this version -d changes the behavior of -s. ITL and Docs have been updated.