### PR TITLE
check_esxi_hardware.py with new --no-lcd parameter

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2922,6 +2922,7 @@ esxi_hardware_novolts   | **Optional.** Do not collect voltage performance data,
 esxi_hardware_nocurrent | **Optional.** Do not collect current performance data, when **esxi_hardware_perfdata** is set to true. Defaults to false.
 esxi_hardware_notemp    | **Optional.** Do not collect temperature performance data, when **esxi_hardware_perfdata** is set to true. Defaults to false.
 esxi_hardware_nofan     | **Optional.** Do not collect fan performance data, when **esxi_hardware_perfdata** is set to true. Defaults to false.
+esxi_hardware_nolcd     | **Optional.** Do not collect lcd/display status data. Defaults to false.
 
 #### VMware <a id="plugin-contrib-vmware"></a>
 

--- a/itl/plugins-contrib.d/virtualization.conf
+++ b/itl/plugins-contrib.d/virtualization.conf
@@ -73,6 +73,10 @@ object CheckCommand "esxi_hardware" {
 			set_if = "$esxi_hardware_nofan$"
 			description = "don't collect fan performance data"
 		}
+		"--no-lcd" = {
+			set_if = "$esxi_hardware_nolcd$"
+			description = "don't collect lcd/display status data"
+		}
 	}
 
 	vars.esxi_hardware_host = "$address$"
@@ -83,5 +87,6 @@ object CheckCommand "esxi_hardware" {
 	vars.esxi_hardware_nocurrent = false
 	vars.esxi_hardware_notemp = false
 	vars.esxi_hardware_nofan = false
+	vars.esxi_hardware_nolcd = false
 }
 


### PR DESCRIPTION
This adds the recently added "--no-lcd" parameter of check_esxi_hardware.py to the ITL CheckCommand and documentation.