### PR TITLE
Fix broken links inside the documentation

### DIFF
--- a/doc/02-getting-started.md
+++ b/doc/02-getting-started.md
@@ -863,10 +863,10 @@ Alpine Linux:
 
 ### Installing Icinga Web 2 <a id="installing-icingaweb2"></a>
 
-Please consult the [installation documentation](https://github.com/Icinga/icingaweb2/blob/master/doc/02-Installation.md)
+Please consult the [installation documentation](https://www.icinga.com/docs/icingaweb2/latest/doc/02-Installation/)
 for further instructions on how to install Icinga Web 2.
 
-The Icinga 2 API can be defined as [command transport](https://github.com/Icinga/icingaweb2/blob/master/modules/monitoring/doc/commandtransports.md)
+The Icinga 2 API can be defined as [command transport](https://www.icinga.com/docs/icingaweb2/latest/modules/monitoring/doc/05-Command-Transports/)
 in Icinga Web 2 >= 2.4.
 
 ## Addons <a id="install-addons"></a>


### PR DESCRIPTION
This replaces the broken link to the command transport chapter inside the Icinga
Web 2 documentation, besides that this also updates the link to the Icinga Web 2
installation documentation to the official page on icinga.com.

Previously the links pointed to the documentation that was found inside the Icinga Web 2 GitHub  repository, now the links point to the corresponding documentation page on icinga.com
