### PR TITLE
Remove build breaking include

### DIFF
--- a/third-party/socketpair/CMakeLists.txt
+++ b/third-party/socketpair/CMakeLists.txt
@@ -25,7 +25,3 @@ set_target_properties (
   socketpair PROPERTIES
   FOLDER Lib
 )
-
-if(WIN32)
-  target_link_libraries(socketpair ws2_32)
-endif()


### PR DESCRIPTION
This breaks the build for windows and does not seem to be required.