### PR TITLE
Fix missing variable name in ApiListener::Start

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -220,7 +220,7 @@ void ApiListener::Start(bool runtimeCreated)
 	ObjectImpl<ApiListener>::Start(runtimeCreated);
 
 	{
-		boost::mutex::scoped_lock(m_LogLock);
+		boost::mutex::scoped_lock lock(m_LogLock);
 		RotateLogFile();
 		OpenLogFile();
 	}


### PR DESCRIPTION
fixes #5924
refs #5807