### PR TITLE
Implement additional functions for printing values with LLDB/GDB

### DIFF
--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -82,6 +82,42 @@ extern "C" void dbg_eval(const char *text)
 	delete expr;
 }
 
+extern "C" void dbg_eval_with_value(const Value& value, const char *text)
+{
+	Expression *expr = NULL;
+
+	try {
+		ScriptFrame frame;
+		frame.Locals = new Dictionary();
+		frame.Locals->Set("arg", value);
+		expr = ConfigCompiler::CompileText("<dbg>", text);
+		Value result = Serialize(expr->Evaluate(frame), 0);
+		dbg_inspect_value(result);
+	} catch (const std::exception& ex) {
+		std::cout << "Error: " << DiagnosticInformation(ex) << "\n";
+	}
+
+	delete expr;
+}
+
+extern "C" void dbg_eval_with_object(Object *object, const char *text)
+{
+	Expression *expr = NULL;
+
+	try {
+		ScriptFrame frame;
+		frame.Locals = new Dictionary();
+		frame.Locals->Set("arg", object);
+		expr = ConfigCompiler::CompileText("<dbg>", text);
+		Value result = Serialize(expr->Evaluate(frame), 0);
+		dbg_inspect_value(result);
+	} catch (const std::exception& ex) {
+		std::cout << "Error: " << DiagnosticInformation(ex) << "\n";
+	}
+
+	delete expr;
+}
+
 void ConsoleCommand::BreakpointHandler(ScriptFrame& frame, ScriptError *ex, const DebugInfo& di)
 {
 	static boost::mutex mutex;


### PR DESCRIPTION
```
Process 5946 stopped
* thread #2, stop reason = breakpoint 1.3
    frame #0: 0x000000010705179e liblivestatus.2.7.0.dylib`icinga::LivestatusQuery::PrintCsvArray(this=0x0000000103ab0260, fp=0x00007000068f3178, array=0x00007000068f2ba8, level=0) const at livestatusquery.cpp:412
   409
   410 	void LivestatusQuery::PrintCsvArray(std::ostream& fp, const Array::Ptr& array, int level) const
   411 	{
-> 412 		bool first = true;
   413
   414 		ObjectLock olock(array);
   415 		for (const Value& value : array) {
(lldb) p *array.px
(icinga::Array) $9 = {
  icinga::Object = {
    m_References = 2
    m_Mutex = 4356521024
    m_LockOwner = 0x0000000000000000
  }
  m_Data = size=1 {
    [0] = {
      m_Value = {
        which_ = 3
        storage_ = {
          boost::detail::aligned_storage::aligned_storage_imp<24, 8> = {
            data_ = (buf = "\x18icingaadmins", align_ = boost::mpl::eval_if_c<false, boost::mpl::identity<boost::detail::max_align>, boost::type_with_alignment<8> >::type @ 0x0000000103a80a68)
          }
        }
      }
    }
  }
}
(lldb) p dbg_eval_with_object((icinga::Object *)array.px, "arg")
[ "icingaadmins" ]
(lldb) p dbg_eval_with_object((icinga::Object *)array.px, "arg[0]")
"icingaadmins"
(lldb)
```