### PR TITLE
Remove the WorkQueue::m_StatsMutex instance variable

### DIFF
--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -310,15 +310,11 @@ void WorkQueue::WorkerThreadProc()
 
 void WorkQueue::IncreaseTaskCount()
 {
-	double now = Utility::GetTime();
-
-	boost::mutex::scoped_lock lock(m_StatsMutex);
-	m_TaskStats.InsertValue(now, 1);
+	m_TaskStats.InsertValue(Utility::GetTime(), 1);
 }
 
 size_t WorkQueue::GetTaskCount(RingBuffer::SizeType span)
 {
-	boost::mutex::scoped_lock lock(m_StatsMutex);
 	return m_TaskStats.UpdateAndGetValues(Utility::GetTime(), span);
 }
 

--- a/lib/base/workqueue.hpp
+++ b/lib/base/workqueue.hpp
@@ -146,7 +146,6 @@ private:
 	Timer::Ptr m_StatusTimer;
 	double m_StatusTimerTimeout;
 
-	mutable boost::mutex m_StatsMutex;
 	RingBuffer m_TaskStats;
 	size_t m_PendingTasks{0};
 	double m_PendingTasksTimestamp{0};


### PR DESCRIPTION
The RingBuffer class already has its own mutex, so there's no point in having _yet_ another mutex for this.