### PR TITLE
Command definition enhacements

### DIFF
--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -253,6 +253,10 @@ object CheckCommand "snmp-interface" {
 			set_if = "$snmp_interface_64bit$"
 			description = "Use 64 bits counters instead of the standard counters when checking bandwidth & performance data for interface >= 1Gbps"
 		}
+                "-2" = {
+                        set_if = "$snmp_interface_v2$"
+                        description = "Use SNMP version 2"
+                }
 		"-e" = {
 			set_if = "$snmp_interface_errors$"
 			description = "Add error & discard to Perfparse output"
@@ -292,6 +296,7 @@ object CheckCommand "snmp-interface" {
 	vars.snmp_interface_kbits = true
 	vars.snmp_interface_megabytes = true
 	vars.snmp_interface_64bit = false
+        vars.snmp_interface_v2 = false
 	vars.snmp_interface_errors = true
 	vars.snmp_interface_noregexp = false
 	vars.snmp_interface_delta = 300

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -580,7 +580,6 @@ object CheckCommand "http" {
 		}
 	}
 
-	vars.http_address = "$check_address$"
 	vars.http_ssl = false
 	vars.http_sni = false
 	vars.http_linespan = false


### PR DESCRIPTION
Plugin Command Enhancements to support SNMP v2 for network interface monitoring, and better support for http virtual hosts,

Every time icinga2 package updates on my server I have to make these 2 changes for my monitors to work again.

First is SNMP v2 support for network interfaces, which is required to support the 64bit parameter already included.  This one looks to just be an oversight. 

The second change is removing the default IP address for an http check.  When using check_http for virtual hosts, the IP address parameter is also always added and overrides the vhost DNS name.  This makes all vhost monitors fail after a package upgrade with `apt-get` or `yum`  Removing the default will force the user to specify either a vhost or IP address for an http montitor, but I think this is better than breaking all vhost montiors by default. 

Thanks.