### PR TITLE
Fix Windows client requirements

### DIFF
--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -599,6 +599,7 @@ Requirements:
 * Windows Vista/Server 2008 or higher
 * Versions older than Windows 10/Server 2016 require the [Universal C Runtime for Windows](https://support.microsoft.com/en-us/help/2999226/update-for-universal-c-runtime-in-windows)
 * [Microsoft .NET Framework 2.0](https://www.microsoft.com/de-de/download/details.aspx?id=1639) for the setup wizard
+* [Microsoft Visual C++ Redistributable 2013](https://www.microsoft.com/en-us/download/details.aspx?id=40784) for the Icinga 2 daemon
 
 The installer package includes the [NSClient++](https://www.nsclient.org/) package
 so that Icinga 2 can use its built-in plugins. You can find more details in


### PR DESCRIPTION
This adds the Microsoft Visual C++ Redistributable 2013 to the requirements for Icinga 2 on Windows.

![screenshot_20171121_180154](https://user-images.githubusercontent.com/18580278/33085859-42551a6e-cee6-11e7-9335-fa15efb76f8d.png)

refs #5780 