### PR TITLE
Update checkable-check.cpp

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -266,8 +266,10 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 
 	bool is_volatile = GetVolatile();
 
+	if (old_StateType == StateTypeHard || is_volatile) {
+		SetLastHardStateRaw(old_state);
+	}
 	if (hardChange || is_volatile) {
-		SetLastHardStateRaw(new_state);
 		SetLastHardStateChange(now);
 	}
 


### PR DESCRIPTION
Changed logic how the last hard state is calculated.
Previously, the LastHardState was set to the current state when a hard state change was encountered, so the LastHardState always showed the current hard state.
Now, LastHardState always shows the last hard state, even when the current state is a hard one.
Fixes #5441 