### PR TITLE
Fix duplicate variable in notification scripts

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)
 
 PROG="`basename $0`"
-HOSTNAME="`hostname`"
+ICINGA2HOST="`hostname`"
 MAILBIN="mail"
 
 if [ -z "`which $MAILBIN`" ] ; then
@@ -93,7 +93,7 @@ SUBJECT="[$NOTIFICATIONTYPE] Host $HOSTDISPLAYNAME is $HOSTSTATE!"
 
 ## Build the notification message
 NOTIFICATION_MESSAGE=`cat << EOF
-***** Host Monitoring on $HOSTNAME *****
+***** Host Monitoring on $ICINGA2HOST *****
 
 $HOSTDISPLAYNAME is $HOSTSTATE!
 

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)
 
 PROG="`basename $0`"
-HOSTNAME="`hostname`"
+ICINGA2HOST="`hostname`"
 MAILBIN="mail"
 
 if [ -z "`which $MAILBIN`" ] ; then
@@ -98,7 +98,7 @@ SUBJECT="[$NOTIFICATIONTYPE] $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICE
 
 ## Build the notification message
 NOTIFICATION_MESSAGE=`cat << EOF
-***** Service Monitoring on $HOSTNAME *****
+***** Service Monitoring on $ICINGA2HOST *****
 
 $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE!
 


### PR DESCRIPTION
This fixes a duplicate variable name in the notification scripts 

see https://monitoring-portal.org/index.php?thread/41563-doppelte-variablennutzung-hostname-in-neuen-mail-notifications-2-7/