### PR TITLE
Improve Windows builds and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
-.vagrant
-.idea
-*.patch
+## Editors
+.idea/
 *.komodoproject
+.*.sw[op]
+*~
+
+## C++ and Tools
+*.patch
 *.playground
-.*.swp
-.*.swo
+.vagrant
+
+## Build artifacts
 build/
 build-debug/
 build-release/
@@ -13,3 +18,6 @@ build64/
 debug/
 release/
 cmake-build-debug
+/Testing/
+/install/
+/vendor/

--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -1,0 +1,101 @@
+# Build Icinga 2 on Windows
+
+The Icinga Project is providing Windows MSI packages under https://packages.icinga.com/windows/
+
+> **Note:**
+> This is a developer documentation on how to build Icinga 2 on Windows!
+
+Also see [INSTALL.md](INSTALL.md) for Linux build instructions.
+
+## Requirements
+
+* 32 or 64-bit system
+* Visual Studio >= 14 2015
+* CMake >= 2.6
+* OpenSSL >= 1.0.1
+* Flex and Bison
+
+## Install Requirements
+
+**Visual Studio**
+
+Download from [visualstudio.com](https://www.visualstudio.com/en/downloads/)
+
+The Community Edition is available for free, and is what we use to build.
+
+Workloads to install:
+* C++ Desktop
+* .NET Desktop
+
+**OpenSSL for Icinga**
+
+See our [openssl-windows GitHub project](https://github.com/Icinga/openssl-windows).
+
+You will need to install a binary dist version to 'C:\\Program Files\\OpenSSL'.
+
+**Chocolatey**
+
+A simple package manager for Windows, please see [install instructions](https://chocolatey.org/install).
+
+**Git**
+
+Best to use Chocolatey, see [package details](https://chocolatey.org/packages/git).
+
+```
+choco install git
+```
+
+**Flex / Bison**
+
+Best to use Chocolatey, see [package details](https://chocolatey.org/packages/winflexbison3).
+
+```
+choco install winflexbison3
+```
+
+**CMake**
+
+Best to use Chocolatey, see [package details](https://chocolatey.org/packages/cmake)
+or download from: [cmake.org](https://cmake.org/download/)
+
+```
+choco install cmake
+```
+
+**WIX**
+
+Best to use Chocolatey, see [package details](https://chocolatey.org/packages/wixtoolset).
+
+```
+choco install wixtoolset
+```
+
+**Boost**
+
+Download third party Windows binaries from: [boost.org](http://www.boost.org/users/download/)
+
+For example: `https://dl.bintray.com/boostorg/release/1.65.1/binaries/boost_1_65_1-msvc-14.1-64.exe`
+
+*Warnings:*
+* Must match your Visual Studio version!
+* CMake might not support the latest Boost version (we used CMake 3.10 and Boost 1_65_1)
+
+Run the installer exe.
+
+## Build Icinga 2
+
+Run VC Native x64 Command Prompt:
+
+```
+cd \local
+git clone https://github.com/Icinga/icinga2.git
+
+cd icinga2
+
+md build
+cd build
+
+"/Program Files/CMake/bin/cmake.exe" .. -G "Visual Studio 15 2017 Win64" -DCPACK_GENERATOR=WIX -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF -DBOOST_ROOT=c:/local/boost_1_65_1 -DBOOST_LIBRARYDIR=c:/local/boost_1_65_1/lib64-msvc-14.1 -DFLEX_EXECUTABLE=C:/ProgramData/chocolatey/bin/win_flex.exe -DBISON_EXECUTABLE=C:/ProgramData/chocolatey/bin/win_bison.exe
+
+"/Program Files/CMake/bin/cmake.exe" --build . --target PACKAGE --config RelWithDebInfo
+```

--- a/BUILD_WINDOWS.md
+++ b/BUILD_WINDOWS.md
@@ -33,6 +33,8 @@ See our [openssl-windows GitHub project](https://github.com/Icinga/openssl-windo
 
 You will need to install a binary dist version to 'C:\\Program Files\\OpenSSL'.
 
+There is a Powershell script to help you downloading: `.\tools\win32\download-openssl.ps1`
+
 **Chocolatey**
 
 A simple package manager for Windows, please see [install instructions](https://chocolatey.org/install).
@@ -84,18 +86,18 @@ Run the installer exe.
 
 ## Build Icinga 2
 
-Run VC Native x64 Command Prompt:
+Run with VC Native x64 Command Prompt:
 
 ```
-cd \local
-git clone https://github.com/Icinga/icinga2.git
-
-cd icinga2
-
-md build
-cd build
-
-"/Program Files/CMake/bin/cmake.exe" .. -G "Visual Studio 15 2017 Win64" -DCPACK_GENERATOR=WIX -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF -DBOOST_ROOT=c:/local/boost_1_65_1 -DBOOST_LIBRARYDIR=c:/local/boost_1_65_1/lib64-msvc-14.1 -DFLEX_EXECUTABLE=C:/ProgramData/chocolatey/bin/win_flex.exe -DBISON_EXECUTABLE=C:/ProgramData/chocolatey/bin/win_bison.exe
-
-"/Program Files/CMake/bin/cmake.exe" --build . --target PACKAGE --config RelWithDebInfo
+powershell .\tools\win32\configure.ps1
+powershell .\tools\win32\build.ps1
+powershell .\tools\win32\test.ps1
 ```
+
+See these scripts for details.
+
+## AppVeyor
+
+We are building [Icinga 2 with AppVeyor](https://ci.appveyor.com/project/icinga/icinga2) for testing and CI integration.
+
+Please check `appveyor.yml` for our instructions.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,55 @@
+---
+version: 2.9.0.dev.{build}
+
+os: Visual Studio 2017
+
+environment:
+  CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+  BOOST_ROOT: 'C:\Libraries\boost_1_65_1'
+  BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_65_1\lib64-msvc-14.1'
+  BISON_BINARY: 'C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_bison.exe'
+  FLEX_BINARY: 'C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_flex.exe'
+
+branches:
+  only:
+    - master
+
+cache:
+- build
+- vendor -> tools\win32\download-openssl.ps1
+- C:\ProgramData\chocolatey\lib\winflexbison3
+
+install:
+- ps: |
+    if (-not (Test-Path "vendor\OpenSSL")) {
+      .\tools\win32\download-openssl.ps1
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+    }
+- ps: |
+    if (-not (Test-Path "C:\ProgramData\chocolatey\lib\winflexbison3")) {
+      choco install winflexbison3
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+    }
+
+before_build:
+- ps: |
+    .\tools\win32\configure.ps1
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+    del build\Icinga*.msi
+
+build_script:
+- ps: |
+    .\tools\win32\build.ps1
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+
+test_script:
+- ps: |
+    .\tools\win32\test.ps1
+    if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode)  }
+
+artifacts:
+- path: build/Icinga*.msi
+- path: build/choco/*.nupkg
+- path: build/Test.xml
+
+deploy: off

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,8 +15,6 @@
 # along with this program; if not, write to the Free Software Foundation
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 
-set(Boost_USE_STATIC_LIBS OFF)
-
 include(BoostTestTargets)
 
 set(base_test_SOURCES

--- a/test/test-runner.cpp
+++ b/test/test-runner.cpp
@@ -17,29 +17,30 @@
 * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
 ******************************************************************************/
 
+#define BOOST_TEST_MAIN
+
 #include "icinga/icingaapplication.hpp"
 #include "base/application.hpp"
 #include <BoostTestTargetConfig.h>
 
 using namespace icinga;
 
-static bool init_unit_test()
+struct TestIcingaApplication
 {
-	return true;
-}
+	TestIcingaApplication()
+	{
+		Application::InitializeBase();
 
-int main(int argc, char *argv[])
-{
-	Application::InitializeBase();
+		IcingaApplication::Ptr appInst;
 
-	IcingaApplication::Ptr appInst;
+		appInst = new IcingaApplication();
+		static_pointer_cast<ConfigObject>(appInst)->OnConfigLoaded();
+	}
 
-	appInst = new IcingaApplication();
-	static_pointer_cast<ConfigObject>(appInst)->OnConfigLoaded();
+	~TestIcingaApplication()
+	{
+		IcingaApplication::GetInstance().reset();
+	}
+};
 
-	int rc = boost::unit_test::unit_test_main(&init_unit_test, argc, argv);
-
-	appInst.reset();
-
-	Application::Exit(rc);
-}
+BOOST_GLOBAL_FIXTURE(TestIcingaApplication);

--- a/tools/win32/build.ps1
+++ b/tools/win32/build.ps1
@@ -1,0 +1,16 @@
+[string]$pwd = Get-Location
+
+if (-not (Test-Path build)) {
+  Write-Host "Path '$pwd\build' does not exist!"
+  exit 1
+}
+
+if (-not (Test-Path env:CMAKE_PATH)) {
+  $env:CMAKE_PATH = 'C:\Program Files\CMake\bin'
+}
+if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
+  $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
+}
+
+cmake.exe --build build --target PACKAGE --config RelWithDebInfo
+if ($lastexitcode -ne 0) { exit $lastexitcode }

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -1,0 +1,53 @@
+if (-not (Test-Path build)) {
+  mkdir build
+}
+if (-not (Test-Path install)) {
+  mkdir install
+}
+if (-not (Test-Path env:CMAKE_PATH)) {
+  $env:CMAKE_PATH = 'C:\Program Files\CMake\bin'
+}
+if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
+  $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
+}
+
+[string]$pwd = Get-Location
+
+if (-not (Test-Path env:CMAKE_GENERATOR)) {
+  $env:CMAKE_GENERATOR = 'Visual Studio 15 2017 Win64'
+}
+if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
+  $env:OPENSSL_ROOT_DIR = $pwd + '\vendor\OpenSSL'
+}
+if (-not (Test-Path env:BOOST_ROOT)) {
+  $env:BOOST_ROOT = 'c:\local\boost_1_65_1'
+}
+if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
+  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_65_1\lib64-msvc-14.1'
+}
+if (-not (Test-Path env:FLEX_BINARY)) {
+  $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'
+}
+if (-not (Test-Path env:BISON_BINARY)) {
+  $env:BISON_BINARY = 'C:\ProgramData\chocolatey\bin\win_bison.exe'
+}
+
+cd build
+
+& cmake.exe .. `
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo `
+  -G $env:CMAKE_GENERATOR -DCPACK_GENERATOR=WIX `
+  -DCMAKE_INSTALL_PREFIX="..\install" `
+  -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF `
+  -DOPENSSL_ROOT_DIR="$env:OPENSSL_ROOT_DIR" `
+  -DBOOST_ROOT="$env:BOOST_ROOT" `
+  -DBOOST_LIBRARYDIR="$env:BOOST_LIBRARYDIR" `
+  -DFLEX_EXECUTABLE="$env:FLEX_BINARY" `
+  -DBISON_EXECUTABLE="$env:BISON_BINARY"
+
+if ($lastexitcode -ne 0) {
+  cd ..
+  exit $lastexitcode
+}
+
+cd ..

--- a/tools/win32/download-openssl.ps1
+++ b/tools/win32/download-openssl.ps1
@@ -1,0 +1,48 @@
+[string]$pwd = Get-Location
+$OpenSSL_version = '1.1.0g'
+$OpenSSL_arch = 'x64'
+$OpenSSL_vcbuild = 'vc150'
+$OpenSSL_fileversion = $OpenSSL_version.Replace('.', '_')
+$OpenSSL_file = [string]::Format(
+  'openssl-{0}-binary-icinga-{1}-{2}.zip',
+  $OpenSSL_fileversion,
+  $OpenSSL_arch,
+  $OpenSSL_vcbuild
+)
+
+# TODO: from GitHub Release!
+#$OpenSSL_url = ''
+$OpenSSL_url = 'https://ci.appveyor.com/api/buildjobs/4hwjjxgvvyeplrjd/artifacts/' + $OpenSSL_file
+
+$OpenSSL_zip_location = $pwd + '\vendor\' + $OpenSSL_file
+$vendor_path = $pwd + '\vendor'
+$OpenSSL_vendor_path = $vendor_path + '\OpenSSL'
+
+if (-not (Test-Path $vendor_path)) {
+  mkdir $vendor_path
+}
+
+if (Test-Path $OpenSSL_zip_location) {
+    Write-Output "OpenSSL archive available at $OpenSSL_zip_location"
+} else {
+    Write-Output "Downloading OpenSSL binary dist from $OpenSSL_url"
+  $progressPreference = 'silentlyContinue'
+    Invoke-WebRequest -Uri $OpenSSL_url -OutFile $OpenSSL_zip_location
+  if ($lastexitcode -ne 0){ exit $lastexitcode }
+  $progressPreference = 'Continue'
+  
+  if (Test-Path $OpenSSL_vendor_path) {
+    Remove-Item -Recurse $OpenSSL_vendor_path
+  }
+}
+
+if (-not (Test-Path $OpenSSL_vendor_path)) {
+  mkdir $OpenSSL_vendor_path
+}
+
+Write-Output "Extracting ZIP to $OpenSSL_vendor_path"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+[System.IO.Compression.ZipFile]::ExtractToDirectory($OpenSSL_zip_location, $OpenSSL_vendor_path)
+if ($lastexitcode -ne 0){ exit $lastexitcode }
+
+exit 0

--- a/tools/win32/download-openssl.ps1
+++ b/tools/win32/download-openssl.ps1
@@ -1,18 +1,19 @@
 [string]$pwd = Get-Location
-$OpenSSL_version = '1.1.0g'
+$OpenSSL_version = '1.1.0g-1'
 $OpenSSL_arch = 'x64'
 $OpenSSL_vcbuild = 'vc150'
-$OpenSSL_fileversion = $OpenSSL_version.Replace('.', '_')
+$OpenSSL_fileversion = $OpenSSL_version.Replace('.', '_').Split('-')[0]
 $OpenSSL_file = [string]::Format(
   'openssl-{0}-binary-icinga-{1}-{2}.zip',
   $OpenSSL_fileversion,
   $OpenSSL_arch,
   $OpenSSL_vcbuild
 )
-
-# TODO: from GitHub Release!
-#$OpenSSL_url = ''
-$OpenSSL_url = 'https://ci.appveyor.com/api/buildjobs/4hwjjxgvvyeplrjd/artifacts/' + $OpenSSL_file
+$OpenSSL_url = [string]::Format(
+  'https://github.com/Icinga/openssl-windows/releases/download/v{0}/{1}',
+  $OpenSSL_version,
+  $OpenSSL_file
+)
 
 $OpenSSL_zip_location = $pwd + '\vendor\' + $OpenSSL_file
 $vendor_path = $pwd + '\vendor'
@@ -23,11 +24,12 @@ if (-not (Test-Path $vendor_path)) {
 }
 
 if (Test-Path $OpenSSL_zip_location) {
-    Write-Output "OpenSSL archive available at $OpenSSL_zip_location"
+  Write-Output "OpenSSL archive available at $OpenSSL_zip_location"
 } else {
-    Write-Output "Downloading OpenSSL binary dist from $OpenSSL_url"
+  Write-Output "Downloading OpenSSL binary dist from $OpenSSL_url"
+
   $progressPreference = 'silentlyContinue'
-    Invoke-WebRequest -Uri $OpenSSL_url -OutFile $OpenSSL_zip_location
+  Invoke-WebRequest -Uri $OpenSSL_url -OutFile $OpenSSL_zip_location
   if ($lastexitcode -ne 0){ exit $lastexitcode }
   $progressPreference = 'Continue'
   
@@ -38,11 +40,11 @@ if (Test-Path $OpenSSL_zip_location) {
 
 if (-not (Test-Path $OpenSSL_vendor_path)) {
   mkdir $OpenSSL_vendor_path
+
+  Write-Output "Extracting ZIP to $OpenSSL_vendor_path"
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($OpenSSL_zip_location, $OpenSSL_vendor_path)
+  if ($lastexitcode -ne 0){ exit $lastexitcode }  
+} else {
+  Write-Output "OpenSSL is already available at $OpenSSL_vendor_path"
 }
-
-Write-Output "Extracting ZIP to $OpenSSL_vendor_path"
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-[System.IO.Compression.ZipFile]::ExtractToDirectory($OpenSSL_zip_location, $OpenSSL_vendor_path)
-if ($lastexitcode -ne 0){ exit $lastexitcode }
-
-exit 0

--- a/tools/win32/test.ps1
+++ b/tools/win32/test.ps1
@@ -1,0 +1,23 @@
+[string]$pwd = Get-Location
+
+if (-not (Test-Path build)) {
+  Write-Host "Path '$pwd\build' does not exist!"
+  exit 1
+}
+
+if (-not (Test-Path env:CMAKE_PATH)) {
+  $env:CMAKE_PATH = 'C:\Program Files\CMake\bin'
+}
+if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
+  $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
+}
+
+cd build
+
+ctest.exe -C RelWithDebInfo -T test -O build/Test.xml --output-on-failure
+if ($lastexitcode -ne 0) {
+  cd ..
+  exit $lastexitcode
+}
+
+cd ..


### PR DESCRIPTION
- [x] Add AppVeyor as test platform integrated in GitHub
- [x] include documentation and scripts for Windows builds
- [x] Fix tests building static and actually working on Windows
- [x] Use release version of openssl-windows