### PR TITLE
services.conf has also be moved to zones.d/global-templates/

### DIFF
--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -1850,7 +1850,7 @@ into your global zone.
 Example:
 
     [root@icinga2-master1.localdomain /]# cd /etc/icinga2/conf.d
-    [root@icinga2-master1.localdomain /etc/icinga2/conf.d]# cp {commands,downtimes,groups,notifications,templates,timeperiods,users}.conf /etc/icinga2/zones.d/global-templates
+    [root@icinga2-master1.localdomain /etc/icinga2/conf.d]# cp {commands,downtimes,groups,notifications,services,templates,timeperiods,users}.conf /etc/icinga2/zones.d/global-templates
 
 ### Health Checks <a id="distributed-monitoring-health-checks"></a>
 


### PR DESCRIPTION
While working through your excelent documentation I stumbled upon this issue. Also `services.conf` was needed.
In fact I moved those files instead of copying them. Maybe this was the wrong way but without I was running into 're-defined previous definition' issues.