### PR TITLE
Update NodeName/ZoneName constants with 'api setup'

### DIFF
--- a/lib/cli/apisetuputility.cpp
+++ b/lib/cli/apisetuputility.cpp
@@ -54,6 +54,9 @@ bool ApiSetupUtility::SetupMaster(const String& cn, bool prompt_restart)
 	if (!SetupMasterEnableApi())
 		return false;
 
+	if (!SetupMasterUpdateConstants(cn))
+		return false;
+
 	if (prompt_restart) {
 		std::cout << "Done.\n\n";
 		std::cout << "Now restart your Icinga 2 daemon to finish the installation!\n\n";
@@ -206,4 +209,10 @@ bool ApiSetupUtility::SetupMasterEnableApi(void)
 	FeatureUtility::EnableFeatures(features);
 
 	return true;
+}
+
+bool ApiSetupUtility::SetupMasterUpdateConstants(const String& cn)
+{
+	NodeUtility::UpdateConstant("NodeName", cn);
+	NodeUtility::UpdateConstant("ZoneName", cn);
 }

--- a/lib/cli/apisetuputility.hpp
+++ b/lib/cli/apisetuputility.hpp
@@ -42,6 +42,7 @@ public:
 	static bool SetupMasterCertificates(const String& cn);
 	static bool SetupMasterApiUser(void);
 	static bool SetupMasterEnableApi(void);
+	static bool SetupMasterUpdateConstants(const String& cn);
 
 	static String GetConfdPath(void);
 

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -213,10 +213,6 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 			<< "CN '" << cn << "' does not match the default FQDN '" << Utility::GetFQDN() << "'. Requires update for NodeName constant in constants.conf!";
 	}
 
-	Log(LogInformation, "cli", "Updating constants.conf.");
-
-	NodeUtility::CreateBackupFile(Application::GetSysconfDir() + "/icinga2/constants.conf");
-
 	NodeUtility::UpdateConstant("NodeName", cn);
 	NodeUtility::UpdateConstant("ZoneName", cn);
 
@@ -439,10 +435,6 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 		Log(LogWarning, "cli")
 		    << "CN '" << cn << "' does not match the default FQDN '" << Utility::GetFQDN() << "'. Requires an update for the NodeName constant in constants.conf!";
 	}
-
-	Log(LogInformation, "cli", "Updating constants.conf.");
-
-	NodeUtility::CreateBackupFile(Application::GetSysconfDir() + "/icinga2/constants.conf");
 
 	NodeUtility::UpdateConstant("NodeName", cn);
 	NodeUtility::UpdateConstant("ZoneName", vm["zone"].as<std::string>());

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -37,6 +37,8 @@ namespace icinga
 class I2_CLI_API NodeUtility
 {
 public:
+	static String GetConstantsConfPath(void);
+
 	static bool CreateBackupFile(const String& target, bool is_private = false);
 
 	static bool WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects);

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -516,12 +516,6 @@ wizard_ticket:
 		    << Utility::GetFQDN() << "'. Requires update for NodeName constant in constants.conf!";
 	}
 
-	Log(LogInformation, "cli", "Updating constants.conf.");
-
-	String constants_file = Application::GetSysconfDir() + "/icinga2/constants.conf";
-
-	NodeUtility::CreateBackupFile(constants_file);
-
 	NodeUtility::UpdateConstant("NodeName", cn);
 	NodeUtility::UpdateConstant("ZoneName", cn);
 
@@ -673,12 +667,6 @@ int NodeWizardCommand::MasterSetup(void) const
 		    << "CN '" << cn << "' does not match the default FQDN '"
 		    << Utility::GetFQDN() << "'. Requires an update for the NodeName constant in constants.conf!";
 	}
-
-	Log(LogInformation, "cli", "Updating constants.conf.");
-
-	String constants_file = Application::GetSysconfDir() + "/icinga2/constants.conf";
-
-	NodeUtility::CreateBackupFile(constants_file);
 
 	NodeUtility::UpdateConstant("NodeName", cn);
 	NodeUtility::UpdateConstant("ZoneName", cn);


### PR DESCRIPTION
This commit also moves the constants.conf backup logic
into NodeUtility::UpdateConstant() where it belongs.

Logging has been slightly adopted too.

fixes #5763