### PR TITLE
ITL: Correct arguments for ipmi-sensor CheckCommand

### DIFF
--- a/itl/plugins-contrib.d/ipmi.conf
+++ b/itl/plugins-contrib.d/ipmi.conf
@@ -52,7 +52,7 @@ object CheckCommand "ipmi-sensor" {
 			description = "Limit sensors to query based on IPMI sensor type (seperated by comma)"
 		}
 		"-ST" = {
-			set_if = "$ipmi_sel_type$"
+			value = "$ipmi_sel_type$"
 			description = "Limit SEL entries to specific types. (seperated by comma)"
 		}
 		"-x" = {
@@ -60,11 +60,11 @@ object CheckCommand "ipmi-sensor" {
 			description = "Exclude sensor matching ipmi_sensor_id"
 		}
 		"-xT" = {
-			set_if = "$ipmi_exclude_sensor$"
+			value = "$ipmi_exclude_sensor$"
 			description = "Exclude sensors based on IPMI sensor type. (seperated by comma)"
 		}
 		"-xST" = {
-			set_if = "$ipmi_exclude_sel$"
+			value = "$ipmi_exclude_sel$"
 			description = "Exclude SEL entries of specific sensor types. (seperated by comma)"
 		}
 		"-i" = {


### PR DESCRIPTION
Replace the wrong "set_if" attribute and assign the value correctly.

fixes #5542