### PR TITLE
Correct node wizard output formatting

### DIFF
--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -340,7 +340,9 @@ wizard_ticket:
 	/* Check whether we can connect to the parent node and fetch the client and CA certificate. */
 	if (connectToParent) {
 		std::cout << ConsoleColorTag(Console_Bold)
-		    << "\nPlease specify the request ticket generated on your Icinga 2 master (optional)."
+		    << "\nPlease specify the request ticket generated on your Icinga 2 master "
+		    << ConsoleColorTag(Console_Normal) << "(optional)"
+		    << ConsoleColorTag(Console_Bold) << "."
 		    << ConsoleColorTag(Console_Normal) << "\n"
 		    << " (Hint: # icinga2 pki ticket --cn '" << cn << "'): ";
 
@@ -408,17 +410,20 @@ wizard_ticket:
 
 	/* apilistener config */
 	std::cout << ConsoleColorTag(Console_Bold)
-	    << "\nPlease specify the API bind host/port"
-	    << ConsoleColorTag(Console_Normal) << " (optional):\n"
-	    << ConsoleColorTag(Console_Bold) << "Bind Host"
-	    << ConsoleColorTag(Console_Normal) << " []: ";
+	    << "Please specify the API bind host/port "
+	    << ConsoleColorTag(Console_Normal) << "(optional)"
+	    << ConsoleColorTag(Console_Bold) << ":\n";
+
+	std::cout << ConsoleColorTag(Console_Bold)
+	    << "Bind Host" << ConsoleColorTag(Console_Normal) << " []: ";
 
 	std::getline(std::cin, answer);
 
 	String bindHost = answer;
 	bindHost = bindHost.Trim();
 
-	std::cout << "Bind Port []: ";
+	std::cout << ConsoleColorTag(Console_Bold)
+	    << "Bind Port" << ConsoleColorTag(Console_Normal) << " []: ";
 
 	std::getline(std::cin, answer);
 
@@ -608,7 +613,10 @@ int NodeWizardCommand::MasterSetup(void) const
 
 	/* apilistener config */
 	std::cout << ConsoleColorTag(Console_Bold)
-	    << "Please specify the API bind host/port (optional):\n";
+	    << "Please specify the API bind host/port "
+	    << ConsoleColorTag(Console_Normal) << "(optional)"
+	    << ConsoleColorTag(Console_Bold) << ":\n";
+
 	std::cout << ConsoleColorTag(Console_Bold)
 	    << "Bind Host" << ConsoleColorTag(Console_Normal) << " []: ";
 


### PR DESCRIPTION
This removes a few formatting/styling differences from the node wizard cli output.

**Example:**
Old
![old](https://user-images.githubusercontent.com/9316896/32537577-64c97aa0-c463-11e7-9afc-2b2d5d9250e4.png)
New
![new](https://user-images.githubusercontent.com/9316896/32537607-7dfc43cc-c463-11e7-9a5c-d55e482200f5.png)

