### PR TITLE
Elasticsearch/GELF: Add metric unit to performance data fields

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -166,6 +166,9 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 				fields->Set(perfdataPrefix + ".warn", pdv->GetWarn());
 			if (pdv->GetCrit())
 				fields->Set(perfdataPrefix + ".crit", pdv->GetCrit());
+
+			if (!pdv->GetUnit().IsEmpty())
+				fields->Set(perfdataPrefix + ".unit", pdv->GetUnit());
 		}
 	}
 }

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -269,6 +269,9 @@ void GelfWriter::CheckResultHandlerInternal(const Checkable::Ptr& checkable, con
 					fields->Set("_" + escaped_key + "_warn", pdv->GetWarn());
 				if (pdv->GetCrit())
 					fields->Set("_" + escaped_key + "_crit", pdv->GetCrit());
+
+				if (!pdv->GetUnit().IsEmpty())
+					fields->Set("_" + escaped_key + "_unit", pdv->GetUnit());
 			}
 		}
 	}


### PR DESCRIPTION
Seen this inside the InfluxDBWriter code, makes sense to store
this in Elasticsearch too.