### PR TITLE
API: Add execution_{start,end} attribute to 'process-check-result' action

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -805,6 +805,8 @@ Send a `POST` request to the URL endpoint `/v1/actions/process-check-result`.
   performance\_data | string array | **Optional.** The performance data.
   check\_command    | string array | **Optional.** The first entry should be the check commands path, then one entry for each command line option followed by an entry for each of its argument.
   check\_source     | string       | **Optional.** Usually the name of the `command_endpoint`
+  execution\_start  | timestamp    | **Optional.** The timestamp where a script/process started its execution.
+  execution\_end    | timestamp    | **Optional.** The timestamp where a script/process ended its execution. This timestamp is used in features to determine e.g. the metric timestamp.
 
 In addition to these parameters a [filter](12-icinga2-api.md#icinga2-api-filters) must be provided. The valid types for this action are `Host` and `Service`.
 

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -103,6 +103,12 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 	cr->SetOutput(HttpUtility::GetLastParameter(params, "plugin_output"));
 	cr->SetState(state);
 
+	if (params->Contains("execution_start"))
+		cr->SetExecutionStart(HttpUtility::GetLastParameter(params, "execution_start"));
+
+	if (params->Contains("execution_end"))
+		cr->SetExecutionEnd(HttpUtility::GetLastParameter(params, "execution_end"));
+
 	cr->SetCheckSource(HttpUtility::GetLastParameter(params, "check_source"));
 	cr->SetPerformanceData(params->Get("performance_data"));
 	cr->SetCommand(params->Get("check_command"));


### PR DESCRIPTION
fixes #5002