### PR TITLE
Include default global zones during node wizard/setup

### DIFF
--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -159,7 +159,12 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 	/* write zones.conf and update with zone + endpoint information */
 	Log(LogInformation, "cli", "Generating zone and object configuration.");
 
-	NodeUtility::GenerateNodeMasterIcingaConfig();
+	std::vector<String> globalZones;
+
+	globalZones.push_back("global-templates");
+	globalZones.push_back("director-global");
+
+	NodeUtility::GenerateNodeMasterIcingaConfig(globalZones);
 
 	/* update the ApiListener config - SetupMaster() will always enable it */
 	Log(LogInformation, "cli", "Updating the APIListener feature.");
@@ -419,7 +424,12 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 
 	Log(LogInformation, "cli", "Generating zone and object configuration.");
 
-	NodeUtility::GenerateNodeIcingaConfig(vm["endpoint"].as<std::vector<std::string> >());
+	std::vector<String> globalZones;
+
+	globalZones.push_back("global-templates");
+	globalZones.push_back("director-global");
+
+	NodeUtility::GenerateNodeIcingaConfig(vm["endpoint"].as<std::vector<std::string> >(), globalZones);
 
 	/* update constants.conf with NodeName = CN */
 	if (cn != Utility::GetFQDN()) {

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -47,7 +47,7 @@ using namespace icinga;
  * Node Setup helpers
  */
 
-int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints)
+int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints, const std::vector<String>& globalZones)
 {
 	Array::Ptr my_config = new Array();
 
@@ -111,6 +111,16 @@ int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoi
 
 	my_zone->Set("endpoints", my_zone_members);
 
+	for (const String& globalzone : globalZones) {
+		Dictionary::Ptr myGlobalZone = new Dictionary();
+
+		myGlobalZone->Set("__name", globalzone);
+		myGlobalZone->Set("__type", "Zone");
+		myGlobalZone->Set("global", true);
+
+		my_config->Add(myGlobalZone);
+    }
+
 	/* store the local config */
 	my_config->Add(my_endpoint);
 	my_config->Add(my_zone);
@@ -123,13 +133,14 @@ int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoi
 	return 0;
 }
 
-int NodeUtility::GenerateNodeMasterIcingaConfig(void)
+int NodeUtility::GenerateNodeMasterIcingaConfig(const std::vector<String>& globalZones)
 {
 	Array::Ptr my_config = new Array();
 
 	/* store the local generated node master configuration */
 	Dictionary::Ptr my_master_endpoint = new Dictionary();
 	Dictionary::Ptr my_master_zone = new Dictionary();
+
 	Array::Ptr my_master_zone_members = new Array();
 
 	my_master_endpoint->Set("__name", new ConfigIdentifier("NodeName"));
@@ -144,6 +155,16 @@ int NodeUtility::GenerateNodeMasterIcingaConfig(void)
 	/* store the local config */
 	my_config->Add(my_master_endpoint);
 	my_config->Add(my_master_zone);
+
+	for (const String& globalzone : globalZones) {
+		Dictionary::Ptr myGlobalZone = new Dictionary();
+
+		myGlobalZone->Set("__name", globalzone);
+		myGlobalZone->Set("__type", "Zone");
+		myGlobalZone->Set("global", true);
+
+		my_config->Add(myGlobalZone);
+	}
 
 	/* write the newly generated configuration */
 	String zones_path = Application::GetSysconfDir() + "/icinga2/zones.conf";

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -44,8 +44,8 @@ public:
 	static void UpdateConstant(const String& name, const String& value);
 
 	/* node setup helpers */
-	static int GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints);
-	static int GenerateNodeMasterIcingaConfig(void);
+	static int GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints, const std::vector<String>& globalZones);
+	static int GenerateNodeMasterIcingaConfig(const std::vector<String>& globalZones);
 
 private:
 	NodeUtility(void);

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -498,7 +498,12 @@ wizard_ticket:
 	/* apilistener config */
 	Log(LogInformation, "cli", "Generating local zones.conf.");
 
-	NodeUtility::GenerateNodeIcingaConfig(endpoints);
+	std::vector<String> globalZones;
+
+	globalZones.push_back("global-templates");
+	globalZones.push_back("director-global");
+
+	NodeUtility::GenerateNodeIcingaConfig(endpoints, globalZones);
 
 	if (cn != Utility::GetFQDN()) {
 		Log(LogWarning, "cli")
@@ -594,7 +599,12 @@ int NodeWizardCommand::MasterSetup(void) const
 	else
 		std::cout << "'api' feature already enabled.\n";
 
-	NodeUtility::GenerateNodeMasterIcingaConfig();
+	std::vector<String> globalZones;
+
+	globalZones.push_back("global-templates");
+	globalZones.push_back("director-global");
+
+	NodeUtility::GenerateNodeMasterIcingaConfig(globalZones);
 
 	/* apilistener config */
 	std::cout << ConsoleColorTag(Console_Bold)


### PR DESCRIPTION
This changes the `GenerateNodeMasterIcingaConfig` and `GenerateNodeIcingaConfig` functions inside the `nodeutillity` class to the effect, that the default global zones `global-templates` and `director-global` will be written to the generated zones.conf that is created during the node wizard/setup.

fixes #5707 
