### PR TITLE
Fix missing include for boost::split

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -34,6 +34,7 @@
 #include "base/process.hpp"
 #include "config.h"
 #include <boost/program_options.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <thread>
 
 #ifndef _WIN32


### PR DESCRIPTION
This adds a missing include for the function boost::split. 

For: 

https://github.com/Icinga/icinga2/blob/ae7cd0105293b5687ae49c1822899acc1893a10a/icinga-app/icinga.cpp#L247