### PR TITLE
Unbreak build against Boost 1.67

### DIFF
--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -292,7 +292,7 @@ void Timer::TimerThreadProc()
 
 		if (wait > 0.01) {
 			/* Wait for the next timer. */
-			l_TimerCV.timed_wait(lock, boost::posix_time::milliseconds(wait * 1000));
+			l_TimerCV.timed_wait(lock, boost::posix_time::milliseconds(long(wait * 1000)));
 
 			continue;
 		}

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -125,7 +125,7 @@ void CheckerComponent::CheckThreadProc()
 
 		if (wait > 0) {
 			/* Wait for the next check. */
-			m_CV.timed_wait(lock, boost::posix_time::milliseconds(wait * 1000));
+			m_CV.timed_wait(lock, boost::posix_time::milliseconds(long(wait * 1000)));
 
 			continue;
 		}

--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -108,7 +108,7 @@ Dictionary::Ptr EventQueue::WaitForEvent(void *client, double timeout)
 			return result;
 		}
 
-		if (!m_CV.timed_wait(lock, boost::posix_time::milliseconds(timeout * 1000)))
+		if (!m_CV.timed_wait(lock, boost::posix_time::milliseconds(long(timeout * 1000))))
 			return nullptr;
 	}
 }


### PR DESCRIPTION
Regressed by boostorg/date_time@f9f2aaf5216c. Found [downstream](https://reviews.freebsd.org/D15030) ([error log](http://package22.nyi.freebsd.org/data/111amd64-default-PR227427/2018-04-14_08h49m03s/logs/errors/icinga2-2.8.2.log)).
