### PR TITLE
Deprecate CheckResultReader

### DIFF
--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -766,6 +766,9 @@ in `/var/log/icinga2/compat`. Rotated log files are moved into
 
 ## Check Result Files <a id="check-result-files"></a>
 
+> **Note**
+> This feature is deprecated and will be removed with Icinga 2.10.0
+
 Icinga 1.x writes its check result files to a temporary spool directory
 where they are processed in a regular interval.
 While this is extremely inefficient in performance regards it has been

--- a/lib/compat/checkresultreader.cpp
+++ b/lib/compat/checkresultreader.cpp
@@ -60,6 +60,8 @@ void CheckResultReader::Start(bool runtimeCreated)
 
 	Log(LogInformation, "CheckResultReader")
 		<< "'" << GetName() << "' started.";
+	Log(LogWarning, "CheckResultReader")
+		<< "The CheckResultReader feature is deprecated and will be removed with Icinga 2.10.0";
 
 #ifndef _WIN32
 	m_ReadTimer = new Timer();


### PR DESCRIPTION
Example output:
[2018-02-02 13:30:26 +0100] information/CheckResultReader: 'reader' started.
[2018-02-02 13:30:26 +0100] warning/CheckResultReader: The CheckResultReader is deprecated and will be removed with Icinga 2.10.0
Context:
	(0) Activating object 'reader' of type 'CheckResultReader'



fixes #6031 