### PR TITLE
Fix possible race condition in ApiListener locking

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1309,37 +1309,37 @@ double ApiListener::CalculateZoneLag(const Endpoint::Ptr& endpoint)
 
 void ApiListener::AddAnonymousClient(const JsonRpcConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_AnonymousClientsLock);
 	m_AnonymousClients.insert(aclient);
 }
 
 void ApiListener::RemoveAnonymousClient(const JsonRpcConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_AnonymousClientsLock);
 	m_AnonymousClients.erase(aclient);
 }
 
 std::set<JsonRpcConnection::Ptr> ApiListener::GetAnonymousClients(void) const
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_AnonymousClientsLock);
 	return m_AnonymousClients;
 }
 
 void ApiListener::AddHttpClient(const HttpServerConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpClientsLock);
 	m_HttpClients.insert(aclient);
 }
 
 void ApiListener::RemoveHttpClient(const HttpServerConnection::Ptr& aclient)
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpClientsLock);
 	m_HttpClients.erase(aclient);
 }
 
 std::set<HttpServerConnection::Ptr> ApiListener::GetHttpClients(void) const
 {
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock(m_HttpClientsLock);
 	return m_HttpClients;
 }
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -115,8 +115,12 @@ protected:
 private:
 	boost::shared_ptr<SSL_CTX> m_SSLContext;
 	std::set<TcpSocket::Ptr> m_Servers;
+
+	mutable boost::mutex m_AnonymousClientsLock;
+	mutable boost::mutex m_HttpClientsLock;
 	std::set<JsonRpcConnection::Ptr> m_AnonymousClients;
 	std::set<HttpServerConnection::Ptr> m_HttpClients;
+
 	Timer::Ptr m_Timer;
 	Timer::Ptr m_ReconnectTimer;
 	Timer::Ptr m_AuthorityTimer;


### PR DESCRIPTION
This was split from #5416 and #5419.

More patches from #5419 are pending.

refs #5419
refs #5418
refs #5416

refs #5408
refs #5148
refs #5007
refs #4968
refs #4910