### PR TITLE
GelfWriter: Fix crash on invalid performance data metrics

### DIFF
--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -250,6 +250,7 @@ void GelfWriter::CheckResultHandlerInternal(const Checkable::Ptr& checkable, con
 						Log(LogWarning, "GelfWriter")
 							<< "Ignoring invalid perfdata value: '" << val << "' for object '"
 							<< checkable->GetName() << "'.";
+						continue;
 					}
 				}
 


### PR DESCRIPTION
Spotted while comparing the source code of several performance data
writer.

refs #6191