### PR TITLE
Fixed doc formatting

### DIFF
--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -1873,7 +1873,7 @@ add a dependency which prevents notifications for all other failing services:
 
       assign where host.vars.client_endpoint
       ignore where service.name == "child-health"
-   }
+    }
 
 ### Pin Checks in a Zone <a id="distributed-monitoring-pin-checks-zone"></a>
 


### PR DESCRIPTION
This fixes a minor doc formatting bug, where one closing bracket is outside the code tag.

![img2017-10-19](https://user-images.githubusercontent.com/18580278/31765008-41b31f58-b4c3-11e7-8769-a2c5ff89a894.PNG)
