### PR TITLE
OpenTSDB writer - Fix function for escaping host tag chars.

### DIFF
--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -120,7 +120,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 	String metric;
 	std::map<String, String> tags;
 
-	String escaped_hostName = EscapeMetric(host->GetName());
+	String escaped_hostName = EscapeTag(host->GetName());
 	tags["host"] = escaped_hostName;
 
 	double ts = cr->GetExecutionEnd();


### PR DESCRIPTION
Escape the correct chars for opentsdb metric host tag.

fixes #5963