### PR TITLE
Fix newline terminator for bulk requests in ElasticsearchWriter

### DIFF
--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -347,7 +347,7 @@ The check results include parsed performance data metrics if enabled.
 
 > **Note**
 >
-> Elasticsearch 5.x+ is required.
+> Elasticsearch 5.x+ is required. This feature has been tested with Elasticsearch 5.6.4 and 6.0.0.
 
 Enable the feature and restart Icinga 2.
 

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -396,6 +396,11 @@ void ElasticsearchWriter::Flush(void)
 	String body = boost::algorithm::join(m_DataBuffer, "\n");
 	m_DataBuffer.clear();
 
+	/* Elasticsearch 6.x requires a new line. This is compatible to 5.x.
+	 * Tested with 6.0.0 and 5.6.4.
+	 */
+	body += "\n";
+
 	SendRequest(body);
 }
 
@@ -455,10 +460,18 @@ void ElasticsearchWriter::SendRequest(const String& body)
 
 	try {
 		resp.Parse(context, true);
+		while (resp.Parse(context, true) && !resp.Complete)
+			; /* Do nothing */
 	} catch (const std::exception& ex) {
 		Log(LogWarning, "ElasticsearchWriter")
-			<< "Cannot read from HTTP API on host '" << GetHost() << "' port '" << GetPort() << "'.";
+		    << "Failed to parse HTTP response from host '" << GetHost() << "' port '" << GetPort() << "': " << DiagnosticInformation(ex, false);
 		throw ex;
+	}
+
+	if (!resp.Complete) {
+		Log(LogWarning, "ElasticsearchWriter")
+		    << "Failed to read a complete HTTP response from the Elasticsearch server.";
+		return;
 	}
 
 	if (resp.StatusCode > 299) {
@@ -478,10 +491,6 @@ void ElasticsearchWriter::SendRequest(const String& body)
 
 		Log(LogWarning, "ElasticsearchWriter")
 		    << "Unexpected response code " << resp.StatusCode;
-
-		/* Finish parsing the headers and body. */
-		while (!resp.Complete)
-			resp.Parse(context, true);
 
 		String contentType = resp.Headers->Get("content-type");
 
@@ -509,6 +518,8 @@ void ElasticsearchWriter::SendRequest(const String& body)
 
 		Log(LogCritical, "ElasticsearchWriter")
 		    << "Elasticsearch error message:\n" << error;
+
+		return;
 	}
 }
 


### PR DESCRIPTION
This enables compatibility with 6.x.

This commit also fixes an incorrect HTTP response parsing
which could lead into false positives.

Analysis and fix in https://github.com/Icinga/icinga2/issues/5795#issuecomment-349920587

fixes #5795