### PR TITLE
Windows plugin check_swap build fix

### DIFF
--- a/plugins/check_swap.cpp
+++ b/plugins/check_swap.cpp
@@ -191,7 +191,7 @@ INT printOutput(printInfoStruct& printInfo)
 	return state;
 }
 
-INT check_swap(printInfoStruct& printInfo
+INT check_swap(printInfoStruct& printInfo)
 {
 	MEMORYSTATUSEX MemBuf;
 	MemBuf.dwLength = sizeof(MemBuf);

--- a/plugins/thresholds.cpp
+++ b/plugins/thresholds.cpp
@@ -114,7 +114,7 @@ std::wstring threshold::pString(CONST DOUBLE max)
 		upperAbs = upper / 100.0 * max;
 	}
 
-	std::wstring s, lowerStr = removeZero(lowerAbs)
+	std::wstring s, lowerStr = removeZero(lowerAbs),
 					upperStr = removeZero(upperAbs);
 
 	if (lower != upper) {


### PR DESCRIPTION
This fixes a build problem that occurred while building the check_swap plugin. 