### PR TITLE
Fix incorrect value for the Dictionary::type attribute

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -209,14 +209,14 @@ String Dictionary::ToString(void) const
 	return msgbuf.str();
 }
 
-Value Dictionary::GetFieldByName(const String& field, bool, const DebugInfo& debugInfo) const
+Value Dictionary::GetFieldByName(const String& field, bool sandboxed, const DebugInfo& debugInfo) const
 {
 	Value value;
 
 	if (Get(field, &value))
 		return value;
 	else
-		return GetPrototypeField(const_cast<Dictionary *>(this), field, false, debugInfo);
+		return Object::GetFieldByName(field, sandboxed, debugInfo);
 }
 
 void Dictionary::SetFieldByName(const String& field, const Value& value, const DebugInfo&)


### PR DESCRIPTION
The `type` attribute for `Dictionary` objects incorrectly returns `null`:

```
<5> => {}.type
null
```

Note that even with this patch `.type` still returns the value for the kv pair if the dictionary contains an element with the key `"type"`.

I'm not 100% sure this is actually a good idea. We should've never started mixing dictionary kvs and prototype attributes for the `.` operator. This is quite confusing.