### PR TITLE
Fix typo in SELinux documentation

### DIFF
--- a/doc/22-selinux.md
+++ b/doc/22-selinux.md
@@ -104,7 +104,7 @@ SELinux is based on the least level of access required for a service to run. Usi
 
 **icinga2_can_connect_all** 
 
-Having this boolean enabled allows icinga2 to connect to all ports. This can be neccesary if you use features which connect to unconfined services.
+Having this boolean enabled allows icinga2 to connect to all ports. This can be necessary if you use features which connect to unconfined services.
 
 **httpd_can_write_icinga2_command** 
 


### PR DESCRIPTION
This fixes a typo in the SELinux documentation.

![2017-12-28-img1](https://user-images.githubusercontent.com/18580278/34410395-41ec938e-ebd0-11e7-9198-8d6a8c2ad694.PNG)
