### PR TITLE
Silence log level for configuration file updates

### DIFF
--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -99,7 +99,7 @@ bool ApiListener::UpdateConfigDir(const ConfigDirInformation& oldConfigInfo, con
 
 	/* skip update if our configuration files are more recent */
 	if (oldTimestamp >= newTimestamp) {
-		Log(LogInformation, "ApiListener")
+		Log(LogNotice, "ApiListener")
 		    << "Our configuration is more recent than the received configuration update."
 		    << " Ignoring configuration file update for path '" << configDir << "'. Current timestamp '"
 		    << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", oldTimestamp) << "' ("


### PR DESCRIPTION
This only helps with debugging the configuration sync, but seems
to be highlighted quite often in default configurations (where
the timestamp is equal).

refs #5566