### PR TITLE
ITL: Re-Add ssl_sni attribute for check_tcp

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -340,6 +340,10 @@ object CheckCommand "ssl" {
 				}
 			}
 		}}
+		"-N" = {
+			value = "$ssl_sni$"
+			description = "Enable SSL/TLS hostname extension support (SNI)"
+		}
 	}
 
 	vars.ssl_address = "$check_address$"


### PR DESCRIPTION
~This drops the `ssl_sni` attribute for the SSL CheckCommand.~ 

The attribute is removed from the ITL in a6978f7b63ff1113530d320cb19b84c46f80cbfa

This Re-Adds the `ssl_sni` attribute for check_tcp.

refs #5577