### PR TITLE
Fix crash with anonymous clients on certificate signing request and storing sent bytes

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -114,10 +114,15 @@ void JsonRpcConnection::SendMessage(const Dictionary::Ptr& message)
 {
 	try {
 		ObjectLock olock(m_Stream);
+
 		if (m_Stream->IsEof())
 			return;
+
 		size_t bytesSent = JsonRpc::SendMessage(m_Stream, message);
-		m_Endpoint->AddMessageSent(bytesSent);
+
+		if (m_Endpoint)
+			m_Endpoint->AddMessageSent(bytesSent);
+
 	} catch (const std::exception& ex) {
 		std::ostringstream info;
 		info << "Error while sending JSON-RPC message for identity '" << m_Identity << "'";


### PR DESCRIPTION
This originates from changes with #5753. Patches have not been backported, happens in git master only.

## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->

```
[2018-02-09 16:55:23 +0100] information/ApiListener: New client connection for identity 'icinga2-satellite1' from [192.168.33.102]:51572 (certificate validation failed: code 18: self signed certificate)
[New Thread 0x7ffff04f6700 (LWP 12563)]
[Thread 0x7ffff073f700 (LWP 12554) exited]
[2018-02-09 16:55:23 +0100] information/JsonRpcConnection: Received certificate request for CN 'icinga2-satellite1' not signed by our CA.
[2018-02-09 16:55:23 +0100] information/JsonRpcConnection: Sending certificate response for CN 'icinga2-satellite1' to endpoint 'icinga2-satellite1' (auto-signing ticket).

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff04f6700 (LWP 12563)]
0x00007ffff5cdac30 in pthread_mutex_lock () from /lib64/libpthread.so.0
Missing separate debuginfos, use: debuginfo-install boost-program-options-1.53.0-27.el7.x86_64 boost-regex-1.53.0-27.el7.x86_64 boost-system-1.53.0-27.el7.x86_64 boost-thread-1.53.0-27.el7.x86_64 bzip2-libs-1.0.6-13.el7.x86_64 elfutils-libelf-0.168-8.el7.x86_64 elfutils-libs-0.168-8.el7.x86_64 glibc-2.17-196.el7_4.2.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-8.el7.x86_64 libattr-2.4.46-12.el7.x86_64 libcap-2.22-9.el7.x86_64 libcom_err-1.42.9-10.el7.x86_64 libedit-3.0-12.20121213cvs.el7.x86_64 libgcc-4.8.5-16.el7_4.1.x86_64 libgcrypt-1.5.3-14.el7.x86_64 libgpg-error-1.12-3.el7.x86_64 libicu-50.1.2-15.el7.x86_64 libselinux-2.5-11.el7.x86_64 libstdc++-4.8.5-16.el7_4.1.x86_64 mariadb-libs-5.5.56-2.el7.x86_64 ncurses-libs-5.9-14.20130511.el7_4.x86_64 openssl-libs-1.0.2k-8.el7.x86_64 pcre-8.32-17.el7.x86_64 systemd-libs-219-42.el7_4.4.x86_64 xz-libs-5.2.2-1.el7.x86_64 zlib-1.2.7-17.el7.x86_64
(gdb) bt
#0  0x00007ffff5cdac30 in pthread_mutex_lock () from /lib64/libpthread.so.0
#1  0x00000000007f5b78 in lock (this=<optimized out>) at /usr/include/boost/thread/pthread/mutex.hpp:67
#2  boost::unique_lock<boost::mutex>::lock (this=0x7ffff04f4c40) at /usr/include/boost/thread/lock_types.hpp:344
#3  0x00000000007dab72 in __base_ctor (this=0x7ffff04f4c40, m_=...) at /usr/include/boost/thread/lock_types.hpp:124
#4  icinga::RingBuffer::InsertValue (this=this@entry=0x128, tv=tv@entry=1518191723, num=num@entry=1) at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/base/ringbuffer.cpp:39
#5  0x00000000008fe220 in icinga::Endpoint::AddMessageSent (this=0x0, bytes=1417) at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/endpoint.cpp:124
#6  0x00000000009ccc36 in icinga::JsonRpcConnection::SendMessage (this=this@entry=0x7fffb8004d80, message=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/jsonrpcconnection.cpp:120
#7  0x00000000009cd6d4 in icinga::JsonRpcConnection::MessageHandler (this=0x7fffb8004d80, jsonString=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/jsonrpcconnection.cpp:236
#8  0x00000000009cde45 in icinga::JsonRpcConnection::MessageHandlerWrapper (this=0x7fffb8004d80, jsonString=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/jsonrpcconnection.cpp:152
#9  0x000000000072d409 in icinga::WorkQueue::RunTaskFunction(std::function<void ()> const&) (this=0x7fffb80051b8, func=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/base/workqueue.cpp:252
#10 0x0000000000732b07 in icinga::WorkQueue::WorkerThreadProc (this=0x7fffb80051b8) at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/base/workqueue.cpp:295
#11 0x00007ffff79cd27a in thread_proxy () from /lib64/libboost_thread-mt.so.1.53.0
#12 0x00007ffff5cd8e25 in start_thread () from /lib64/libpthread.so.0
#13 0x00007ffff5a0634d in clone () from /lib64/libc.so.6
```

```
(gdb) bt full
#0  0x00007ffff5cdac30 in pthread_mutex_lock () from /lib64/libpthread.so.0
No symbol table info available.
#1  0x00000000007f5b78 in lock (this=<optimized out>) at /usr/include/boost/thread/pthread/mutex.hpp:67
        res = <optimized out>
#2  boost::unique_lock<boost::mutex>::lock (this=0x7ffff04f4c40) at /usr/include/boost/thread/lock_types.hpp:344
No locals.
#3  0x00000000007dab72 in __base_ctor (this=0x7ffff04f4c40, m_=...) at /usr/include/boost/thread/lock_types.hpp:124
        this = 0x7ffff04f4c40
#4  icinga::RingBuffer::InsertValue (this=this@entry=0x128, tv=tv@entry=1518191723, num=num@entry=1) at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/base/ringbuffer.cpp:39
        lock = {m = 0x128, is_locked = false}
#5  0x00000000008fe220 in icinga::Endpoint::AddMessageSent (this=0x0, bytes=1417) at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/endpoint.cpp:124
        time = 1518191723.155091
#6  0x00000000009ccc36 in icinga::JsonRpcConnection::SendMessage (this=this@entry=0x7fffb8004d80, message=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/jsonrpcconnection.cpp:120
        olock = {m_Object = 0x7fffb8000c50, m_Locked = true}
        bytesSent = 1417
#7  0x00000000009cd6d4 in icinga::JsonRpcConnection::MessageHandler (this=0x7fffb8004d80, jsonString=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/jsonrpcconnection.cpp:236
        message = {px = 0x7fffcc092380}
        origin = {px = 0x7fffcc0cb4e0}
        vmethod = {m_Value = {which_ = 3, storage_ = {<boost::detail::aligned_storage::aligned_storage_imp> = {data_ = {buf = "\230\266\001\314\377\177\000",
                  align_ = {<No data fields>}}}, <No data fields>}}}
        method = {m_Data = <incomplete type>}
        resultMessage = {px = 0x7fffcc0d1510}
#8  0x00000000009cde45 in icinga::JsonRpcConnection::MessageHandlerWrapper (this=0x7fffb8004d80, jsonString=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/remote/jsonrpcconnection.cpp:152
No locals.
#9  0x000000000072d409 in icinga::WorkQueue::RunTaskFunction(std::function<void ()> const&) (this=0x7fffb80051b8, func=...)
    at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/base/workqueue.cpp:252
No locals.
#10 0x0000000000732b07 in icinga::WorkQueue::WorkerThreadProc (this=0x7fffb80051b8) at /usr/src/debug/icinga2-2.8.1.406.g407a2d0/lib/base/workqueue.cpp:295
No locals.
#11 0x00007ffff79cd27a in thread_proxy () from /lib64/libboost_thread-mt.so.1.53.0
No symbol table info available.
#12 0x00007ffff5cd8e25 in start_thread () from /lib64/libpthread.so.0
No symbol table info available.
#13 0x00007ffff5a0634d in clone () from /lib64/libc.so.6
No symbol table info available.
```


## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
<!--- or ideas how to implement:  the addition or change -->

```
void JsonRpcConnection::SendMessage(const Dictionary::Ptr& message)
{
        try {
                ObjectLock olock(m_Stream);
                if (m_Stream->IsEof())
                        return;
                size_t bytesSent = JsonRpc::SendMessage(m_Stream, message);
                m_Endpoint->AddMessageSent(bytesSent);
        } catch (const std::exception& ex) {
                std::ostringstream info;
                info << "Error while sending JSON-RPC message for identity '" << m_Identity << "'";
                Log(LogWarning, "JsonRpcConnection")
                        << info.str() << "\n" << DiagnosticInformation(ex);

                Disconnect();
        }
}
```

does not check whether `m_Endpoint` actually exists and is not a nullptr. We can have anonymous clients, which exactly happens for certificate requests @N-o-X :)





## Steps to Reproduce (for bugs)
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include configuration, logs, etc. to reproduce, if relevant -->
1. Configure a central Icinga master with CA
2. Send a CSR signing requrest
3. Master crashes on sending the signed ticket as message. The exact crash happens for counting the endpoint message bytes, which is stored in the Ringbuffer.

```
[root@icinga2-satellite1 ~]# icinga2 pki request --host 192.168.33.101 --port 5665 --ca /etc/icinga2/pki/ca.crt --key /etc/icinga2/pki/icinga2-satellite1.key --cert /etc/icinga2/pki/icinga2-satellite1.crt --trustedcert /etc/icinga2/pki/trusted-cert.crt --ticket f9d6559c2afe259731a4a681b8dd8fe00a6fd890
```


## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->

## Your Environment
<!--- Include as many relevant details about the environment you experienced the problem in -->
* Version used (`icinga2 --version`): 

```
[root@icinga2-master1 ~]# icinga2 --version
icinga2 - The Icinga 2 network monitoring daemon (version: v2.8.1-406-g407a2d0)

Copyright (c) 2012-2018 Icinga Development Team (https://www.icinga.com/)
License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl2.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Application information:
  Installation root: /usr
  Sysconf directory: /etc
  Run directory: /run
  Local state directory: /var
  Package data directory: /usr/share/icinga2
  State path: /var/lib/icinga2/icinga2.state
  Modified attributes path: /var/lib/icinga2/modified-attributes.conf
  Objects path: /var/cache/icinga2/icinga2.debug
  Vars path: /var/cache/icinga2/icinga2.vars
  PID path: /run/icinga2/icinga2.pid

System information:
  Platform: CentOS Linux
  Platform version: 7 (Core)
  Kernel: Linux
  Kernel version: 3.10.0-693.11.1.el7.x86_64
  Architecture: x86_64

Build information:
  Compiler: GNU 4.8.5
  Build host: unknown
```

* Operating System and version: CentOS 7.4
* Enabled features (`icinga2 feature list`): `Enabled features: api checker ido-mysql mainlog notification`
* Icinga Web 2 version and modules (System - About): 

```
Icinga Web 2 Version
2.5.1
Git commit
801ccb80f001dcd3330535698a0ff28fbd6dcb4d
Git commit date
2018-01-26
```

* Config validation (`icinga2 daemon -C`):

```
[root@icinga2-master1 ~]# icinga2 daemon -C
information/cli: Icinga application loader (version: v2.8.1-406-g407a2d0)
information/cli: Loading configuration file(s).
information/ConfigItem: Committing config item(s).
warning/globals.getHostGeoLocation: Cannot find 'be' in GeoLocationShort
warning/ApiListener: Attribute 'key_path' for object 'api' of type 'ApiListener' is deprecated and should not be used.
warning/ApiListener: Attribute 'ca_path' for object 'api' of type 'ApiListener' is deprecated and should not be used.
warning/ApiListener: Attribute 'cert_path' for object 'api' of type 'ApiListener' is deprecated and should not be used.
warning/ApiListener: Please read the upgrading documentation for v2.8: https://www.icinga.com/docs/icinga2/latest/doc/16-upgrading-icinga-2/
information/ApiListener: My API identity: icinga2-master1
warning/ApplyRule: Apply rule 'many-dummy' (in /etc/icinga2/demo/many.conf: 36:1-36:39) for type 'Notification' does not match anywhere!
warning/ApplyRule: Apply rule 'many-dummy' (in /etc/icinga2/demo/many.conf: 41:1-41:42) for type 'Notification' does not match anywhere!
warning/ApplyRule: Apply rule 'many-test-0' (in /etc/icinga2/demo/many.conf: 16:3-16:32) for type 'Service' does not match anywhere!
warning/ApplyRule: Apply rule 'many-test-1' (in /etc/icinga2/demo/many.conf: 16:3-16:32) for type 'Service' does not match anywhere!
warning/ApplyRule: Apply rule 'many-test-2' (in /etc/icinga2/demo/many.conf: 16:3-16:32) for type 'Service' does not match anywhere!
information/ConfigItem: Instantiated 134 Services.
information/ConfigItem: Instantiated 3 ServiceGroups.
information/ConfigItem: Instantiated 4 HostGroups.
information/ConfigItem: Instantiated 1 NotificationComponent.
information/ConfigItem: Instantiated 3 NotificationCommands.
information/ConfigItem: Instantiated 28 Notifications.
information/ConfigItem: Instantiated 1 IcingaApplication.
information/ConfigItem: Instantiated 3 ApiUsers.
information/ConfigItem: Instantiated 89 Hosts.
information/ConfigItem: Instantiated 1 ApiListener.
information/ConfigItem: Instantiated 1 FileLogger.
information/ConfigItem: Instantiated 1 CheckerComponent.
information/ConfigItem: Instantiated 3 Zones.
information/ConfigItem: Instantiated 2 Endpoints.
information/ConfigItem: Instantiated 1 UserGroup.
information/ConfigItem: Instantiated 1 IdoMysqlConnection.
information/ConfigItem: Instantiated 205 CheckCommands.
information/ConfigItem: Instantiated 3 TimePeriods.
information/ConfigItem: Instantiated 2 Users.
information/ScriptGlobal: Dumping variables to file '/var/cache/icinga2/icinga2.vars'
information/cli: Finished validating the configuration file(s).
```

* If you run multiple Icinga 2 instances, the `zones.conf` file (or `icinga2 object list --type Endpoint` and `icinga2 object list --type Zone`) from all affected nodes.

```
[root@icinga2-master1 ~]# cat /etc/icinga2/zones.conf
# This file is managed by Puppet. DO NOT EDIT.

object Endpoint "icinga2-master1"  {
}

object Endpoint "icinga2-satellite1"  {
  host = "192.168.33.102"
}

object Zone "global-templates"  {
  global = true
}

object Zone "master"  {
  endpoints = [ "icinga2-master1", ]
}

object Zone "satellite"  {
  endpoints = [ "icinga2-satellite1", ]
  parent = "master"
}
```

