### PR TITLE
Fixed missing include statement in unit tests

### DIFF
--- a/test/icinga-checkresult.cpp
+++ b/test/icinga-checkresult.cpp
@@ -19,6 +19,7 @@
 
 #include "icinga/host.hpp"
 #include <BoostTestTargetConfig.h>
+#include <iostream>
 
 using namespace icinga;
 


### PR DESCRIPTION
This adds the missing include statement to icinga-checkresult.cpp

fixes #5613