### PR TITLE
Fix wrong schema constraint for fresh 2.8.0 installations

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -15,6 +15,11 @@ There are additional indexes and schema fixes which require an update.
 
 Please proceed here for [MySQL](16-upgrading-icinga-2.md#upgrading-mysql-db) or [PostgreSQL](16-upgrading-icinga-2.md#upgrading-postgresql-db).
 
+> **Note**
+>
+> `2.8.1.sql` fixes a unique constraint problem with fresh 2.8.0 installations.
+> You don't need this update if you are upgrading from an older version.
+
 ### Changed Certificate Paths <a id="upgrading-to-2-8-certificate-paths"></a>
 
 The default certificate path was changed from `/etc/icinga2/pki` to

--- a/lib/db_ido_mysql/schema/mysql.sql
+++ b/lib/db_ido_mysql/schema/mysql.sql
@@ -80,8 +80,7 @@ CREATE TABLE IF NOT EXISTS icinga_commenthistory (
   deletion_time timestamp NULL,
   deletion_time_usec  int default 0,
   name TEXT character set latin1 default NULL,
-  PRIMARY KEY  (commenthistory_id),
-  UNIQUE KEY instance_id (instance_id,object_id,comment_time,internal_comment_id)
+  PRIMARY KEY  (commenthistory_id)
 ) ENGINE=InnoDB  COMMENT='Historical host and service comments';
 
 -- --------------------------------------------------------
@@ -108,8 +107,7 @@ CREATE TABLE IF NOT EXISTS icinga_comments (
   expiration_time timestamp NULL,
   name TEXT character set latin1 default NULL,
   session_token int default NULL,
-  PRIMARY KEY  (comment_id),
-  UNIQUE KEY instance_id (instance_id,object_id,comment_time,internal_comment_id)
+  PRIMARY KEY  (comment_id)
 ) ENGINE=InnoDB  COMMENT='Usercomments on Icinga objects';
 
 -- --------------------------------------------------------
@@ -412,8 +410,7 @@ CREATE TABLE IF NOT EXISTS icinga_downtimehistory (
   is_in_effect smallint default 0,
   trigger_time timestamp NULL,
   name TEXT character set latin1 default NULL,
-  PRIMARY KEY  (downtimehistory_id),
-  UNIQUE KEY instance_id (instance_id,object_id,entry_time,internal_downtime_id)
+  PRIMARY KEY  (downtimehistory_id)
 ) ENGINE=InnoDB  COMMENT='Historical scheduled host and service downtime';
 
 -- --------------------------------------------------------
@@ -977,8 +974,7 @@ CREATE TABLE IF NOT EXISTS icinga_scheduleddowntime (
   trigger_time timestamp NULL,
   name TEXT character set latin1 default NULL,
   session_token int default NULL,
-  PRIMARY KEY  (scheduleddowntime_id),
-  UNIQUE KEY instance_id (instance_id,object_id,entry_time,internal_downtime_id)
+  PRIMARY KEY  (scheduleddowntime_id)
 ) ENGINE=InnoDB COMMENT='Current scheduled host and service downtime';
 
 -- --------------------------------------------------------

--- a/lib/db_ido_mysql/schema/upgrade/2.8.1.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.8.1.sql
@@ -1,0 +1,67 @@
+-- -----------------------------------------
+-- upgrade path for Icinga 2.8.1 (fix for fresh 2.8.0 installation only)
+--
+-- -----------------------------------------
+-- Copyright (c) 2018 Icinga Development Team (https://www.icinga.com)
+--
+-- Please check https://docs.icinga.com for upgrading information!
+-- -----------------------------------------
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+
+-- --------------------------------------------------------
+-- Helper functions and procedures for DROP INDEX IF EXISTS
+-- --------------------------------------------------------
+
+DELIMITER //
+DROP FUNCTION IF EXISTS ido_index_exists //
+CREATE FUNCTION ido_index_exists(
+  f_table_name varchar(64),
+  f_index_name varchar(64)
+)
+  RETURNS BOOL
+  DETERMINISTIC
+  READS SQL DATA
+  BEGIN
+    DECLARE index_exists BOOL DEFAULT FALSE;
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.statistics
+        WHERE table_schema = SCHEMA()
+              AND table_name = f_table_name
+              AND index_name = f_index_name
+    ) INTO index_exists;
+    RETURN index_exists;
+  END //
+
+DROP PROCEDURE IF EXISTS ido_drop_index_if_exists //
+CREATE PROCEDURE ido_drop_index_if_exists (
+  IN p_table_name varchar(64),
+  IN p_index_name varchar(64)
+)
+  DETERMINISTIC
+  MODIFIES SQL DATA
+  BEGIN
+    IF ido_index_exists(p_table_name, p_index_name)
+    THEN
+      SET @ido_drop_index_sql = CONCAT('ALTER TABLE `', SCHEMA(), '`.`', p_table_name, '` DROP INDEX `', p_index_name, '`');
+      PREPARE stmt FROM @ido_drop_index_sql;
+      EXECUTE stmt;
+      DEALLOCATE PREPARE stmt;
+      SET @ido_drop_index_sql = NULL;
+    END IF;
+  END //
+DELIMITER ;
+
+CALL ido_drop_index_if_exists('icinga_downtimehistory', 'instance_id');
+CALL ido_drop_index_if_exists('icinga_scheduleddowntime', 'instance_id');
+CALL ido_drop_index_if_exists('icinga_commenthistory', 'instance_id');
+CALL ido_drop_index_if_exists('icinga_comments', 'instance_id');
+
+DROP FUNCTION ido_index_exists;
+DROP PROCEDURE ido_drop_index_if_exists;
+
+-- -----------------------------------------
+-- set dbversion (same as 2.8.0)
+-- -----------------------------------------
+INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.14.3', NOW(), NOW()) ON DUPLICATE KEY UPDATE version='1.14.3', modify_time=NOW();

--- a/lib/db_ido_pgsql/schema/pgsql.sql
+++ b/lib/db_ido_pgsql/schema/pgsql.sql
@@ -112,8 +112,7 @@ CREATE TABLE  icinga_commenthistory (
   deletion_time timestamp,
   deletion_time_usec INTEGER  default 0,
   name TEXT default NULL,
-  CONSTRAINT PK_commenthistory_id PRIMARY KEY (commenthistory_id) ,
-  CONSTRAINT UQ_commenthistory UNIQUE (instance_id,object_id,comment_time,internal_comment_id)
+  CONSTRAINT PK_commenthistory_id PRIMARY KEY (commenthistory_id)
 );
 
 -- --------------------------------------------------------
@@ -140,8 +139,7 @@ CREATE TABLE  icinga_comments (
   expiration_time timestamp,
   name TEXT default NULL,
   session_token INTEGER default NULL,
-  CONSTRAINT PK_comment_id PRIMARY KEY (comment_id) ,
-  CONSTRAINT UQ_comments UNIQUE (instance_id,object_id,comment_time,internal_comment_id)
+  CONSTRAINT PK_comment_id PRIMARY KEY (comment_id)
 )  ;
 
 -- --------------------------------------------------------
@@ -448,8 +446,7 @@ CREATE TABLE  icinga_downtimehistory (
   is_in_effect INTEGER  default 0,
   trigger_time timestamp,
   name TEXT default NULL,
-  CONSTRAINT PK_downtimehistory_id PRIMARY KEY (downtimehistory_id) ,
-  CONSTRAINT UQ_downtimehistory UNIQUE (instance_id,object_id,entry_time,internal_downtime_id)
+  CONSTRAINT PK_downtimehistory_id PRIMARY KEY (downtimehistory_id)
 ) ;
 
 -- --------------------------------------------------------
@@ -1014,8 +1011,7 @@ CREATE TABLE  icinga_scheduleddowntime (
   trigger_time timestamp,
   name TEXT default NULL,
   session_token INTEGER default NULL,
-  CONSTRAINT PK_scheduleddowntime_id PRIMARY KEY (scheduleddowntime_id) ,
-  CONSTRAINT UQ_scheduleddowntime UNIQUE (instance_id,object_id,entry_time,internal_downtime_id)
+  CONSTRAINT PK_scheduleddowntime_id PRIMARY KEY (scheduleddowntime_id)
 ) ;
 
 -- --------------------------------------------------------

--- a/lib/db_ido_pgsql/schema/upgrade/2.8.1.sql
+++ b/lib/db_ido_pgsql/schema/upgrade/2.8.1.sql
@@ -1,0 +1,19 @@
+-- -----------------------------------------
+-- upgrade path for Icinga 2.8.1 (fix for fresh 2.8.0 installation only)
+--
+-- -----------------------------------------
+-- Copyright (c) 2018 Icinga Development Team (https://www.icinga.com)
+--
+-- Please check https://docs.icinga.com for upgrading information!
+-- -----------------------------------------
+
+ALTER TABLE icinga_downtimehistory DROP CONSTRAINT IF EXISTS UQ_downtimehistory;
+ALTER TABLE icinga_scheduleddowntime DROP CONSTRAINT IF EXISTS UQ_scheduleddowntime;
+ALTER TABLE icinga_commenthistory DROP CONSTRAINT IF EXISTS UQ_commenthistory;
+ALTER TABLE icinga_comments DROP CONSTRAINT IF EXISTS UQ_comments;
+
+-- -----------------------------------------
+-- set dbversion (same as 2.8.0)
+-- -----------------------------------------
+
+SELECT updatedbversion('1.14.3');


### PR DESCRIPTION
This fix is only needed for a fresh 2.8.0 setup, older versions
and upgrades to current do not need this (can be applied as idempotent
update).

fixes #5947