### PR TITLE
tests: Ensure IcingaApplication is initialized before adding config

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@
 include(BoostTestTargets)
 
 set(base_test_SOURCES
+  icingaapplication-fixture.cpp
   base-array.cpp
   base-base64.cpp
   base-convert.cpp
@@ -56,7 +57,7 @@ endif()
 add_boost_test(base
   SOURCES test-runner.cpp ${base_test_SOURCES}
   LIBRARIES ${base_DEPS}
-  TESTS 
+  TESTS
     base_array/construct
     base_array/getset
     base_array/resize
@@ -145,6 +146,7 @@ add_boost_test(base
 
 if(ICINGA2_WITH_LIVESTATUS)
   set(livestatus_test_SOURCES
+    icingaapplication-fixture.cpp
     livestatus-fixture.cpp
     livestatus.cpp
     ${base_OBJS}
@@ -167,6 +169,7 @@ if(ICINGA2_WITH_LIVESTATUS)
 endif()
 
 set(icinga_checkable_test_SOURCES
+  icingaapplication-fixture.cpp
   icinga-checkable-fixture.cpp
   icinga-checkable-flapping.cpp
   ${base_OBJS}

--- a/test/icingaapplication-fixture.cpp
+++ b/test/icingaapplication-fixture.cpp
@@ -17,6 +17,33 @@
 * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
 ******************************************************************************/
 
-#define BOOST_TEST_MAIN
+#include "icingaapplication-fixture.hpp"
 
-#include <BoostTestTargetConfig.h>
+using namespace icinga;
+
+static bool IcingaInitialized = false;
+
+IcingaApplicationFixture::IcingaApplicationFixture()
+{
+	if (!IcingaInitialized)
+		InitIcingaApplication();
+}
+
+void IcingaApplicationFixture::InitIcingaApplication()
+{
+	BOOST_TEST_MESSAGE("Initializing Application...");
+	Application::InitializeBase();
+
+	BOOST_TEST_MESSAGE("Initializing IcingaApplication...");
+	IcingaApplication::Ptr appInst = new IcingaApplication();
+	static_pointer_cast<ConfigObject>(appInst)->OnConfigLoaded();
+
+	IcingaInitialized = true;
+}
+
+IcingaApplicationFixture::~IcingaApplicationFixture()
+{
+	IcingaApplication::GetInstance().reset();
+}
+
+BOOST_GLOBAL_FIXTURE(IcingaApplicationFixture);

--- a/test/icingaapplication-fixture.hpp
+++ b/test/icingaapplication-fixture.hpp
@@ -17,6 +17,22 @@
 * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.             *
 ******************************************************************************/
 
-#define BOOST_TEST_MAIN
+#ifndef ICINGAAPPLICATION_FIXTURE_H
+#define ICINGAAPPLICATION_FIXTURE_H
 
+#include "icinga/icingaapplication.hpp"
+#include "base/application.hpp"
 #include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+struct IcingaApplicationFixture
+{
+	IcingaApplicationFixture();
+
+	void InitIcingaApplication();
+
+	~IcingaApplicationFixture();
+};
+
+#endif // ICINGAAPPLICATION_FIXTURE_H

--- a/test/livestatus-fixture.cpp
+++ b/test/livestatus-fixture.cpp
@@ -21,6 +21,7 @@
 #include "config/configitem.hpp"
 #include "base/application.hpp"
 #include "base/loader.hpp"
+#include "icingaapplication-fixture.hpp"
 #include <BoostTestTargetConfig.h>
 
 using namespace icinga;
@@ -29,6 +30,9 @@ struct LivestatusFixture
 {
 	LivestatusFixture()
 	{
+		// ensure IcingaApplication is initialized before we try to add config
+		IcingaApplicationFixture icinga;
+
 		BOOST_TEST_MESSAGE("Preparing config objects...");
 
 		ConfigItem::RunWithActivationContext(new Function("CreateTestObjects", CreateTestObjects));


### PR DESCRIPTION
This is basically a workaround for fixture ordering in Boost 1.55.

It fixes builds for Debian jessie and Ubuntu trusty.

fixes #6105 