### PR TITLE
Replace boost::function with std::function

### DIFF
--- a/lib/base/threadpool.hpp
+++ b/lib/base/threadpool.hpp
@@ -21,7 +21,6 @@
 #define THREADPOOL_H
 
 #include "base/i2-base.hpp"
-#include <boost/function.hpp>
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -47,7 +46,7 @@ enum SchedulerPolicy
 class I2_BASE_API ThreadPool
 {
 public:
-	typedef boost::function<void ()> WorkFunction;
+	typedef std::function<void ()> WorkFunction;
 
 	ThreadPool(size_t max_threads = UINT_MAX);
 	~ThreadPool(void);

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -915,7 +915,7 @@ void Utility::SetNonBlockingSocket(SOCKET s, bool nb)
 #endif /* _WIN32 */
 }
 
-void Utility::QueueAsyncCallback(const boost::function<void (void)>& callback, SchedulerPolicy policy)
+void Utility::QueueAsyncCallback(const std::function<void (void)>& callback, SchedulerPolicy policy)
 {
 	Application::GetTP().Post(callback, policy);
 }

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -85,7 +85,7 @@ public:
 	static void MkDirP(const String& path, int mode);
 	static bool SetFileOwnership(const String& file, const String& user, const String& group);
 
-	static void QueueAsyncCallback(const boost::function<void (void)>& callback, SchedulerPolicy policy = DefaultScheduler);
+	static void QueueAsyncCallback(const std::function<void (void)>& callback, SchedulerPolicy policy = DefaultScheduler);
 
 	static String NaturalJoin(const std::vector<String>& tokens);
 	static String Join(const Array::Ptr& tokens, char separator, bool escapeSeparator = true);


### PR DESCRIPTION
Somehow I missed some boost::function<T> variables while refactoring this in an earlier PR.