### PR TITLE
Do not replace colons in plugin output

### DIFF
--- a/lib/icinga/compatutility.cpp
+++ b/lib/icinga/compatutility.cpp
@@ -615,12 +615,6 @@ String CompatUtility::GetCheckResultOutput(const CheckResult::Ptr& cr)
 
 	String raw_output = cr->GetOutput();
 
-	/*
-	 * replace semi-colons with colons in output
-	 * semi-colon is used as delimiter in various interfaces
-	 */
-	boost::algorithm::replace_all(raw_output, ";", ":");
-
 	size_t line_end = raw_output.Find("\n");
 
 	return raw_output.SubStr(0, line_end);
@@ -635,12 +629,6 @@ String CompatUtility::GetCheckResultLongOutput(const CheckResult::Ptr& cr)
 	String output;
 
 	String raw_output = cr->GetOutput();
-
-	/*
-	 * replace semi-colons with colons in output
-	 * semi-colon is used as delimiter in various interfaces
-	 */
-	boost::algorithm::replace_all(raw_output, ";", ":");
 
 	size_t line_end = raw_output.Find("\n");
 


### PR DESCRIPTION
This affects all interfaces which are using the CompatUtility class
format helpers for short and long output.

fixes #4785