### PR TITLE
API: Unify verbose error messages

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -103,7 +103,7 @@ The output will be sent back as a JSON object:
 
 > **Tip**
 >
-> You can use the `pretty` parameter to beautify the JSON response with Icinga v2.9+.
+> You can use the [pretty](12-icinga2-api.md#icinga2-api-parameters-global) parameter to beautify the JSON response with Icinga v2.9+.
 
 You can also use [jq](https://stedolan.github.io/jq/) or `python -m json.tool`
 in combination with curl on the CLI.
@@ -271,6 +271,27 @@ Here are the exact same query parameters as a JSON object:
 
 The [match function](18-library-reference.md#global-functions-match) is available as global function
 in Icinga 2.
+
+### Global Parameters <a id="icinga2-api-parameters-global"></a>
+
+Name            | Description
+----------------|--------------------
+pretty          | Pretty-print the JSON response.
+verbose         | Add verbose debug information inside the `diagnostic_information` key into the response if available. This helps with troubleshooting failing requests.
+
+Example as URL parameter:
+
+```
+/v1/objects/hosts?pretty=1
+```
+
+Example as JSON object:
+
+```
+{ "pretty": true }
+```
+
+Both parameters have been added in Icinga 2 v2.9.
 
 ### Request Method Override <a id="icinga2-api-requests-method-override"></a>
 

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -124,7 +124,8 @@ The API will return standard [HTTP statuses](https://www.ietf.org/rfc/rfc2616.tx
 including error codes.
 
 When an error occurs, the response body will contain additional information
-about the problem and its source.
+about the problem and its source. Set `verbose` to true to retrieve more
+insights into what may be causing the error.
 
 A status code between 200 and 299 generally means that the request was
 successful.

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -702,6 +702,33 @@ Look into the log and check whether the feature logs anything specific for this 
 grep GraphiteWriter /var/log/icinga2/icinga2.log
 ```
 
+## REST API Troubleshooting <a id="troubleshooting-api"></a>
+
+In order to analyse errors on API requests, you can explicitly enable the [verbose parameter](12-icinga2-api.md#icinga2-api-parameters-global).
+
+```
+$ curl -k -s -u root:icinga -H 'Accept: application/json' -X DELETE 'https://localhost:5665/v1/objects/hosts/example-cmdb?pretty=1&verbose=1'
+{
+    "diagnostic_information": "Error: Object does not exist.\n\n ....",
+    "error": 404.0,
+    "status": "No objects found."
+}
+```
+
+## REST API Troubleshooting: No Objects Found <a id="troubleshooting-api-no-objects-found"></a>
+
+Please note that the `404` status with no objects being found can also originate
+from missing or too strict object permissions for the authenticated user.
+
+This is a security feature to disable object name guessing. If this would not be the
+case, restricted users would be able to get a list of names of your objects just by
+trying every character combination.
+
+In order to analyse and fix the problem, please check the following:
+
+- use an administrative account with full permissions to check whether the objects are actually there.
+- verify the permissions on the affected ApiUser object and fix them.
+
 
 ## Certificate Troubleshooting <a id="troubleshooting-certificate"></a>
 

--- a/lib/icinga/comment.cpp
+++ b/lib/icinga/comment.cpp
@@ -182,7 +182,7 @@ String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryTyp
 
 	Array::Ptr errors = new Array();
 
-	if (!ConfigObjectUtility::CreateObject(Comment::TypeInstance, fullName, config, errors)) {
+	if (!ConfigObjectUtility::CreateObject(Comment::TypeInstance, fullName, config, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (const String& error : errors) {
 			Log(LogCritical, "Comment", error);
@@ -214,7 +214,7 @@ void Comment::RemoveComment(const String& id, const MessageOrigin::Ptr& origin)
 
 	Array::Ptr errors = new Array();
 
-	if (!ConfigObjectUtility::DeleteObject(comment, false, errors)) {
+	if (!ConfigObjectUtility::DeleteObject(comment, false, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (const String& error : errors) {
 			Log(LogCritical, "Comment", error);

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -256,7 +256,7 @@ String Downtime::AddDowntime(const Checkable::Ptr& checkable, const String& auth
 
 	Array::Ptr errors = new Array();
 
-	if (!ConfigObjectUtility::CreateObject(Downtime::TypeInstance, fullName, config, errors)) {
+	if (!ConfigObjectUtility::CreateObject(Downtime::TypeInstance, fullName, config, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (const String& error : errors) {
 			Log(LogCritical, "Downtime", error);
@@ -309,7 +309,7 @@ void Downtime::RemoveDowntime(const String& id, bool cancelled, bool expired, co
 
 	Array::Ptr errors = new Array();
 
-	if (!ConfigObjectUtility::DeleteObject(downtime, false, errors)) {
+	if (!ConfigObjectUtility::DeleteObject(downtime, false, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (const String& error : errors) {
 			Log(LogCritical, "Downtime", error);

--- a/lib/remote/actionshandler.cpp
+++ b/lib/remote/actionshandler.cpp
@@ -62,7 +62,7 @@ bool ActionsHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& reques
 		} catch (const std::exception& ex) {
 			HttpUtility::SendJsonError(response, params, 404,
 				"No objects found.",
-				HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+				DiagnosticInformation(ex));
 			return true;
 		}
 	} else {
@@ -75,6 +75,11 @@ bool ActionsHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& reques
 	Log(LogNotice, "ApiActionHandler")
 		<< "Running action " << actionName;
 
+	bool verbose = false;
+
+	if (params)
+		verbose = HttpUtility::GetLastParameter(params, "verbose");
+
 	for (const ConfigObject::Ptr& obj : objs) {
 		try {
 			results.emplace_back(action->Invoke(obj, params));
@@ -84,8 +89,9 @@ bool ActionsHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& reques
 				{ "status", "Action execution failed: '" + DiagnosticInformation(ex, false) + "'." }
 			});
 
-			if (HttpUtility::GetLastParameter(params, "verboseErrors"))
-				fail->Set("diagnostic information", DiagnosticInformation(ex));
+			/* Exception for actions. Normally we would handle this inside SendJsonError(). */
+			if (verbose)
+				fail->Set("diagnostic_information", DiagnosticInformation(ex));
 
 			results.emplace_back(std::move(fail));
 		}

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -116,15 +116,14 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 		/* object does not exist, create it through the API */
 		Array::Ptr errors = new Array();
 
-		if (!ConfigObjectUtility::CreateObject(ptype,
-			objName, config, errors)) {
+		if (!ConfigObjectUtility::CreateObject(ptype, objName, config, errors, nullptr)) {
 			Log(LogCritical, "ApiListener")
 				<< "Could not create object '" << objName << "':";
 
-				ObjectLock olock(errors);
+			ObjectLock olock(errors);
 			for (const String& error : errors) {
-					Log(LogCritical, "ApiListener", error);
-				}
+				Log(LogCritical, "ApiListener", error);
+			}
 
 			return Empty;
 		}
@@ -256,7 +255,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	Array::Ptr errors = new Array();
 
-	if (!ConfigObjectUtility::DeleteObject(object, true, errors)) {
+	if (!ConfigObjectUtility::DeleteObject(object, true, errors, nullptr)) {
 		Log(LogCritical, "ApiListener", "Could not delete object:");
 
 		ObjectLock olock(errors);

--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -91,7 +91,7 @@ bool ConfigFilesHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& re
 		response.WriteBody(content.CStr(), content.GetLength());
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 500, "Could not read file.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 	}
 
 	return true;

--- a/lib/remote/configobjectutility.hpp
+++ b/lib/remote/configobjectutility.hpp
@@ -45,13 +45,15 @@ public:
 		bool ignoreOnError, const Array::Ptr& templates, const Dictionary::Ptr& attrs);
 
 	static bool CreateObject(const Type::Ptr& type, const String& fullName,
-		const String& config, const Array::Ptr& errors);
+		const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation);
 
-	static bool DeleteObject(const ConfigObject::Ptr& object, bool cascade, const Array::Ptr& errors);
+	static bool DeleteObject(const ConfigObject::Ptr& object, bool cascade, const Array::Ptr& errors,
+		const Array::Ptr& diagnosticInformation);
 
 private:
 	static String EscapeName(const String& name);
-	static bool DeleteObjectHelper(const ConfigObject::Ptr& object, bool cascade, const Array::Ptr& errors);
+	static bool DeleteObjectHelper(const ConfigObject::Ptr& object, bool cascade, const Array::Ptr& errors,
+		const Array::Ptr& diagnosticInformation);
 };
 
 }

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -54,7 +54,7 @@ void ConfigPackagesHandler::HandleGet(const ApiUser::Ptr& user, HttpRequest& req
 		packages = ConfigPackageUtility::GetPackages();
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 500, "Could not retrieve packages.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex, false));
 		return;
 	}
 
@@ -89,7 +89,7 @@ void ConfigPackagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& re
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 
 	if (!ConfigPackageUtility::ValidateName(packageName)) {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
+		HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 		return;
 	}
 
@@ -97,8 +97,8 @@ void ConfigPackagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& re
 		boost::mutex::scoped_lock lock(ConfigPackageUtility::GetStaticMutex());
 		ConfigPackageUtility::CreatePackage(packageName);
 	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 500, "Could not create package.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+		HttpUtility::SendJsonError(response, params, 500, "Could not create package '" + packageName + "'.",
+			DiagnosticInformation(ex, false));
 		return;
 	}
 
@@ -125,7 +125,7 @@ void ConfigPackagesHandler::HandleDelete(const ApiUser::Ptr& user, HttpRequest& 
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 
 	if (!ConfigPackageUtility::ValidateName(packageName)) {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
+		HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 		return;
 	}
 

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -135,12 +135,13 @@ void ConfigPackagesHandler::HandleDelete(const ApiUser::Ptr& user, HttpRequest& 
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 500, "Failed to delete package '" + packageName + "'.",
 			DiagnosticInformation(ex));
+		return;
 	}
 
 	Dictionary::Ptr result1 = new Dictionary({
 		{ "code", 200 },
 		{ "package", packageName },
-		{ "status", "Created package." }
+		{ "status", "Deleted package." }
 	});
 
 	Dictionary::Ptr result = new Dictionary({

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -54,7 +54,7 @@ void ConfigPackagesHandler::HandleGet(const ApiUser::Ptr& user, HttpRequest& req
 		packages = ConfigPackageUtility::GetPackages();
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 500, "Could not retrieve packages.",
-			DiagnosticInformation(ex, false));
+			DiagnosticInformation(ex));
 		return;
 	}
 
@@ -98,12 +98,13 @@ void ConfigPackagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& re
 		ConfigPackageUtility::CreatePackage(packageName);
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 500, "Could not create package '" + packageName + "'.",
-			DiagnosticInformation(ex, false));
+			DiagnosticInformation(ex));
 		return;
 	}
 
 	Dictionary::Ptr result1 = new Dictionary({
 		{ "code", 200 },
+		{ "package", packageName },
 		{ "status", "Created package." }
 	});
 
@@ -129,27 +130,23 @@ void ConfigPackagesHandler::HandleDelete(const ApiUser::Ptr& user, HttpRequest& 
 		return;
 	}
 
-	int code = 200;
-	String status = "Deleted package.";
-	DictionaryData result1;
-
 	try {
 		ConfigPackageUtility::DeletePackage(packageName);
 	} catch (const std::exception& ex) {
-		code = 500;
-		status = "Failed to delete package.";
-		if (HttpUtility::GetLastParameter(params, "verboseErrors"))
-			result1.emplace_back("diagnostic information", DiagnosticInformation(ex));
+		HttpUtility::SendJsonError(response, params, 500, "Failed to delete package '" + packageName + "'.",
+			DiagnosticInformation(ex));
 	}
 
-	result1.emplace_back("package", packageName);
-	result1.emplace_back("code", code);
-	result1.emplace_back("status", status);
-
-	Dictionary::Ptr result = new Dictionary({
-		{ "results", new Array({ new Dictionary(std::move(result1)) }) }
+	Dictionary::Ptr result1 = new Dictionary({
+		{ "code", 200 },
+		{ "package", packageName },
+		{ "status", "Created package." }
 	});
 
-	response.SetStatus(code, (code == 200) ? "OK" : "Internal Server Error");
+	Dictionary::Ptr result = new Dictionary({
+		{ "results", new Array({ result1 }) }
+	});
+
+	response.SetStatus(200, "OK");
 	HttpUtility::SendJsonBody(response, params, result);
 }

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -98,6 +98,7 @@ void ConfigStagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& requ
 		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
 	bool reload = true;
+
 	if (params->Contains("reload"))
 		reload = HttpUtility::GetLastParameter(params, "reload");
 
@@ -116,13 +117,17 @@ void ConfigStagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& requ
 		ConfigPackageUtility::AsyncTryActivateStage(packageName, stageName, reload);
 	} catch (const std::exception& ex) {
 		return HttpUtility::SendJsonError(response, params, 500,
-			"Stage creation failed for '" + stageName + "'.",
-			DiagnosticInformation(ex, false));
+			"Stage creation failed.",
+			DiagnosticInformation(ex));
 	}
 
 
 	String responseStatus = "Created stage. ";
-	responseStatus += (reload ? " Icinga2 will reload." : " Icinga2 reload skipped.");
+
+	if (reload)
+		responseStatus += "Reload triggered.";
+	else
+		responseStatus += "Reload skipped.";
 
 	Dictionary::Ptr result1 = new Dictionary({
 		{ "package", packageName },
@@ -163,11 +168,13 @@ void ConfigStagesHandler::HandleDelete(const ApiUser::Ptr& user, HttpRequest& re
 	} catch (const std::exception& ex) {
 		return HttpUtility::SendJsonError(response, params, 500,
 			"Failed to delete stage '" + stageName + "' in package '" + packageName + "'.",
-			DiagnosticInformation(ex, false));
+			DiagnosticInformation(ex));
 	}
 
 	Dictionary::Ptr result1 = new Dictionary({
 		{ "code", 200 },
+		{ "package", packageName },
+		{ "stage", stageName },
 		{ "status", "Stage deleted." }
 	});
 

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -59,10 +59,10 @@ void ConfigStagesHandler::HandleGet(const ApiUser::Ptr& user, HttpRequest& reque
 	String stageName = HttpUtility::GetLastParameter(params, "stage");
 
 	if (!ConfigPackageUtility::ValidateName(packageName))
-		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
+		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
 	if (!ConfigPackageUtility::ValidateName(stageName))
-		return HttpUtility::SendJsonError(response, params, 400, "Invalid stage name.");
+		return HttpUtility::SendJsonError(response, params, 400, "Invalid stage name '" + stageName + "'.");
 
 	ArrayData results;
 
@@ -95,7 +95,7 @@ void ConfigStagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& requ
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 
 	if (!ConfigPackageUtility::ValidateName(packageName))
-		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
+		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
 	bool reload = true;
 	if (params->Contains("reload"))
@@ -116,8 +116,8 @@ void ConfigStagesHandler::HandlePost(const ApiUser::Ptr& user, HttpRequest& requ
 		ConfigPackageUtility::AsyncTryActivateStage(packageName, stageName, reload);
 	} catch (const std::exception& ex) {
 		return HttpUtility::SendJsonError(response, params, 500,
-				"Stage creation failed.",
-				HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			"Stage creation failed for '" + stageName + "'.",
+			DiagnosticInformation(ex, false));
 	}
 
 
@@ -153,17 +153,17 @@ void ConfigStagesHandler::HandleDelete(const ApiUser::Ptr& user, HttpRequest& re
 	String stageName = HttpUtility::GetLastParameter(params, "stage");
 
 	if (!ConfigPackageUtility::ValidateName(packageName))
-		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
+		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
 	if (!ConfigPackageUtility::ValidateName(stageName))
-		return HttpUtility::SendJsonError(response, params, 400, "Invalid stage name.");
+		return HttpUtility::SendJsonError(response, params, 400, "Invalid stage name '" + stageName + "'.");
 
 	try {
 		ConfigPackageUtility::DeleteStage(packageName, stageName);
 	} catch (const std::exception& ex) {
 		return HttpUtility::SendJsonError(response, params, 500,
-			"Failed to delete stage.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			"Failed to delete stage '" + stageName + "' in package '" + packageName + "'.",
+			DiagnosticInformation(ex, false));
 	}
 
 	Dictionary::Ptr result1 = new Dictionary({

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -89,11 +89,18 @@ void HttpUtility::SendJsonError(HttpResponse& response, const Dictionary::Ptr& p
 	response.SetStatus(code, HttpUtility::GetErrorNameByCode(code));
 	result->Set("error", code);
 
+	bool verbose = false;
+
+	if (params)
+		verbose = HttpUtility::GetLastParameter(params, "verbose");
+
 	if (!info.IsEmpty())
 		result->Set("status", info);
 
-	if (!diagnosticInformation.IsEmpty())
-		result->Set("diagnostic information", diagnosticInformation);
+	if (verbose) {
+		if (!diagnosticInformation.IsEmpty())
+			result->Set("diagnostic_information", diagnosticInformation);
+	}
 
 	HttpUtility::SendJsonBody(response, params, result);
 }

--- a/lib/remote/modifyobjecthandler.cpp
+++ b/lib/remote/modifyobjecthandler.cpp
@@ -77,6 +77,11 @@ bool ModifyObjectHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& r
 
 	Dictionary::Ptr attrs = attrsVal;
 
+	bool verbose = false;
+
+	if (params)
+		verbose = HttpUtility::GetLastParameter(params, "verbose");
+
 	ArrayData results;
 
 	for (const ConfigObject::Ptr& obj : objs) {
@@ -100,7 +105,10 @@ bool ModifyObjectHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& r
 			result1->Set("status", "Attributes updated.");
 		} catch (const std::exception& ex) {
 			result1->Set("code", 500);
-			result1->Set("status", "Attribute '" + key + "' could not be set: " + DiagnosticInformation(ex));
+			result1->Set("status", "Attribute '" + key + "' could not be set: " + DiagnosticInformation(ex, false));
+
+			if (verbose)
+				result1->Set("diagnostic_information", DiagnosticInformation(ex));
 		}
 
 		results.push_back(std::move(result1));

--- a/lib/remote/modifyobjecthandler.cpp
+++ b/lib/remote/modifyobjecthandler.cpp
@@ -63,7 +63,7 @@ bool ModifyObjectHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& r
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 404,
 			"No objects found.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 		return true;
 	}
 
@@ -71,7 +71,7 @@ bool ModifyObjectHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& r
 
 	if (attrsVal.GetReflectionType() != Dictionary::TypeInstance) {
 		HttpUtility::SendJsonError(response, params, 400,
-			"Invalid type for 'attrs' attribute specified. Dictionary type is required.", Empty);
+			"Invalid type for 'attrs' attribute specified. Dictionary type is required.");
 		return true;
 	}
 

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -129,7 +129,7 @@ bool ObjectQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& re
 		uattrs = params->Get("attrs");
 	} catch (const std::exception&) {
 		HttpUtility::SendJsonError(response, params, 400,
-			"Invalid type for 'attrs' attribute specified. Array type is required.", Empty);
+			"Invalid type for 'attrs' attribute specified. Array type is required.");
 		return true;
 	}
 
@@ -137,7 +137,7 @@ bool ObjectQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& re
 		ujoins = params->Get("joins");
 	} catch (const std::exception&) {
 		HttpUtility::SendJsonError(response, params, 400,
-			"Invalid type for 'joins' attribute specified. Array type is required.", Empty);
+			"Invalid type for 'joins' attribute specified. Array type is required.");
 		return true;
 	}
 
@@ -145,7 +145,7 @@ bool ObjectQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& re
 		umetas = params->Get("meta");
 	} catch (const std::exception&) {
 		HttpUtility::SendJsonError(response, params, 400,
-			"Invalid type for 'meta' attribute specified. Array type is required.", Empty);
+			"Invalid type for 'meta' attribute specified. Array type is required.");
 		return true;
 	}
 
@@ -166,7 +166,7 @@ bool ObjectQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& re
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 404,
 			"No objects found.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 		return true;
 	}
 

--- a/lib/remote/statushandler.cpp
+++ b/lib/remote/statushandler.cpp
@@ -104,7 +104,7 @@ bool StatusHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& request
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 404,
 			"No objects found.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 		return true;
 	}
 

--- a/lib/remote/templatequeryhandler.cpp
+++ b/lib/remote/templatequeryhandler.cpp
@@ -127,7 +127,7 @@ bool TemplateQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& 
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 404,
 			"No templates found.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 		return true;
 	}
 

--- a/lib/remote/typequeryhandler.cpp
+++ b/lib/remote/typequeryhandler.cpp
@@ -91,7 +91,7 @@ bool TypeQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& requ
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 404,
 			"No objects found.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 		return true;
 	}
 

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -97,7 +97,7 @@ bool VariableQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& 
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 404,
 			"No variables found.",
-			HttpUtility::GetLastParameter(params, "verboseErrors") ? DiagnosticInformation(ex) : "");
+			DiagnosticInformation(ex));
 		return true;
 	}
 


### PR DESCRIPTION
This PR adds the `verbose` parameter and replaces
the previous not documented param. Verbose information
is stored in the `diagnostic_information` return field,
if set by the handler.

This is unified into SendJsonError() where possible.

An exception applies to config object create/modify/delete
where the errors are collected into an array. Obviously
existing API implementations rely on the `errors` array
returned, so we cannot modify its structure. Instead this
PR adds `diagnostic_information` as array too to help developers
analyse the problems.

fixes #6158