### PR TITLE
add order tags to disk check

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1399,10 +1399,12 @@ object CheckCommand "disk" {
 		"-W" = {
 			value = "$disk_inode_wfree$"
 			description = "Exit with WARNING status if less than PERCENT of inode space is free"
+			order = -3
 		}
 		"-K" = {
 			value = "$disk_inode_cfree$"
 			description = "Exit with CRITICAL status if less than PERCENT of inode space is free"
+			order = -3
 		}
 		"-p" = {
 			value = "$disk_partitions$"
@@ -1466,6 +1468,7 @@ object CheckCommand "disk" {
 		"-A" = {
 			set_if = "$disk_all$"
 			description = "Explicitly select all paths. This is equivalent to -R .*"
+			order = 1
 		}
 		"-R" = {
 			value = "$disk_eregi_path$"


### PR DESCRIPTION
Ensure argument order for inode parameters and "all"-flag is the same as for other disk-free options and partition-parameter. As a result the inode-checks should actually work with the "disk_all" (-A) flag.