### PR TITLE
Fix incorrect ::Start call

### DIFF
--- a/lib/base/filelogger.cpp
+++ b/lib/base/filelogger.cpp
@@ -46,11 +46,11 @@ void FileLogger::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
  */
 void FileLogger::Start(bool runtimeCreated)
 {
-	ObjectImpl<FileLogger>::Start(runtimeCreated);
-
 	ReopenLogFile();
 
 	Application::OnReopenLogs.connect(std::bind(&FileLogger::ReopenLogFile, this));
+
+	ObjectImpl<FileLogger>::Start(runtimeCreated);
 }
 
 void FileLogger::ReopenLogFile(void)


### PR DESCRIPTION
The way we're currently calling the base class' Start() method we might end up with an 'activated' FileLogger (i.e. IsActive() returns true) which doesn't have a valid file handle. This can cause a crash via Log::~Log() (passes IsActive() check for the logger) -> StreamLogger::ProcessLogEntry (derefs nullptr).