### PR TITLE
Fix missing word in pin checks in a zone doc chapter

### DIFF
--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -1931,7 +1931,7 @@ add a dependency which prevents notifications for all other failing services:
 
 In case you want to pin specific checks to their endpoints in a given zone you'll need to use
 the `command_endpoint` attribute. This is reasonable if you want to
-execute a local disk check in the `master` on a specific endpoint then.
+execute a local disk check in the `master` Zone on a specific endpoint then.
 
     [root@icinga2-master1.localdomain /]# mkdir -p /etc/icinga2/zones.d/master
     [root@icinga2-master1.localdomain /]# vim /etc/icinga2/zones.d/master/icinga2-master1.localdomain.conf


### PR DESCRIPTION
Fix missing word in Pin Checks in a Zone documentation chapter

![screenshot_20171111_145737](https://user-images.githubusercontent.com/18580278/32690096-cad29e00-c6f0-11e7-8f77-94efa4098aae.png)
 