### PR TITLE
Handle exceptions from X509Certificate2

### DIFF
--- a/agent/windows-setup-agent/SetupWizard.cs
+++ b/agent/windows-setup-agent/SetupWizard.cs
@@ -176,9 +176,12 @@ namespace Icinga
 			}
 
 			SetRetrievalStatus(100);
-
-			X509Certificate2 cert = new X509Certificate2(_TrustedFile);
-			Invoke((MethodInvoker)delegate { ShowCertificatePrompt(cert); });
+			try {
+				X509Certificate2 cert = new X509Certificate2(_TrustedFile);
+				Invoke((MethodInvoker)delegate { ShowCertificatePrompt(cert); });
+			} catch (Exception e) {
+				ShowErrorText("Failed to receive certificate: " + e.Message);
+			}
 		}
 
 		private void ConfigureService()


### PR DESCRIPTION
This way the setup agent won't crash anymore when X509Certificate2 throws an exception

refs #6200 