### PR TITLE
Fix check_service not working with names

### DIFF
--- a/plugins/check_service.cpp
+++ b/plugins/check_service.cpp
@@ -38,7 +38,7 @@ INT wmain(INT argc, WCHAR **argv)
 	if (ret != -1)
 		return ret;
 
-	if (vm.count("description"));
+	if (vm.count("description"))
 		printInfo.service = GetServiceByDescription(vm["service"].as<std::wstring>());
 
 	if (printInfo.service.empty()) {


### PR DESCRIPTION
This change fixes check_service not working correctly when using
descriptions instead of names.
This should probably be in 2.8.0