### PR TITLE
Use std::unique_ptr for Expression objects

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -176,20 +176,16 @@ static int Main(void)
 	String initconfig = Application::GetSysconfDir() + "/icinga2/init.conf";
 
 	if (Utility::PathExists(initconfig)) {
-		Expression *expression;
+		std::unique_ptr<Expression> expression;
 		try {
 			expression = ConfigCompiler::CompileFile(initconfig);
 
 			ScriptFrame frame;
 			expression->Evaluate(frame);
 		} catch (const std::exception& ex) {
-			delete expression;
-
 			Log(LogCritical, "config", DiagnosticInformation(ex));
 			return EXIT_FAILURE;
 		}
-
-		delete expression;
 	}
 
 	if (!autocomplete)

--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -68,7 +68,7 @@ extern "C" void dbg_inspect_object(Object *obj)
 
 extern "C" void dbg_eval(const char *text)
 {
-	Expression *expr = nullptr;
+	std::unique_ptr<Expression> expr;
 
 	try {
 		ScriptFrame frame;
@@ -78,13 +78,11 @@ extern "C" void dbg_eval(const char *text)
 	} catch (const std::exception& ex) {
 		std::cout << "Error: " << DiagnosticInformation(ex) << "\n";
 	}
-
-	delete expr;
 }
 
 extern "C" void dbg_eval_with_value(const Value& value, const char *text)
 {
-	Expression *expr = nullptr;
+	std::unique_ptr<Expression> expr;
 
 	try {
 		ScriptFrame frame;
@@ -96,13 +94,11 @@ extern "C" void dbg_eval_with_value(const Value& value, const char *text)
 	} catch (const std::exception& ex) {
 		std::cout << "Error: " << DiagnosticInformation(ex) << "\n";
 	}
-
-	delete expr;
 }
 
 extern "C" void dbg_eval_with_object(Object *object, const char *text)
 {
-	Expression *expr = nullptr;
+	std::unique_ptr<Expression> expr;
 
 	try {
 		ScriptFrame frame;
@@ -114,8 +110,6 @@ extern "C" void dbg_eval_with_object(Object *object, const char *text)
 	} catch (const std::exception& ex) {
 		std::cout << "Error: " << DiagnosticInformation(ex) << "\n";
 	}
-
-	delete expr;
 }
 
 void ConsoleCommand::BreakpointHandler(ScriptFrame& frame, ScriptError *ex, const DebugInfo& di)
@@ -400,7 +394,7 @@ incomplete:
 
 		command += line;
 
-		Expression *expr = nullptr;
+		std::unique_ptr<Expression> expr;
 
 		try {
 			lines[fileName] = command;
@@ -412,7 +406,7 @@ incomplete:
 
 				/* This relies on the fact that - for syntax errors - CompileText()
 				 * returns an AST where the top-level expression is a 'throw'. */
-				if (!syntaxOnly || dynamic_cast<ThrowExpression *>(expr)) {
+				if (!syntaxOnly || dynamic_cast<ThrowExpression *>(expr.get())) {
 					if (syntaxOnly)
 						std::cerr << "    => " << command << std::endl;
 					result = Serialize(expr->Evaluate(scriptFrame), 0);
@@ -502,8 +496,6 @@ incomplete:
 			if (!commandOnce.IsEmpty())
 				return EXIT_FAILURE;
 		}
-
-		delete expr;
 	}
 
 	return EXIT_SUCCESS;

--- a/lib/config/configcompiler.hpp
+++ b/lib/config/configcompiler.hpp
@@ -90,13 +90,13 @@ public:
 	    const String& zone = String(), const String& package = String());
 	virtual ~ConfigCompiler(void);
 
-	Expression *Compile(void);
+	std::unique_ptr<Expression> Compile(void);
 
