### PR TITLE
Ensure that the cache directory always is set and add a note to upgrading docs

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -24,6 +24,22 @@ In case are having troubles with OpenSSL 1.1.0 and the
 public CA certificates, please read [this advisory](https://www.icinga.com/2017/08/30/advisory-for-ssl-problems-with-leading-zeros-on-openssl-1-1-0/)
 and check the [troubleshooting chapter](15-troubleshooting.md#troubleshooting).
 
+If Icinga 2 fails to start with an empty reference to `$ICINGA2_CACHE_DIR`
+ensure to set it inside `/etc/sysconfig/icinga2` (RHEL) or `/etc/default/icinga2` (Debian).
+
+RPM packages will put a file called `/etc/sysconfig/icinga2.rpmnew`
+if you have modified the original file.
+
+Example on CentOS 7:
+
+```
+vim /etc/sysconfig/icinga2
+
+ICINGA2_CACHE_DIR=/var/cache/icinga2
+
+systemctl restart icinga2
+```
+
 ## Upgrading the MySQL database <a id="upgrading-mysql-db"></a>
 
 If you're upgrading an existing Icinga 2 instance, you should check the

--- a/etc/initsystem/prepare-dirs
+++ b/etc/initsystem/prepare-dirs
@@ -52,6 +52,10 @@ if type restorecon >/dev/null 2>&1; then
 fi
 chmod 2750 $ICINGA2_RUN_DIR/icinga2/cmd
 
+# Add a fallback if the user did not specify this directory in the sysconfig file
+if [ -z "$ICINGA2_CACHE_DIR" ]; then
+	ICINGA2_CACHE_DIR=$ICINGA2_STATE_DIR/cache/icinga2
+fi
 mkdir -p $ICINGA2_CACHE_DIR
 chown $ICINGA2_USER:$ICINGA2_GROUP $ICINGA2_CACHE_DIR
 chmod 750 $ICINGA2_CACHE_DIR


### PR DESCRIPTION
Thanks @dgoetz 

## Description

If the user modified `/etc/sysconfig/icinga2` then the ICINGA2_CACHE_DIR variable might not be set. prepare-dirs fails with an ugly error.

### Steps to reproduce

```
docker run -ti centos:latest bash

yum -y install https://packages.icinga.com/epel/icinga-rpm-release-7-latest.noarch.rpm
yum -y install vim wget curl icinga2

vim /etc/sysconfig/icinga2

#ICINGA2_CACHE_DIR=$ICINGA2_STATE_DIR/cache/icinga2

/usr/lib/icinga2/prepare-dirs /etc/sysconfig/icinga2
mkdir: missing operand
Try 'mkdir --help' for more information.
chown: missing operand after 'icinga:icinga'
Try 'chown --help' for more information.
chmod: missing operand after '750'
Try 'chmod --help' for more information.
```

## Solution

Add a fallback to the default value in prepare-dirs.

Add a note to upgrading docs that this variable must be set inside `/etc/sysconfig/icinga2`.