### PR TITLE
Process: Fix JSON parsing error on process helper crash

### DIFF
--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -415,7 +415,7 @@ send_message:
 
 	ssize_t rc = recv(l_ProcessControlFD, buf, sizeof(buf), 0);
 
-	if (rc < 0)
+	if (rc <= 0)
 		return -1;
 
 	String jresponse = String(buf, buf + rc);
@@ -447,7 +447,7 @@ send_message:
 
 	ssize_t rc = recv(l_ProcessControlFD, buf, sizeof(buf), 0);
 
-	if (rc < 0)
+	if (rc <= 0)
 		return -1;
 
 	String jresponse = String(buf, buf + rc);
@@ -478,7 +478,7 @@ send_message:
 
 	ssize_t rc = recv(l_ProcessControlFD, buf, sizeof(buf), 0);
 
-	if (rc < 0)
+	if (rc <= 0)
 		return -1;
 
 	String jresponse = String(buf, buf + rc);


### PR DESCRIPTION
If the process helper crashes rc is equal to 0 and JsonDecode() will fail.

**One way to reproduce:**
- Add this to hosts.conf:
```
for (i in range(100)) {
    object Host "Test" + i {
        import "generic-host"
        address = "127.0.0.1"
    }
}
```
- Add `TasksMax=35` to icinga2.service
- Start Icinga with `systemctl start icinga2`

This should produce something like:
```
[2017-08-14 10:36:38 +0200] critical/checker: Exception occured while checking 'Test73': Error: Function call 'fork' failed with error code 11, 'Resource temporarily unavailable'

        (0) Executing check for object 'Test73'

[2017-08-14 10:36:38 +0200] critical/checker: Exception occured while checking 'Test25': Error: parse error: premature EOF

                     (right here) ------^
```