### PR TITLE
Implement support for user-defined post-creation validators/rules

### DIFF
--- a/etc/icinga2/conf.d/notifications.conf
+++ b/etc/icinga2/conf.d/notifications.conf
@@ -20,6 +20,12 @@ apply Notification "mail-icingaadmin" to Host {
   assign where host.vars.notification.mail
 }
 
+rule Host {
+  if (vars.notification.mail) {
+    require vars.notification.mail.groups || vars.notification.mail.users
+  }
+}
+
 apply Notification "mail-icingaadmin" to Service {
   import "mail-service-notification"
   user_groups = host.vars.notification.mail.groups
@@ -31,3 +37,4 @@ apply Notification "mail-icingaadmin" to Service {
 
   assign where host.vars.notification.mail
 }
+

--- a/lib/config/CMakeLists.txt
+++ b/lib/config/CMakeLists.txt
@@ -43,6 +43,7 @@ set(config_SOURCES
   configitem.cpp configitem.hpp
   configitembuilder.cpp configitembuilder.hpp
   expression.cpp expression.hpp
+  mutatorrule.cpp mutatorrule.hpp
   objectrule.cpp objectrule.hpp
   vmops.hpp
   ${FLEX_config_lexer_OUTPUTS} ${BISON_config_parser_OUTPUTS}

--- a/lib/config/config_lexer.ll
+++ b/lib/config/config_lexer.ll
@@ -167,6 +167,8 @@ do {							\
 <INITIAL>{
 object				return T_OBJECT;
 template			return T_TEMPLATE;
+rule				return T_RULE;
+require				return T_REQUIRE;
 include				return T_INCLUDE;
 include_recursive		return T_INCLUDE_RECURSIVE;
 include_zones			return T_INCLUDE_ZONES;

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -21,6 +21,7 @@
 #include "config/configcompilercontext.hpp"
 #include "config/applyrule.hpp"
 #include "config/objectrule.hpp"
+#include "config/mutatorrule.hpp"
 #include "config/configcompiler.hpp"
 #include "base/application.hpp"
 #include "base/configtype.hpp"
@@ -201,6 +202,7 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 		m_Scope->CopyTo(frame.Locals);
 	try {
 		m_Expression->Evaluate(frame, &debugHints);
+		MutatorRule::EvaluateRules(frame, dobj, &debugHints);
 	} catch (const std::exception& ex) {
 		if (m_IgnoreOnError) {
 			Log(LogNotice, "ConfigObject")

--- a/lib/config/expression.hpp
+++ b/lib/config/expression.hpp
@@ -661,6 +661,35 @@ private:
 	std::unique_ptr<Expression> m_LoopBody;
 };
 
+class RequireExpression final : public UnaryExpression
+{
+public:
+	RequireExpression(std::unique_ptr<Expression> expression, const DebugInfo& debugInfo = DebugInfo())
+		: UnaryExpression(std::move(expression), debugInfo)
+	{ }
+
+protected:
+	ExpressionResult DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const override;
+};
+
+class MutatorExpression final : public DebuggableExpression
+{
+public:
+	MutatorExpression(std::unique_ptr<Expression> name, std::unique_ptr<Expression> targets,
+		std::unique_ptr<Expression> expression, std::map<String, std::unique_ptr<Expression> >&& closedVars, const DebugInfo& debugInfo = DebugInfo())
+		: DebuggableExpression(debugInfo), m_Name(std::move(name)), m_Targets(std::move(targets)), m_Expression(std::move(expression)),
+		m_ClosedVars(std::move(closedVars))
+	{ }
+
+protected:
+	ExpressionResult DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const override;
+
+private:
+	std::unique_ptr<Expression> m_Name;
+	std::unique_ptr<Expression> m_Targets;
+	std::shared_ptr<Expression> m_Expression;
+	std::map<String, std::unique_ptr<Expression> > m_ClosedVars;
+};
 
 class ReturnExpression final : public UnaryExpression
 {

--- a/lib/config/mutatorrule.cpp
+++ b/lib/config/mutatorrule.cpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * Icinga 2                                                                   *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
+ *                                                                            *
+ * This program is free software; you can redistribute it and/or              *
+ * modify it under the terms of the GNU General Public License                *
+ * as published by the Free Software Foundation; either version 2             *
+ * of the License, or (at your option) any later version.                     *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program; if not, write to the Free Software Foundation     *
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ ******************************************************************************/
+
+#include "config/mutatorrule.hpp"
+#include "base/logger.hpp"
+#include <set>
+
+using namespace icinga;
+
+MutatorRule::RuleVector MutatorRule::m_Rules;
+
+MutatorRule::MutatorRule(String namePattern, std::set<Type::Ptr> targets, std::shared_ptr<Expression> expression,
+	DebugInfo di, Dictionary::Ptr scope)
+	: m_NamePattern(std::move(namePattern)), m_TargetTypes(std::move(targets)),
+	m_Expression(std::move(expression)), m_DebugInfo(std::move(di)), m_Scope(std::move(scope))
+{ }
+
+String MutatorRule::GetNamePattern() const
+{
+	return m_NamePattern;
+}
+
+std::set<Type::Ptr> MutatorRule::GetTargetTypes() const
+{
+	return m_TargetTypes;
+}
+
+std::shared_ptr<Expression> MutatorRule::GetExpression() const
+{
+	return m_Expression;
+}
+
+DebugInfo MutatorRule::GetDebugInfo() const
+{
+	return m_DebugInfo;
+}
+
+Dictionary::Ptr MutatorRule::GetScope() const
+{
+	return m_Scope;
+}
+
+void MutatorRule::AddRule(const String& namePattern, const std::set<Type::Ptr>& targetTypes, const std::shared_ptr<Expression>& expression,
+	const DebugInfo& di, const Dictionary::Ptr& scope)
+{
+	m_Rules.push_back(MutatorRule(namePattern, targetTypes, expression, di, scope));
+}
+
+void MutatorRule::EvaluateRule(ScriptFrame& frame, const ConfigObject::Ptr& object, DebugHint *dhint) const
+{
+	if (m_Scope)
+		m_Scope->CopyTo(frame.Locals);
+
+	ASSERT(frame.Self == object);
+
+	m_Expression->Evaluate(frame, dhint);
+}
+
+void MutatorRule::EvaluateRules(ScriptFrame& frame, const ConfigObject::Ptr& object, DebugHint *dhint)
+{
+	for (const MutatorRule& rule : m_Rules) {
+		if (!rule.m_TargetTypes.empty()) {
+			bool found = false;
+			Type::Ptr type = object->GetReflectionType();
+
+			for (const Type::Ptr& targetType : rule.m_TargetTypes) {
+				if (targetType->IsAssignableFrom(type)) {
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+				continue;
+		}
+
+		if (!rule.m_NamePattern.IsEmpty() && !Utility::Match(rule.m_NamePattern, object->GetName()))
+			continue;
+
+		rule.EvaluateRule(frame, object, dhint);
+	}
+}

--- a/lib/config/mutatorrule.hpp
+++ b/lib/config/mutatorrule.hpp
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Icinga 2                                                                   *
+ * Copyright (C) 2012-2018 Icinga Development Team (https://www.icinga.com/)  *
+ *                                                                            *
+ * This program is free software; you can redistribute it and/or              *
+ * modify it under the terms of the GNU General Public License                *
+ * as published by the Free Software Foundation; either version 2             *
+ * of the License, or (at your option) any later version.                     *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful,            *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              *
+ * GNU General Public License for more details.                               *
+ *                                                                            *
+ * You should have received a copy of the GNU General Public License          *
+ * along with this program; if not, write to the Free Software Foundation     *
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ ******************************************************************************/
+
+#ifndef MUTATORRULE_H
+#define MUTATORRULE_H
+
+#include "config/i2-config.hpp"
+#include "config/expression.hpp"
+#include "base/debuginfo.hpp"
+
+namespace icinga
+{
+
+/**
+ * @ingroup config
+ */
+class MutatorRule
+{
+public:
+	typedef std::vector<MutatorRule> RuleVector;
+
+	String GetNamePattern() const;
+	std::set<Type::Ptr> GetTargetTypes() const;
+	std::shared_ptr<Expression> GetExpression() const;
+	DebugInfo GetDebugInfo() const;
+	Dictionary::Ptr GetScope() const;
+
+	void EvaluateRule(ScriptFrame& frame, const ConfigObject::Ptr& object, DebugHint *dhint = nullptr) const;
+
+	static void AddRule(const String& namePattern, const std::set<Type::Ptr>& targets, const std::shared_ptr<Expression>& expression,
+		const DebugInfo& di, const Dictionary::Ptr& scope);
+	static void EvaluateRules(ScriptFrame& frame, const ConfigObject::Ptr& object, DebugHint *dhint = nullptr);
+
+private:
+	String m_NamePattern;
+	std::set<Type::Ptr> m_TargetTypes;
+	std::shared_ptr<Expression> m_Expression;
+	DebugInfo m_DebugInfo;
+	Dictionary::Ptr m_Scope;
+
+	static RuleVector m_Rules;
+
+	MutatorRule(String namePattern, std::set<Type::Ptr> targetTypes, std::shared_ptr<Expression> expression,
+		DebugInfo di, Dictionary::Ptr scope);
+};
+
+}
+
+#endif /* MUTATORRULE_H */

--- a/lib/config/vmops.hpp
+++ b/lib/config/vmops.hpp
@@ -25,6 +25,7 @@
 #include "config/configitembuilder.hpp"
 #include "config/applyrule.hpp"
 #include "config/objectrule.hpp"
+#include "config/mutatorrule.hpp"
 #include "base/debuginfo.hpp"
 #include "base/array.hpp"
 #include "base/dictionary.hpp"
@@ -131,6 +132,14 @@ public:
 		};
 
 		return new Function(name, wrapper, argNames);
+	}
+
+	static inline Value NewMutator(ScriptFrame& frame, const String& name, const std::set<Type::Ptr>& targetTypes, const std::shared_ptr<Expression>& expression,
+		const std::map<String, std::unique_ptr<Expression> >& closedVars, const DebugInfo& debugInfo = DebugInfo())
+	{
+		MutatorRule::AddRule(name, targetTypes, expression, debugInfo, EvaluateClosedVars(frame, closedVars));
+
+		return Empty;
 	}
 
 	static inline Value NewApply(ScriptFrame& frame, const String& type, const String& target, const String& name, const std::shared_ptr<Expression>& filter,


### PR DESCRIPTION
This adds support for two new keywords:

* rule (used to specify custom validator and post-creation rules)
* require (a short-cut for ("if (!<expr>) { throw ... })

Rules can be used to add arbitrary user-defined validation rules and modify objects after they've been created:

This rule specifies that all hosts must have a custom variable `type`:

```
rule Host {
        require vars.type
}
```

This specifies that all physical hosts must have a custom variable `location`:

```
rule Host {
        if (vars.type == "physical") {
                require vars.location
        }
}
```

This ensures that all hosts and services which use the `ping` check command have a check_interval that's less than one minute:

```
rule [Host, Service] {
        if (check_command == "ping") {
                require check_interval < 1m
        }
}
```

This creates a custom attribute 'z' for all objects which can have custom attributes (i.e. all objects which inherit from the CustomVarObject type):

```
rule CustomVarObject {
        vars.z = 3
}
```

This rule ensures that no objects (of any kind) exist whose name contains the letter "z":

```
rule {
       require !match("*z*", name)
}
```

```
critical/config: Error: Error while evaluating expression: Validation failed for object 'breeze' of type 'CheckCommand': User-defined validator failed.
Location: in /Users/gunnar/i2/etc/icinga2/conf.d/test.conf: 61:2-61:28
/Users/gunnar/i2/etc/icinga2/conf.d/test.conf(59):
/Users/gunnar/i2/etc/icinga2/conf.d/test.conf(60): rule {
/Users/gunnar/i2/etc/icinga2/conf.d/test.conf(61):  require !match("*z*", name)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/gunnar/i2/etc/icinga2/conf.d/test.conf(62): }
/Users/gunnar/i2/etc/icinga2/conf.d/test.conf(63):
```

This rule ensures that there's a service group for each host with the same name:

```
rule Host {
        require get_service_group(name)
}
```

TODOs:
* [ ] Documentation
* [x]  Closure support
* [ ]  Figure out whether we actually want this

fixes #4722