### PR TITLE
Fixed missing include statement in unit test

### DIFF
--- a/test/icinga-notification.cpp
+++ b/test/icinga-notification.cpp
@@ -19,6 +19,7 @@
 
 #include "icinga/notification.hpp"
 #include <BoostTestTargetConfig.h>
+#include <iostream>
 
 using namespace icinga;
 


### PR DESCRIPTION
This adds the missing iostream include to the notification unit test.

refs #5613