### PR TITLE
livestatus: custom variables return empty arrays instead of strings

### DIFF
--- a/lib/livestatus/commandstable.cpp
+++ b/lib/livestatus/commandstable.cpp
@@ -106,10 +106,10 @@ Value CommandsTable::CustomVariableNamesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(command);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	{
 		ObjectLock xlock(vars);
@@ -135,10 +135,10 @@ Value CommandsTable::CustomVariableValuesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(command);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	{
 		ObjectLock xlock(vars);
@@ -164,10 +164,10 @@ Value CommandsTable::CustomVariablesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(command);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	{
 		ObjectLock xlock(vars);

--- a/lib/livestatus/contactstable.cpp
+++ b/lib/livestatus/contactstable.cpp
@@ -210,10 +210,10 @@ Value ContactsTable::CustomVariableNamesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(user);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {
@@ -237,10 +237,10 @@ Value ContactsTable::CustomVariableValuesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(user);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {
@@ -267,10 +267,10 @@ Value ContactsTable::CustomVariablesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(user);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {

--- a/lib/livestatus/hoststable.cpp
+++ b/lib/livestatus/hoststable.cpp
@@ -1016,10 +1016,10 @@ Value HostsTable::CustomVariableNamesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(host);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {
@@ -1043,10 +1043,10 @@ Value HostsTable::CustomVariableValuesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(host);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {
@@ -1073,10 +1073,10 @@ Value HostsTable::CustomVariablesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(host);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {

--- a/lib/livestatus/servicestable.cpp
+++ b/lib/livestatus/servicestable.cpp
@@ -1055,10 +1055,10 @@ Value ServicesTable::CustomVariableNamesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(service);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {
@@ -1082,10 +1082,10 @@ Value ServicesTable::CustomVariableValuesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(service);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {
@@ -1112,10 +1112,10 @@ Value ServicesTable::CustomVariablesAccessor(const Value& row)
 		vars = CompatUtility::GetCustomAttributeConfig(service);
 	}
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	ObjectLock olock(vars);
 	for (const Dictionary::Pair& kv : vars) {

--- a/lib/livestatus/statustable.cpp
+++ b/lib/livestatus/statustable.cpp
@@ -233,10 +233,10 @@ Value StatusTable::CustomVariableNamesAccessor(const Value&)
 {
 	Dictionary::Ptr vars = IcingaApplication::GetInstance()->GetVars();
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	{
 		ObjectLock olock(vars);
@@ -252,10 +252,10 @@ Value StatusTable::CustomVariableValuesAccessor(const Value&)
 {
 	Dictionary::Ptr vars = IcingaApplication::GetInstance()->GetVars();
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	{
 		ObjectLock olock(vars);
@@ -271,10 +271,10 @@ Value StatusTable::CustomVariablesAccessor(const Value&)
 {
 	Dictionary::Ptr vars = IcingaApplication::GetInstance()->GetVars();
 
-	if (!vars)
-		return Empty;
-
 	Array::Ptr cv = new Array();
+
+	if (!vars)
+		return cv;
 
 	{
 		ObjectLock olock(vars);


### PR DESCRIPTION
livestatus queries for custom variables should return an empty list, ex: []
instead of an empty string or null if there are no variables.

Ex.:
`GET services\nOutputFormat: json\nColumns: host_name custom_variable_names\n`

Before:
[["localhost",null]]

After:
[["localhost",[]]]

This also fixes a problem when filtering for those lists which result sometimes in "unknown operator"  errors, because you handle lists differently than scalars.

Signed-off-by: Sven Nierlein <sven@nierlein.de>