### PR TITLE
Fix incorrect socket handling for the HTTP client

### DIFF
--- a/lib/base/stream.cpp
+++ b/lib/base/stream.cpp
@@ -145,6 +145,9 @@ bool StreamReadContext::FillFromStream(const Stream::Ptr& stream, bool may_wait)
 		if (!Buffer)
 			throw std::bad_alloc();
 
+		if (stream->IsEof())
+			break;
+
 		size_t rc = stream->Read(Buffer + Size, 4096, true);
 
 		Size += rc;


### PR DESCRIPTION
This fixes a number of issues with the HTTP client:

* Icinga might crash with some HTTP/1.0 responses.
* HttpResponse::Parse has an incorrect return value in some cases (especially for blocking mode).
* StreamReadContext::FillFromStream might call Read() for a stream that is already closed.