-	static Expression *CompileStream(const String& path, std::istream *stream,
+	static std::unique_ptr<Expression>CompileStream(const String& path, std::istream *stream,
 	    const String& zone = String(), const String& package = String());
-	static Expression *CompileFile(const String& path, const String& zone = String(),
+	static std::unique_ptr<Expression>CompileFile(const String& path, const String& zone = String(),
 	    const String& package = String());
-	static Expression *CompileText(const String& path, const String& text,
+	static std::unique_ptr<Expression>CompileText(const String& path, const String& text,
 	    const String& zone = String(), const String& package = String());
 
 	static void AddIncludeSearchDir(const String& dir);
@@ -109,14 +109,14 @@ public:
 	void SetPackage(const String& package);
 	String GetPackage(void) const;
 
-	static void CollectIncludes(std::vector<Expression *>& expressions,
+	static void CollectIncludes(std::vector<std::unique_ptr<Expression> >& expressions,
 	    const String& file, const String& zone, const String& package);
 
-	static Expression *HandleInclude(const String& relativeBase, const String& path, bool search,
+	static std::unique_ptr<Expression> HandleInclude(const String& relativeBase, const String& path, bool search,
 	    const String& zone, const String& package, const DebugInfo& debuginfo = DebugInfo());
-	static Expression *HandleIncludeRecursive(const String& relativeBase, const String& path,
+	static std::unique_ptr<Expression> HandleIncludeRecursive(const String& relativeBase, const String& path,
 	    const String& pattern, const String& zone, const String& package, const DebugInfo& debuginfo = DebugInfo());
-	static Expression *HandleIncludeZones(const String& relativeBase, const String& tag,
+	static std::unique_ptr<Expression> HandleIncludeZones(const String& relativeBase, const String& tag,
 	    const String& path, const String& pattern, const String& package, const DebugInfo& debuginfo = DebugInfo());
 
 	size_t ReadInput(char *buffer, size_t max_bytes);
@@ -144,7 +144,7 @@ private:
 	void InitializeScanner(void);
 	void DestroyScanner(void);
 
-	static void HandleIncludeZone(const String& relativeBase, const String& tag, const String& path, const String& pattern, const String& package, std::vector<Expression *>& expressions);
+	static void HandleIncludeZone(const String& relativeBase, const String& tag, const String& path, const String& pattern, const String& package, std::vector<std::unique_ptr<Expression> >& expressions);
 
 	static bool IsAbsolutePath(const String& path);
 

--- a/lib/config/configfragment.hpp
+++ b/lib/config/configfragment.hpp
@@ -28,7 +28,7 @@
 
 #define REGISTER_CONFIG_FRAGMENT(name, fragment) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
-		icinga::Expression *expression = icinga::ConfigCompiler::CompileText(name, fragment); \
+		std::unique_ptr<icinga::Expression> expression = icinga::ConfigCompiler::CompileText(name, fragment); \
 		VERIFY(expression); \
 		try { \
 			icinga::ScriptFrame frame; \
@@ -37,7 +37,6 @@
 			std::cerr << icinga::DiagnosticInformation(ex) << std::endl; \
 			icinga::Application::Exit(1); \
 		} \
-		delete expression; \
 	}, 5)
 
 #endif /* CONFIGFRAGMENT_H */

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -580,7 +580,7 @@ bool ConfigItem::ActivateItems(WorkQueue& upq, const std::vector<ConfigItem::Ptr
 	if (withModAttrs) {
 		/* restore modified attributes */
 		if (Utility::PathExists(Application::GetModAttrPath())) {
-			Expression *expression = ConfigCompiler::CompileFile(Application::GetModAttrPath());
+			std::unique_ptr<Expression> expression = ConfigCompiler::CompileFile(Application::GetModAttrPath());
 
 			if (expression) {
 				try {
@@ -590,8 +590,6 @@ bool ConfigItem::ActivateItems(WorkQueue& upq, const std::vector<ConfigItem::Ptr
 					Log(LogCritical, "config", DiagnosticInformation(ex));
 				}
 			}
-
-			delete expression;
 		}
 	}
 

--- a/lib/config/configitembuilder.hpp
+++ b/lib/config/configitembuilder.hpp
@@ -60,7 +60,7 @@ private:
 	Type::Ptr m_Type; /**< The object type. */
 	String m_Name; /**< The name. */
 	bool m_Abstract; /**< Whether the item is abstract. */
-	std::vector<Expression *> m_Expressions; /**< Expressions for this item. */
+	std::vector<std::unique_ptr<Expression> > m_Expressions; /**< Expressions for this item. */
 	std::shared_ptr<Expression> m_Filter; /**< Filter expression. */
 	DebugInfo m_DebugInfo; /**< Debug information. */
 	Dictionary::Ptr m_Scope; /**< variable scope. */

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -124,15 +124,14 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 	fp << config;
 	fp.close();
 
-	Expression *expr = ConfigCompiler::CompileFile(path, String(), "_api");
+	std::unique_ptr<Expression> expr = ConfigCompiler::CompileFile(path, String(), "_api");
 
 	try {
 		ActivationScope ascope;
 
 		ScriptFrame frame;
 		expr->Evaluate(frame);
-		delete expr;
-		expr = nullptr;
+		expr.reset();
 
 		WorkQueue upq;
 		std::vector<ConfigItem::Ptr> newItems;
@@ -156,8 +155,6 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 
 		ApiListener::UpdateObjectAuthority();
 	} catch (const std::exception& ex) {
-		delete expr;
-
 		if (unlink(path.CStr()) < 0 && errno != ENOENT) {
 			BOOST_THROW_EXCEPTION(posix_error()
 			    << boost::errinfo_api_function("unlink")

--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -123,7 +123,7 @@ bool ConsoleHandler::ExecuteScriptHelper(HttpRequest& request, HttpResponse& res
 
 	Array::Ptr results = new Array();
 	Dictionary::Ptr resultInfo = new Dictionary();
-	Expression *expr = nullptr;
+	std::unique_ptr<Expression> expr;
 	Value exprResult;
 
 	try {
@@ -160,11 +160,7 @@ bool ConsoleHandler::ExecuteScriptHelper(HttpRequest& request, HttpResponse& res
 		debugInfo->Set("last_line", di.LastLine);
 		debugInfo->Set("last_column", di.LastColumn);
 		resultInfo->Set("debug_info", debugInfo);
-	} catch (...) {
-		delete expr;
-		throw;
 	}
-	delete expr;
 
 	results->Add(resultInfo);
 
@@ -301,13 +297,12 @@ std::vector<String> ConsoleHandler::GetAutocompletionSuggestions(const String& w
 		Value value;
 
 		try {
-			Expression *expr = ConfigCompiler::CompileText("temp", pword);
+			std::unique_ptr<Expression> expr = ConfigCompiler::CompileText("temp", pword);
 
 			if (expr)
 				value = expr->Evaluate(frame);
 
 			AddSuggestions(matches, word, pword, true, value);
-
 		} catch (...) { /* Ignore the exception */ }
 	}
 

--- a/lib/remote/eventqueue.hpp
+++ b/lib/remote/eventqueue.hpp
@@ -38,7 +38,6 @@ public:
 	DECLARE_PTR_TYPEDEFS(EventQueue);
 
 	EventQueue(const String& name);
-	~EventQueue(void);
 
 	bool CanProcessEvent(const String& type) const;
 	void ProcessEvent(const Dictionary::Ptr& event);
@@ -46,7 +45,7 @@ public:
 	void RemoveClient(void *client);
 
 	void SetTypes(const std::set<String>& types);
-	void SetFilter(Expression *filter);
+	void SetFilter(std::unique_ptr<Expression> filter);
 
 	Dictionary::Ptr WaitForEvent(void *client, double timeout = 5);
 
@@ -64,7 +63,7 @@ private:
 	boost::condition_variable m_CV;
 
 	std::set<String> m_Types;
-	Expression *m_Filter;
+	std::unique_ptr<Expression> m_Filter;
 
 	std::map<void *, std::deque<Dictionary::Ptr> > m_Events;
 };

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -66,7 +66,7 @@ bool EventsHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& request
 
 	String filter = HttpUtility::GetLastParameter(params, "filter");
 
-	Expression *ufilter = nullptr;
+	std::unique_ptr<Expression> ufilter;
 
 	if (!filter.IsEmpty())
 		ufilter = ConfigCompiler::CompileText("<API query>", filter);
@@ -80,7 +80,7 @@ bool EventsHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& request
 	}
 
 	queue->SetTypes(types->ToSet<String>());
-	queue->SetFilter(ufilter);
+	queue->SetFilter(std::move(ufilter));
 
 	queue->AddClient(&request);
 

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -162,14 +162,15 @@ void FilterUtility::CheckPermission(const ApiUser::Ptr& user, const String& perm
 			foundPermission = true;
 
 			if (filter && permissionFilter) {
-				std::vector<Expression *> args;
-				args.push_back(new GetScopeExpression(ScopeLocal));
-				FunctionCallExpression *fexpr = new FunctionCallExpression(new IndexerExpression(MakeLiteral(filter), MakeLiteral("call")), args);
+				std::vector<std::unique_ptr<Expression> > args;
+				args.emplace_back(new GetScopeExpression(ScopeLocal));
+				std::unique_ptr<Expression> indexer{new IndexerExpression(std::unique_ptr<Expression>(MakeLiteral(filter)), std::unique_ptr<Expression>(MakeLiteral("call")))};
+				FunctionCallExpression *fexpr = new FunctionCallExpression(std::move(indexer), std::move(args));
 
 				if (!*permissionFilter)
 					*permissionFilter = fexpr;
 				else
-					*permissionFilter = new LogicalOrExpression(*permissionFilter, fexpr);
+					*permissionFilter = new LogicalOrExpression(std::unique_ptr<Expression>(*permissionFilter), std::unique_ptr<Expression>(fexpr));
 			}
 		}
 	}
@@ -250,7 +251,7 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 		frame.Sandboxed = true;
 		Dictionary::Ptr uvars = new Dictionary();
 
-		Expression *ufilter = nullptr;
+		std::unique_ptr<Expression> ufilter;
 
 		if (query->Contains("filter")) {
 			String filter = HttpUtility::GetLastParameter(query, "filter");
@@ -267,16 +268,9 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 
 		frame.Self = uvars;
 
-		try {
-			provider->FindTargets(type, std::bind(&FilteredAddTarget,
-			    std::ref(permissionFrame), permissionFilter,
-			    std::ref(frame), ufilter, std::ref(result), variableName, _1));
-		} catch (const std::exception&) {
-			delete ufilter;
-			throw;
-		}
-
-		delete ufilter;
+		provider->FindTargets(type, std::bind(&FilteredAddTarget,
+		    std::ref(permissionFrame), permissionFilter,
+		    std::ref(frame), &*ufilter, std::ref(result), variableName, _1));
 	}
 
 	return result;

--- a/test/config-ops.cpp
+++ b/test/config-ops.cpp
@@ -28,308 +28,236 @@ BOOST_AUTO_TEST_SUITE(config_ops)
 BOOST_AUTO_TEST_CASE(simple)
 {
 	ScriptFrame frame;
-	Expression *expr;
+	std::unique_ptr<Expression> expr;
 	Dictionary::Ptr dict;
 
 	expr = ConfigCompiler::CompileText("<test>", "");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == Empty);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\n3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "{ 3\n\n5 }");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "1 + 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 4);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 - 1");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 2);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "5m * 10");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3000);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "5m / 5");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 60);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "7 & 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "2 | 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "true && false");
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "true || false");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 < 5");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 > 5");
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 <= 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 >= 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "2 + 3 * 4");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 14);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(2 + 3) * 4");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 20);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "2 * - 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == -6);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "-(2 + 3)");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == -5);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "- 2 * 2 - 2 * 3 - 4 * - 5");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 10);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "!0 == true");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "~0");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == (double)~(long)0);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "4 << 8");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 1024);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "1024 >> 4");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 64);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "2 << 3 << 4");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 256);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "256 >> 4 >> 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 2);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"hello\" == \"hello\"");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"hello\" != \"hello\"");
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" in [ \"foo\", \"bar\" ]");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" in [ \"bar\", \"baz\" ]");
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" in null");
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" in \"bar\"");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" !in [ \"bar\", \"baz\" ]");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" !in [ \"foo\", \"bar\" ]");
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" !in null");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"foo\" !in \"bar\"");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "{ a += 3 }");
 	dict = expr->Evaluate(frame).GetValue();
