### PR TITLE
[WIP] Add more options to pass a password to the "icinga2 api user" command

### DIFF
--- a/lib/cli/apiusercommand.cpp
+++ b/lib/cli/apiusercommand.cpp
@@ -21,8 +21,39 @@
 #include "base/logger.hpp"
 #include "base/tlsutility.hpp"
 #include "base/configwriter.hpp"
+#include "base/console.hpp"
 #include "remote/apiuser.hpp"
 #include <iostream>
+
+#ifndef _WIN32
+extern "C" {
+#include <termios.h>
+#include <unistd.h>
+}
+
+static void setTermEcho(bool echo) {
+	termios t;
+	tcgetattr(STDIN_FILENO, &t);
+	if (echo) {
+		t.c_lflag |= ECHO;
+	} else {
+		t.c_lflag &= ~ECHO;
+	}
+	tcsetattr(STDIN_FILENO, TCSANOW, &t);;
+}
+
+static String promptPassword(String prompt) {
+	setTermEcho(false);
+	std::string password;
+	std::cerr << prompt << std::flush;
+	std::getline(std::cin, password);
+	// manually print a new line as echo is turned off, so pressing enter
+	// in the password prompt won't produce a new line in the terminal
+	std::cerr << std::endl;
+	setTermEcho(true);
+	return password;
+}
+#endif
 
 using namespace icinga;
 namespace po = boost::program_options;
@@ -45,6 +76,7 @@ void ApiUserCommand::InitParameters(boost::program_options::options_description&
 	visibleDesc.add_options()
 		("user", po::value<std::string>(), "API username")
 		("password", po::value<std::string>(), "Password in clear text")
+		("random-password", "Generate a random password")
 		("salt", po::value<std::string>(), "Optional salt (default: 8 random chars)")
 		("oneline", "Print only the password hash");
 }
@@ -62,17 +94,47 @@ int ApiUserCommand::Run(const boost::program_options::variables_map& vm, const s
 		return 1;
 	}
 
-	if (!vm.count("password")) {
-		Log(LogCritical, "cli", "Password (--password) must be specified.");
+	if (vm.count("password") && vm.count("random-password")) {
+		Log(LogCritical, "cli", "Only one of --password and --random-password may be specified.");
 		return 1;
 	}
 
-	passwd = vm["password"].as<std::string>();
 	salt = vm.count("salt") ? String(vm["salt"].as<std::string>()) : RandomString(8);
-
 	if (salt.FindFirstOf('$') != String::NPos) {
 		Log(LogCritical, "cli", "Salt (--salt) may not contain '$'");
 		return 1;
+	}
+
+	if (vm.count("password")) {
+		// password is passed as a command line argument
+		passwd = vm["password"].as<std::string>();
+	} else if (vm.count("random-password")) {
+		// generating a random password was requested
+		passwd = RandomString(16);
+		std::cerr << "// Generated random password: " << passwd << std::endl;
+#ifndef _WIN32
+	} else if (isatty(STDIN_FILENO) && isatty(STDERR_FILENO)) {
+		// interactive password entry
+		while (true) {
+			passwd = promptPassword("Enter password: ");
+			if (passwd.IsEmpty()) {
+				std::cerr << "No password entered, please try again." << std::endl;
+				continue;
+			}
+			String confirm = promptPassword("Confirm password: ");
+			if (passwd != confirm) {
+				std::cerr << "Passwords did not match, please try again." << std::endl;
+				continue;
+			}
+			// entered passwords are fine
+			break;
+		}
+		std::cerr << "// Entered password: " << passwd << std::endl; // TODO: left for testing, remove later
+#endif
+	} else {
+		std::string std_passwd;
+		std::getline(std::cin, std_passwd);
+		passwd = std_passwd;
 	}
 
 	String hashedPassword = CreateHashedPasswordString(passwd, salt, 5);


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Icinga/icinga2/pull/5715#issuecomment-373381198 and provides ways to use the `icinga2 api user` cli command without leaking the password to other users via the process list.

Things I've changed:
 - Add a `--random-password` option which then outputs the generated password to stderr (should work fine).
 - Allow password entry on `stdin`, making the `--password` parameter optional.
   - Interactive mode: Queries password + comfirmation (type password again), code suppresses terminal echo, no implementation for Windows so far, see below.
   - Non-interactive mode: Support `echo 'SeCuRe(tm)' | icinga2 api user --name foo` without a prompt or asking for confirmation (should work fine).

Things that are missing so far:
 - Documentation (will update this after receiving some feedback on the changes itself)
 - Windows support + testing on non-Linux

So the biggest thing missing is the multi-plattform support for the interactive mode. I see that there already is `icinga::Console` which implements color output for both Unix and Windows, but the framework it provides doesn't really fit my needs here: On Unix, it checks `isatty(1)` (1 is `STDOUT_FILENO`) to determine if it's run interactively. However I have to check stdin and stderr, as that's what's used to prompt for the password, and `icinga2 user --name foo >> api.conf` should still invoke the interactive mode (which it wouldn't if I relied on `Console::GetType() != Console_Dumb`). Any feedback on how to solve this?