### PR TITLE
Allocate ConfigItemBuilder objects on the stack

### DIFF
--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -148,11 +148,11 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 	Type::Ptr appType = Type::GetByName(ScriptGlobal::Get("ApplicationType", &Empty));
 
 	if (ConfigItem::GetItems(appType).empty()) {
-		ConfigItemBuilder::Ptr builder = new ConfigItemBuilder();
-		builder->SetType(appType);
-		builder->SetName("app");
-		builder->AddExpression(new ImportDefaultTemplatesExpression());
-		ConfigItem::Ptr item = builder->Compile();
+		ConfigItemBuilder builder;
+		builder.SetType(appType);
+		builder.SetName("app");
+		builder.AddExpression(new ImportDefaultTemplatesExpression());
+		ConfigItem::Ptr item = builder.Compile();
 		item->Register();
 	}
 

--- a/lib/config/configitembuilder.hpp
+++ b/lib/config/configitembuilder.hpp
@@ -34,7 +34,7 @@ namespace icinga
  *
  * @ingroup config
  */
-class ConfigItemBuilder final : public Object
+class ConfigItemBuilder final
 {
 public:
 	DECLARE_PTR_TYPEDEFS(ConfigItemBuilder);

--- a/lib/config/vmops.hpp
+++ b/lib/config/vmops.hpp
@@ -146,7 +146,7 @@ public:
 	static inline Value NewObject(ScriptFrame& frame, bool abstract, const Type::Ptr& type, const String& name, const std::shared_ptr<Expression>& filter,
 		const String& zone, const String& package, bool defaultTmpl, bool ignoreOnError, const std::map<String, std::unique_ptr<Expression> >& closedVars, const std::shared_ptr<Expression>& expression, const DebugInfo& debugInfo = DebugInfo())
 	{
-		ConfigItemBuilder::Ptr item = new ConfigItemBuilder(debugInfo);
+		ConfigItemBuilder item{debugInfo};
 
 		String checkName = name;
 
@@ -173,21 +173,21 @@ public:
 			BOOST_THROW_EXCEPTION(ScriptError(msgbuf.str(), debugInfo));
 		}
 
-		item->SetType(type);
-		item->SetName(name);
+		item.SetType(type);
+		item.SetName(name);
 
 		if (!abstract)
-			item->AddExpression(new ImportDefaultTemplatesExpression());
+			item.AddExpression(new ImportDefaultTemplatesExpression());
 
-		item->AddExpression(new OwnedExpression(expression));
-		item->SetAbstract(abstract);
-		item->SetScope(EvaluateClosedVars(frame, closedVars));
-		item->SetZone(zone);
-		item->SetPackage(package);
-		item->SetFilter(filter);
-		item->SetDefaultTemplate(defaultTmpl);
-		item->SetIgnoreOnError(ignoreOnError);
-		item->Compile()->Register();
+		item.AddExpression(new OwnedExpression(expression));
+		item.SetAbstract(abstract);
+		item.SetScope(EvaluateClosedVars(frame, closedVars));
+		item.SetZone(zone);
+		item.SetPackage(package);
+		item.SetFilter(filter);
+		item.SetDefaultTemplate(defaultTmpl);
+		item.SetIgnoreOnError(ignoreOnError);
+		item.Compile()->Register();
 
 		return Empty;
 	}

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -46,34 +46,34 @@ bool Dependency::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, cons
 		<< "Applying dependency '" << name << "' to object '" << checkable->GetName() << "' for rule " << di;
 #endif /* _DEBUG */
 
-	ConfigItemBuilder::Ptr builder = new ConfigItemBuilder(di);
-	builder->SetType(Dependency::TypeInstance);
-	builder->SetName(name);
-	builder->SetScope(frame.Locals->ShallowClone());
-	builder->SetIgnoreOnError(rule.GetIgnoreOnError());
+	ConfigItemBuilder builder{di};
+	builder.SetType(Dependency::TypeInstance);
+	builder.SetName(name);
+	builder.SetScope(frame.Locals->ShallowClone());
+	builder.SetIgnoreOnError(rule.GetIgnoreOnError());
 
 	Host::Ptr host;
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "parent_host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "child_host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "parent_host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "child_host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
 
 	if (service)
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "child_service_name"), OpSetLiteral, MakeLiteral(service->GetShortName()), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "child_service_name"), OpSetLiteral, MakeLiteral(service->GetShortName()), di));
 
 	String zone = checkable->GetZoneName();
 
 	if (!zone.IsEmpty())
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
 
-	builder->AddExpression(new ImportDefaultTemplatesExpression());
+	builder.AddExpression(new ImportDefaultTemplatesExpression());
 
-	builder->AddExpression(new OwnedExpression(rule.GetExpression()));
+	builder.AddExpression(new OwnedExpression(rule.GetExpression()));
 
-	ConfigItem::Ptr dependencyItem = builder->Compile();
+	ConfigItem::Ptr dependencyItem = builder.Compile();
 	dependencyItem->Register();
 
 	return true;

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -46,33 +46,33 @@ bool Notification::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, co
 		<< "Applying notification '" << name << "' to object '" << checkable->GetName() << "' for rule " << di;
 #endif /* _DEBUG */
 
