### PR TITLE
Avoid unnecessary casts in the JSON encoder

### DIFF
--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -81,12 +81,24 @@ static void Encode(yajl_gen handle, const Value& value)
 
 			break;
 		case ValueObject:
-			if (value.IsObjectType<Dictionary>())
-				EncodeDictionary(handle, value);
-			else if (value.IsObjectType<Array>())
-				EncodeArray(handle, value);
-			else
-				yajl_gen_null(handle);
+			{
+				const Object::Ptr& obj = value.Get<Object::Ptr>();
+				Dictionary::Ptr dict = dynamic_pointer_cast<Dictionary>(obj);
+
+				if (dict) {
+					EncodeDictionary(handle, dict);
+					break;
+				}
+
+				Array::Ptr arr = dynamic_pointer_cast<Array>(obj);
+
+				if (arr) {
+					EncodeArray(handle, arr);
+					break;
+				}
+			}
+
+			yajl_gen_null(handle);
 
 			break;
 		case ValueEmpty:


### PR DESCRIPTION
1. IsObjectType() checks whether the Value is actually an object - which we know to be true already.
2. IsObjectType() then does a dynamic_cast to see if the contained Object::Ptr points to an object of the specified type.
3. Then... we do the whole thing again via the implicit <T>::Ptr operator (when passing the original value to EncodeDictionary/EncodeArray as an argument).