### PR TITLE
Update PostgreSQL documentation

### DIFF
--- a/doc/02-getting-started.md
+++ b/doc/02-getting-started.md
@@ -714,13 +714,10 @@ Set up a PostgreSQL database for Icinga 2:
     # cd /tmp
     # sudo -u postgres psql -c "CREATE ROLE icinga WITH LOGIN PASSWORD 'icinga'"
     # sudo -u postgres createdb -O icinga -E UTF8 icinga
-    # sudo -u postgres createlang plpgsql icinga
 
 > **Note**
 >
-> When using PostgreSQL 9.x or higher, the `createlang` command can be omitted.
-> Also it is assumed here that your locale is set to utf-8, you may run into
-> problems otherwise.
+> It is assumed here that your locale is set to utf-8, you may run into problems otherwise.
 
 Locate your pg\_hba.conf (Debian: `/etc/postgresql/*/main/pg_hba.conf`,
 RHEL/SUSE: `/var/lib/pgsql/data/pg_hba.conf`), add the icinga user with md5

--- a/doc/02-getting-started.md
+++ b/doc/02-getting-started.md
@@ -718,7 +718,7 @@ Set up a PostgreSQL database for Icinga 2:
 
 > **Note**
 >
-> When using PostgreSQL 9.x you can omit the `createlang` command.
+> When using PostgreSQL 9.x or higher, the `createlang` command can be omitted.
 > Also it is assumed here that your locale is set to utf-8, you may run into
 > problems otherwise.
 


### PR DESCRIPTION
`createlang` was removed with postgresql 10 and versions prior to 9.3 are not supported anymore