### PR TITLE
Fix the explanation of `types` and `states` for user objects

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1708,8 +1708,8 @@ Configuration Attributes:
   groups                    | Array of object names | **Optional.** An array of group names.
   enable\_notifications     | Boolean               | **Optional.** Whether notifications are enabled for this user.
   period                    | Object name           | **Optional.** The name of a time period which determines when a notification for this user should be triggered. Not set by default.
-  types                     | Array                 | **Optional.** A set of type filters when this notification should be triggered. By default everything is matched.
-  states                    | Array                 | **Optional.** A set of state filters when this notification should be triggered. By default everything is matched.
+  types                     | Array                 | **Optional.** A set of type filters when a notification for this user should be triggered. By default everything is matched.
+  states                    | Array                 | **Optional.** A set of state filters when a notification for this should be triggered. By default everything is matched.
 
 Runtime Attributes:
 


### PR DESCRIPTION
I assume the original explanation string was copied from the notification object. I changed the text to refer to a user object instead of a notification object.