### PR TITLE
Implement better way to check parameters in notification scripts

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -90,14 +90,14 @@ done
 
 shift $((OPTIND - 1))
 
-## Check required parameters (TODO: better error message)
 ## Keep formatting in sync with mail-service-notification.sh
-if [ ! "$LONGDATETIME" ] \
-|| [ ! "$HOSTNAME" ] || [ ! "$HOSTDISPLAYNAME" ] \
-|| [ ! "$HOSTOUTPUT" ] || [ ! "$HOSTSTATE" ] \
-|| [ ! "$USEREMAIL" ] || [ ! "$NOTIFICATIONTYPE" ]; then
-  Error "Requirement parameters are missing."
-fi
+for P in LONGDATETIME HOSTNAME HOSTDISPLAYNAME HOSTOUTPUT HOSTSTATE USEREMAIL NOTIFICATIONTYPE ; do
+	eval "PAR=\$${P}"
+
+	if [ ! "$PAR" ] ; then
+		Error "Required parameter '$P' is missing."
+	fi
+done
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] Host $HOSTDISPLAYNAME is $HOSTSTATE!"

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -94,15 +94,14 @@ done
 
 shift $((OPTIND - 1))
 
-## Check required parameters (TODO: better error message)
 ## Keep formatting in sync with mail-host-notification.sh
-if [ ! "$LONGDATETIME" ] \
-|| [ ! "$HOSTNAME" ] || [ ! "$HOSTDISPLAYNAME" ] \
-|| [ ! "$SERVICENAME" ] || [ ! "$SERVICEDISPLAYNAME" ] \
-|| [ ! "$SERVICEOUTPUT" ] || [ ! "$SERVICESTATE" ] \
-|| [ ! "$USEREMAIL" ] || [ ! "$NOTIFICATIONTYPE" ]; then
-  Error "Requirement parameters are missing."
-fi
+for P in LONGDATETIME HOSTNAME HOSTDISPLAYNAME SERVICENAME SERVICEDISPLAYNAME SERVICEOUTPUT SERVICESTATE USEREMAIL NOTIFICATIONTYPE ; do
+        eval "PAR=\$${P}"
+
+        if [ ! "$PAR" ] ; then
+                Error "Required parameter '$P' is missing."
+        fi
+done
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE!"


### PR DESCRIPTION
Thanks to @B-LUC

This changes the function for checking required parameters in the notification scripts.
This also enhances the error message.

# Tests

All required parameters given:

```
$ etc/icinga2/scripts/mail-host-notification.sh -d 201804181919 -n TESTHOST -o KAPUTT -r nix@nein.local -s KAPUTT -t WHAT
```
One required parameter missing: 

```
$ etc/icinga2/scripts/mail-host-notification.sh -d 201804181919 -n TESTHOST -o KAPUTT -r nix@nein.local -s KAPUTT
Required parameter 'NOTIFICATIONTYPE' is missing.

Required parameters:
  -d LONGDATETIME ($icinga.long_date_time$)
  -l HOSTNAME ($host.name$)
  -n HOSTDISPLAYNAME ($host.display_name$)
  -o HOSTOUTPUT ($host.output$)
  -r USEREMAIL ($user.email$)
  -s HOSTSTATE ($host.state$)
  -t NOTIFICATIONTYPE ($notification.type$)

Optional parameters:
  -4 HOSTADDRESS ($address$)
  -6 HOSTADDRESS6 ($address6$)
  -b NOTIFICATIONAUTHORNAME ($notification.author$)
  -c NOTIFICATIONCOMMENT ($notification.comment$)
  -i ICINGAWEB2URL ($notification_icingaweb2url$, Default: unset)
  -f MAILFROM ($notification_mailfrom$, requires GNU mailutils (Debian/Ubuntu) or mailx (RHEL/SUSE))
  -v ($notification_sendtosyslog$, Default: false)
```

Two required parameters missing:

In this case the first missing parameter will be returned in the message.

```
$ etc/icinga2/scripts/mail-host-notification.sh -d 201804181919 -n TESTHOST -o KAPUTT -r nix@nein.local
Required parameter 'HOSTSTATE' is missing.                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                          
Required parameters:                                                                                                                                                                                                                                                                      
  -d LONGDATETIME ($icinga.long_date_time$)                                                                                                                                                                                                                                               
  -l HOSTNAME ($host.name$)                                                                                                                                                                                                                                                               
  -n HOSTDISPLAYNAME ($host.display_name$)                                                                                                                                                                                                                                                
  -o HOSTOUTPUT ($host.output$)                                                                                                                                                                                                                                                           
  -r USEREMAIL ($user.email$)                                                                                                                                                                                                                                                             
  -s HOSTSTATE ($host.state$)                                                                                                                                                                                                                                                             
  -t NOTIFICATIONTYPE ($notification.type$)                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                          
Optional parameters:                                                                                                                                                                                                                                                                      
  -4 HOSTADDRESS ($address$)                                                                                                                                                                                                                                                              
  -6 HOSTADDRESS6 ($address6$)                                                                                                                                                                                                                                                            
  -b NOTIFICATIONAUTHORNAME ($notification.author$)                                                                                                                                                                                                                                       
  -c NOTIFICATIONCOMMENT ($notification.comment$)                                                                                                                                                                                                                                         
  -i ICINGAWEB2URL ($notification_icingaweb2url$, Default: unset)                                                                                                                                                                                                                         
  -f MAILFROM ($notification_mailfrom$, requires GNU mailutils (Debian/Ubuntu) or mailx (RHEL/SUSE))                                                                                                                                                                                      
  -v ($notification_sendtosyslog$, Default: false)
```

Same behavior for `mail-service-notification.sh`. 

You maybe noticed that I didn't give the required parameter `-l HOSTNAME` and this is not returned as missing, that's because the variable `HOSTNAME` is default set to the local host name.

fixes #5812