### PR TITLE
Replace incorrect fclose() call with pclose()

### DIFF
--- a/lib/cli/clicommand.cpp
+++ b/lib/cli/clicommand.cpp
@@ -47,7 +47,8 @@ std::vector<String> icinga::GetBashCompletionSuggestions(const String& type, con
 		boost::algorithm::trim_right_if(wline, boost::is_any_of("\r\n"));
 		result.push_back(wline);
 	}
-	fclose(fp);
+
+	pclose(fp);
 
 	/* Append a slash if there's only one suggestion and it's a directory */
 	if ((type == "file" || type == "directory") && result.size() == 1) {


### PR DESCRIPTION
This fixes the following Coverity warning:

```
CID 1272372 (#1 of 1): Incorrect deallocator used (ALLOC_FREE_MISMATCH)
8. free: Calling fclose frees fp using fclose but it should have been freed using pclose.
 50        fclose(fp);
```