### PR TITLE
Fix for wrong attribute in ITL mongodb CheckCommand

### DIFF
--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -618,7 +618,7 @@ object CheckCommand "mongodb" {
 
 	arguments = {
 		"-H" = {
-			value = "$mongodb_address$"
+			value = "$mongodb_host$"
 			description = "The hostname you want to connect to"
 		}
 		"-P" = {
@@ -688,7 +688,18 @@ object CheckCommand "mongodb" {
 		}
 	}
 
-	vars.mongodb_address = "$check_address$"
+	vars.mongodb_host = {{
+		var mongodbAddress = macro("$mongodb_address$")
+		var checkAddress = macro("$check_address$")
+
+		if (mongodbAddress) {
+			log(LogWarning, "CheckerComponent", "The attribute 'mongodb_address' is deprecated, use 'mongodb_host' instead.")
+			return mongodbAddress
+		} else {
+			return checkAddress
+        }
+	}}
+
 	vars.mongodb_perfdata = true
 	vars.mongodb_action = "connections"
 }


### PR DESCRIPTION
This corrects the attribute `mongodb_address` to `mongodb_host`, if the old attribute is set Icinga will use that and output a Log message to the Log.

fixes #5817