### PR TITLE
Ensure that expired/removed downtimes/comments are correctly updated in DB IDO

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -5,6 +5,12 @@ are scheme updates for the IDO database.
 
 ## Upgrading to v2.8 <a id="upgrading-to-2-8"></a>
 
+### DB IDO Schema Update to 2.8.0 <a id="upgrading-to-2-8-db-ido"></a>
+
+There are additional indexes and schema fixes which require an update.
+
+Please proceed here for [MySQL](16-upgrading-icinga-2.md#upgrading-mysql-db) for [PostgreSQL](16-upgrading-icinga-2.md#upgrading-postgresql-db).
+
 ### Changed Certificate Paths <a id="upgrading-to-2-8-certificate-paths"></a>
 
 The default certificate path was changed from `/etc/icinga2/pki` to
@@ -149,8 +155,8 @@ systemctl restart icinga2
 
 ## Upgrading the MySQL database <a id="upgrading-mysql-db"></a>
 
-If you're upgrading an existing Icinga 2 instance, you should check the
-`/usr/share/icinga2-ido-mysql/schema/upgrade` directory for an incremental schema upgrade file.
+If you want to upgrade an existing Icinga 2 instance, check the
+`/usr/share/icinga2-ido-mysql/schema/upgrade` directory for incremental schema upgrade file(s).
 
 > **Note**
 >
@@ -158,25 +164,35 @@ If you're upgrading an existing Icinga 2 instance, you should check the
 
 Apply all database schema upgrade files incrementally.
 
-    # mysql -u root -p icinga < /usr/share/icinga2-ido-mysql/schema/upgrade/<version>.sql
+```
+# mysql -u root -p icinga < /usr/share/icinga2-ido-mysql/schema/upgrade/<version>.sql
+```
 
-The Icinga 2 DB IDO module will check for the required database schema version on startup
-and generate an error message if not satisfied.
+The Icinga 2 DB IDO feature checks the required database schema version on startup
+and generates an log message if not satisfied.
 
 
-**Example:** You are upgrading Icinga 2 from version `2.0.2` to `2.3.0`. Look into
-the *upgrade* directory:
+**Example:** You are upgrading Icinga 2 from version `2.4.0` to `2.8.0`. Look into
+the `upgrade` directory:
 
-    $ ls /usr/share/icinga2-ido-mysql/schema/upgrade/
-    2.0.2.sql  2.1.0.sql 2.2.0.sql 2.3.0.sql
+```
+$ ls /usr/share/icinga2-ido-mysql/schema/upgrade/
+2.0.2.sql 2.1.0.sql 2.2.0.sql 2.3.0.sql 2.4.0.sql 2.5.0.sql 2.6.0.sql 2.8.0.sql
+```
 
-There are two new upgrade files called `2.1.0.sql`, `2.2.0.sql` and `2.3.0.sql`
+There are two new upgrade files called `2.5.0.sql`, `2.6.0.sql` and `2.8.0.sql`
 which must be applied incrementally to your IDO database.
+
+```
+# mysql -u root -p icinga < /usr/share/icinga2-ido-mysql/schema/upgrade/2.5.0.sql
+# mysql -u root -p icinga < /usr/share/icinga2-ido-mysql/schema/upgrade/2.6.0.sql
+# mysql -u root -p icinga < /usr/share/icinga2-ido-mysql/schema/upgrade/2.8.0.sql
+```
 
 ## Upgrading the PostgreSQL database <a id="upgrading-postgresql-db"></a>
 
-If you're updating an existing Icinga 2 instance, you should check the
-`/usr/share/icinga2-ido-pgsql/schema/upgrade` directory for an incremental schema upgrade file.
+If you want to upgrade an existing Icinga 2 instance, check the
+`/usr/share/icinga2-ido-mysql/schema/upgrade` directory for incremental schema upgrade file(s).
 
 > **Note**
 >
@@ -184,17 +200,28 @@ If you're updating an existing Icinga 2 instance, you should check the
 
 Apply all database schema upgrade files incrementally.
 
-    # export PGPASSWORD=icinga
-    # psql -U icinga -d icinga < /usr/share/icinga2-ido-pgsql/schema/upgrade/<version>.sql
+```
+# export PGPASSWORD=icinga
+# psql -U icinga -d icinga < /usr/share/icinga2-ido-pgsql/schema/upgrade/<version>.sql
+```
 
-The Icinga 2 DB IDO module will check for the required database schema version on startup
-and generate an error message if not satisfied.
+The Icinga 2 DB IDO feature checks the required database schema version on startup
+and generates an log message if not satisfied.
 
-**Example:** You are upgrading Icinga 2 from version `2.0.2` to `2.3.0`. Look into
-the *upgrade* directory:
+**Example:** You are upgrading Icinga 2 from version `2.4.0` to `2.8.0`. Look into
+the `upgrade` directory:
 
-    $ ls /usr/share/icinga2-ido-pgsql/schema/upgrade/
-    2.0.2.sql  2.1.0.sql 2.2.0.sql 2.3.0.sql
+```
+$ ls /usr/share/icinga2-ido-pgsql/schema/upgrade/
+2.0.2.sql 2.1.0.sql 2.2.0.sql 2.3.0.sql 2.4.0.sql 2.5.0.sql 2.6.0.sql 2.8.0.sql
+```
 
-There are two new upgrade files called `2.1.0.sql`, `2.2.0.sql` and `2.3.0.sql`
+There are two new upgrade files called `2.5.0.sql`, `2.6.0.sql` and `2.8.0.sql`
 which must be applied incrementally to your IDO database.
+
+```
+# export PGPASSWORD=icinga
+# psql -U icinga -d icinga < /usr/share/icinga2-ido-pgsql/schema/upgrade/2.5.0.sql
+# psql -U icinga -d icinga < /usr/share/icinga2-ido-pgsql/schema/upgrade/2.6.0.sql
+# psql -U icinga -d icinga < /usr/share/icinga2-ido-pgsql/schema/upgrade/2.8.0.sql
+```

--- a/lib/db_ido/dbconnection.hpp
+++ b/lib/db_ido/dbconnection.hpp
@@ -29,7 +29,7 @@
 #include <boost/thread/once.hpp>
 #include <boost/thread/mutex.hpp>
 
-#define IDO_CURRENT_SCHEMA_VERSION "1.14.2"
+#define IDO_CURRENT_SCHEMA_VERSION "1.14.3"
 #define IDO_COMPAT_SCHEMA_VERSION "1.14.2"
 
 namespace icinga

--- a/lib/db_ido/dbconnection.hpp
+++ b/lib/db_ido/dbconnection.hpp
@@ -30,7 +30,7 @@
 #include <boost/thread/mutex.hpp>
 
 #define IDO_CURRENT_SCHEMA_VERSION "1.14.3"
-#define IDO_COMPAT_SCHEMA_VERSION "1.14.2"
+#define IDO_COMPAT_SCHEMA_VERSION "1.14.3"
 
 namespace icinga
 {

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -586,6 +586,7 @@ void DbEvents::RemoveDowntimeInternal(std::vector<DbQuery>& queries, const Downt
 	query1.Type = DbQueryDelete;
 	query1.Category = DbCatDowntime;
 	query1.WhereCriteria = new Dictionary();
+
 	query1.WhereCriteria->Set("object_id", checkable);
 	query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
 	query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -375,10 +375,8 @@ void DbEvents::AddCommentInternal(std::vector<DbQuery>& queries, const Comment::
 
 		query1.WhereCriteria = new Dictionary();
 		query1.WhereCriteria->Set("object_id", checkable);
+		query1.WhereCriteria->Set("name", comment->GetName());
 		query1.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
-		query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
-		/* Match the unique constraint. */
-		query1.WhereCriteria->Set("internal_comment_id", comment->GetLegacyId());
 	} else {
 		query1.Table = "commenthistory";
 		query1.Type = DbQueryInsert;
@@ -410,7 +408,6 @@ void DbEvents::RemoveCommentInternal(std::vector<DbQuery>& queries, const Commen
 	query1.WhereCriteria = new Dictionary();
 	query1.WhereCriteria->Set("object_id", checkable);
 	query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(entry_time));
-	query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
 	query1.WhereCriteria->Set("name", comment->GetName());
 	queries.push_back(query1);
 
@@ -431,7 +428,6 @@ void DbEvents::RemoveCommentInternal(std::vector<DbQuery>& queries, const Commen
 	query2.WhereCriteria = new Dictionary();
 	query2.WhereCriteria->Set("object_id", checkable);
 	query2.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(entry_time));
-	query2.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
 	query2.WhereCriteria->Set("name", comment->GetName());
 	queries.push_back(query2);
 }
@@ -521,10 +517,8 @@ void DbEvents::AddDowntimeInternal(std::vector<DbQuery>& queries, const Downtime
 
 		query1.WhereCriteria = new Dictionary();
 		query1.WhereCriteria->Set("object_id", checkable);
+		query1.WhereCriteria->Set("name", downtime->GetName());
 		query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
-		query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
-		/* Match the unique constraint. */
-		query1.WhereCriteria->Set("internal_downtime_id", downtime->GetLegacyId());
 	} else {
 		query1.Table = "downtimehistory";
 		query1.Type = DbQueryInsert;

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -409,7 +409,7 @@ void DbEvents::RemoveCommentInternal(std::vector<DbQuery>& queries, const Commen
 	query1.Category = DbCatComment;
 	query1.WhereCriteria = new Dictionary();
 	query1.WhereCriteria->Set("object_id", checkable);
-	query1.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
+	query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(entry_time));
 	query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
 	query1.WhereCriteria->Set("name", comment->GetName());
 	queries.push_back(query1);
@@ -430,7 +430,7 @@ void DbEvents::RemoveCommentInternal(std::vector<DbQuery>& queries, const Commen
 
 	query2.WhereCriteria = new Dictionary();
 	query2.WhereCriteria->Set("object_id", checkable);
-	query2.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
+	query2.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(entry_time));
 	query2.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
 	query2.WhereCriteria->Set("name", comment->GetName());
 	queries.push_back(query2);

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -376,7 +376,7 @@ void DbEvents::AddCommentInternal(std::vector<DbQuery>& queries, const Comment::
 		query1.WhereCriteria = new Dictionary();
 		query1.WhereCriteria->Set("object_id", checkable);
 		query1.WhereCriteria->Set("name", comment->GetName());
-		query1.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
+		query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(entry_time));
 	} else {
 		query1.Table = "commenthistory";
 		query1.Type = DbQueryInsert;

--- a/lib/db_ido_mysql/schema/mysql.sql
+++ b/lib/db_ido_mysql/schema/mysql.sql
@@ -1682,9 +1682,12 @@ CREATE INDEX idx_service_contacts_service_id on icinga_service_contacts(service_
 CREATE INDEX idx_host_contacts_host_id on icinga_host_contacts(host_id);
 
 -- #5458
-CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
-CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+create index idx_downtimehistory_remove on icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+create index idx_scheduleddowntime_remove on icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
 
+-- #5492
+CREATE INDEX idx_commenthistory_remove ON icinga_commenthistory (object_id, entry_time);
+CREATE INDEX idx_comments_remove ON icinga_comments (object_id, entry_time);
 
 -- -----------------------------------------
 -- set dbversion

--- a/lib/db_ido_mysql/schema/mysql.sql
+++ b/lib/db_ido_mysql/schema/mysql.sql
@@ -2,7 +2,7 @@
 -- mysql.sql
 -- DB definition for IDO MySQL
 --
--- Copyright (c) 2009-2016 Icinga Development Team (https://www.icinga.com/)
+-- Copyright (c) 2009-2017 Icinga Development Team (https://www.icinga.com/)
 --
 -- -- --------------------------------------------------------
 
@@ -1681,10 +1681,15 @@ CREATE INDEX idx_hostdependencies_dependent_host_object_id on icinga_hostdepende
 CREATE INDEX idx_service_contacts_service_id on icinga_service_contacts(service_id);
 CREATE INDEX idx_host_contacts_host_id on icinga_host_contacts(host_id);
 
+-- #5458
+CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+
+
 -- -----------------------------------------
 -- set dbversion
 -- -----------------------------------------
-INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.14.2', NOW(), NOW())
-ON DUPLICATE KEY UPDATE version='1.14.2', modify_time=NOW();
+INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.14.3', NOW(), NOW())
+ON DUPLICATE KEY UPDATE version='1.14.3', modify_time=NOW();
 
 

--- a/lib/db_ido_mysql/schema/upgrade/2.8.0.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.8.0.sql
@@ -9,6 +9,58 @@
 
 SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 
+-- --------------------------------------------------------
+-- Helper functions and procedures for DROP INDEX IF EXISTS
+-- --------------------------------------------------------
+
+DELIMITER //
+DROP FUNCTION IF EXISTS ido_index_exists //
+CREATE FUNCTION ido_index_exists(
+  f_table_name varchar(64),
+  f_index_name varchar(64)
+)
+  RETURNS BOOL
+  DETERMINISTIC
+  READS SQL DATA
+  BEGIN
+    DECLARE index_exists BOOL DEFAULT FALSE;
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = SCHEMA()
+              AND table_name = f_table_name
+              AND index_name = f_index_name
+    ) INTO index_exists;
+    RETURN index_exists;
+  END //
+
+DROP PROCEDURE IF EXISTS ido_drop_index_if_exists //
+CREATE PROCEDURE ido_drop_index_if_exists (
+  IN p_table_name varchar(64),
+  IN p_index_name varchar(64)
+)
+  DETERMINISTIC
+  MODIFIES SQL DATA
+  BEGIN
+    IF ido_index_exists(p_table_name, p_index_name)
+    THEN
+      SET @ido_drop_index_sql = CONCAT('ALTER TABLE `', SCHEMA(), '`.`', p_table_name, '` DROP INDEX `', p_index_name, '`');
+      PREPARE stmt FROM @ido_drop_index_sql;
+      EXECUTE stmt;
+      DEALLOCATE PREPARE stmt;
+      SET @ido_drop_index_sql = NULL;
+    END IF;
+  END //
+DELIMITER ;
+
+CALL ido_drop_index_if_exists('icinga_downtimehistory', 'instance_id');
+CALL ido_drop_index_if_exists('icinga_scheduleddowntime', 'instance_id');
+CALL ido_drop_index_if_exists('icinga_commenthistory', 'instance_id');
+CALL ido_drop_index_if_exists('icinga_comments', 'instance_id');
+
+DROP FUNCTION ido_index_exists;
+DROP PROCEDURE ido_drop_index_if_exists;
+
 -- -----------------------------------------
 -- #5458 IDO: Improve downtime removal/cancel
 -- -----------------------------------------

--- a/lib/db_ido_mysql/schema/upgrade/2.8.0.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.8.0.sql
@@ -17,6 +17,13 @@ CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, en
 CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
 
 -- -----------------------------------------
+-- #5492 IDO: Improve comment removal
+-- -----------------------------------------
+
+CREATE INDEX idx_commenthistory_remove ON icinga_commenthistory (object_id, entry_time);
+CREATE INDEX idx_comments_remove ON icinga_comments (object_id, entry_time);
+
+-- -----------------------------------------
 -- set dbversion
 -- -----------------------------------------
 INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.14.3', NOW(), NOW()) ON DUPLICATE KEY UPDATE version='1.14.3', modify_time=NOW();

--- a/lib/db_ido_mysql/schema/upgrade/2.8.0.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.8.0.sql
@@ -1,0 +1,22 @@
+-- -----------------------------------------
+-- upgrade path for Icinga 2.8.0
+--
+-- -----------------------------------------
+-- Copyright (c) 2017 Icinga Development Team (https://www.icinga.com)
+--
+-- Please check https://docs.icinga.com for upgrading information!
+-- -----------------------------------------
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+
+-- -----------------------------------------
+-- #5458 IDO: Improve downtime removal/cancel
+-- -----------------------------------------
+
+CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+
+-- -----------------------------------------
+-- set dbversion
+-- -----------------------------------------
+INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.14.3', NOW(), NOW()) ON DUPLICATE KEY UPDATE version='1.14.3', modify_time=NOW();

--- a/lib/db_ido_pgsql/schema/pgsql.sql
+++ b/lib/db_ido_pgsql/schema/pgsql.sql
@@ -2,7 +2,7 @@
 -- pgsql.sql
 -- DB definition for IDO Postgresql
 --
--- Copyright (c) 2009-2016 Icinga Development Team (https://www.icinga.com/)
+-- Copyright (c) 2009-2017 Icinga Development Team (https://www.icinga.com/)
 --
 -- --------------------------------------------------------
 
@@ -1721,9 +1721,13 @@ CREATE INDEX idx_hostdependencies_dependent_host_object_id on icinga_hostdepende
 CREATE INDEX idx_service_contacts_service_id on icinga_service_contacts(service_id);
 CREATE INDEX idx_host_contacts_host_id on icinga_host_contacts(host_id);
 
+-- #5458
+CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+
 -- -----------------------------------------
 -- set dbversion
 -- -----------------------------------------
 
-SELECT updatedbversion('1.14.2');
+SELECT updatedbversion('1.14.3');
 

--- a/lib/db_ido_pgsql/schema/pgsql.sql
+++ b/lib/db_ido_pgsql/schema/pgsql.sql
@@ -1725,6 +1725,10 @@ CREATE INDEX idx_host_contacts_host_id on icinga_host_contacts(host_id);
 CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
 CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
 
+-- #5492
+CREATE INDEX idx_commenthistory_remove ON icinga_commenthistory (object_id, entry_time);
+CREATE INDEX idx_comments_remove ON icinga_comments (object_id, entry_time);
+
 -- -----------------------------------------
 -- set dbversion
 -- -----------------------------------------

--- a/lib/db_ido_pgsql/schema/upgrade/2.8.0.sql
+++ b/lib/db_ido_pgsql/schema/upgrade/2.8.0.sql
@@ -1,0 +1,21 @@
+-- -----------------------------------------
+-- upgrade path for Icinga 2.8.0
+--
+-- -----------------------------------------
+-- Copyright (c) 2017 Icinga Development Team (https://www.icinga.com)
+--
+-- Please check https://docs.icinga.com for upgrading information!
+-- -----------------------------------------
+
+-- -----------------------------------------
+-- #5458 IDO: Improve downtime removal/cancel
+-- -----------------------------------------
+
+CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
+
+-- -----------------------------------------
+-- set dbversion
+-- -----------------------------------------
+
+SELECT updatedbversion('1.14.3');

--- a/lib/db_ido_pgsql/schema/upgrade/2.8.0.sql
+++ b/lib/db_ido_pgsql/schema/upgrade/2.8.0.sql
@@ -15,6 +15,12 @@ CREATE INDEX idx_downtimehistory_remove ON icinga_downtimehistory (object_id, en
 CREATE INDEX idx_scheduleddowntime_remove ON icinga_scheduleddowntime (object_id, entry_time, scheduled_start_time, scheduled_end_time);
 
 -- -----------------------------------------
+-- #5492
+-- -----------------------------------------
+
+CREATE INDEX idx_commenthistory_remove ON icinga_commenthistory (object_id, entry_time);
+CREATE INDEX idx_comments_remove ON icinga_comments (object_id, entry_time);
+-- -----------------------------------------
 -- set dbversion
 -- -----------------------------------------
 

--- a/lib/db_ido_pgsql/schema/upgrade/2.8.0.sql
+++ b/lib/db_ido_pgsql/schema/upgrade/2.8.0.sql
@@ -7,6 +7,11 @@
 -- Please check https://docs.icinga.com for upgrading information!
 -- -----------------------------------------
 
+ALTER TABLE icinga_downtimehistory DROP CONSTRAINT IF EXISTS UQ_downtimehistory;
+ALTER TABLE icinga_scheduleddowntime DROP CONSTRAINT IF EXISTS UQ_scheduleddowntime;
+ALTER TABLE icinga_commenthistory DROP CONSTRAINT IF EXISTS UQ_commenthistory;
+ALTER TABLE icinga_comments DROP CONSTRAINT IF EXISTS UQ_comments;
+
 -- -----------------------------------------
 -- #5458 IDO: Improve downtime removal/cancel
 -- -----------------------------------------


### PR DESCRIPTION
This adds an additional index to the downtimehistory and updates the
dbevents in a way that it uses that index.

Refs #5458 