### PR TITLE
Add parameter --octetlength to snmp-storage command.

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2023,6 +2023,7 @@ snmp_crit               | **Optional.** The critical threshold.
 snmp_storage_name       | **Optional.** Storage name. Default to regex "^/$$". More options available in the [snmp storage](http://nagios.manubulon.com/snmp_storage.html) documentation.
 snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
 snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
+snmp_storage_olength	| **Optional.** Max-size of the SNMP message, usefull in case of Too Long responses.
 
 ### snmp-interface <a id="plugin-check-command-snmp-interface"></a>
 

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -201,6 +201,10 @@ object CheckCommand "snmp-storage" {
 			set_if = "$snmp_perf$"
 			description = "Perfparse compatible output"
 		}
+		"-o" = {
+			value = "$snmp_storage_olength$"
+			description = "Max-size of the SNMP message, usefull in case of Too Long responses."
+		}
 	}
 
 	vars.snmp_storage_name = "^/$$"


### PR DESCRIPTION
Add parameter --octetlength to snmp-storage command.

This will help to handle large response sizes, e.g. when there are many partitions you want to check.