-	ConfigItemBuilder::Ptr builder = new ConfigItemBuilder(di);
-	builder->SetType(Notification::TypeInstance);
-	builder->SetName(name);
-	builder->SetScope(frame.Locals->ShallowClone());
-	builder->SetIgnoreOnError(rule.GetIgnoreOnError());
+	ConfigItemBuilder builder{di};
+	builder.SetType(Notification::TypeInstance);
+	builder.SetName(name);
+	builder.SetScope(frame.Locals->ShallowClone());
+	builder.SetIgnoreOnError(rule.GetIgnoreOnError());
 
 	Host::Ptr host;
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
 
 	if (service)
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "service_name"), OpSetLiteral, MakeLiteral(service->GetShortName()), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "service_name"), OpSetLiteral, MakeLiteral(service->GetShortName()), di));
 
 	String zone = checkable->GetZoneName();
 
 	if (!zone.IsEmpty())
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
 
-	builder->AddExpression(new OwnedExpression(rule.GetExpression()));
+	builder.AddExpression(new OwnedExpression(rule.GetExpression()));
 
-	builder->AddExpression(new ImportDefaultTemplatesExpression());
+	builder.AddExpression(new ImportDefaultTemplatesExpression());
 
-	ConfigItem::Ptr notificationItem = builder->Compile();
+	ConfigItem::Ptr notificationItem = builder.Compile();
 	notificationItem->Register();
 
 	return true;

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -45,33 +45,33 @@ bool ScheduledDowntime::EvaluateApplyRuleInstance(const Checkable::Ptr& checkabl
 		<< "Applying scheduled downtime '" << rule.GetName() << "' to object '" << checkable->GetName() << "' for rule " << di;
 #endif /* _DEBUG */
 
-	ConfigItemBuilder::Ptr builder = new ConfigItemBuilder(di);
-	builder->SetType(ScheduledDowntime::TypeInstance);
-	builder->SetName(name);
-	builder->SetScope(frame.Locals->ShallowClone());
-	builder->SetIgnoreOnError(rule.GetIgnoreOnError());
+	ConfigItemBuilder builder{di};
+	builder.SetType(ScheduledDowntime::TypeInstance);
+	builder.SetName(name);
+	builder.SetScope(frame.Locals->ShallowClone());
+	builder.SetIgnoreOnError(rule.GetIgnoreOnError());
 
 	Host::Ptr host;
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
 
 	if (service)
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "service_name"), OpSetLiteral, MakeLiteral(service->GetShortName()), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "service_name"), OpSetLiteral, MakeLiteral(service->GetShortName()), di));
 
 	String zone = checkable->GetZoneName();
 
 	if (!zone.IsEmpty())
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
 
-	builder->AddExpression(new OwnedExpression(rule.GetExpression()));
+	builder.AddExpression(new OwnedExpression(rule.GetExpression()));
 
-	builder->AddExpression(new ImportDefaultTemplatesExpression());
+	builder.AddExpression(new ImportDefaultTemplatesExpression());
 
-	ConfigItem::Ptr downtimeItem = builder->Compile();
+	ConfigItem::Ptr downtimeItem = builder.Compile();
 	downtimeItem->Register();
 
 	return true;

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -45,28 +45,28 @@ bool Service::EvaluateApplyRuleInstance(const Host::Ptr& host, const String& nam
 		<< "Applying service '" << name << "' to host '" << host->GetName() << "' for rule " << di;
 #endif /* _DEBUG */
 
-	ConfigItemBuilder::Ptr builder = new ConfigItemBuilder(di);
-	builder->SetType(Service::TypeInstance);
-	builder->SetName(name);
-	builder->SetScope(frame.Locals->ShallowClone());
-	builder->SetIgnoreOnError(rule.GetIgnoreOnError());
+	ConfigItemBuilder builder{di};
+	builder.SetType(Service::TypeInstance);
+	builder.SetName(name);
+	builder.SetScope(frame.Locals->ShallowClone());
+	builder.SetIgnoreOnError(rule.GetIgnoreOnError());
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "host_name"), OpSetLiteral, MakeLiteral(host->GetName()), di));
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "name"), OpSetLiteral, MakeLiteral(name), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "name"), OpSetLiteral, MakeLiteral(name), di));
 
 	String zone = host->GetZoneName();
 
 	if (!zone.IsEmpty())
-		builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
+		builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "zone"), OpSetLiteral, MakeLiteral(zone), di));
 
-	builder->AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
+	builder.AddExpression(new SetExpression(MakeIndexer(ScopeThis, "package"), OpSetLiteral, MakeLiteral(rule.GetPackage()), di));
 
-	builder->AddExpression(new OwnedExpression(rule.GetExpression()));
+	builder.AddExpression(new OwnedExpression(rule.GetExpression()));
 
-	builder->AddExpression(new ImportDefaultTemplatesExpression());
+	builder.AddExpression(new ImportDefaultTemplatesExpression());
 
-	ConfigItem::Ptr serviceItem = builder->Compile();
+	ConfigItem::Ptr serviceItem = builder.Compile();
 	serviceItem->Register();
 
 	return true;


### PR DESCRIPTION
ConfigItemBuilder objects are exceptionally short-lived and should therefore be allocated on the stack - which allows us to avoid all the overhead that comes with inheriting from Object (heap allocation, atomic increments/decrements for Ptrs).