### PR TITLE
Fix where clause for non-matching {downtime,comment}history IDO database updates

### DIFF
--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -374,10 +374,10 @@ void DbEvents::AddCommentInternal(std::vector<DbQuery>& queries, const Comment::
 		fields1->Set("session_token", 0); /* DbConnection class fills in real ID */
 
 		query1.WhereCriteria = new Dictionary();
-		query1.WhereCriteria->Set("internal_comment_id", comment->GetLegacyId());
 		query1.WhereCriteria->Set("object_id", checkable);
 		query1.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
 		query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+		query1.WhereCriteria->Set("name", comment->GetName());
 	} else {
 		query1.Table = "commenthistory";
 		query1.Type = DbQueryInsert;
@@ -407,10 +407,10 @@ void DbEvents::RemoveCommentInternal(std::vector<DbQuery>& queries, const Commen
 	query1.Type = DbQueryDelete;
 	query1.Category = DbCatComment;
 	query1.WhereCriteria = new Dictionary();
-	query1.WhereCriteria->Set("internal_comment_id", comment->GetLegacyId());
 	query1.WhereCriteria->Set("object_id", checkable);
 	query1.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
 	query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+	query1.WhereCriteria->Set("name", comment->GetName());
 	queries.push_back(query1);
 
 	/* History - update deletion time for service/host */
@@ -428,10 +428,10 @@ void DbEvents::RemoveCommentInternal(std::vector<DbQuery>& queries, const Commen
 	query2.Fields = fields2;
 
 	query2.WhereCriteria = new Dictionary();
-	query2.WhereCriteria->Set("internal_comment_id", comment->GetLegacyId());
 	query2.WhereCriteria->Set("object_id", checkable);
 	query2.WhereCriteria->Set("comment_time", DbValue::FromTimestamp(entry_time));
 	query2.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+	query2.WhereCriteria->Set("name", comment->GetName());
 	queries.push_back(query2);
 }
 
@@ -483,7 +483,6 @@ void DbEvents::AddDowntimeInternal(std::vector<DbQuery>& queries, const Downtime
 		return;
 	}
 
-	fields1->Set("name", downtime->GetName());
 	fields1->Set("author_name", downtime->GetAuthor());
 	fields1->Set("comment_data", downtime->GetComment());
 	fields1->Set("triggered_by_id", Downtime::GetByName(downtime->GetTriggeredBy()));
@@ -491,6 +490,7 @@ void DbEvents::AddDowntimeInternal(std::vector<DbQuery>& queries, const Downtime
 	fields1->Set("duration", downtime->GetDuration());
 	fields1->Set("scheduled_start_time", DbValue::FromTimestamp(downtime->GetStartTime()));
 	fields1->Set("scheduled_end_time", DbValue::FromTimestamp(downtime->GetEndTime()));
+	fields1->Set("name", downtime->GetName());
 
 	/* flexible downtimes are started at trigger time */
 	if (downtime->GetFixed()) {
@@ -520,9 +520,11 @@ void DbEvents::AddDowntimeInternal(std::vector<DbQuery>& queries, const Downtime
 
 		query1.WhereCriteria = new Dictionary();
 		query1.WhereCriteria->Set("object_id", checkable);
-		query1.WhereCriteria->Set("internal_downtime_id", downtime->GetLegacyId());
 		query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
 		query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+		query1.WhereCriteria->Set("scheduled_start_time", DbValue::FromTimestamp(downtime->GetStartTime()));
+		query1.WhereCriteria->Set("scheduled_end_time", DbValue::FromTimestamp(downtime->GetEndTime()));
+		query1.WhereCriteria->Set("name", downtime->GetName());
 	} else {
 		query1.Table = "downtimehistory";
 		query1.Type = DbQueryInsert;
@@ -585,9 +587,11 @@ void DbEvents::RemoveDowntimeInternal(std::vector<DbQuery>& queries, const Downt
 	query1.Category = DbCatDowntime;
 	query1.WhereCriteria = new Dictionary();
 	query1.WhereCriteria->Set("object_id", checkable);
-	query1.WhereCriteria->Set("internal_downtime_id", downtime->GetLegacyId());
 	query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
 	query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+	query1.WhereCriteria->Set("scheduled_start_time", DbValue::FromTimestamp(downtime->GetStartTime()));
+	query1.WhereCriteria->Set("scheduled_end_time", DbValue::FromTimestamp(downtime->GetEndTime()));
+	query1.WhereCriteria->Set("name", downtime->GetName());
 	queries.push_back(query1);
 
 	/* History - update actual_end_time, was_cancelled for service (and host in case) */
@@ -612,9 +616,11 @@ void DbEvents::RemoveDowntimeInternal(std::vector<DbQuery>& queries, const Downt
 
 	query3.WhereCriteria = new Dictionary();
 	query3.WhereCriteria->Set("object_id", checkable);
-	query3.WhereCriteria->Set("internal_downtime_id", downtime->GetLegacyId());
 	query3.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
 	query3.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+	query3.WhereCriteria->Set("scheduled_start_time", DbValue::FromTimestamp(downtime->GetStartTime()));
+	query3.WhereCriteria->Set("scheduled_end_time", DbValue::FromTimestamp(downtime->GetEndTime()));
+	query3.WhereCriteria->Set("name", downtime->GetName());
 
 	queries.push_back(query3);
 
@@ -673,7 +679,11 @@ void DbEvents::TriggerDowntime(const Downtime::Ptr& downtime)
 
 	query1.WhereCriteria = new Dictionary();
 	query1.WhereCriteria->Set("object_id", checkable);
-	query1.WhereCriteria->Set("internal_downtime_id", downtime->GetLegacyId());
+	query1.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
+	query1.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+	query1.WhereCriteria->Set("scheduled_start_time", DbValue::FromTimestamp(downtime->GetStartTime()));
+	query1.WhereCriteria->Set("scheduled_end_time", DbValue::FromTimestamp(downtime->GetEndTime()));
+	query1.WhereCriteria->Set("name", downtime->GetName());
 
 	query1.Fields = fields1;
 	DbObject::OnQuery(query1);
@@ -692,13 +702,7 @@ void DbEvents::TriggerDowntime(const Downtime::Ptr& downtime)
 	fields3->Set("trigger_time", DbValue::FromTimestamp(downtime->GetTriggerTime()));
 	query3.Fields = fields3;
 
-	query3.WhereCriteria = new Dictionary();
-	query3.WhereCriteria->Set("object_id", checkable);
-	query3.WhereCriteria->Set("internal_downtime_id", downtime->GetLegacyId());
-	query3.WhereCriteria->Set("entry_time", DbValue::FromTimestamp(downtime->GetEntryTime()));
-	query3.WhereCriteria->Set("scheduled_start_time", DbValue::FromTimestamp(downtime->GetStartTime()));
-	query3.WhereCriteria->Set("scheduled_end_time", DbValue::FromTimestamp(downtime->GetEndTime()));
-	query3.WhereCriteria->Set("instance_id", 0); /* DbConnection class fills in real ID */
+	query3.WhereCriteria = query1.WhereCriteria;
 
 	DbObject::OnQuery(query3);
 


### PR DESCRIPTION
This is our partial fix for 2.7.1 full fix with new index will come in 2.8.0. See #5485

fixes #5458 #5492 
