### PR TITLE
WIP: Implement AppVersion constant; add compare_version as global function

### DIFF
--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -398,6 +398,7 @@ PlatformKernelVersion|**Read-only.** The version of the operating system kernel,
 BuildCompilerName   |**Read-only.** The name of the compiler Icinga was built with, e.g. "Clang".
 BuildCompilerVersion|**Read-only.** The version of the compiler Icinga was built with, e.g. "7.3.0.7030031".
 BuildHostName       |**Read-only.** The name of the host Icinga was built on, e.g. "acheron".
+AppVersion          |**Read-only.** The application version, e.g. "2.9.0".
 MaxConcurrentChecks |**Read-write**. The number of max checks run simultaneously. Defaults to 512.
 
 

--- a/doc/18-library-reference.md
+++ b/doc/18-library-reference.md
@@ -518,6 +518,52 @@ and `GlobDirectory` constants. The default value is `GlobFile | GlobDirectory`.
     <3> => glob_recursive(path, pattern)
     [ "/etc/icinga2/zones.d/global-templates/templates.conf", "/etc/icinga2/zones.d/master/hosts.conf", ... ]
 
+### compare\_version <a id="global-functions-compare-version"></a>
+
+Signature:
+
+    function compare_version(version1, version2)
+
+Compares two version strings in the format `X.Y.Z`. Removes any trailing characters
+by implicitly calling `parse_version`.
+
+Returns
+
+* 0 if version1 is equal to version2
+* 1 if version1 is less than version2
+* -1 if version1 is greater than version2
+
+Example:
+
+```
+$ icinga2 console
+Icinga 2 (version: v2.7.0)
+<1> => compare_version("v2.9.0", "v2.9.0")
+0.000000
+<2> => compare_version("v2.8.0", "v2.9.0")
+1.000000
+<3> => compare_version("v2.9.0", "v2.8.0")
+-1.000000
+```
+
+### parse\_version <a id="global-functions-parse-version"></a>
+
+Signature:
+
+    function parse_version(version)
+
+Parses a given version string into the format `X.Y.Z`. This helper function
+removes the `v` or `r` prefix, and any revision suffix.
+
+Example:
+
+```
+$ icinga2 console
+Icinga 2 (version: v2.7.0)
+<1> => parse_version("v2.8.1-402-ge1e06ce76")
+"2.8.1"
+```
+
 ### escape_shell_arg <a id="global-functions-escape_shell_arg"></a>
 
 Signature:

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -72,6 +72,8 @@ REGISTER_SCRIPTFUNCTION_NS(System, sleep, &Utility::Sleep, "interval");
 REGISTER_SCRIPTFUNCTION_NS(System, path_exists, &Utility::PathExists, "path");
 REGISTER_SCRIPTFUNCTION_NS(System, glob, &ScriptUtils::Glob, "pathspec:callback:type");
 REGISTER_SCRIPTFUNCTION_NS(System, glob_recursive, &ScriptUtils::GlobRecursive, "pathspec:callback:type");
+REGISTER_SAFE_SCRIPTFUNCTION_NS(System, compare_version, &ScriptUtils::CompareVersion, "version1:version2");
+REGISTER_SAFE_SCRIPTFUNCTION_NS(System, parse_version, &Utility::ParseVersion, "version");
 
 INITIALIZE_ONCE(&ScriptUtils::StaticInitialize);
 
@@ -88,6 +90,8 @@ void ScriptUtils::StaticInitialize()
 
 	ScriptGlobal::Set("GlobFile", GlobFile);
 	ScriptGlobal::Set("GlobDirectory", GlobDirectory);
+
+	ScriptGlobal::Set("AppVersion", Application::GetAppVersion());
 }
 
 String ScriptUtils::CastString(const Value& value)
@@ -502,4 +506,12 @@ Value ScriptUtils::GlobRecursive(const std::vector<Value>& args)
 	Utility::GlobRecursive(path, pattern, std::bind(&GlobCallbackHelper, std::ref(paths), _1), type);
 
 	return Array::FromVector(paths);
+}
+
+int ScriptUtils::CompareVersion(const String& v1, const String& v2)
+{
+	String parsedVersion1 = Utility::ParseVersion(v1);
+	String parsedVersion2 = Utility::ParseVersion(v2);
+
+	return Utility::CompareVersion(parsedVersion1, parsedVersion2);
 }

--- a/lib/base/scriptutils.hpp
+++ b/lib/base/scriptutils.hpp
@@ -58,6 +58,7 @@ public:
 	static double Ptr(const Object::Ptr& object);
 	static Value Glob(const std::vector<Value>& args);
 	static Value GlobRecursive(const std::vector<Value>& args);
+	static int CompareVersion(const String& v1, const String& v2);
 
 private:
 	ScriptUtils();

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -31,6 +31,7 @@
 #include <boost/thread/tss.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/regex.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <ios>
@@ -1263,6 +1264,24 @@ int Utility::CompareVersion(const String& v1, const String& v2)
 	}
 
 	return 0;
+}
+
+String Utility::ParseVersion(const String& version)
+{
+	bool ret;
+	boost::smatch match;
+
+	try {
+		boost::regex expr("[rv]?(\\d+[.\\d+]*).*");
+		ret = boost::regex_search(version.GetData(), match, expr);
+	} catch (boost::exception&) {
+		ret = false;
+	}
+
+	if (ret)
+		return String(match[1].first, match[1].second);
+
+	return version;
 }
 
 String Utility::GetHostName()

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -116,6 +116,7 @@ public:
 	static unsigned long SDBM(const String& str, size_t len = String::NPos);
 
 	static int CompareVersion(const String& v1, const String& v2);
+	static String ParseVersion(const String& version);
 
 	static int Random();
 


### PR DESCRIPTION
This commit includes the `parse_version` helper function which is
implicitly called by `compare_version`.

```
<2> => compare_version(AppVersion, "v2.9.0")
1.000000
<3> => compare_version(AppVersion, "v2.8.0")
-1.000000
<4> => compare_version(AppVersion, "v2.8.1")
0.000000
<5> => AppVersion
"v2.8.1-402-ge1e06ce76"
```

fixes #5784