### PR TITLE
Fix incorrect indentation for code generated by mkclass

### DIFF
--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -309,7 +309,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			}
 
 			m_Impl << std::endl
-					<< "\t\t\t\tbreak;" << std::endl;
+					<< "\t\t\tbreak;" << std::endl;
 		}
 
 		m_Impl << "\t}" << std::endl;


### PR DESCRIPTION
This fixes a number of compiler warnings that are due to the way how mkclass (incorrectly) indents code:

```
/root/icinga2/build/lib/db_ido/dbconnection.tcpp: In member function 'virtual int icinga::TypeImpl<icinga::DbConnection>::GetFieldId(const icinga::String&) const':
/root/icinga2/build/lib/db_ido/dbconnection.tcpp:51:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
    if (name == "connected")
    ^~
/root/icinga2/build/lib/db_ido/dbconnection.tcpp:54:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
     break;
     ^~~~~
```

The `break` keyword is improperly indented - however, semantically it's working properly:

```
        switch (static_cast<int>(Utility::SDBM(name, 1))) {
                case 99:
                        if (name == "categories")
                                return offset + 3;
                        if (name == "cleanup")
                                return offset + 4;
                        if (name == "categories_filter_real")
                                return offset + 5;
                        if (name == "connected")
                                return offset + 7;

                                break;
```