### PR TITLE
Change cluster check output

### DIFF
--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -30,7 +30,6 @@
 #include "base/function.hpp"
 #include "base/configtype.hpp"
 #include <boost/algorithm/string/join.hpp>
-#include <boost/algorithm/string.hpp>
 
 using namespace icinga;
 

--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -59,40 +59,34 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 	std::pair<Dictionary::Ptr, Array::Ptr> feature_stats = CIB::GetFeatureStats();
 	cr->SetPerformanceData(feature_stats.second);
 
-	String connected_endpoints = FormatArray(status->Get("conn_endpoints"));
-	String not_connected_endpoints = FormatArray(status->Get("not_conn_endpoints"));
-
-	boost::replace_all(not_connected_endpoints, ", ", "\n-");
+	String connected_endpoints = FormatArrayToList(status->Get("conn_endpoints"));
+	String not_connected_endpoints = FormatArrayToList(status->Get("not_conn_endpoints"));
 
 	if (status->Get("num_not_conn_endpoints") > 0) {
 		cr->SetState(ServiceCritical);
-		cr->SetOutput("Icinga 2 Cluster Problem: " + Convert::ToString(status->Get("num_not_conn_endpoints")) +
-		    "\nNot connected Endpoints: \n" +
-		    not_connected_endpoints);
+		cr->SetOutput("Icinga 2 Cluster Problem: " + Convert::ToString(status->Get("num_not_conn_endpoints")) + "\n" +
+			"Not connected Endpoints:\n" +
+			not_connected_endpoints);
 	} else {
 		cr->SetState(ServiceOK);
-		cr->SetOutput("Icinga 2 Cluster is running: Connected Endpoints: "+ Convert::ToString(status->Get("num_conn_endpoints")) +
-		    " (" + connected_endpoints + ").");
+		cr->SetOutput("Icinga 2 Cluster is running: Connected Endpoints: "+ Convert::ToString(status->Get("num_conn_endpoints")) + "\n" +
+		    "Connected Endpoints:\n" +
+			connected_endpoints);
 	}
 
 	checkable->ProcessCheckResult(cr);
 }
 
-String ClusterCheckTask::FormatArray(const Array::Ptr& arr)
+String ClusterCheckTask::FormatArrayToList(const Array::Ptr& arr)
 {
 	bool first = true;
 	String str;
 
 	if (arr) {
 		ObjectLock olock(arr);
-		for (const Value& value : arr) {
-			if (first)
-				first = false;
-			else
-				str += ", ";
 
-			str += Convert::ToString(value);
-		}
+		for (const Value& value : arr)
+			str += "- " + Convert::ToString(value) + "\n";
 	}
 
 	return str;

--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -58,17 +58,17 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 	std::pair<Dictionary::Ptr, Array::Ptr> feature_stats = CIB::GetFeatureStats();
 	cr->SetPerformanceData(feature_stats.second);
 
-	String connected_endpoints = FormatArrayToList(status->Get("conn_endpoints"));
-	String not_connected_endpoints = FormatArrayToList(status->Get("not_conn_endpoints"));
+	String connected_endpoints = FormatArray(status->Get("conn_endpoints"));
+	String not_connected_endpoints = FormatArray(status->Get("not_conn_endpoints"));
 
 	if (status->Get("num_not_conn_endpoints") > 0) {
 		cr->SetState(ServiceCritical);
-		cr->SetOutput("Icinga 2 Cluster Problem: " + Convert::ToString(status->Get("num_not_conn_endpoints")) + "\n" +
+		cr->SetOutput("Icinga 2 Cluster Problem: Not Connected Endpoints: " + Convert::ToString(status->Get("num_not_conn_endpoints")) + "\n" +
 			"Not connected Endpoints:\n" +
 			not_connected_endpoints);
 	} else {
 		cr->SetState(ServiceOK);
-		cr->SetOutput("Icinga 2 Cluster is running: Connected Endpoints: "+ Convert::ToString(status->Get("num_conn_endpoints")) + "\n" +
+		cr->SetOutput("Icinga 2 Cluster is running: Connected Endpoints: " + Convert::ToString(status->Get("num_conn_endpoints")) + "\n" +
 		    "Connected Endpoints:\n" +
 			connected_endpoints);
 	}
@@ -76,16 +76,21 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 	checkable->ProcessCheckResult(cr);
 }
 
-String ClusterCheckTask::FormatArrayToList(const Array::Ptr& arr)
+String ClusterCheckTask::FormatArray(const Array::Ptr& arr)
 {
 	bool first = true;
 	String str;
 
 	if (arr) {
 		ObjectLock olock(arr);
+		for (const Value& value : arr) {
+			if (first)
+				first = false;
+			else
+				str += ", ";
 
-		for (const Value& value : arr)
-			str += "- " + Convert::ToString(value) + "\n";
+			str += Convert::ToString(value);
+		}
 	}
 
 	return str;

--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -30,6 +30,7 @@
 #include "base/function.hpp"
 #include "base/configtype.hpp"
 #include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string.hpp>
 
 using namespace icinga;
 
@@ -61,10 +62,13 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 	String connected_endpoints = FormatArray(status->Get("conn_endpoints"));
 	String not_connected_endpoints = FormatArray(status->Get("not_conn_endpoints"));
 
+	boost::replace_all(not_connected_endpoints, ", ", "\n-");
+
 	if (status->Get("num_not_conn_endpoints") > 0) {
 		cr->SetState(ServiceCritical);
 		cr->SetOutput("Icinga 2 Cluster Problem: " + Convert::ToString(status->Get("num_not_conn_endpoints")) +
-		    " Endpoints (" + not_connected_endpoints + ") not connected.");
+		    "\nNot connected Endpoints: \n" +
+		    not_connected_endpoints);
 	} else {
 		cr->SetState(ServiceOK);
 		cr->SetOutput("Icinga 2 Cluster is running: Connected Endpoints: "+ Convert::ToString(status->Get("num_conn_endpoints")) +

--- a/lib/methods/clusterchecktask.hpp
+++ b/lib/methods/clusterchecktask.hpp
@@ -38,7 +38,7 @@ public:
 
 private:
 	ClusterCheckTask(void);
-	static String FormatArrayToList(const Array::Ptr& arr);
+	static String FormatArray(const Array::Ptr& arr);
 };
 
 }

--- a/lib/methods/clusterchecktask.hpp
+++ b/lib/methods/clusterchecktask.hpp
@@ -38,7 +38,7 @@ public:
 
 private:
 	ClusterCheckTask(void);
-	static String FormatArray(const Array::Ptr& arr);
+	static String FormatArrayToList(const Array::Ptr& arr);
 };
 
 }


### PR DESCRIPTION
This changes the cluster check output to get a cleaner and a more readable Icinga Web 2 output.

Critical state:
![28841293-0a734b1e-76fa-11e7-93e3-f1d574629c5a](https://user-images.githubusercontent.com/18580278/28889828-9882030c-77c5-11e7-9bdd-070d8f45291f.png)

OK state:
![screenshot at 2017-08-02 20 33 19](https://user-images.githubusercontent.com/18580278/28889829-99db2e4a-77c5-11e7-8b79-a764884cf887.png)

fixes #5444 