### PR TITLE
Add icingacli-director check to ITL

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2505,6 +2505,8 @@ smart_attributes_device         | **Required.** Device name (e.g. /dev/sda) to m
 
 This category includes all plugins using the icingacli provided by Icinga Web 2.
 
+The user running Icinga 2 needs sufficient permissions to read the Icinga Web 2 configuration directory. e.g. `usermod -a -G icingaweb2 icinga`. You need to restart, not reload Icinga 2 for the new group membership to work.
+
 #### Business Process <a id="plugin-contrib-icingacli-businessprocess"></a>
 
 This subcommand is provided by the [business process module](https://exchange.icinga.com/icinga/Business+Process)
@@ -2519,6 +2521,16 @@ icingacli_businessprocess_config          | **Optional.** Configuration file con
 icingacli_businessprocess_details         | **Optional.** Get details for root cause analysis. Defaults to false.
 icingacli_businessprocess_statetype       | **Optional.** Define which state type to look at, `soft` or `hard`. Overrides the default value inside the businessprocess module, if configured.
 
+#### Director <a id="plugin-contrib-icingacli-director"></a>
+
+This subcommand is provided by the [director module](https://github.com/Icinga/icingaweb2-module-director) > 1.4.2 and executed as `icingacli director health check`. Please refer to the [documentation](https://github.com/Icinga/icingaweb2-module-director/blob/master/doc/60-CLI.md#health-check-plugin) for all available sub-checks.
+
+Custom attributes passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
+
+Name                                      | Description
+------------------------------------------|-----------------------------------------------------------------------------------------
+icingacli_director_check                  | **Optional.** Run only a specific test suite.
+icingacli_director_db                     | **Optional.** Use a specific Icinga Web DB resource.
 
 ### IPMI Devices <a id="plugin-contrib-ipmi"></a>
 

--- a/itl/plugins-contrib.d/icingacli.conf
+++ b/itl/plugins-contrib.d/icingacli.conf
@@ -51,3 +51,20 @@ object CheckCommand "icingacli-businessprocess" {
 	vars.icingacli_businessprocess_details = false
 }
 
+object CheckCommand "icingacli-director" {
+        import "icingacli"
+
+        command += [ "director", "health", "check" ]
+
+        arguments = {
+                "--check" = {
+                        value = "$icingacli_director_check$"
+                        description = "Run only a specific test suite"
+                }
+                "--db" = {
+                        value = "$icingacli_director_db$"
+                        description = "Use a specific Icinga Web DB resource"
+                }
+        }
+}
+


### PR DESCRIPTION
Including documentation.
Add a hint to the documentation of all icingacli commands that Icinga 2 has to be allowed access to the icingaweb2 directory.

fixes: #5920