### PR TITLE
Add minimum version check to the built-in icinga command

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -74,9 +74,13 @@ plugin scripts.
 ### icinga <a id="itl-icinga"></a>
 
 Check command for the built-in `icinga` check. This check returns performance
-data for the current Icinga instance.
+data for the current Icinga instance and optionally allows for minimum version checks.
 
-The `icinga` check command does not support any vars.
+Custom attributes passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
+
+Name                   | Description
+-----------------------|---------------
+icinga\_min\_version   | **Optional.** Required minimum Icinga 2 version, e.g. `2.8.0`. If not satisfied, the state changes to `Critical`. Release packages only.
 
 ### cluster <a id="itl-icinga-cluster"></a>
 

--- a/lib/methods/icingachecktask.hpp
+++ b/lib/methods/icingachecktask.hpp
@@ -34,7 +34,7 @@ namespace icinga
 class IcingaCheckTask
 {
 public:
-	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
+	static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
 		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:


### PR DESCRIPTION
<img width="620" alt="screen shot 2018-01-08 at 19 45 33" src="https://user-images.githubusercontent.com/382049/34686677-a7943f4a-f4ac-11e7-95d0-ae4349281305.png">

```
object Host "3998-host" {
  check_command = "icinga"

  vars.icinga_min_version = "2.9.4"
  //vars.icinga_min_version = "2.7.2"
}
```

fixes #3998
 