### PR TITLE
Fix for Notification Begin and End Times

### DIFF
--- a/lib/icinga/apievents.cpp
+++ b/lib/icinga/apievents.cpp
@@ -46,6 +46,8 @@ void ApiEvents::StaticInitialize()
 	Downtime::OnDowntimeRemoved.connect(&ApiEvents::DowntimeRemovedHandler);
 	Downtime::OnDowntimeStarted.connect(&ApiEvents::DowntimeStartedHandler);
 	Downtime::OnDowntimeTriggered.connect(&ApiEvents::DowntimeTriggeredHandler);
+
+	Notification::OnNotificationTriggerTimeUpdate.connect(&ApiEvents::NotificationTriggerTimeUpdateHandler);
 }
 
 void ApiEvents::CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr& origin)
@@ -367,3 +369,24 @@ void ApiEvents::DowntimeTriggeredHandler(const Downtime::Ptr& downtime)
 		queue->ProcessEvent(result);
 	}
 }
+
+void ApiEvents::NotificationTriggerTimeUpdateHandler(const Notification::Ptr& notification, const MessageOrigin::Ptr& origin)
+{
+       std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("NotificationTriggerTimeUpdate");
+
+       if (queues.empty())
+               return;
+
+       Log(LogDebug, "ApiEvents", "Processing event type 'NotificationTriggerTimeUpdate'.");
+
+       Dictionary::Ptr result = new Dictionary();
+       result->Set("type", "NotificationTriggerTimeUpdate");
+       result->Set("timestamp", Utility::GetTime());
+
+       result->Set("notification", Serialize(notification, FAConfig | FAState));
+
+       for (const EventQueue::Ptr& queue : queues) {
+               queue->ProcessEvent(result);
+       }
+}
+

--- a/lib/icinga/apievents.hpp
+++ b/lib/icinga/apievents.hpp
@@ -56,6 +56,8 @@ public:
 	static void DowntimeRemovedHandler(const Downtime::Ptr& downtime);
 	static void DowntimeStartedHandler(const Downtime::Ptr& downtime);
 	static void DowntimeTriggeredHandler(const Downtime::Ptr& downtime);
+
+	static void NotificationTriggerTimeUpdateHandler(const Notification::Ptr& notification, const MessageOrigin::Ptr& origin);
 };
 
 }

--- a/lib/icinga/clusterevents.hpp
+++ b/lib/icinga/clusterevents.hpp
@@ -78,6 +78,9 @@ public:
 	static int GetCheckRequestQueueSize();
 	static void LogRemoteCheckQueueInformation();
 
+	static void NotificationTriggerTimeUpdateHandler(const Notification::Ptr& notification, const MessageOrigin::Ptr& origin);
+	static Value NotificationTriggerTimeUpdateAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
+
 private:
 	static boost::mutex m_Mutex;
 	static std::deque<std::function<void ()>> m_CheckRequestQueue;

--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -115,6 +115,10 @@ public:
 	static const std::map<String, int>& GetStateFilterMap();
 	static const std::map<String, int>& GetTypeFilterMap();
 
+	void ResetTriggerTime(void);
+	void TriggerNotification(double triggerTime);
+	static boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> OnNotificationTriggerTimeUpdate;
+
 protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -96,6 +96,7 @@ class Notification : CustomVarObject < NotificationNameComposer
 
 	[state] Timestamp last_notification;
 	[state] Timestamp next_notification;
+	[state] Timestamp trigger_time;
 	[state] int notification_number;
 	[state] Timestamp last_problem_notification;
 


### PR DESCRIPTION
I would like to submit for consideration this patch which fixes Issue 5561, where Notifications with a "begin" time are erroneously delayed, and also avoids delaying begin and end times for a notification due to changes in a problem state, even when the Notification should apply to all problem states.

The patch adds a timestamp field to the Notification class called "trigger_time".  This is set when an object first goes into a problem state for which the Notification applies.  It is reset on a recovery, or on entering a problem state for which the Notification does not apply.

"Begin" and "end" times for the notification are referenced back to this "trigger_time".

I believe these changes will make the Notifications escalate in a way that is much more predictable for users of the monitoring system.  If a Notification should start 10 minutes after a problem is detected (in hard state), it will go out at the ten minute mark without the random delay currently seen.  If a service flips from warning to critical before the first notification goes out, and the Notification should apply to both warning and critical states, the Notification will STILL go out 10 minutes after the first hard problem state was detected.  It will also end AT its end time, relative to that first hard problem state change.
