### PR TITLE
Fix missing space in check_service output

### DIFF
--- a/plugins/check_service.cpp
+++ b/plugins/check_service.cpp
@@ -157,10 +157,10 @@ INT printOutput(CONST printInfoStruct& printInfo)
 		std::wcout << L"SERVICE \"" << printInfo.service << "\" OK RUNNING | service=4;;;1;7" << '\n';
 		break;
 	case WARNING:
-		std::wcout << L"SERVICE \"" << printInfo.service << "\"WARNING NOT RUNNING | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
+		std::wcout << L"SERVICE \"" << printInfo.service << "\" WARNING NOT RUNNING | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
 		break;
 	case CRITICAL:
-		std::wcout << L"SERVICE \"" << printInfo.service << "\"CRITICAL NOT RUNNING | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
+		std::wcout << L"SERVICE \"" << printInfo.service << "\" CRITICAL NOT RUNNING | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
 		break;
 	}
 


### PR DESCRIPTION
This adds a missing space in the check_service output between the service name and the state.

**Before:**
```
.\check_service.exe -s w32time
SERVICE "w32time"WARNING NOT RUNNING | service=1;;;1;7
```

**After:**
```
.\check_service.exe -s w32time
SERVICE "w32time" WARNING NOT RUNNING | service=1;;;1;7
```