### PR TITLE
ITL: Drop ssl_sni default setting

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1307,7 +1307,7 @@ ssl_port                      | **Optional.** The port that should be checked. D
 ssl_timeout                   | **Optional.** Timeout in seconds for the connect and handshake. The plugin default is 10 seconds.
 ssl_cert_valid_days_warn      | **Optional.** Warning threshold for days before the certificate will expire. When used, the default for ssl_cert_valid_days_critical is 0.
 ssl_cert_valid_days_critical  | **Optional.** Critical threshold for days before the certificate will expire. When used, ssl_cert_valid_days_warn must also be set.
-ssl_sni                       | **Optional.** The `server_name` that is send to select the SSL certificate to check. Important if SNI is used. Defaults to "$ssl_address$".
+ssl_sni                       | **Optional.** The `server_name` that is send to select the SSL certificate to check. Important if SNI is used.
 
 
 ### ssmtp <a id="plugin-check-command-ssmtp"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -350,7 +350,6 @@ object CheckCommand "ssl" {
 	vars.ssl_port = 443
 	vars.ssl_cert_valid_days_warn = false
 	vars.ssl_cert_valid_days_critical = false
-	vars.ssl_sni = "$ssl_address$"
 }
 
 


### PR DESCRIPTION
That's not supported by all plugin suites out there, and as such
should not be the default value. The user must set it explicitly.

fixes #5775