### PR TITLE
Unify zone name settings in node setup/wizard; add connection-less mode for node setup

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -9,8 +9,14 @@ follow the instructions for v2.7 too.
 
 ## Upgrading to v2.9 <a id="upgrading-to-2-9"></a>
 
+### Configuration Changes <a id="upgrading-to-2-9-config-changes"></a>
+
 The CORS attributes `access_control_allow_credentials`, `access_control_allow_headers` and
-`access_control_allow_methods` are now controlled by Icinga 2 and are not changeable by config any more.
+`access_control_allow_methods` are now controlled by Icinga 2 and cannot be changed anymore.
+
+### CLI Command Changes <a id="upgrading-to-2-9-cli-changes"></a>
+
+The `node setup` parameter `--master_host` was deprecated and replaced with `--parent_host`. This parameter is now optional to allow connection-less client setups similar to the `node wizard` CLI command. The `parent_zone` parameter has been added to modify the parent zone name e.g. for client-to-satellite setups.
 
 ## Upgrading to v2.8.2 <a id="upgrading-to-2-8-2"></a>
 

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -129,6 +129,15 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 	if (vm.count("cn"))
 		cn = vm["cn"].as<std::string>();
 
+	/* Setup command hardcodes this as FQDN */
+	String endpointName = cn;
+
+	/* Allow to specify zone name. */
+	String zoneName = "master";
+
+	if (vm.count("zone"))
+		zoneName = vm["zone"].as<std::string>();
+
 	/* check whether the user wants to generate a new certificate or not */
 	String existingPath = ApiListener::GetCertsDir() + "/" + cn + ".crt";
 
@@ -174,9 +183,10 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 
 	globalZones.insert(globalZones.end(), setupGlobalZones.begin(), setupGlobalZones.end());
 
-	NodeUtility::GenerateNodeMasterIcingaConfig(globalZones);
+	/* Generate master configuration. */
+	NodeUtility::GenerateNodeMasterIcingaConfig(endpointName, zoneName, globalZones);
 
-	/* update the ApiListener config - SetupMaster() will always enable it */
+	/* Update the ApiListener config. */
 	Log(LogInformation, "cli", "Updating the APIListener feature.");
 
 	String apipath = FeatureUtility::GetFeaturesAvailablePath() + "/api.conf";

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -46,80 +46,83 @@ String NodeUtility::GetConstantsConfPath()
 	return Application::GetSysconfDir() + "/icinga2/constants.conf";
 }
 
+String NodeUtility::GetZonesConfPath()
+{
+	return Application::GetSysconfDir() + "/icinga2/zones.conf";
+}
+
 /*
  * Node Setup helpers
  */
 
