### PR TITLE
Updates the install dependencies for Debian 9 'stretch'

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ libopenssl-devel on SLES12, libssl-dev on Debian, libressl-dev on Alpine)
 * GNU flex (flex) >= 2.5.35
 * recommended: libexecinfo on FreeBSD (automatically used when Icinga 2 is
                installed via port or package)
-* optional: MySQL (mysql-devel on RHEL, libmysqlclient-devel on SUSE, libmysqlclient-dev on Debian, mariadb-dev on Alpine);
+* optional: MySQL (mysql-devel on RHEL, libmysqlclient-devel on SUSE, libmysqlclient-dev until Debian 8 jessie / default-libmysqlclient-dev from Debian 9 stretch, mariadb-dev on Alpine);
             set CMake variable `ICINGA2_WITH_MYSQL` to `OFF` to disable this module
 * optional: PostgreSQL (postgresql-devel on RHEL, libpq-dev on Debian, postgresql-dev on Alpine); set CMake
             variable `ICINGA2_WITH_PGSQL` to `OFF` to disable this module


### PR DESCRIPTION
This updates the dependencies for an installtion on Debian 9 'stretch'. The package `libmysqlclient-dev` is no longer available on Debian 9, therefore we need to install the (meta) package `default-libmysqlclient-dev`, which points to `libmariadbclient-dev-compat` and is compatibl to `libmysqlclient-dev`.

See also https://packages.debian.org/search?keywords=libmysqlclient-dev and https://packages.debian.org/stretch/default-libmysqlclient-dev

The `default-libmysqlclient-dev` package is also available on jessie through the backports, but not on wheezy. So i guess it is best to stay on the `libmysqlclient-dev` package until Stretch.
