### PR TITLE
Fixed URL encoding for SERVICENAME

### DIFF
--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -134,7 +134,7 @@ fi
 if [ -n "$ICINGAWEB2URL" ] ; then
   NOTIFICATION_MESSAGE="$NOTIFICATION_MESSAGE
 
-$ICINGAWEB2URL/monitoring/service/show?host=$HOSTNAME&service=$SERVICENAME"
+$ICINGAWEB2URL/monitoring/service/show?host=$HOSTNAME&service=${SERVICENAME// /%20}"
 fi
 
 ## Check whether verbose mode was enabled and log to syslog.


### PR DESCRIPTION
If the SERVICENAME containts whitespaces some mail clients will not recognize the URL.
This fix will encode whitespace to %20 in the SERVICENAME