### PR TITLE
Elasticsearch: Fix crash with invalid performance data metrics

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -145,6 +145,7 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 					Log(LogWarning, "ElasticsearchWriter")
 						<< "Ignoring invalid perfdata value: '" << val << "' for object '"
 						<< checkable->GetName() << "'.";
+					continue;
 				}
 			}
 


### PR DESCRIPTION
fixes #6191