### PR TITLE
Propagate Downtimes to Hosts: API/ExternalCommand

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1385,7 +1385,7 @@ Configuration Attributes:
   fixed                     | Boolean               | **Optional.** Whether this is a fixed downtime. Defaults to `true`.
   duration                  | Duration              | **Optional.** How long the downtime lasts. Only has an effect for flexible (non-fixed) downtimes.
   ranges                    | Dictionary            | **Required.** A dictionary containing information which days and durations apply to this timeperiod.
-  child\_options            | String                | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. Defaults to `DowntimeNoChildren`.
+  child\_options            | String                | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. `DowntimeTriggeredChildrenAndServices` schedules child downtimes triggered by this downtime and includes services on child hosts.  `DowntimeNonTriggeredChildrenAndServices` schedules non-triggered downtimes and includes services on child hosts. Defaults to `DowntimeNoChildren`.
 
 ScheduledDowntime objects have composite names, i.e. their names are based
 on the `host_name` and `service_name` attributes and the

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1117,7 +1117,7 @@ Send a `POST` request to the URL endpoint `/v1/actions/schedule-downtime`.
   fixed         | Boolean   | **Optional.** Defaults to `true`. If true, the downtime is `fixed` otherwise `flexible`. See [downtimes](08-advanced-topics.md#downtimes) for more information.
   duration      | Number    | **Required for flexible downtimes.** Duration of the downtime in seconds if `fixed` is set to false.
   trigger\_name | String    | **Optional.** Sets the trigger for a triggered downtime. See [downtimes](08-advanced-topics.md#downtimes) for more information on triggered downtimes.
-  child\_options| String    | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. Defaults to `DowntimeNoChildren`.
+  child\_options| String    | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. `DowntimeTriggeredChildrenAndServices` schedules child downtimes triggered by this downtime and includes services on child hosts.  `DowntimeNonTriggeredChildrenAndServices` schedules non-triggered downtimes and includes services on child hosts. Defaults to `DowntimeNoChildren`.
 
 In addition to these parameters a [filter](12-icinga2-api.md#icinga2-api-filters) must be provided. The valid types for this action are `Host` and `Service`.
 

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -49,6 +49,8 @@ void Downtime::StaticInitialize()
 	ScriptGlobal::Set("DowntimeNoChildren", "DowntimeNoChildren");
 	ScriptGlobal::Set("DowntimeTriggeredChildren", "DowntimeTriggeredChildren");
 	ScriptGlobal::Set("DowntimeNonTriggeredChildren", "DowntimeNonTriggeredChildren");
+	ScriptGlobal::Set("DowntimeTriggeredChildrenAndServices", "DowntimeTriggeredChildrenAndServices");
+	ScriptGlobal::Set("DowntimeNonTriggeredChildrenAndServices", "DowntimeNonTriggeredChildrenAndServices");
 }
 
 String DowntimeNameComposer::MakeName(const String& shortName, const Object::Ptr& context) const
@@ -438,9 +440,13 @@ DowntimeChildOptions Downtime::ChildOptionsFromValue(const Value& options)
 		return DowntimeTriggeredChildren;
 	else if (options == "DowntimeNonTriggeredChildren")
 		return DowntimeNonTriggeredChildren;
+	else if (options == "DowntimeTriggeredChildrenAndServices")
+		return DowntimeTriggeredChildrenAndServices;
+	else if (options == "DowntimeNonTriggeredChildrenAndServices")
+		return DowntimeNonTriggeredChildrenAndServices;
 	else if (options.IsNumber()) {
 		int number = options;
-		if (number >= 0 && number <= 2)
+		if (number >= 0 && number <= 4)
 			return static_cast<DowntimeChildOptions>(number);
 	}
 

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -32,7 +32,9 @@ enum DowntimeChildOptions
 {
 	DowntimeNoChildren,
 	DowntimeTriggeredChildren,
-	DowntimeNonTriggeredChildren
+	DowntimeNonTriggeredChildren,
+	DowntimeTriggeredChildrenAndServices,
+	DowntimeNonTriggeredChildrenAndServices
 };
 
 /**


### PR DESCRIPTION
I would like to submit for consideration this branch to Icinga2, which implements a feature in downtime handling, both in the API and External command processors.

The feature allows one to easily include a host's services, and "child" hosts' services, when scheduling a new Downtime period for a host.

This change would partially address an issue/feature request I made while ago:

https://github.com/Icinga/icingaweb2/issues/2938

in which I noted that in icingaweb2 when someone programs Downtime and indicates that they want  child hosts and all services included, only the original host's service were Downtime'd.

The patch works by adding a "service_options" parameter to the schedule-downtime API endpoint, which works very similarly to the "child_options" parameter, and also adds two new External Commands: 

SCHEDULE_AND_PROPAGATE_HOST_SVC_DOWNTIME,
SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_SVC_DOWNTIME

which are similar to the other "SCHEDULE_AND_PROPAGATE..." Downtime commands, except they tack on the services.

