### PR TITLE
Rename ElasticWriter to ElasticsearchWriter

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -470,17 +470,17 @@ Runtime Attributes:
   triggered\_by             | Object name           | The name of the downtime this downtime was triggered by.
 
 
-## ElasticWriter <a id="objecttype-elasticwriter"></a>
+## ElasticsearchWriter <a id="objecttype-elasticsearchwriter"></a>
 
 Writes check result metrics and performance data to an Elasticsearch instance.
-This configuration object is available as [elastic feature](14-features.md#elastic-writer).
+This configuration object is available as [elasticsearch feature](14-features.md#elasticsearch-writer).
 
 Example:
 
 ```
 library "perfdata"
 
-object ElasticWriter "elastic" {
+object ElasticsearchWriter "elasticsearch" {
   host = "127.0.0.1"
   port = 9200
   index = "icinga2"

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -338,7 +338,7 @@ More integrations:
 * [Logstash output](https://github.com/Icinga/logstash-output-icinga) for the Icinga 2 API.
 * [Logstash Grok Pattern](https://github.com/Icinga/logstash-grok-pattern) for Icinga 2 logs.
 
-#### Elastic Writer <a id="elastic-writer"></a>
+#### Elasticsearch Writer <a id="elasticsearch-writer"></a>
 
 This feature forwards check results, state changes and notification events
 to an [Elasticsearch](https://www.elastic.co/products/elasticsearch) installation over its HTTP API.
@@ -352,13 +352,13 @@ The check results include parsed performance data metrics if enabled.
 Enable the feature and restart Icinga 2.
 
 ```
-# icinga2 feature enable elastic
+# icinga2 feature enable elasticsearch
 ```
 
 The default configuration expects an Elasticsearch instance running on `localhost` on port `9200
  and writes to an index called `icinga2`.
 
-More configuration details can be found [here](09-object-types.md#objecttype-elasticwriter).
+More configuration details can be found [here](09-object-types.md#objecttype-elasticsearchwriter).
 
 #### Current Elasticsearch Schema <a id="elastic-writer-schema"></a>
 

--- a/etc/icinga2/features-available/elasticsearch.conf
+++ b/etc/icinga2/features-available/elasticsearch.conf
@@ -1,6 +1,6 @@
 library "perfdata"
 
-object ElasticWriter "elastic" {
+object ElasticsearchWriter "elasticsearch" {
   //host = "127.0.0.1"
   //port = 9200
   //index = "icinga2"

--- a/lib/perfdata/CMakeLists.txt
+++ b/lib/perfdata/CMakeLists.txt
@@ -18,12 +18,12 @@
 mkclass_target(gelfwriter.ti gelfwriter.tcpp gelfwriter.thpp)
 mkclass_target(graphitewriter.ti graphitewriter.tcpp graphitewriter.thpp)
 mkclass_target(influxdbwriter.ti influxdbwriter.tcpp influxdbwriter.thpp)
-mkclass_target(elasticwriter.ti elasticwriter.tcpp elasticwriter.thpp)
+mkclass_target(elasticsearchwriter.ti elasticsearchwriter.tcpp elasticsearchwriter.thpp)
 mkclass_target(opentsdbwriter.ti opentsdbwriter.tcpp opentsdbwriter.thpp)
 mkclass_target(perfdatawriter.ti perfdatawriter.tcpp perfdatawriter.thpp)
 
 set(perfdata_SOURCES
-  gelfwriter.cpp gelfwriter.thpp graphitewriter.cpp graphitewriter.thpp influxdbwriter.cpp influxdbwriter.thpp elasticwriter.cpp elasticwriter.thpp opentsdbwriter.cpp opentsdbwriter.thpp perfdatawriter.cpp perfdatawriter.thpp
+  gelfwriter.cpp gelfwriter.thpp graphitewriter.cpp graphitewriter.thpp influxdbwriter.cpp influxdbwriter.thpp elasticsearchwriter.cpp elasticsearchwriter.thpp opentsdbwriter.cpp opentsdbwriter.thpp perfdatawriter.cpp perfdatawriter.thpp
 )
 
 if(ICINGA2_UNITY_BUILD)
@@ -58,7 +58,7 @@ install_if_not_exists(
 )
 
 install_if_not_exists(
-  ${PROJECT_SOURCE_DIR}/etc/icinga2/features-available/elastic.conf
+  ${PROJECT_SOURCE_DIR}/etc/icinga2/features-available/elasticsearch.conf
   ${CMAKE_INSTALL_SYSCONFDIR}/icinga2/features-available
 )
 

--- a/lib/perfdata/elasticsearchwriter.hpp
+++ b/lib/perfdata/elasticsearchwriter.hpp
@@ -17,10 +17,10 @@
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
  ******************************************************************************/
 
-#ifndef ELASTICWRITER_H
-#define ELASTICWRITER_H
+#ifndef ELASTICSEARCHWRITER_H
+#define ELASTICSEARCHWRITER_H
 
-#include "perfdata/elasticwriter.thpp"
+#include "perfdata/elasticsearchwriter.thpp"
 #include "icinga/service.hpp"
 #include "base/configobject.hpp"
 #include "base/workqueue.hpp"
@@ -29,13 +29,13 @@
 namespace icinga
 {
 
-class ElasticWriter : public ObjectImpl<ElasticWriter>
+class ElasticsearchWriter : public ObjectImpl<ElasticsearchWriter>
 {
 public:
-	DECLARE_OBJECT(ElasticWriter);
-	DECLARE_OBJECTNAME(ElasticWriter);
+	DECLARE_OBJECT(ElasticsearchWriter);
+	DECLARE_OBJECTNAME(ElasticsearchWriter);
 
-	ElasticWriter(void);
+	ElasticsearchWriter(void);
 
 	static void StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata);
 
@@ -78,4 +78,4 @@ private:
 
 }
 
-#endif /* ELASTICWRITER_H */
+#endif /* ELASTICSEARCHWRITER_H */

--- a/lib/perfdata/elasticsearchwriter.ti
+++ b/lib/perfdata/elasticsearchwriter.ti
@@ -5,7 +5,7 @@ library perfdata;
 namespace icinga
 {
 
-class ElasticWriter : ConfigObject
+class ElasticsearchWriter : ConfigObject
 {
 	[config, required] String host {
 		default {{{ return "127.0.0.1"; }}}


### PR DESCRIPTION
This better reflects its purpose as otherwise it would imply
that you need Elastic Stack for it. Graylog also reads from
Elasticsearch instances, this could serve as additional integration
here.

refs #5564
refs #5538