-int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints, const std::vector<String>& globalZones)
+int NodeUtility::GenerateNodeIcingaConfig(const String& endpointName, const String& zoneName,
+	const String& parentZoneName, const std::vector<std::string>& endpoints,
+	const std::vector<String>& globalZones)
 {
-	Array::Ptr my_config = new Array();
+	Array::Ptr config = new Array();
 
-	Array::Ptr my_master_zone_members = new Array();
-
-	String master_zone_name = "master"; //TODO: Find a better name.
+	Array::Ptr myParentZoneMembers = new Array();
 
 	for (const String& endpoint : endpoints) {
 		/* extract all --endpoint arguments and store host,port info */
 		std::vector<String> tokens = endpoint.Split(",");
 
-		Dictionary::Ptr my_master_endpoint = new Dictionary();
+		Dictionary::Ptr myParentEndpoint = new Dictionary();
 
 		if (tokens.size() > 1) {
 			String host = tokens[1].Trim();
 
 			if (!host.IsEmpty())
-				my_master_endpoint->Set("host", host);
+				myParentEndpoint->Set("host", host);
 		}
 
 		if (tokens.size() > 2) {
 			String port = tokens[2].Trim();
 
 			if (!port.IsEmpty())
-				my_master_endpoint->Set("port", port);
+				myParentEndpoint->Set("port", port);
 		}
 
-		String cn = tokens[0].Trim();
-		my_master_endpoint->Set("__name", cn);
-		my_master_endpoint->Set("__type", "Endpoint");
+		String myEndpointName = tokens[0].Trim();
+		myParentEndpoint->Set("__name", myEndpointName);
+		myParentEndpoint->Set("__type", "Endpoint");
 
 		/* save endpoint in master zone */
-		my_master_zone_members->Add(cn);
+		myParentZoneMembers->Add(myEndpointName);
 
-		my_config->Add(my_master_endpoint);
+		config->Add(myParentEndpoint);
 	}
 
-	/* add the master zone to the config */
-	my_config->Add(new Dictionary({
-		{ "__name", master_zone_name },
+	/* add the parent zone to the config */
+	config->Add(new Dictionary({
+		{ "__name", parentZoneName },
 		{ "__type", "Zone" },
-		{ "endpoints", my_master_zone_members }
+		{ "endpoints", myParentZoneMembers }
 	}));
 
 	/* store the local generated node configuration */
-	my_config->Add(new Dictionary({
-		{ "__name", new ConfigIdentifier("NodeName") },
+	config->Add(new Dictionary({
+		{ "__name", endpointName },
 		{ "__type", "Endpoint" }
 	}));
 
-	my_config->Add(new Dictionary({
-		{ "__name", new ConfigIdentifier("ZoneName") },
+	config->Add(new Dictionary({
+		{ "__name", zoneName },
 		{ "__type", "Zone" },
-		{ "parent", master_zone_name }, //set the master zone as parent
-		{ "endpoints", new Array({ new ConfigIdentifier("ZoneName") }) }
+		{ "parent", parentZoneName },
+		{ "endpoints", new Array({ endpointName }) }
 	}));
 
 	for (const String& globalzone : globalZones) {
-		my_config->Add(new Dictionary({
+		config->Add(new Dictionary({
 			{ "__name", globalzone },
 			{ "__type", "Zone" },
 			{ "global", true }
 		}));
 	}
 
-	/* write the newly generated configuration */
-	String zones_path = Application::GetSysconfDir() + "/icinga2/zones.conf";
-
-	NodeUtility::WriteNodeConfigObjects(zones_path, my_config);
+	/* Write the newly generated configuration. */
+	NodeUtility::WriteNodeConfigObjects(GetZonesConfPath(), config);
 
 	return 0;
 }
@@ -127,32 +130,30 @@ int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoi
 int NodeUtility::GenerateNodeMasterIcingaConfig(const String& endpointName, const String& zoneName,
 	const std::vector<String>& globalZones)
 {
-	Array::Ptr my_config = new Array();
+	Array::Ptr config = new Array();
 
 	/* store the local generated node master configuration */
-	my_config->Add(new Dictionary({
+	config->Add(new Dictionary({
 		{ "__name", endpointName },
 		{ "__type", "Endpoint" }
 	}));
 
-	my_config->Add(new Dictionary({
+	config->Add(new Dictionary({
 		{ "__name", zoneName },
 		{ "__type", "Zone" },
 		{ "endpoints", new Array({ endpointName }) }
 	}));
 
 	for (const String& globalzone : globalZones) {
-		my_config->Add(new Dictionary({
+		config->Add(new Dictionary({
 			{ "__name", globalzone },
 			{ "__type", "Zone" },
 			{ "global", true }
 		}));
 	}
 
-	/* write the newly generated configuration */
-	String zones_path = Application::GetSysconfDir() + "/icinga2/zones.conf";
-
-	NodeUtility::WriteNodeConfigObjects(zones_path, my_config);
+	/* Write the newly generated configuration. */
+	NodeUtility::WriteNodeConfigObjects(GetZonesConfPath(), config);
 
 	return 0;
 }
@@ -215,7 +216,7 @@ bool NodeUtility::WriteNodeConfigObjects(const String& filename, const Array::Pt
 /*
  * We generally don't overwrite files without backup before
  */
-bool NodeUtility::CreateBackupFile(const String& target, bool is_private)
+bool NodeUtility::CreateBackupFile(const String& target, bool isPrivate)
 {
 	if (!Utility::PathExists(target))
 		return false;
@@ -231,7 +232,7 @@ bool NodeUtility::CreateBackupFile(const String& target, bool is_private)
 	Utility::CopyFile(target, backup);
 
 #ifndef _WIN32
-	if (is_private)
+	if (isPrivate)
 		chmod(backup.CStr(), 0600);
 #endif /* _WIN32 */
 

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -124,20 +124,21 @@ int NodeUtility::GenerateNodeIcingaConfig(const std::vector<std::string>& endpoi
 	return 0;
 }
 
-int NodeUtility::GenerateNodeMasterIcingaConfig(const std::vector<String>& globalZones)
+int NodeUtility::GenerateNodeMasterIcingaConfig(const String& endpointName, const String& zoneName,
+	const std::vector<String>& globalZones)
 {
 	Array::Ptr my_config = new Array();
 
 	/* store the local generated node master configuration */
 	my_config->Add(new Dictionary({
-		{ "__name", new ConfigIdentifier("NodeName") },
+		{ "__name", endpointName },
 		{ "__type", "Endpoint" }
 	}));
 
 	my_config->Add(new Dictionary({
-		{ "__name", new ConfigIdentifier("ZoneName") },
+		{ "__name", zoneName },
 		{ "__type", "Zone" },
-		{ "endpoints", new Array({ new ConfigIdentifier("NodeName") }) }
+		{ "endpoints", new Array({ endpointName }) }
 	}));
 
 	for (const String& globalzone : globalZones) {

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -38,15 +38,18 @@ class NodeUtility
 {
 public:
 	static String GetConstantsConfPath();
+	static String GetZonesConfPath();
 
-	static bool CreateBackupFile(const String& target, bool is_private = false);
+	static bool CreateBackupFile(const String& target, bool isPrivate = false);
 
 	static bool WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects);
 
 	static void UpdateConstant(const String& name, const String& value);
 
 	/* node setup helpers */
-	static int GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints, const std::vector<String>& globalZones);
+	static int GenerateNodeIcingaConfig(const String& endpointName, const String& zoneName,
+		const String& parentZoneName, const std::vector<std::string>& endpoints,
+		const std::vector<String>& globalZones);
 	static int GenerateNodeMasterIcingaConfig(const String& endpointName, const String& zoneName,
 		const std::vector<String>& globalZones);
 

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -47,7 +47,8 @@ public:
 
 	/* node setup helpers */
 	static int GenerateNodeIcingaConfig(const std::vector<std::string>& endpoints, const std::vector<String>& globalZones);
-	static int GenerateNodeMasterIcingaConfig(const std::vector<String>& globalZones);
+	static int GenerateNodeMasterIcingaConfig(const String& endpointName, const String& zoneName,
+		const std::vector<String>& globalZones);
 
 private:
 	NodeUtility();

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -605,6 +605,16 @@ wizard_global_zone_loop_start:
 		}
 	}
 
+	/* If no parent connection was made, the user must supply the ca.crt before restarting Icinga 2.*/
+	if (!connectToParent) {
+		Log(LogWarning, "cli")
+			<< "No connection to the parent node was specified.\n\n"
+			<< "Please copy the public CA certificate from your master/satellite\n"
+			<< "into '" << nodeCA << "' before starting Icinga 2.\n";
+	} else {
+		Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
+	}
+
 	return 0;
 }
 

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -254,6 +254,7 @@ wizard_endpoint_loop_start:
 	if (choice.Contains("y"))
 		goto wizard_endpoint_loop_start;
 
+	/* Extract parent node information. */
 	String parentHost, parentPort;
 
 	for (const String& endpoint : endpoints) {
@@ -496,9 +497,33 @@ wizard_ticket:
 			<< boost::errinfo_file_name(tempApiConfPath));
 	}
 
-	/* apilistener config */
+	/* Zones configuration. */
 	Log(LogInformation, "cli", "Generating local zones.conf.");
 
+	/* Setup command hardcodes this as FQDN */
+	String endpointName = cn;
+
+	/* Different local zone name. */
+	std::cout << "\nLocal zone name [" + endpointName + "]: ";
+	std::getline(std::cin, answer);
+
+	if (answer.empty())
+		answer = endpointName;
+
+	String zoneName = answer;
+	zoneName = zoneName.Trim();
+
+	/* Different parent zone name. */
+	std::cout << "Parent zone name [master]: ";
+	std::getline(std::cin, answer);
+
+	if (answer.empty())
+		answer = "master";
+
+	String parentZoneName = answer;
+	parentZoneName = parentZoneName.Trim();
+
+	/* Global zones. */
 	std::vector<String> globalZones { "global-templates", "director-global" };
 
 	std::cout << "\nDo you want to specify additional global zones? [y/N]: ";
@@ -540,7 +565,8 @@ wizard_global_zone_loop_start:
 	} else
 		Log(LogInformation, "cli", "No additional global Zones have been specified");
 
-	NodeUtility::GenerateNodeIcingaConfig(endpoints, globalZones);
+	/* Generate node configuration. */
+	NodeUtility::GenerateNodeIcingaConfig(endpointName, zoneName, parentZoneName, endpoints, globalZones);
 
 	if (cn != Utility::GetFQDN()) {
 		Log(LogWarning, "cli")

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -623,6 +623,7 @@ int NodeWizardCommand::MasterSetup() const
 	std::cout << ConsoleColorTag(Console_Bold)
 		<< "Generating master configuration for Icinga 2.\n"
 		<< ConsoleColorTag(Console_Normal);
+
 	ApiSetupUtility::SetupMasterApiUser();
 
 	if (!FeatureUtility::CheckFeatureEnabled("api"))
@@ -630,6 +631,20 @@ int NodeWizardCommand::MasterSetup() const
 	else
 		std::cout << "'api' feature already enabled.\n";
 
+	/* Setup command hardcodes this as FQDN */
+	String endpointName = cn;
+
+	/* Different zone name. */
+	std::cout << "\nMaster zone name [master]: ";
+	std::getline(std::cin, answer);
+
+	if (answer.empty())
+		answer = "master";
+
+	String zoneName = answer;
+	zoneName = zoneName.Trim();
+
+	/* Global zones. */
 	std::vector<String> globalZones { "global-templates", "director-global" };
 
 	std::cout << "\nDo you want to specify additional global zones? [y/N]: ";
@@ -671,7 +686,8 @@ wizard_global_zone_loop_start:
 	} else
 		Log(LogInformation, "cli", "No additional global Zones have been specified");
 
-	NodeUtility::GenerateNodeMasterIcingaConfig(globalZones);
+	/* Generate master configuration. */
+	NodeUtility::GenerateNodeMasterIcingaConfig(endpointName, zoneName, globalZones);
 
 	/* apilistener config */
 	std::cout << ConsoleColorTag(Console_Bold)


### PR DESCRIPTION
node setup:

- master_host is deprecated
- parent_host is the replacement and optional (allows connection-less setups)
- master: --zone sets the local zone name
- clients: --parent_zone sets the parent zone name, defaults to master

node wizard:

- master: allow to set the zone name
- clients: allow to set the local and parent zone name

fixes #4966
fixes #5743
fixes #6208