### PR TITLE
Reduce client disconnect frequency

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -318,9 +318,11 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 void JsonRpcConnection::CheckLiveness(void)
 {
-	if (m_Seen < Utility::GetTime() - 60 && (!m_Endpoint || !m_Endpoint->GetSyncing())) {
+	int offset = 300;
+
+	if (m_Seen < Utility::GetTime() - offset && (!m_Endpoint || !m_Endpoint->GetSyncing())) {
 		Log(LogInformation, "JsonRpcConnection")
-		    <<  "No messages for identity '" << m_Identity << "' have been received in the last 60 seconds.";
+		    <<  "No messages for identity '" << m_Identity << "' have been received in the last " << offset << " seconds.";
 		Disconnect();
 	}
 }


### PR DESCRIPTION
This has been added years ago when we had one thread per client.
This changed, but we shouldn't entirely remove this cleanup timer.

Instead, move the disconnect timer from 1m to 5m.

refs #5513