### PR TITLE
Systemd: Add DefaultTasksMax=infinity to service file

### DIFF
--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -324,7 +324,8 @@ In order to solve the problem, increase the value for `DefaultTasksMax`
 or set it to `infinity`:
 
 
-    [root@icinga2-master1.localdomain /]# vim /usr/lib/systemd/system/icinga2.service
+    [root@icinga2-master1.localdomain /]# cp /usr/lib/systemd/system/icinga2.service /etc/systemd/system/icinga2.service
+    [root@icinga2-master1.localdomain /]# vim /etc/systemd/system/icinga2.service
 
     [Service]
 
@@ -334,6 +335,10 @@ or set it to `infinity`:
     [root@icinga2-master1.localdomain /]# systemctl restart icinga2
 
 Please note that this setting is available since Systemd version 226.
+
+> **Note**
+>
+> Future versions of Icinga 2 will add the setting as default.
 
 ### Late Check Results <a id="late-check-results"></a>
 

--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -10,6 +10,8 @@ ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/icinga2 daemon -d -e ${ICINGA2_ERROR_LOG}
 PIDFile=@ICINGA2_RUNDIR@/icinga2/icinga2.pid
 ExecReload=@CMAKE_INSTALL_PREFIX@/lib/icinga2/safe-reload @ICINGA2_SYSCONFIGFILE@
 TimeoutStartSec=30m
+# Introduced in Systemd 226, defaults to 512. Icinga 2 requires more tasks (checks, notifications, etc.)
+DefaultTasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This solves the problem with Systemd >= 226 and fork errors with
Icinga 2. Seen on SLES 11 SP2.

fixes #4918