### PR TITLE
Implement DummyCheckTask and move dummy into embedded in-memory checks

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -144,7 +144,7 @@ detail how to set up your own check commands.
 #### Host Check Alternatives <a id="host-check-alternatives"></a>
 
 If the host is not reachable with ICMP, HTTP, etc. you can
-also use the [dummy](10-icinga-template-library.md#plugin-check-command-dummy) CheckCommand to set a default state.
+also use the [dummy](10-icinga-template-library.md#itl-dummy) CheckCommand to set a default state.
 
 ```
 object Host "dummy-host" {

--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -380,7 +380,7 @@ the threshold is based on the last time a check result was received:
 
 If the freshness checks fail, Icinga 2 will execute the defined check command.
 
-Best practice is to define a [dummy](10-icinga-template-library.md#plugin-check-command-dummy) `check_command` which gets
+Best practice is to define a [dummy](10-icinga-template-library.md#itl-dummy) `check_command` which gets
 executed when freshness checks fail.
 
 ```

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -108,6 +108,21 @@ Name         | Description
 ido\_type    | **Required.** The type of the IDO connection object. Can be either "IdoMysqlConnection" or "IdoPgsqlConnection".
 ido\_name    | **Required.** The name of the IDO connection object.
 
+### dummy <a id="itl-dummy"></a>
+
+Check command for the built-in `dummy` check. This allows to set
+a check result state and output and can be used in [freshness checks](08-advanced-topics.md#check-result-freshness)
+or [runtime object checks](08-advanced-topics.md#access-object-attributes-at-runtime).
+In contrast to the [check_dummy](https://www.monitoring-plugins.org/doc/man/check_dummy.html)
+plugin, Icinga 2 implements a light-weight in memory check with 2.9+.
+
+Custom attributes passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
+
+Name            | Description
+----------------|--------------
+dummy\_state     | **Optional.** The state. Can be one of 0 (ok), 1 (warning), 2 (critical) and 3 (unknown). Defaults to 0.
+dummy\_text      | **Optional.** Plugin output. Defaults to "Check was successful.".
+
 ### random <a id="itl-random"></a>
 
 Check command for the built-in `random` check. This check returns random states
@@ -349,19 +364,6 @@ dns_wtime            | **Optional.** Return warning if elapsed time exceeds valu
 dns_ctime            | **Optional.** Return critical if elapsed time exceeds value.
 dns_timeout          | **Optional.** Seconds before connection times out. Defaults to 10.
 
-
-### dummy <a id="plugin-check-command-dummy"></a>
-
-The [check_dummy](https://www.monitoring-plugins.org/doc/man/check_dummy.html) plugin
-will simply return the state corresponding to the numeric value of the `dummy_state`
-argument with optional text.
-
-Custom attributes passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
-
-Name            | Description
-----------------|--------------
-dummy_state     | **Optional.** The state. Can be one of 0 (ok), 1 (warning), 2 (critical) and 3 (unknown). Defaults to 0.
-dummy_text      | **Optional.** Plugin output. Defaults to "Check was successful.".
 
 
 ### file_age <a id="plugin-check-command-file-age"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -176,28 +176,6 @@ object CheckCommand "fping6" {
 	vars.fping_address = "$address6$"
 }
 
-object CheckCommand "dummy" {
-	command = [ PluginDir + "/check_dummy" ]
-
-	arguments = {
-		"state" = {
-			value = "$dummy_state$"
-			skip_key = true
-			order = 1
-			description = "The state. Can be one of 0 (ok), 1 (warning), 2 (critical) and 3 (unknown). Defaults to 0."
-		}
-		"text" = {
-			value = "$dummy_text$"
-			skip_key = true
-			order = 2
-			description = "Plugin output. Defaults to Check was successful."
-		}
-	}
-
-	vars.dummy_state = 0
-	vars.dummy_text = "Check was successful."
-}
-
 object CheckCommand "passive" {
 	import "dummy"
 

--- a/lib/methods/CMakeLists.txt
+++ b/lib/methods/CMakeLists.txt
@@ -24,8 +24,9 @@ else()
 endif()
 
 set(methods_SOURCES
-  clusterchecktask.cpp clusterzonechecktask.cpp exceptionchecktask.cpp
-  icingachecktask.cpp methods-itl.cpp nullchecktask.cpp nulleventtask.cpp
+  clusterchecktask.cpp clusterzonechecktask.cpp dummychecktask.cpp
+  exceptionchecktask.cpp icingachecktask.cpp methods-itl.cpp
+  nullchecktask.cpp nulleventtask.cpp
   pluginchecktask.cpp plugineventtask.cpp pluginnotificationtask.cpp
   randomchecktask.cpp timeperiodtask.cpp ${WindowsSources}
 )

--- a/lib/methods/dummychecktask.cpp
+++ b/lib/methods/dummychecktask.cpp
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * Icinga 2                                                                   *
+ * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ *                                                                            *
+ * This program is free software; you can redistribute it and/or              *
+ * modify it under the terms of the GNU General Public License                *
+ * as published by the Free Software Foundation; either version 2             *
+ * of the License, or (at your option) any later version.                     *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program; if not, write to the Free Software Foundation     *
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ ******************************************************************************/
+
+#ifndef _WIN32
+#	include <stdlib.h>
+#endif /* _WIN32 */
+#include "methods/dummychecktask.hpp"
+#include "icinga/icingaapplication.hpp"
+#include "icinga/pluginutility.hpp"
+#include "base/utility.hpp"
+#include "base/perfdatavalue.hpp"
+#include "base/convert.hpp"
+#include "base/function.hpp"
+#include "base/logger.hpp"
+
+using namespace icinga;
+
+REGISTER_SCRIPTFUNCTION_NS(Internal, DummyCheck, &DummyCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+
+void DummyCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
+    const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+{
+	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
+
+	Host::Ptr host;
+	Service::Ptr service;
+	tie(host, service) = GetHostService(checkable);
+
+	MacroProcessor::ResolverList resolvers;
+	if (service)
+		resolvers.push_back(std::make_pair("service", service));
+	resolvers.push_back(std::make_pair("host", host));
+	resolvers.push_back(std::make_pair("command", commandObj));
+	resolvers.push_back(std::make_pair("icinga", IcingaApplication::GetInstance()));
+
+	int dummyState = MacroProcessor::ResolveMacros("$dummy_state$", resolvers, checkable->GetLastCheckResult(),
+	    NULL, MacroProcessor::EscapeCallback(), resolvedMacros, useResolvedMacros);
+
+	String dummyText = MacroProcessor::ResolveMacros("$dummy_text$", resolvers, checkable->GetLastCheckResult(),
+	    NULL, MacroProcessor::EscapeCallback(), resolvedMacros, useResolvedMacros);
+
+	if (resolvedMacros && !useResolvedMacros)
+		return;
+
+	/* Parse output and performance data. */
+	std::pair<String, String> co = PluginUtility::ParseCheckOutput(dummyText);
+
+	double now = Utility::GetTime();
+
+	cr->SetOutput(co.first);
+	cr->SetPerformanceData(PluginUtility::SplitPerfdata(co.second));
+	cr->SetState(PluginUtility::ExitStatusToState(dummyState));
+	cr->SetExitStatus(dummyState);
+	cr->SetExecutionStart(now);
+	cr->SetExecutionEnd(now);
+
+	checkable->ProcessCheckResult(cr);
+}

--- a/lib/methods/dummychecktask.hpp
+++ b/lib/methods/dummychecktask.hpp
@@ -17,31 +17,31 @@
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
  ******************************************************************************/
 
-object CheckCommand "icinga" {
-	import "icinga-check-command"
+#ifndef DUMMYCHECKTASK_H
+#define DUMMYCHECKTASK_H
+
+#include "methods/i2-methods.hpp"
+#include "icinga/service.hpp"
+#include "base/dictionary.hpp"
+
+namespace icinga
+{
+
+/**
+ * Test class for additional check types. Implements the "dummy" check type.
+ *
+ * @ingroup methods
+ */
+class I2_METHODS_API DummyCheckTask
+{
+public:
+	static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
+	    const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+
+private:
+	DummyCheckTask(void);
+};
+
 }
 
-object CheckCommand "cluster" {
-	import "cluster-check-command"
-}
-
-object CheckCommand "cluster-zone" {
-	import "cluster-zone-check-command"
-
-	vars.cluster_zone = "$host.name$"
-}
-
-object CheckCommand "dummy" {
-	import "dummy-check-command"
-
-	vars.dummy_state = 0
-	vars.dummy_text = "Check was successful."
-}
-
-object CheckCommand "random" {
-	import "random-check-command"
-}
-
-object CheckCommand "exception" {
-	import "exception-check-command"
-}
+#endif /* DUMMYCHECKTASK_H */

--- a/lib/methods/methods-itl.conf
+++ b/lib/methods/methods-itl.conf
@@ -89,7 +89,7 @@ var methods = [
 	"ClrCheck",
 	"PluginNotification",
 	"PluginEvent",
-        "DummyCheck",
+	"DummyCheck",
 	"RandomCheck",
 	"ExceptionCheck",
 	"NullCheck",

--- a/lib/methods/methods-itl.conf
+++ b/lib/methods/methods-itl.conf
@@ -52,6 +52,10 @@ System.assert(Internal.run_with_activation_context(function() {
 		execute = _Internal.PluginEvent
 	}
 
+	template CheckCommand "dummy-check-command" use (_Internal) {
+		execute = _Internal.DummyCheck
+	}
+
 	template CheckCommand "random-check-command" use (_Internal) {
 		execute = _Internal.RandomCheck
 	}
@@ -85,6 +89,7 @@ var methods = [
 	"ClrCheck",
 	"PluginNotification",
 	"PluginEvent",
+        "DummyCheck",
 	"RandomCheck",
 	"ExceptionCheck",
 	"NullCheck",


### PR DESCRIPTION
This replaces the previous "dummy" CheckCommand, and the user won't
notice it. Provided performance data will be parsed the same way.

This saves a shell fork and check_dummy execution.

We're relying on this when creating cluster checks with Icinga 2 DSL
and more. If one does not have the plugins installed, this then also works.

fixes #5740