-	delete expr;
 	BOOST_CHECK(dict->GetLength() == 1);
 	BOOST_CHECK(dict->Get("a") == 3);
 
 	expr = ConfigCompiler::CompileText("<test>", "test");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "null + 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 + null");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"test\" + 3");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == "test3");
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"\\\"te\\\\st\"");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == "\"te\\st");
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"\\'test\"");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "({ a = 3\nb = 3 })");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue().IsObjectType<Dictionary>());
-	delete expr;
 }
 
 BOOST_AUTO_TEST_CASE(advanced)
 {
 	ScriptFrame frame;
-	Expression *expr;
+	std::unique_ptr<Expression> expr;
 	Function::Ptr func;
 
 	expr = ConfigCompiler::CompileText("<test>", "regex(\"^Hello\", \"Hello World\")");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "__boost_test()");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	Object::Ptr self = new Object();
 	ScriptFrame frame2(self);
 	expr = ConfigCompiler::CompileText("<test>", "this");
 	BOOST_CHECK(expr->Evaluate(frame2).GetValue() == Value(self));
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "var v = 7; v");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "{ a = 3 }.a");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "[ 2, 3 ][1]");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "var v = { a = 3}; v.a");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "a = 3 b = 3");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "function() { 3 }()");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "function() { return 3, 5 }()");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "typeof([]) == Array");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "typeof({}) == Dictionary");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "typeof(3) == Number");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "typeof(\"test\") == String");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(7 | 8) == 15");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(7 ^ 8) == 15");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(7 & 15) == 7");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "7 in [7] == true");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "7 !in [7] == false");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(7 | 8) > 14");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(7 ^ 8) > 14");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "(7 & 15) > 6");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "\"a\" = 3");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "3 = 3");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "var e; e");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue().IsEmpty());
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "var e = 3; e");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue() == 3);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "Array.x");
 	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
-	delete expr;
 
 	expr = ConfigCompiler::CompileText("<test>", "{{ 3 }}");
 	func = expr->Evaluate(frame).GetValue();
 	BOOST_CHECK(func->Invoke() == 3);
-	delete expr;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/livestatus-fixture.cpp
+++ b/test/livestatus-fixture.cpp
@@ -58,7 +58,7 @@ apply Service "livestatus" {
 }
 )CONFIG";
 
-		Expression *expr = ConfigCompiler::CompileText("<livestatus>", config);
+		std::unique_ptr<Expression> expr = ConfigCompiler::CompileText("<livestatus>", config);
 		expr->Evaluate(*ScriptFrame::GetCurrentFrame());
 	}
 };


### PR DESCRIPTION
This is part of an effort to remove all manual memory management. As a side effect this makes the config parser (more) exception-safe and also fixes a few minor memory leaks.