### PR TITLE
itl: Add command parameters for snmp-memory

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1996,6 +1996,8 @@ snmp_crit               | **Optional.** The critical threshold.
 snmp_is_cisco		| **Optional.** Change OIDs for Cisco switches. Defaults to false.
 snmp_is_hp              | **Optional.** Change OIDs for HP/Procurve switches. Defaults to false.
 snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
+snmp_memcached          | **Optional.** Include cached memory in used memory, Defaults to false.
+snmp_membuffer          | **Optional.** Exclude buffered memory in used memory, Defaults to false.
 snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 
 ### snmp-storage <a id="plugin-check-command-snmp-storage"></a>

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -174,12 +174,22 @@ object CheckCommand "snmp-memory" {
 			set_if = "$snmp_is_hp$"
 			description = "check HP / Procurve memory"
 		}
+		"-m" = {
+			set_if = "$snmp_memcached$"
+			description = "Include cached memory in used memory"
+		}
+		"-b" = {
+			set_if = "$snmp_membuffer$"
+			description = "Exclude buffered memory in used memory"
+		}
 	}
 
 	vars.snmp_warn = "94,50"
 	vars.snmp_crit = "98,80"
 	vars.snmp_perf = true
 	vars.snmp_is_cisco = false
+	vars.snmp_memcached = false
+	vars.snmp_membuffer = false
 }
 
 


### PR DESCRIPTION
Changes parameters to `set_if` and fixed whitespacing for the user.

This superseeds #5654