### PR TITLE
HTTP Security fixes

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -208,23 +208,27 @@ The [regex function](18-library-reference.md#global-functions-regex) is availabl
 
 More information about filters can be found in the [filters](12-icinga2-api.md#icinga2-api-filters) chapter.
 
+Note that the permissions a API user has also specify the max body size of their requests.
+A API user with `*` permissions is allowed to send 512 MB.
+
+
 Available permissions for specific URL endpoints:
 
-  Permissions                   | URL Endpoint  | Supports Filters
-  ------------------------------|---------------|-----------------
-  actions/&lt;action&gt;        | /v1/actions   | Yes
-  config/query                  | /v1/config    | No
-  config/modify                 | /v1/config    | No
-  console                       | /v1/console   | No
-  events/&lt;type&gt;           | /v1/events    | No
-  objects/query/&lt;type&gt;    | /v1/objects   | Yes
-  objects/create/&lt;type&gt;   | /v1/objects   | No
-  objects/modify/&lt;type&gt;   | /v1/objects   | Yes
-  objects/delete/&lt;type&gt;   | /v1/objects   | Yes
-  status/query                  | /v1/status    | Yes
-  templates/&lt;type&gt;        | /v1/templates | Yes
-  types                         | /v1/types     | Yes
-  variables                     | /v1/variables | Yes
+  Permissions                   | URL Endpoint  | Supports Filters  | Max Body Size in MB
+  ------------------------------|---------------|-------------------|---------------------
+  actions/&lt;action&gt;        | /v1/actions   | Yes               | 1
+  config/query                  | /v1/config    | No                | 1
+  config/modify                 | /v1/config    | No                | 512
+  console                       | /v1/console   | No                | 512
+  events/&lt;type&gt;           | /v1/events    | No                | 1
+  objects/query/&lt;type&gt;    | /v1/objects   | Yes               | 1
+  objects/create/&lt;type&gt;   | /v1/objects   | No                | 512
+  objects/modify/&lt;type&gt;   | /v1/objects   | Yes               | 512
+  objects/delete/&lt;type&gt;   | /v1/objects   | Yes               | 512
+  status/query                  | /v1/status    | Yes               | 1
+  templates/&lt;type&gt;        | /v1/templates | Yes               | 1
+  types                         | /v1/types     | Yes               | 1
+  variables                     | /v1/variables | Yes               | 1
 
 The required actions or types can be replaced by using a wildcard match ("\*").
 

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -208,13 +208,12 @@ The [regex function](18-library-reference.md#global-functions-regex) is availabl
 
 More information about filters can be found in the [filters](12-icinga2-api.md#icinga2-api-filters) chapter.
 
-Note that the permissions a API user has also specify the max body size of their requests.
-A API user with `*` permissions is allowed to send 512 MB.
-
+Permissions are tied to a maximum HTTP request size to prevent abuse, responses sent by Icinga are not limited.
+An API user with all permissions ("\*") may send up to 512 MB regardless of the endpoint.
 
 Available permissions for specific URL endpoints:
 
-  Permissions                   | URL Endpoint  | Supports Filters  | Max Body Size in MB
+  Permissions                   | URL Endpoint  | Supports filters  | Max body size in MB
   ------------------------------|---------------|-------------------|---------------------
   actions/&lt;action&gt;        | /v1/actions   | Yes               | 1
   config/query                  | /v1/config    | No                | 1
@@ -234,8 +233,7 @@ The required actions or types can be replaced by using a wildcard match ("\*").
 
 ### Parameters <a id="icinga2-api-parameters"></a>
 
-Depending on the request method there are two ways of
-passing parameters to the request:
+Depending on the request method there are two ways of passing parameters to the request:
 
 * JSON object as request body (all request methods other than `GET`)
 * Query string as URL parameter (all request methods)

--- a/lib/base/stream.hpp
+++ b/lib/base/stream.hpp
@@ -122,8 +122,10 @@ public:
 
 	/**
 	 * Waits until data can be read from the stream.
+	 * Optionally with a timeout.
 	 */
-	bool WaitForData(int timeout = -1);
+	bool WaitForData();
+	bool WaitForData(int timeout);
 
 	virtual bool SupportsWaiting() const;
 

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -27,6 +27,9 @@
 #	include <poll.h>
 #endif /* _WIN32 */
 
+#define TLS_TIMEOUT_SECONDS 10
+#define TLS_TIMEOUT_STEP_SECONDS 1
+
 using namespace icinga;
 
 int TlsStream::m_SSLIndex;
@@ -285,8 +288,14 @@ void TlsStream::Handshake()
 	m_CurrentAction = TlsActionHandshake;
 	ChangeEvents(POLLOUT);
 
-	while (!m_HandshakeOK && !m_ErrorOccurred && !m_Eof)
-		m_CV.wait(lock);
+	boost::system_time const timeout = boost::get_system_time() + boost::posix_time::seconds(TLS_TIMEOUT_SECONDS);
+
+	while (!m_HandshakeOK && !m_ErrorOccurred && !m_Eof && timeout > boost::get_system_time())
+		m_CV.timed_wait(lock, timeout);
+
+	// We should _NOT_ (underline, bold, itallic and wordart) throw an exception for a timeout.
+	if (timeout < boost::get_system_time())
+		BOOST_THROW_EXCEPTION(std::runtime_error("Timeout during handshake."));
 
 	if (m_Eof)
 		BOOST_THROW_EXCEPTION(std::runtime_error("Socket was closed during TLS handshake."));

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -28,7 +28,6 @@
 #endif /* _WIN32 */
 
 #define TLS_TIMEOUT_SECONDS 10
-#define TLS_TIMEOUT_STEP_SECONDS 1
 
 using namespace icinga;
 

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -512,11 +512,17 @@ void ApiListener::NewClientHandlerInternal(const Socket::Ptr& client, const Stri
 		JsonRpc::SendMessage(tlsStream, message);
 		ctype = ClientJsonRpc;
 	} else {
-		tlsStream->WaitForData(5);
+		tlsStream->WaitForData(10);
 
 		if (!tlsStream->IsDataAvailable()) {
-			Log(LogWarning, "ApiListener")
-				<< "No data received on new API connection for identity '" << identity << "'. Ensure that the remote endpoints are properly configured in a cluster setup.";
+			if (identity.IsEmpty())
+				Log(LogInformation, "ApiListener")
+					<< "No data received on new API connection. "
+					<< "Ensure that the remote endpoints are properly configured in a cluster setup.";
+			else
+				Log(LogWarning, "ApiListener")
+					<< "No data received on new API connection for identity '" << identity << "'. "
+					<< "Ensure that the remote endpoints are properly configured in a cluster setup.";
 			return;
 		}
 

--- a/lib/remote/apiuser.cpp
+++ b/lib/remote/apiuser.cpp
@@ -36,7 +36,8 @@ ApiUser::Ptr ApiUser::GetByClientCN(const String& cn)
 	return nullptr;
 }
 
-ApiUser::Ptr ApiUser::GetByAuthHeader(const String& auth_header) {
+ApiUser::Ptr ApiUser::GetByAuthHeader(const String& auth_header)
+{
 	String::SizeType pos = auth_header.FindFirstOf(" ");
 	String username, password;
 

--- a/lib/remote/apiuser.hpp
+++ b/lib/remote/apiuser.hpp
@@ -36,6 +36,7 @@ public:
 	DECLARE_OBJECTNAME(ApiUser);
 
 	static ApiUser::Ptr GetByClientCN(const String& cn);
+	static ApiUser::Ptr GetByAuthHeader(const String& auth_header);
 };
 
 }

--- a/lib/remote/httpchunkedencoding.cpp
+++ b/lib/remote/httpchunkedencoding.cpp
@@ -37,6 +37,8 @@ StreamReadStatus HttpChunkedEncoding::ReadChunkFromStream(const Stream::Ptr& str
 		msgbuf << std::hex << line;
 		msgbuf >> context.LengthIndicator;
 
+		if (context.LengthIndicator < 0)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("HTTP chunk length must not be negative."));
 	}
 
 	StreamReadContext& scontext = context.StreamContext;

--- a/lib/remote/httprequest.cpp
+++ b/lib/remote/httprequest.cpp
@@ -25,134 +25,147 @@
 using namespace icinga;
 
 HttpRequest::HttpRequest(Stream::Ptr stream)
-	: Complete(false),
+	: CompleteHeaders(false),
+	CompleteBody(false),
 	ProtocolVersion(HttpVersion11),
 	Headers(new Dictionary()),
 	m_Stream(std::move(stream)),
 	m_State(HttpRequestStart)
 { }
 
-bool HttpRequest::Parse(StreamReadContext& src, bool may_wait)
+bool HttpRequest::ParseHeader(StreamReadContext& src, bool may_wait)
 {
 	if (!m_Stream)
 		return false;
 
-	if (m_State != HttpRequestBody) {
-		String line;
-		StreamReadStatus srs = m_Stream->ReadLine(&line, src, may_wait);
+	if (m_State != HttpRequestStart && m_State != HttpRequestHeaders)
+		return false;
 
-		if (srs != StatusNewItem) {
-			if (src.Size > 512)
-				BOOST_THROW_EXCEPTION(std::invalid_argument("Line length for HTTP header exceeded"));
+	String line;
+	StreamReadStatus srs = m_Stream->ReadLine(&line, src, may_wait);
 
+	if (srs != StatusNewItem) {
+		if (src.Size > 512)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Line length for HTTP header exceeded"));
+
+		return false;
+	}
+
+	if (line.GetLength() > 512)
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Line length for HTTP header exceeded"));
+
+	if (m_State == HttpRequestStart) {
+		/* ignore trailing new-lines */
+		if (line == "")
+			return true;
+
+		std::vector<String> tokens = line.Split(" ");
+		Log(LogDebug, "HttpRequest")
+			<< "line: " << line << ", tokens: " << tokens.size();
+		if (tokens.size() != 3)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid HTTP request"));
+
+		RequestMethod = tokens[0];
+		RequestUrl = new class Url(tokens[1]);
+
+		if (tokens[2] == "HTTP/1.0")
+			ProtocolVersion = HttpVersion10;
+		else if (tokens[2] == "HTTP/1.1") {
+			ProtocolVersion = HttpVersion11;
+		} else
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Unsupported HTTP version"));
+
+		m_State = HttpRequestHeaders;
+		return true;
+	} else { // m_State = HttpRequestHeaders
+		if (line == "") {
+			m_State = HttpRequestBody;
+			CompleteHeaders = true;
+			return true;
+
+		} else {
+			if (Headers->GetLength() > 128)
+				BOOST_THROW_EXCEPTION(std::invalid_argument("Maximum number of HTTP request headers exceeded"));
+
+			String::SizeType pos = line.FindFirstOf(":");
+			if (pos == String::NPos)
+				BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid HTTP request"));
+
+			String key = line.SubStr(0, pos).ToLower().Trim();
+			String value = line.SubStr(pos + 1).Trim();
+			Headers->Set(key, value);
+
+			if (key == "x-http-method-override")
+				RequestMethod = value;
+
+			return true;
+		}
+	}
+}
+
+bool HttpRequest::ParseBody(StreamReadContext& src, bool may_wait)
+{
+	if (!m_Stream || m_State != HttpRequestBody)
+		return false;
+
+	/* we're done if the request doesn't contain a message body */
+	if (!Headers->Contains("content-length") && !Headers->Contains("transfer-encoding")) {
+		CompleteBody = true;
+		return true;
+	} else if (!m_Body)
+		m_Body = new FIFO();
+
+	if (CompleteBody)
+		return true;
+
+	if (Headers->Get("transfer-encoding") == "chunked") {
+		if (!m_ChunkContext)
+			m_ChunkContext = std::make_shared<ChunkReadContext>(std::ref(src));
+
+		char *data;
+		size_t size;
+		StreamReadStatus srs = HttpChunkedEncoding::ReadChunkFromStream(m_Stream, &data, &size, *m_ChunkContext.get(), may_wait);
+
+		if (srs != StatusNewItem)
+			return false;
+
+		m_Body->Write(data, size);
+
+		delete [] data;
+
+		if (size == 0) {
+			CompleteBody = true;
+			return true;
+		}
+	} else {
+		if (src.Eof)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
+
+		if (src.MustRead) {
+			if (!src.FillFromStream(m_Stream, false)) {
+				src.Eof = true;
+				BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
+			}
+
+			src.MustRead = false;
+		}
+
+		long length_indicator_signed = Convert::ToLong(Headers->Get("content-length"));
+
+		if (length_indicator_signed < 0)
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Content-Length must not be negative."));
+
+		size_t length_indicator = length_indicator_signed;
+
+		if (src.Size < length_indicator) {
+			src.MustRead = true;
 			return false;
 		}
 
-		if (line.GetLength() > 512)
-			BOOST_THROW_EXCEPTION(std::invalid_argument("Line length for HTTP header exceeded"));
-
-		if (m_State == HttpRequestStart) {
-			/* ignore trailing new-lines */
-			if (line == "")
-				return true;
-
-			std::vector<String> tokens = line.Split(" ");
-			Log(LogDebug, "HttpRequest")
-				<< "line: " << line << ", tokens: " << tokens.size();
-			if (tokens.size() != 3)
-				BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid HTTP request"));
-
-			RequestMethod = tokens[0];
-			RequestUrl = new class Url(tokens[1]);
-
-			if (tokens[2] == "HTTP/1.0")
-				ProtocolVersion = HttpVersion10;
-			else if (tokens[2] == "HTTP/1.1") {
-				ProtocolVersion = HttpVersion11;
-			} else
-				BOOST_THROW_EXCEPTION(std::invalid_argument("Unsupported HTTP version"));
-
-			m_State = HttpRequestHeaders;
-		} else if (m_State == HttpRequestHeaders) {
-			if (line == "") {
-				m_State = HttpRequestBody;
-
-				/* we're done if the request doesn't contain a message body */
-				if (!Headers->Contains("content-length") && !Headers->Contains("transfer-encoding"))
-					Complete = true;
-				else
-					m_Body = new FIFO();
-
-				return true;
-
-			} else {
-				if (Headers->GetLength() > 128)
-					BOOST_THROW_EXCEPTION(std::invalid_argument("Maximum number of HTTP request headers exceeded"));
-
-				String::SizeType pos = line.FindFirstOf(":");
-				if (pos == String::NPos)
-					BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid HTTP request"));
-
-				String key = line.SubStr(0, pos).ToLower().Trim();
-				String value = line.SubStr(pos + 1).Trim();
-				Headers->Set(key, value);
-
-				if (key == "x-http-method-override")
-					RequestMethod = value;
-			}
-		} else {
-			VERIFY(!"Invalid HTTP request state.");
-		}
-	} else if (m_State == HttpRequestBody) {
-		if (Headers->Get("transfer-encoding") == "chunked") {
-			if (!m_ChunkContext)
-				m_ChunkContext = std::make_shared<ChunkReadContext>(std::ref(src));
-
-			char *data;
-			size_t size;
-			StreamReadStatus srs = HttpChunkedEncoding::ReadChunkFromStream(m_Stream, &data, &size, *m_ChunkContext.get(), may_wait);
-
-			if (srs != StatusNewItem)
-				return false;
-
-			m_Body->Write(data, size);
-
-			delete [] data;
-
-			if (size == 0) {
-				Complete = true;
-				return true;
-			}
-		} else {
-			if (src.Eof)
-				BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
-
-			if (src.MustRead) {
-				if (!src.FillFromStream(m_Stream, false)) {
-					src.Eof = true;
-					BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
-				}
-
-				src.MustRead = false;
-			}
-
-			long length_indicator_signed = Convert::ToLong(Headers->Get("content-length"));
-
-			if (length_indicator_signed < 0)
-				BOOST_THROW_EXCEPTION(std::invalid_argument("Content-Length must not be negative."));
-
-			size_t length_indicator = length_indicator_signed;
-
-			if (src.Size < length_indicator) {
-				src.MustRead = true;
-				return false;
-			}
-
-			m_Body->Write(src.Buffer, length_indicator);
-			src.DropData(length_indicator);
-			Complete = true;
-			return true;
-		}
+		m_Body->Write(src.Buffer, length_indicator);
+		src.DropData(length_indicator);
+		CompleteBody = true;
+		return true;
 	}
 
 	return true;

--- a/lib/remote/httprequest.cpp
+++ b/lib/remote/httprequest.cpp
@@ -126,7 +126,12 @@ bool HttpRequest::Parse(StreamReadContext& src, bool may_wait)
 				src.MustRead = false;
 			}
 
-			size_t length_indicator = Convert::ToLong(Headers->Get("content-length"));
+			long length_indicator_signed = Convert::ToLong(Headers->Get("content-length"));
+
+			if (length_indicator_signed < 0)
+				BOOST_THROW_EXCEPTION(std::invalid_argument("Content-Length must not be negative."));
+
+			size_t length_indicator = length_indicator_signed;
 
 			if (src.Size < length_indicator) {
 				src.MustRead = true;

--- a/lib/remote/httprequest.cpp
+++ b/lib/remote/httprequest.cpp
@@ -34,7 +34,7 @@ HttpRequest::HttpRequest(Stream::Ptr stream)
 	m_State(HttpRequestStart)
 { }
 
-bool HttpRequest::ParseHeader(StreamReadContext& src, bool may_wait)
+bool HttpRequest::ParseHeaders(StreamReadContext& src, bool may_wait)
 {
 	if (!m_Stream)
 		return false;

--- a/lib/remote/httprequest.cpp
+++ b/lib/remote/httprequest.cpp
@@ -26,6 +26,7 @@ using namespace icinga;
 
 HttpRequest::HttpRequest(Stream::Ptr stream)
 	: CompleteHeaders(false),
+	CompleteHeaderCheck(false),
 	CompleteBody(false),
 	ProtocolVersion(HttpVersion11),
 	Headers(new Dictionary()),
@@ -39,7 +40,7 @@ bool HttpRequest::ParseHeader(StreamReadContext& src, bool may_wait)
 		return false;
 
 	if (m_State != HttpRequestStart && m_State != HttpRequestHeaders)
-		return false;
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid HTTP state"));
 
 	String line;
 	StreamReadStatus srs = m_Stream->ReadLine(&line, src, may_wait);
@@ -105,18 +106,18 @@ bool HttpRequest::ParseHeader(StreamReadContext& src, bool may_wait)
 
 bool HttpRequest::ParseBody(StreamReadContext& src, bool may_wait)
 {
-	if (!m_Stream || m_State != HttpRequestBody)
+	if (!m_Stream)
 		return false;
+
+	if (m_State != HttpRequestBody)
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid HTTP state"));
 
 	/* we're done if the request doesn't contain a message body */
 	if (!Headers->Contains("content-length") && !Headers->Contains("transfer-encoding")) {
 		CompleteBody = true;
-		return true;
+		return false;
 	} else if (!m_Body)
 		m_Body = new FIFO();
-
-	if (CompleteBody)
-		return true;
 
 	if (Headers->Get("transfer-encoding") == "chunked") {
 		if (!m_ChunkContext)
@@ -135,39 +136,38 @@ bool HttpRequest::ParseBody(StreamReadContext& src, bool may_wait)
 
 		if (size == 0) {
 			CompleteBody = true;
-			return true;
-		}
-	} else {
-		if (src.Eof)
-			BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
-
-		if (src.MustRead) {
-			if (!src.FillFromStream(m_Stream, false)) {
-				src.Eof = true;
-				BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
-			}
-
-			src.MustRead = false;
-		}
-
-		long length_indicator_signed = Convert::ToLong(Headers->Get("content-length"));
-
-		if (length_indicator_signed < 0)
-			BOOST_THROW_EXCEPTION(std::invalid_argument("Content-Length must not be negative."));
-
-		size_t length_indicator = length_indicator_signed;
-
-		if (src.Size < length_indicator) {
-			src.MustRead = true;
 			return false;
-		}
-
-		m_Body->Write(src.Buffer, length_indicator);
-		src.DropData(length_indicator);
-		CompleteBody = true;
-		return true;
+		} else
+			return true;
 	}
 
+	if (src.Eof)
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
+
+	if (src.MustRead) {
+		if (!src.FillFromStream(m_Stream, false)) {
+			src.Eof = true;
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Unexpected EOF in HTTP body"));
+		}
+
+		src.MustRead = false;
+	}
+
+	long length_indicator_signed = Convert::ToLong(Headers->Get("content-length"));
+
+	if (length_indicator_signed < 0)
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Content-Length must not be negative."));
+
+	size_t length_indicator = length_indicator_signed;
+
+	if (src.Size < length_indicator) {
+		src.MustRead = true;
+		return false;
+	}
+
+	m_Body->Write(src.Buffer, length_indicator);
+	src.DropData(length_indicator);
+	CompleteBody = true;
 	return true;
 }
 

--- a/lib/remote/httprequest.hpp
+++ b/lib/remote/httprequest.hpp
@@ -64,7 +64,7 @@ public:
 
 	HttpRequest(Stream::Ptr stream);
 
-	bool ParseHeader(StreamReadContext& src, bool may_wait);
+	bool ParseHeaders(StreamReadContext& src, bool may_wait);
 	bool ParseBody(StreamReadContext& src, bool may_wait);
 	size_t ReadBody(char *data, size_t count);
 

--- a/lib/remote/httprequest.hpp
+++ b/lib/remote/httprequest.hpp
@@ -52,7 +52,8 @@ enum HttpRequestState
 struct HttpRequest
 {
 public:
-	bool Complete;
+	bool CompleteHeaders;
+	bool CompleteBody;
 
 	String RequestMethod;
 	Url::Ptr RequestUrl;
@@ -62,7 +63,8 @@ public:
 
 	HttpRequest(Stream::Ptr stream);
 
-	bool Parse(StreamReadContext& src, bool may_wait);
+	bool ParseHeader(StreamReadContext& src, bool may_wait);
+	bool ParseBody(StreamReadContext& src, bool may_wait);
 	size_t ReadBody(char *data, size_t count);
 
 	void AddHeader(const String& key, const String& value);

--- a/lib/remote/httprequest.hpp
+++ b/lib/remote/httprequest.hpp
@@ -53,6 +53,7 @@ struct HttpRequest
 {
 public:
 	bool CompleteHeaders;
+	bool CompleteHeaderCheck;
 	bool CompleteBody;
 
 	String RequestMethod;

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -107,7 +107,11 @@ bool HttpServerConnection::ProcessMessage()
 			response.WriteBody(msg.CStr(), msg.GetLength());
 			response.Finish();
 
+			m_CurrentRequest.~HttpRequest();
+			new (&m_CurrentRequest) HttpRequest(m_Stream);
+
 			m_Stream->Shutdown();
+
 			return false;
 		} catch (const std::exception& ex) {
 			response.SetStatus(500, "Internal Server Error");
@@ -115,7 +119,11 @@ bool HttpServerConnection::ProcessMessage()
 			response.WriteBody(msg.CStr(), msg.GetLength());
 			response.Finish();
 
+			m_CurrentRequest.~HttpRequest();
+			new (&m_CurrentRequest) HttpRequest(m_Stream);
+
 			m_Stream->Shutdown();
+
 			return false;
 		}
 		return res;
@@ -124,7 +132,11 @@ bool HttpServerConnection::ProcessMessage()
 	if (!m_CurrentRequest.CompleteHeaderCheck) {
 		m_CurrentRequest.CompleteHeaderCheck = true;
 		if (!ManageHeaders(response)) {
+			m_CurrentRequest.~HttpRequest();
+			new (&m_CurrentRequest) HttpRequest(m_Stream);
+
 			m_Stream->Shutdown();
+
 			return false;
 		}
 	}
@@ -138,7 +150,11 @@ bool HttpServerConnection::ProcessMessage()
 			response.WriteBody(msg.CStr(), msg.GetLength());
 			response.Finish();
 
+			m_CurrentRequest.~HttpRequest();
+			new (&m_CurrentRequest) HttpRequest(m_Stream);
+
 			m_Stream->Shutdown();
+
 			return false;
 		} catch (const std::exception& ex) {
 			response.SetStatus(500, "Internal Server Error");
@@ -146,7 +162,11 @@ bool HttpServerConnection::ProcessMessage()
 			response.WriteBody(msg.CStr(), msg.GetLength());
 			response.Finish();
 
+			m_CurrentRequest.~HttpRequest();
+			new (&m_CurrentRequest) HttpRequest(m_Stream);
+
 			m_Stream->Shutdown();
+
 			return false;
 		}
 		return res;

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -165,9 +165,12 @@ void HttpServerConnection::ProcessMessageAsync(HttpRequest& request)
 
 	String requestUrl = request.RequestUrl->Format();
 
+	Socket::Ptr socket = m_Stream->GetSocket();
+
 	Log(LogInformation, "HttpServerConnection")
 		<< "Request: " << request.RequestMethod << " " << requestUrl
-		<< " (from " << m_Stream->GetSocket()->GetPeerAddress() << ", user: " << (user ? user->GetName() : "<unauthenticated>") << ")";
+		<< " (from " << (socket ? socket->GetPeerAddress() : "<unkown>")
+		<< ", user: " << (user ? user->GetName() : "<unauthenticated>") << ")";
 
 	HttpResponse response(m_Stream, request);
 

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -24,12 +24,13 @@
 #include "remote/apifunction.hpp"
 #include "remote/jsonrpc.hpp"
 #include "base/base64.hpp"
-#include "base/configtype.hpp"
-#include "base/objectlock.hpp"
-#include "base/utility.hpp"
-#include "base/logger.hpp"
-#include "base/exception.hpp"
 #include "base/convert.hpp"
+#include "base/configtype.hpp"
+#include "base/exception.hpp"
+#include "base/logger.hpp"
+#include "base/objectlock.hpp"
+#include "base/timer.hpp"
+#include "base/utility.hpp"
 #include <boost/thread/once.hpp>
 
 using namespace icinga;
@@ -101,7 +102,7 @@ bool HttpServerConnection::ProcessMessage()
 
 	if (!m_CurrentRequest.CompleteHeaders) {
 		try {
-			res = m_CurrentRequest.ParseHeader(m_Context, false);
+			res = m_CurrentRequest.ParseHeaders(m_Context, false);
 		} catch (const std::invalid_argument& ex) {
 			response.SetStatus(400, "Bad Request");
 			String msg = String("<h1>Bad Request</h1><p><pre>") + ex.what() + "</pre></p>";

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -92,7 +92,7 @@ bool HttpServerConnection::ProcessMessage()
 	bool res;
 
 	try {
-		res = m_CurrentRequest.Parse(m_Context, false);
+		res = m_CurrentRequest.ParseHeader(m_Context, false);
 	} catch (const std::invalid_argument& ex) {
 		HttpResponse response(m_Stream, m_CurrentRequest);
 		response.SetStatus(400, "Bad request");
@@ -113,7 +113,7 @@ bool HttpServerConnection::ProcessMessage()
 		return false;
 	}
 
-	if (m_CurrentRequest.Complete) {
+	if (m_CurrentRequest.CompleteHeaders) {
 		m_RequestQueue.Enqueue(std::bind(&HttpServerConnection::ProcessMessageAsync,
 			HttpServerConnection::Ptr(this), m_CurrentRequest));
 
@@ -241,25 +241,37 @@ void HttpServerConnection::ProcessMessageAsync(HttpRequest& request)
 			response.WriteBody(msg.CStr(), msg.GetLength());
 		}
 	} else {
-		try {
-			HttpHandler::ProcessRequest(user, request, response);
-		} catch (const std::exception& ex) {
-			Log(LogCritical, "HttpServerConnection")
-				<< "Unhandled exception while processing Http request: " << DiagnosticInformation(ex);
-			response.SetStatus(503, "Unhandled exception");
+		bool res = true;
+		while (!request.CompleteBody)
+			res = request.ParseBody(m_Context, false);
+		if (!res) {
+			Log(LogCritical, "HttpServerConnection", "Failed to read body");
+			Dictionary::Ptr result = new Dictionary({
+				{ "error", 400 },
+				{ "status", "Bad Request: Malformed body." }
+			});
+			HttpUtility::SendJsonBody(response, nullptr, result);
+		} else {
+			try {
+				HttpHandler::ProcessRequest(user, request, response);
+			} catch (const std::exception& ex) {
+				Log(LogCritical, "HttpServerConnection")
+					<< "Unhandled exception while processing Http request: " << DiagnosticInformation(ex);
+				response.SetStatus(503, "Unhandled exception");
 
-			String errorInfo = DiagnosticInformation(ex);
+				String errorInfo = DiagnosticInformation(ex);
 
-			if (request.Headers->Get("accept") == "application/json") {
-				Dictionary::Ptr result = new Dictionary({
-					{ "error", 503 },
-					{ "status", errorInfo }
-				});
+				if (request.Headers->Get("accept") == "application/json") {
+					Dictionary::Ptr result = new Dictionary({
+						{ "error", 503 },
+						{ "status", errorInfo }
+					});
 
-				HttpUtility::SendJsonBody(response, nullptr, result);
-			} else {
-				response.AddHeader("Content-Type", "text/plain");
-				response.WriteBody(errorInfo.CStr(), errorInfo.GetLength());
+					HttpUtility::SendJsonBody(response, nullptr, result);
+				} else {
+					response.AddHeader("Content-Type", "text/plain");
+					response.WriteBody(errorInfo.CStr(), errorInfo.GetLength());
+				}
 			}
 		}
 	}

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -95,6 +95,7 @@ void HttpServerConnection::Disconnect()
 
 bool HttpServerConnection::ProcessMessage()
 {
+
 	bool res;
 	HttpResponse response(m_Stream, m_CurrentRequest);
 
@@ -186,6 +187,16 @@ bool HttpServerConnection::ProcessMessage()
 
 bool HttpServerConnection::ManageHeaders(HttpResponse& response)
 {
+	static const size_t defaultContentLengthLimit = 1 * 1028 * 1028;
+	static const Dictionary::Ptr specialContentLengthLimits = new Dictionary({
+		  {"*", 512 * 1028 * 1028},
+		  {"config/modify", 512 * 1028 * 1028},
+		  {"console", 512 * 1028 * 1028},
+		  {"objects/create", 512 * 1028 * 1028},
+		  {"objects/modify", 512 * 1028 * 1028},
+		  {"objects/delete", 512 * 1028 * 1028}
+	});
+
 	if (m_CurrentRequest.Headers->Get("expect") == "100-continue") {
 		String continueResponse = "HTTP/1.1 100 Continue\r\n\r\n";
 		m_Stream->Write(continueResponse.CStr(), continueResponse.GetLength());
@@ -273,6 +284,29 @@ bool HttpServerConnection::ManageHeaders(HttpResponse& response)
 		}
 
 		response.Finish();
+		return false;
+	}
+
+	size_t maxSize = defaultContentLengthLimit;
+
+	Array::Ptr permissions = m_AuthenticatedUser->GetPermissions();
+	ObjectLock olock(permissions);
+
+	for (const Value& permission : permissions) {
+		std::vector<String> permissionParts = String(permission).Split("/");
+		String permissionPath = permissionParts[0] + (permissionParts.size() > 1 ? "/" + permissionParts[1] : "");
+		int size = specialContentLengthLimits->Get(permissionPath);
+		maxSize = size > maxSize ? size : maxSize;
+	}
+
+	size_t contentLength = m_CurrentRequest.Headers->Get("content-length");
+
+	if (contentLength > maxSize) {
+		response.SetStatus(400, "Bad Request");
+		String msg = String("<h1>Content length exceeded maximum</h1>");
+		response.WriteBody(msg.CStr(), msg.GetLength());
+		response.Finish();
+
 		return false;
 	}
 

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -90,100 +90,105 @@ void HttpServerConnection::Disconnect()
 bool HttpServerConnection::ProcessMessage()
 {
 	bool res;
+	HttpResponse response(m_Stream, m_CurrentRequest);
 
-	try {
-		res = m_CurrentRequest.ParseHeader(m_Context, false);
-	} catch (const std::invalid_argument& ex) {
-		HttpResponse response(m_Stream, m_CurrentRequest);
-		response.SetStatus(400, "Bad request");
-		String msg = String("<h1>Bad request</h1><p><pre>") + ex.what() + "</pre></p>";
-		response.WriteBody(msg.CStr(), msg.GetLength());
-		response.Finish();
+	if (!m_CurrentRequest.CompleteHeaders) {
+		try {
+			res = m_CurrentRequest.ParseHeader(m_Context, false);
+		} catch (const std::invalid_argument& ex) {
+			response.SetStatus(400, "Bad Request");
+			String msg = String("<h1>Bad Request</h1><p><pre>") + ex.what() + "</pre></p>";
+			response.WriteBody(msg.CStr(), msg.GetLength());
+			response.Finish();
 
-		m_Stream->Shutdown();
-		return false;
-	} catch (const std::exception& ex) {
-		HttpResponse response(m_Stream, m_CurrentRequest);
-		response.SetStatus(400, "Bad request");
-		String msg = "<h1>Bad request</h1><p><pre>" + DiagnosticInformation(ex) + "</pre></p>";
-		response.WriteBody(msg.CStr(), msg.GetLength());
-		response.Finish();
+			m_Stream->Shutdown();
+			return false;
+		} catch (const std::exception& ex) {
+			response.SetStatus(500, "Internal Server Error");
+			String msg = "<h1>Internal Server Error</h1><p><pre>" + DiagnosticInformation(ex) + "</pre></p>";
+			response.WriteBody(msg.CStr(), msg.GetLength());
+			response.Finish();
 
-		m_Stream->Shutdown();
-		return false;
+			m_Stream->Shutdown();
+			return false;
+		}
+		return res;
 	}
 
-	if (m_CurrentRequest.CompleteHeaders) {
-		m_RequestQueue.Enqueue(std::bind(&HttpServerConnection::ProcessMessageAsync,
-			HttpServerConnection::Ptr(this), m_CurrentRequest));
-
-		m_Seen = Utility::GetTime();
-		m_PendingRequests++;
-
-		m_CurrentRequest.~HttpRequest();
-		new (&m_CurrentRequest) HttpRequest(m_Stream);
-
-		return true;
-	}
-
-	return res;
-}
-
-void HttpServerConnection::ProcessMessageAsync(HttpRequest& request)
-{
-	String auth_header = request.Headers->Get("authorization");
-
-	String::SizeType pos = auth_header.FindFirstOf(" ");
-	String username, password;
-
-	if (pos != String::NPos && auth_header.SubStr(0, pos) == "Basic") {
-		String credentials_base64 = auth_header.SubStr(pos + 1);
-		String credentials = Base64::Decode(credentials_base64);
-
-		String::SizeType cpos = credentials.FindFirstOf(":");
-
-		if (cpos != String::NPos) {
-			username = credentials.SubStr(0, cpos);
-			password = credentials.SubStr(cpos + 1);
+	if (!m_CurrentRequest.CompleteHeaderCheck) {
+		m_CurrentRequest.CompleteHeaderCheck = true;
+		if (!ManageHeaders(response)) {
+			m_Stream->Shutdown();
+			return false;
 		}
 	}
 
-	ApiUser::Ptr user;
+	if (!m_CurrentRequest.CompleteBody) {
+		try {
+			res = m_CurrentRequest.ParseBody(m_Context, false);
+		} catch (const std::invalid_argument& ex) {
+			response.SetStatus(400, "Bad Request");
+			String msg = String("<h1>Bad Request</h1><p><pre>") + ex.what() + "</pre></p>";
+			response.WriteBody(msg.CStr(), msg.GetLength());
+			response.Finish();
+
+			m_Stream->Shutdown();
+			return false;
+		} catch (const std::exception& ex) {
+			response.SetStatus(500, "Internal Server Error");
+			String msg = "<h1>Internal Server Error</h1><p><pre>" + DiagnosticInformation(ex) + "</pre></p>";
+			response.WriteBody(msg.CStr(), msg.GetLength());
+			response.Finish();
+
+			m_Stream->Shutdown();
+			return false;
+		}
+		return res;
+	}
+
+	m_RequestQueue.Enqueue(std::bind(&HttpServerConnection::ProcessMessageAsync,
+		HttpServerConnection::Ptr(this), m_CurrentRequest, response, m_AuthenticatedUser));
+
+	m_Seen = Utility::GetTime();
+	m_PendingRequests++;
+
+	m_CurrentRequest.~HttpRequest();
+	new (&m_CurrentRequest) HttpRequest(m_Stream);
+
+	return false;
+}
+
+bool HttpServerConnection::ManageHeaders(HttpResponse& response)
+{
+	if (m_CurrentRequest.Headers->Get("expect") == "100-continue") {
+		String continueResponse = "HTTP/1.1 100 Continue\r\n\r\n";
+		m_Stream->Write(continueResponse.CStr(), continueResponse.GetLength());
+	}
 
 	/* client_cn matched. */
 	if (m_ApiUser)
-		user = m_ApiUser;
-	else {
-		user = ApiUser::GetByName(username);
+		m_AuthenticatedUser = m_ApiUser;
+	else
+		m_AuthenticatedUser = ApiUser::GetByAuthHeader(m_CurrentRequest.Headers->Get("authorization"));
 
-		/* Deny authentication if 1) given password is empty 2) configured password does not match. */
-		if (password.IsEmpty())
-			user.reset();
-		else if (user && user->GetPassword() != password)
-			user.reset();
-	}
-
-	String requestUrl = request.RequestUrl->Format();
+	String requestUrl = m_CurrentRequest.RequestUrl->Format();
 
 	Socket::Ptr socket = m_Stream->GetSocket();
 
 	Log(LogInformation, "HttpServerConnection")
-		<< "Request: " << request.RequestMethod << " " << requestUrl
+		<< "Request: " << m_CurrentRequest.RequestMethod << " " << requestUrl
 		<< " (from " << (socket ? socket->GetPeerAddress() : "<unkown>")
-		<< ", user: " << (user ? user->GetName() : "<unauthenticated>") << ")";
-
-	HttpResponse response(m_Stream, request);
+		<< ", user: " << (m_AuthenticatedUser ? m_AuthenticatedUser->GetName() : "<unauthenticated>") << ")";
 
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 
 	if (!listener)
-		return;
+		return false;
 
 	Array::Ptr headerAllowOrigin = listener->GetAccessControlAllowOrigin();
 
 	if (headerAllowOrigin->GetLength() != 0) {
-		String origin = request.Headers->Get("origin");
-
+		String origin = m_CurrentRequest.Headers->Get("origin");
 		{
 			ObjectLock olock(headerAllowOrigin);
 
@@ -196,9 +201,9 @@ void HttpServerConnection::ProcessMessageAsync(HttpRequest& request)
 		if (listener->GetAccessControlAllowCredentials())
 			response.AddHeader("Access-Control-Allow-Credentials", "true");
 
-		String accessControlRequestMethodHeader = request.Headers->Get("access-control-request-method");
+		String accessControlRequestMethodHeader = m_CurrentRequest.Headers->Get("access-control-request-method");
 
-		if (!accessControlRequestMethodHeader.IsEmpty()) {
+		if (m_CurrentRequest.RequestMethod == "OPTIONS" && !accessControlRequestMethodHeader.IsEmpty()) {
 			response.SetStatus(200, "OK");
 
 			response.AddHeader("Access-Control-Allow-Methods", listener->GetAccessControlAllowMethods());
@@ -208,27 +213,27 @@ void HttpServerConnection::ProcessMessageAsync(HttpRequest& request)
 			response.WriteBody(msg.CStr(), msg.GetLength());
 
 			response.Finish();
-			m_PendingRequests--;
-
-			return;
+			return false;
 		}
 	}
 
-	String accept_header = request.Headers->Get("accept");
-
-	if (request.RequestMethod != "GET" && accept_header != "application/json") {
+	if (m_CurrentRequest.RequestMethod != "GET" && m_CurrentRequest.Headers->Get("accept") != "application/json") {
 		response.SetStatus(400, "Wrong Accept header");
 		response.AddHeader("Content-Type", "text/html");
 		String msg = "<h1>Accept header is missing or not set to 'application/json'.</h1>";
 		response.WriteBody(msg.CStr(), msg.GetLength());
-	} else if (!user) {
+		response.Finish();
+		return false;
+	}
+
+	if (!m_AuthenticatedUser) {
 		Log(LogWarning, "HttpServerConnection")
-			<< "Unauthorized request: " << request.RequestMethod << " " << requestUrl;
+			<< "Unauthorized request: " << m_CurrentRequest.RequestMethod << " " << requestUrl;
 
 		response.SetStatus(401, "Unauthorized");
 		response.AddHeader("WWW-Authenticate", "Basic realm=\"Icinga 2\"");
 
-		if (request.Headers->Get("accept") == "application/json") {
+		if (m_CurrentRequest.Headers->Get("accept") == "application/json") {
 			Dictionary::Ptr result = new Dictionary({
 				{ "error", 401 },
 				{ "status", "Unauthorized. Please check your user credentials." }
@@ -240,44 +245,25 @@ void HttpServerConnection::ProcessMessageAsync(HttpRequest& request)
 			String msg = "<h1>Unauthorized. Please check your user credentials.</h1>";
 			response.WriteBody(msg.CStr(), msg.GetLength());
 		}
-	} else {
-		bool res = true;
-		while (!request.CompleteBody)
-			res = request.ParseBody(m_Context, false);
-		if (!res) {
-			Log(LogCritical, "HttpServerConnection", "Failed to read body");
-			Dictionary::Ptr result = new Dictionary({
-				{ "error", 400 },
-				{ "status", "Bad Request: Malformed body." }
-			});
-			HttpUtility::SendJsonBody(response, nullptr, result);
-		} else {
-			try {
-				HttpHandler::ProcessRequest(user, request, response);
-			} catch (const std::exception& ex) {
-				Log(LogCritical, "HttpServerConnection")
-					<< "Unhandled exception while processing Http request: " << DiagnosticInformation(ex);
-				response.SetStatus(503, "Unhandled exception");
 
-				String errorInfo = DiagnosticInformation(ex);
+		response.Finish();
+		return false;
+	}
 
-				if (request.Headers->Get("accept") == "application/json") {
-					Dictionary::Ptr result = new Dictionary({
-						{ "error", 503 },
-						{ "status", errorInfo }
-					});
+	return true;
+}
 
-					HttpUtility::SendJsonBody(response, nullptr, result);
-				} else {
-					response.AddHeader("Content-Type", "text/plain");
-					response.WriteBody(errorInfo.CStr(), errorInfo.GetLength());
-				}
-			}
-		}
+void HttpServerConnection::ProcessMessageAsync(HttpRequest& request, HttpResponse& response, const ApiUser::Ptr& user)
+{
+	try {
+		HttpHandler::ProcessRequest(user, request, response);
+	} catch (const std::exception& ex) {
+		Log(LogCritical, "HttpServerConnection")
+			<< "Unhandled exception while processing Http request: " << DiagnosticInformation(ex);
+		HttpUtility::SendJsonError(response, nullptr, 503, "Unhandled exception" , DiagnosticInformation(ex));
 	}
 
 	response.Finish();
-
 	m_PendingRequests--;
 }
 

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -21,6 +21,7 @@
 #define HTTPSERVERCONNECTION_H
 
 #include "remote/httprequest.hpp"
+#include "remote/httpresponse.hpp"
 #include "remote/apiuser.hpp"
 #include "base/tlsstream.hpp"
 #include "base/timer.hpp"
@@ -51,6 +52,7 @@ public:
 
 private:
 	ApiUser::Ptr m_ApiUser;
+	ApiUser::Ptr m_AuthenticatedUser;
 	TlsStream::Ptr m_Stream;
 	double m_Seen;
 	HttpRequest m_CurrentRequest;
@@ -67,7 +69,9 @@ private:
 	static void TimeoutTimerHandler();
 	void CheckLiveness();
 
-	void ProcessMessageAsync(HttpRequest& request);
+	bool ManageHeaders(HttpResponse& response);
+
+	void ProcessMessageAsync(HttpRequest& request, HttpResponse& response, const ApiUser::Ptr&);
 };
 
 }

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -24,7 +24,6 @@
 #include "remote/httpresponse.hpp"
 #include "remote/apiuser.hpp"
 #include "base/tlsstream.hpp"
-#include "base/timer.hpp"
 #include "base/workqueue.hpp"
 
 namespace icinga

--- a/lib/remote/pkiutility.cpp
+++ b/lib/remote/pkiutility.cpp
@@ -121,8 +121,10 @@ std::shared_ptr<X509> PkiUtility::FetchCert(const String& host, const String& po
 
 	try {
 		stream->Handshake();
-	} catch (...) {
-
+	} catch (const std::exception& ex) {
+		Log(LogCritical, "pki")
+			<< "Client TLS handshake failed. (" << ex.what() << ")";
+		return std::shared_ptr<X509>();
 	}
 
 	return stream->GetPeerCertificate();


### PR DESCRIPTION
This PR addresses a number of security issues with the HTTP server. These changes aim prevent the abuse of the API in a way that causes Icinga 2 to crash.

Refs CVE-2018-6532 