### PR TITLE
Make default getters and setters non-virtual

### DIFF
--- a/tools/mkclass/class_lexer.ll
+++ b/tools/mkclass/class_lexer.ll
@@ -148,6 +148,9 @@ no_storage			{ yylval->num = FANoStorage; return T_FIELD_ATTRIBUTE; }
 no_user_modify			{ yylval->num = FANoUserModify; return T_FIELD_ATTRIBUTE; }
 no_user_view			{ yylval->num = FANoUserView; return T_FIELD_ATTRIBUTE; }
 deprecated			{ yylval->num = FADeprecated; return T_FIELD_ATTRIBUTE; }
+get_virtual			{ yylval->num = FAGetVirtual; return T_FIELD_ATTRIBUTE; }
+set_virtual			{ yylval->num = FASetVirtual; return T_FIELD_ATTRIBUTE; }
+virtual				{ yylval->num = FAGetVirtual | FASetVirtual; return T_FIELD_ATTRIBUTE; }
 navigation			{ return T_NAVIGATION; }
 validator			{ return T_VALIDATOR; }
 required			{ return T_REQUIRED; }

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -706,7 +706,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 		/* NotifyField */
 		m_Header << "public:" << std::endl
-			 << "\t" << "virtual void NotifyField(int id, const Value& cookie = Empty) override;" << std::endl;
+			 << "\t" << "void NotifyField(int id, const Value& cookie = Empty) override;" << std::endl;
 
 		m_Impl << "void ObjectImpl<" << klass.Name << ">::NotifyField(int id, const Value& cookie)" << std::endl
 		       << "{" << std::endl;
@@ -784,7 +784,12 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				prot = "public";
 
 			m_Header << prot << ":" << std::endl
-			 	 << "\t" << "virtual " << field.Type.GetRealType() << " Get" << field.GetFriendlyName() << "(void) const";
+				 << "\t";
+
+			if (field.Attributes & FAGetVirtual || field.PureGetAccessor)
+				m_Header << "virtual ";
+
+			m_Header << field.Type.GetRealType() << " Get" << field.GetFriendlyName() << "(void) const";
 
 			if (field.PureGetAccessor) {
 				m_Header << " = 0;" << std::endl;
@@ -813,7 +818,12 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				prot = "public";
 
 			m_Header << prot << ":" << std::endl
-				 << "\t" << "virtual void Set" << field.GetFriendlyName() << "(" << field.Type.GetArgumentType() << " value, bool suppress_events = false, const Value& cookie = Empty)";
+				 << "\t";
+
+			if (field.Attributes & FASetVirtual || field.PureSetAccessor)
+				m_Header << "virtual ";
+
+			m_Header << "void Set" << field.GetFriendlyName() << "(" << field.Type.GetArgumentType() << " value, bool suppress_events = false, const Value& cookie = Empty)";
 
 			if (field.PureSetAccessor) {
 				m_Header << " = 0;" << std::endl;
@@ -859,7 +869,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 			needs_tracking = true;
 
-			m_Header << "\t" << "virtual void Track" << field.GetFriendlyName() << "(" << field.Type.GetArgumentType() << " oldValue, " << field.Type.GetArgumentType() << " newValue);";
+			m_Header << "\t" << "void Track" << field.GetFriendlyName() << "(" << field.Type.GetArgumentType() << " oldValue, " << field.Type.GetArgumentType() << " newValue);" << std::endl;
 
 			m_Impl << "void ObjectImpl<" << klass.Name << ">::Track" << field.GetFriendlyName() << "(" << field.Type.GetArgumentType() << " oldValue, " << field.Type.GetArgumentType() << " newValue)" << std::endl
 			       << "{" << std::endl;
@@ -930,7 +940,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				continue;
 
 			m_Header << "public:" << std::endl
-				 << "\t" << "virtual Object::Ptr Navigate" << field.GetFriendlyName() << "(void) const";
+				 << "\t" << "Object::Ptr Navigate" << field.GetFriendlyName() << "(void) const";
 
 			if (field.PureNavigateAccessor) {
 				m_Header << " = 0;" << std::endl;
@@ -951,8 +961,9 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 		/* start/stop */
 		if (needs_tracking) {
-			m_Header << "virtual void Start(bool runtimeCreated = false) override;" << std::endl
-				 << "virtual void Stop(bool runtimeRemoved = false) override;" << std::endl;
+			m_Header << "protected:" << std::endl
+				 << "\tvirtual void Start(bool runtimeCreated = false) override;" << std::endl
+				 << "\tvirtual void Stop(bool runtimeRemoved = false) override;" << std::endl;
 
 			m_Impl << "void ObjectImpl<" << klass.Name << ">::Start(bool runtimeCreated)" << std::endl
 			       << "{" << std::endl

--- a/tools/mkclass/classcompiler.hpp
+++ b/tools/mkclass/classcompiler.hpp
@@ -73,7 +73,9 @@ enum FieldAttribute
 	FANavigation = 512,
 	FANoUserModify = 1024,
 	FANoUserView = 2048,
-	FADeprecated = 4096
+	FADeprecated = 4096,
+	FAGetVirtual = 8192,
+	FASetVirtual = 16384
 };
 
 struct FieldType


### PR DESCRIPTION
This makes all auto-generated getters and setters non-virtual by default. By doing so we avoid an unconditional branch which in turn improves performance. This also allows for inlining getters/setters by the compiler.