### PR TITLE
Improve error handling for empty packages in /v1/config/packages

### DIFF
--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -48,7 +48,15 @@ void ConfigPackagesHandler::HandleGet(const ApiUser::Ptr& user, HttpRequest& req
 {
 	FilterUtility::CheckPermission(user, "config/query");
 
-	std::vector<String> packages = ConfigPackageUtility::GetPackages();
+	std::vector<String> packages;
+
+	try {
+		packages = ConfigPackageUtility::GetPackages();
+	} catch (const std::exception& ex) {
+		HttpUtility::SendJsonError(response, params, 500, "Could not retrieve packages.",
+			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+		return;
+	}
 
 	ArrayData results;
 

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -57,9 +57,17 @@ void ConfigPackageUtility::DeletePackage(const String& name)
 
 std::vector<String> ConfigPackageUtility::GetPackages()
 {
+	String packageDir = GetPackageDir();
+
 	std::vector<String> packages;
-	Utility::Glob(GetPackageDir() + "/*", std::bind(&ConfigPackageUtility::CollectDirNames,
+
+	/* Package directory does not exist, no packages have been created thus far. */
+	if (!Utility::PathExists(packageDir))
+		return packages;
+
+	Utility::Glob(packageDir + "/*", std::bind(&ConfigPackageUtility::CollectDirNames,
 		_1, std::ref(packages)), GlobDirectory);
+
 	return packages;
 }
 


### PR DESCRIPTION
- If there is no package main directory, assume "empty packages".
- Catch exceptions thrown through GlobRecursive() and present a better http 500
to the user.

The packages directory tree is automatically created with the first
package creation, either from the user, or by the `_api` package.

fixes #6129