### PR TITLE
Change a bunch more copyright headers for 2018

### DIFF
--- a/cmake/InstallConfig.cmake
+++ b/cmake/InstallConfig.cmake
@@ -1,5 +1,5 @@
 # Icinga 2
-# Copyright (C) 2012-2016 Icinga Development Team (https://www.icinga.com)
+# Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -395,7 +395,7 @@ static int Main()
 			}
 
 			if (vm.count("version")) {
-				std::cout << "Copyright (c) 2012-2017 Icinga Development Team (https://www.icinga.com/)" << std::endl
+				std::cout << "Copyright (c) 2012-2018 Icinga Development Team (https://www.icinga.com/)" << std::endl
 					<< "License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl2.html>" << std::endl
 					<< "This is free software: you are free to change and redistribute it." << std::endl
 					<< "There is NO WARRANTY, to the extent permitted by law.";

--- a/lib/base/library.cpp
+++ b/lib/base/library.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/lib/base/library.hpp
+++ b/lib/base/library.hpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/lib/db_ido_mysql/schema/mysql.sql
+++ b/lib/db_ido_mysql/schema/mysql.sql
@@ -2,7 +2,7 @@
 -- mysql.sql
 -- DB definition for IDO MySQL
 --
--- Copyright (c) 2009-2017 Icinga Development Team (https://www.icinga.com/)
+-- Copyright (c) 2009-2018 Icinga Development Team (https://www.icinga.com/)
 --
 -- -- --------------------------------------------------------
 

--- a/lib/db_ido_pgsql/schema/pgsql.sql
+++ b/lib/db_ido_pgsql/schema/pgsql.sql
@@ -2,7 +2,7 @@
 -- pgsql.sql
 -- DB definition for IDO Postgresql
 --
--- Copyright (c) 2009-2017 Icinga Development Team (https://www.icinga.com/)
+-- Copyright (c) 2009-2018 Icinga Development Team (https://www.icinga.com/)
 --
 -- --------------------------------------------------------
 

--- a/lib/mysql_shim/CMakeLists.txt
+++ b/lib/mysql_shim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Icinga 2
-# Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)
+# Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/lib/mysql_shim/mysqlinterface.cpp
+++ b/lib/mysql_shim/mysqlinterface.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/lib/mysql_shim/mysqlinterface.hpp
+++ b/lib/mysql_shim/mysqlinterface.hpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/lib/pgsql_shim/CMakeLists.txt
+++ b/lib/pgsql_shim/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Icinga 2
-# Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)
+# Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/lib/pgsql_shim/pgsqlinterface.cpp
+++ b/lib/pgsql_shim/pgsqlinterface.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/lib/pgsql_shim/pgsqlinterface.hpp
+++ b/lib/pgsql_shim/pgsqlinterface.hpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2017 Icinga Development Team (https://www.icinga.com/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/test/icinga-checkable-fixture.cpp
+++ b/test/icinga-checkable-fixture.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2016 Icinga Development Team (https://www.icinga.org/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.org/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/test/icinga-checkable-flapping.cpp
+++ b/test/icinga-checkable-flapping.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2016 Icinga Development Team (https://www.icinga.org/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.org/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Icinga 2                                                                   *
- * Copyright (C) 2012-2016 Icinga Development Team (https://www.icinga.org/)  *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.org/)  *
  *                                                                            *
  * This program is free software; you can redistribute it and/or              *
  * modify it under the terms of the GNU General Public License                *


### PR DESCRIPTION
This changes more copyright headers for 2018. This also changes the copyright date range in the `icinga2 --version` output.

refs #5933 