### PR TITLE
Fix incorrect memory access

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -634,7 +634,10 @@ void Application::AttachDebugger(const String& filename, bool interactive)
 				my_pid_str,
 				NULL
 			};
+
 			argv = const_cast<char **>(uargv);
+
+			(void) execvp(argv[0], argv);
 		} else {
 			const char *uargv[] = {
 				"gdb",
@@ -649,10 +652,12 @@ void Application::AttachDebugger(const String& filename, bool interactive)
 				"quit",
 				NULL
 			};
+
 			argv = const_cast<char **>(uargv);
+
+			(void) execvp(argv[0], argv);
 		}
 
-		(void)execvp(argv[0], argv);
 		perror("Failed to launch GDB");
 		free(my_pid_str);
 		_exit(0);


### PR DESCRIPTION
The `uargv` variable goes out of scope before it is being used (in the execvp call).

```
7. Condition interactive, taking false branch.
630                if (interactive) {
631                        const char *uargv[] = {
632                                "gdb",
633                                "-p",
634                                my_pid_str,
635                                NULL
636                        };
637                        argv = const_cast<char **>(uargv);
638                } else {
639                        const char *uargv[] = {
640                                "gdb",
641                                "--batch",
642                                "-p",
643                                my_pid_str,
644                                "-ex",
645                                "thread apply all bt full",
646                                "-ex",
647                                "detach",
648                                "-ex",
649                                "quit",
650                                NULL
651                        };
   	8. local_ptr_assign_local: Assigning: argv = uargv (address of local variable uargv).
652                        argv = const_cast<char **>(uargv);
   	9. out_of_scope: Variable uargv goes out of scope.
653                }
654
   	
CID 1462896 (#1-2 of 2): Pointer to local outside scope (RETURN_LOCAL)
10. use_invalid: Using argv, which points to an out-of-scope variable uargv.
655                (void)execvp(argv[0], argv);
```