### PR TITLE
Fix HTTP parser crash/hang

### DIFF
--- a/lib/remote/httprequest.cpp
+++ b/lib/remote/httprequest.cpp
@@ -115,7 +115,7 @@ bool HttpRequest::ParseBody(StreamReadContext& src, bool may_wait)
 	/* we're done if the request doesn't contain a message body */
 	if (!Headers->Contains("content-length") && !Headers->Contains("transfer-encoding")) {
 		CompleteBody = true;
-		return false;
+		return true;
 	} else if (!m_Body)
 		m_Body = new FIFO();
 

--- a/lib/remote/httpresponse.cpp
+++ b/lib/remote/httpresponse.cpp
@@ -26,7 +26,7 @@
 using namespace icinga;
 
 HttpResponse::HttpResponse(Stream::Ptr stream, const HttpRequest& request)
-	: Complete(false), m_State(HttpResponseStart), m_Request(request), m_Stream(std::move(stream))
+	: Complete(false), m_State(HttpResponseStart), m_Request(&request), m_Stream(std::move(stream))
 { }
 
 void HttpResponse::SetStatus(int code, const String& message)
@@ -41,7 +41,7 @@ void HttpResponse::SetStatus(int code, const String& message)
 
 	String status = "HTTP/";
 
-	if (m_Request.ProtocolVersion == HttpVersion10)
+	if (m_Request->ProtocolVersion == HttpVersion10)
 		status += "1.0";
 	else
 		status += "1.1";
@@ -61,7 +61,7 @@ void HttpResponse::AddHeader(const String& key, const String& value)
 void HttpResponse::FinishHeaders()
 {
 	if (m_State == HttpResponseHeaders) {
-		if (m_Request.ProtocolVersion == HttpVersion11)
+		if (m_Request->ProtocolVersion == HttpVersion11)
 			AddHeader("Transfer-Encoding", "chunked");
 
 		AddHeader("Server", "Icinga/" + Application::GetAppVersion());
@@ -78,7 +78,7 @@ void HttpResponse::WriteBody(const char *data, size_t count)
 {
 	ASSERT(m_State == HttpResponseHeaders || m_State == HttpResponseBody);
 
-	if (m_Request.ProtocolVersion == HttpVersion10) {
+	if (m_Request->ProtocolVersion == HttpVersion10) {
 		if (!m_Body)
 			m_Body = new FIFO();
 
@@ -94,7 +94,7 @@ void HttpResponse::Finish()
 {
 	ASSERT(m_State != HttpResponseEnd);
 
-	if (m_Request.ProtocolVersion == HttpVersion10) {
+	if (m_Request->ProtocolVersion == HttpVersion10) {
 		if (m_Body)
 			AddHeader("Content-Length", Convert::ToString(m_Body->GetAvailableBytes()));
 
@@ -112,7 +112,7 @@ void HttpResponse::Finish()
 
 	m_State = HttpResponseEnd;
 
-	if (m_Request.ProtocolVersion == HttpVersion10 || m_Request.Headers->Get("connection") == "close")
+	if (m_Request->ProtocolVersion == HttpVersion10 || m_Request->Headers->Get("connection") == "close")
 		m_Stream->Shutdown();
 }
 
@@ -262,4 +262,9 @@ size_t HttpResponse::GetBodySize() const
 bool HttpResponse::IsPeerConnected() const
 {
 	return !m_Stream->IsEof();
+}
+
+void HttpResponse::RebindRequest(const HttpRequest& request)
+{
+	m_Request = &request;
 }

--- a/lib/remote/httpresponse.hpp
+++ b/lib/remote/httpresponse.hpp
@@ -65,10 +65,12 @@ public:
 
 	bool IsPeerConnected() const;
 
+	void RebindRequest(const HttpRequest& request);
+
 private:
 	HttpResponseState m_State;
 	std::shared_ptr<ChunkReadContext> m_ChunkContext;
-	const HttpRequest& m_Request;
+	const HttpRequest *m_Request;
 	Stream::Ptr m_Stream;
 	FIFO::Ptr m_Body;
 	std::vector<String> m_Headers;

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -316,6 +316,8 @@ bool HttpServerConnection::ManageHeaders(HttpResponse& response)
 
 void HttpServerConnection::ProcessMessageAsync(HttpRequest& request, HttpResponse& response, const ApiUser::Ptr& user)
 {
+	response.RebindRequest(request);
+
 	try {
 		HttpHandler::ProcessRequest(user, request, response);
 	} catch (const std::exception& ex) {


### PR DESCRIPTION
The first commit fixes an issue where HTTP connections can hang for extended periods of time. The other commit fixes a crash I observed while fixing the first issue.

fixes #6130