### PR TITLE
Improve documentation and systemd config on TaskMax

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -272,14 +272,24 @@ components (e.g. for check execution, notifications, etc.):
     [2016-12-08 16:44:25 +0100] information/ConfigItem: Committing config item(s).
     ...
 
+### Init Script
+
 Icinga 2 can be started as a daemon using the provided init script:
 
     # /etc/init.d/icinga2
     Usage: /etc/init.d/icinga2 {start|stop|restart|reload|checkconfig|status}
 
-If your distribution uses systemd:
+### Systemd
+
+If your distribution uses Systemd:
 
     # systemctl {start|stop|reload|status|enable|disable} icinga2
+
+In case the distribution is running Systemd >227, you'll also
+need to package and install the `etc/initsystem/icinga2.service.limits.conf`
+file into `/etc/systemd/system/icinga2.service.d`.
+
+### openrc
 
 Or if your distribution uses openrc (like Alpine):
 

--- a/doc/02-getting-started.md
+++ b/doc/02-getting-started.md
@@ -169,6 +169,7 @@ By default Icinga 2 uses the following files and directories:
   ----------------------------------------------|------------------------------------
   /etc/icinga2                        		| Contains Icinga 2 configuration files.
   /usr/lib/systemd/system/icinga2.service 	| The Icinga 2 Systemd service file on systems using Systemd.
+  /etc/systemd/system/icinga2.service.d/limits.conf | On distributions with Systemd >227, additional service limits are required.
   /etc/init.d/icinga2                 		| The Icinga 2 init script on systems using SysVinit or OpenRC
   /usr/sbin/icinga2                   		| Shell wrapper for the Icinga 2 binary.
   /usr/lib\*/icinga2				| Libraries and the Icinga 2 binary (use `find /usr -type f -name icinga2` to locate the binary path).
@@ -295,12 +296,12 @@ By default the Icinga 2 daemon is running as `icinga` user and group
 using the init script. Using Debian packages the user and group are set to
 `nagios` for historical reasons.
 
-### systemd Service <a id="systemd-service"></a>
+### Systemd Service <a id="systemd-service"></a>
 
-Some distributions (e.g. Fedora, openSUSE and RHEL/CentOS 7) use systemd. The
-Icinga 2 packages automatically install the necessary systemd unit files.
+Some distributions (e.g. Fedora, openSUSE and RHEL/CentOS 7) use Systemd. The
+Icinga 2 packages automatically install the necessary Systemd unit files.
 
-The Icinga 2 systemd service can be (re-)started, reloaded, stopped and also
+The Icinga 2 Systemd service can be (re-)started, reloaded, stopped and also
 queried for its current status.
 
     # systemctl status icinga2
@@ -342,6 +343,11 @@ Examples:
 
 If you're stuck with configuration errors, you can manually invoke the
 [configuration validation](11-cli-commands.md#config-validation).
+
+> **Tip**
+>
+> If you are running into fork errors with Systemd enabled distributions,
+> please check the [troubleshooting chapter](15-troubleshooting.md#check-fork-errors).
 
 ### FreeBSD <a id="running-icinga2-freebsd"></a>
 

--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -10,8 +10,17 @@ ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/icinga2 daemon -d -e ${ICINGA2_ERROR_LOG}
 PIDFile=@ICINGA2_RUNDIR@/icinga2/icinga2.pid
 ExecReload=@CMAKE_INSTALL_PREFIX@/lib/icinga2/safe-reload @ICINGA2_SYSCONFIGFILE@
 TimeoutStartSec=30m
-# Introduced in Systemd 226, defaults to 512. Icinga 2 requires more tasks (checks, notifications, etc.)
-DefaultTasksMax=infinity
+
+# Systemd >228 enforces a lower process number for services.
+# Depending on the distribution and Systemd version, this must
+# be explicitly raised. Packages will set the needed values
+# into /etc/systemd/system/icinga2.service.d/limits.conf
+#
+# Please check the troubleshooting documentation for further details.
+# The values below can be used as examples for customized service files.
+
+#TasksMax=infinity
+#LimitNPROC=62883
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/initsystem/icinga2.service.limits.conf
+++ b/etc/initsystem/icinga2.service.limits.conf
@@ -1,0 +1,9 @@
+# Icinga 2 sets Systemd default values to extend OS defaults.
+#
+# Please check the troubleshooting documentation for further details.
+
+[Service]
+TasksMax=infinity
+
+# Uncomment this setting in case of further problems.
+#LimitNPROC=62883


### PR DESCRIPTION
This also disables setting a value by default.

Packaging should decide to install the config file:
`/etc/systemd/system/icinga2.service.d`

Older systemd versions will throw warnings.

fixes #5611