### PR TITLE
Add support for LD_LIBRARY_PATH env variable in oracle_health ITL CheckCommand

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2306,8 +2306,9 @@ Environment Macros:
 
 Name                | Description
 --------------------|------------------------------------------------------------------------------------------------------------------------------------------
-ORACLE_HOME         | **Required.** Specifies the location of the oracle instant client libraries. Defaults to "/usr/lib/oracle/11.2/client64/lib". Can be overridden by setting "oracle_home".
-TNS_ADMIN           | **Required.** Specifies the location of the tnsnames.ora including the database connection strings. Defaults to "/etc/icinga2/plugin-configs". Can be overridden by setting "oracle_tns_admin".
+ORACLE\_HOME         | **Required.** Specifies the location of the oracle instant client libraries. Defaults to "/usr/lib/oracle/11.2/client64/lib". Can be overridden by setting the custom attribute `oracle_home`.
+LD\_LIBRARY\_PATH    | **Required.** Specifies the location of the oracle instant client libraries for the run-time shared library loader. Defaults to "/usr/lib/oracle/11.2/client64/lib". Can be overridden by setting the custom attribute `oracle_ld_library_path`.
+TNS\_ADMIN           | **Required.** Specifies the location of the tnsnames.ora including the database connection strings. Defaults to "/etc/icinga2/plugin-configs". Can be overridden by setting the custom attribute `oracle_tns_admin`.
 
 #### postgres <a id="plugin-contrib-command-postgres"></a>
 

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -505,6 +505,7 @@ object CheckCommand "oracle_health" {
 
 	env = {
 		"ORACLE_HOME" = "$oracle_home$"
+		"LD_LIBRARY_PATH" = "$oracle_ld_library_path$"
 		"TNS_ADMIN" = "$oracle_tns_admin$"
 	}
 
@@ -515,6 +516,7 @@ object CheckCommand "oracle_health" {
 	vars.oracle_health_report = "long"
 
 	vars.oracle_home = "/usr/lib/oracle/11.2/client64/lib"
+	vars.oracle_ld_library_path = "/usr/lib/oracle/11.2/client64/lib"
 	vars.oracle_tns_admin = SysconfDir + "/icinga2/plugin-configs"
 }
 


### PR DESCRIPTION
It seems there is an error when I use oracle_health check with original settings.

I got this error message:


CRITICAL - cannot connect to (***). install_driver(Oracle) failed: Can't load '/usr/share/perl5/auto/DBD/Oracle/Oracle.so' for module DBD::Oracle: libocci.so.11.1: cannot open shared object file: No such file or directory at /usr/lib64/perl5/DynaLoader.pm line 190.
at (eval 13) line 3.
Compilation failed in require at (eval 13) line 3.
Perhaps a required shared library or dll isn't installed where expected
at /usr/lib64/nagios/plugins/check_oracle_health line 4755.

Adding LD_LIBRARY_PATH as env can fix the problem for me.
CentOS 7
Icinga 2.8
Oracle 11.2 instant client