### PR TITLE
Exclude configfs from disk checks

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -307,7 +307,7 @@ disk\_ignore\_eregi\_path | **Optional.** Regular expression to ignore selected 
 disk\_ignore\_ereg\_path  | **Optional.** Regular expression to ignore selected path or partition. Multiple regular expression strings must be defined as array.
 disk\_timeout             | **Optional.** Seconds before connection times out (default: 10).
 disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB (default: MB).
-disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs".
+disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs".
 
 ### disk_smb <a id="plugin-check-command-disk-smb"></a>
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1499,7 +1499,7 @@ object CheckCommand "disk" {
 	vars.disk_wfree = "20%"
 	vars.disk_cfree = "10%"
 	vars.disk_megabytes = true
-	vars.disk_exclude_type = [ "none", "tmpfs", "sysfs", "proc", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs" ]
+	vars.disk_exclude_type = [ "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs" ]
 }
 
 object CheckCommand "disk_smb" {


### PR DESCRIPTION
Add "configfs" to vars.disk_exclude_type in itl/command-plugins.conf.

Otherwise on CentOS with SELinux enabled you get
```
/sys/kernel/config is not accessible: Permission denied
```