### PR TITLE
Add missing notification state filter to documentation 

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -1245,7 +1245,7 @@ Available state and type filters for notifications are:
 
     template Notification "generic-notification" {
 
-      states = [ Warning, Critical, Unknown ]
+      states = [ OK, Warning, Critical, Unknown ]
       types = [ Problem, Acknowledgement, Recovery, Custom, FlappingStart,
                 FlappingEnd, DowntimeStart, DowntimeEnd, DowntimeRemoved ]
     }


### PR DESCRIPTION
This adds the missing `OK` state to the `Notification Filters by State and Type` chapter.