### PR TITLE
Allow to pass raw performance data in 'process-check-result' API action

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -806,7 +806,7 @@ Send a `POST` request to the URL endpoint `/v1/actions/process-check-result`.
   ------------------|--------------|--------------
   exit\_status      | Number       | **Required.** For services: 0=OK, 1=WARNING, 2=CRITICAL, 3=UNKNOWN, for hosts: 0=OK, 1=CRITICAL.
   plugin\_output    | String       | **Required.** One or more lines of the plugin main output. Does **not** contain the performance data.
-  performance\_data | Array        | **Optional.** The performance data.
+  performance\_data | Array|String | **Optional.** The performance data as array of strings. The raw performance data string can be used too.
   check\_command    | Array        | **Optional.** The first entry should be the check commands path, then one entry for each command line option followed by an entry for each of its argument.
   check\_source     | String       | **Optional.** Usually the name of the `command_endpoint`
   execution\_start  | Timestamp    | **Optional.** The timestamp where a script/process started its execution.

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -112,7 +112,15 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 		cr->SetExecutionEnd(HttpUtility::GetLastParameter(params, "execution_end"));
 
 	cr->SetCheckSource(HttpUtility::GetLastParameter(params, "check_source"));
-	cr->SetPerformanceData(params->Get("performance_data"));
+
+	Value perfData = params->Get("performance_data");
+
+	/* Allow to pass a performance data string from Icinga Web 2 next to the new Array notation. */
+	if (perfData.IsString())
+		cr->SetPerformanceData(PluginUtility::SplitPerfdata(perfData));
+	else
+		cr->SetPerformanceData(perfData);
+
 	cr->SetCommand(params->Get("check_command"));
 
 	/* Mark this check result as passive. */


### PR DESCRIPTION
This is how data is coming from Icinga Web 2 and still a valid input
type.

fixes #4786