### PR TITLE
Make notification mails more readable. Remove redundancy and cruft.

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -93,14 +93,14 @@ SUBJECT="[$NOTIFICATIONTYPE] Host $HOSTDISPLAYNAME is $HOSTSTATE!"
 
 ## Build the notification message
 NOTIFICATION_MESSAGE=`cat << EOF
-***** Icinga 2 Host Monitoring on $HOSTNAME *****
+***** Host Monitoring on $HOSTNAME *****
 
-==> $HOSTDISPLAYNAME ($HOSTNAME) is $HOSTSTATE! <==
+$HOSTDISPLAYNAME is $HOSTSTATE!
 
 Info:    $HOSTOUTPUT
 
 When:    $LONGDATETIME
-Host:    $HOSTNAME (Display Name: "$HOSTDISPLAYNAME")
+Host:    $HOSTNAME
 EOF
 `
 
@@ -128,8 +128,7 @@ fi
 if [ -n "$ICINGAWEB2URL" ] ; then
   NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
 
-URL:
-  $ICINGAWEB2URL/monitoring/host/show?host=$HOSTNAME"
+$ICINGAWEB2URL/monitoring/host/show?host=$HOSTNAME"
 fi
 
 ## Check whether verbose mode was enabled and log to syslog.

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -98,15 +98,15 @@ SUBJECT="[$NOTIFICATIONTYPE] $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICE
 
 ## Build the notification message
 NOTIFICATION_MESSAGE=`cat << EOF
-***** Icinga 2 Service Monitoring on $HOSTNAME *****
+***** Service Monitoring on $HOSTNAME *****
 
-==> $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE! <==
+$SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE!
 
 Info:    $SERVICEOUTPUT
 
 When:    $LONGDATETIME
-Service: $SERVICENAME (Display Name: "$SERVICEDISPLAYNAME")
-Host:    $HOSTNAME (Display Name: "$HOSTDISPLAYNAME")
+Service: $SERVICENAME
+Host:    $HOSTNAME
 EOF
 `
 
@@ -134,8 +134,7 @@ fi
 if [ -n "$ICINGAWEB2URL" ] ; then
   NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
 
-URL:
-  $ICINGAWEB2URL/monitoring/service/show?host=$HOSTNAME&service=$SERVICENAME"
+$ICINGAWEB2URL/monitoring/service/show?host=$HOSTNAME&service=$SERVICENAME"
 fi
 
 ## Check whether verbose mode was enabled and log to syslog.


### PR DESCRIPTION
I tried to make Icinga's notification mails more readable, especially on mobile devices. Would be glad, if you could incorporate the changes:
- remove the Icinga 2 name.
- remove cruft around the primary status message
- do not precede URL with anything, it speaks for itself
- remove display names from table, as they are also in the subject and in the primary status message