### PR TITLE
Fix Windows check_memory rounding

### DIFF
--- a/plugins/check_memory.cpp
+++ b/plugins/check_memory.cpp
@@ -203,8 +203,8 @@ static int check_memory(printInfoStruct& printInfo)
 	memBuf.dwLength = sizeof(memBuf);
 	GlobalMemoryStatusEx(&memBuf);
 
-	printInfo.tRam = round(memBuf.ullTotalPhys / pow(1024.0, printInfo.unit));
-	printInfo.aRam = round(memBuf.ullAvailPhys / pow(1024.0, printInfo.unit));
+	printInfo.tRam = round((memBuf.ullTotalPhys / pow(1024.0, printInfo.unit) * pow(10.0, printInfo.unit))) / pow(10.0, printInfo.unit);
+	printInfo.aRam = round((memBuf.ullAvailPhys / pow(1024.0, printInfo.unit) * pow(10.0, printInfo.unit))) / pow(10.0, printInfo.unit);
 	printInfo.percentFree = 100.0 * memBuf.ullAvailPhys / memBuf.ullTotalPhys;
 
 	if (l_Debug)


### PR DESCRIPTION
This PR adds floating numbers to the performance data output to correct the rounding and the return value calculation. 

# Tests

Without this PR:

```
.\check_memory.exe -u GB -w 20% -c 0.1%
MEMORY OK - 17.7469% free| memory=1GB;0.80000000000000004;0.0040000000000000001;0;4
```

Returns OK, although the warning threshold is exceeded.

With PR: 

```
.\check_memory.exe -u GB -w 20% -c 0.1%
MEMORY WARNING - 17.7633% free| memory=0.71GB;0.80000000000000004;0.0040000000000000001;0;4
```

Returns rightly WARNING.

Other units:

```
 .\check_memory.exe -u KB
MEMORY OK - 16.8722% free| memory=707592kB;;;0;4.19384e+06

.\check_memory.exe -u MB
MEMORY OK - 16.8862% free| memory=691.58MB;;;0;4095.55

.\check_memory.exe -u GB
MEMORY OK - 16.9085% free| memory=0.676GB;;;0;4

.\check_memory.exe -u TB
MEMORY OK - 16.9132% free| memory=0.0007TB;;;0;0.0039
```

fixes #6161