### PR TITLE
add bogus zero reply in livestatus when aggregate and non matching filter

### DIFF
--- a/lib/livestatus/livestatusquery.cpp
+++ b/lib/livestatus/livestatusquery.cpp
@@ -571,6 +571,17 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 
 			AppendResultRow(result, row, first_row);
 		}
+
+		/* add a bogus zero value if aggregated is empty*/
+		if (allStats.empty()) {
+			Array::Ptr row = new Array();
+
+			for (size_t i = 1; i <= m_Aggregators.size(); i++) {
+				row->Add(0);
+			}
+
+			AppendResultRow(result, row, first_row);
+		}
 	}
 
 	EndResultSet(result);


### PR DESCRIPTION
This should fix issue #5626, mildly tested on debian stretch against following queries

shurely matching

------------------------
GET services
ResponseHeader: fixed16
OutputFormat: json
Stats: sum percent_state_change
Stats: min percent_state_change
Stats: max percent_state_change

-------------------------

shurely not matching

-------------------------
GET services
ResponseHeader: fixed16
OutputFormat: json
Filter: host_alias = nonexistinghostalias
Stats: sum percent_state_change
Stats: min percent_state_change
Stats: max percent_state_change

--------------------------

Original issue query not matching in my test case

---------------------------

GET services
ResponseHeader: fixed16
OutputFormat: json
Filter: check_type = 1
Filter: has_been_checked = 1
Stats: sum percent_state_change
Stats: min percent_state_change
Stats: max percent_state_change