### PR TITLE
Allow MYSQL_LIB to be specified by ENV variable

### DIFF
--- a/third-party/cmake/FindMySQL.cmake
+++ b/third-party/cmake/FindMySQL.cmake
@@ -66,6 +66,7 @@ IF (WIN32)
 
   FIND_LIBRARY(MYSQL_LIB NAMES mysqlclient
     PATHS
+    $ENV{MYSQL_DIR}
     $ENV{MYSQL_DIR}/lib/${libsuffixDist}
     $ENV{MYSQL_DIR}/libmysql
     $ENV{MYSQL_DIR}/libmysql/${libsuffixBuild}
@@ -82,6 +83,7 @@ ELSE (WIN32)
 
   FIND_LIBRARY(MYSQL_LIB NAMES ${MYSQL_CLIENT_LIBS}
     PATHS
+    $ENV{MYSQL_DIR}
     $ENV{MYSQL_DIR}/libmysql_r/.libs
     $ENV{MYSQL_DIR}/lib
     $ENV{MYSQL_DIR}/lib/mysql


### PR DESCRIPTION
When I was compiling Icinga2 on macOS I run into minor issue when I had MariaDB client libs located on path (`/opt/local/lib/mariadb/mysql/`) FindMySQL.cmake was unable to find.  It was not possible to specify `MYSQL_LIB ` entirely by environment variable (like `MYSQL_INCLUDE_DIR`).

This PR allows to specify `MYSQL_LIB` path entirely from `MYSQL_DIR` environment variable.

Not sure if `MYSQL_DIR` is best var name for this case. It might be better to change it to something else ( maybe `MYSQL_LIB_DIR`?).