### PR TITLE
Remove '-n' option from check_swap

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1381,7 +1381,6 @@ swap_wfree      | **Optional.** The free swap space warning threshold in % (enab
 swap_cfree      | **Optional.** The free swap space critical threshold in % (enable `swap_integer` for number values). Defaults to `25%`.
 swap_integer    | **Optional.** Specifies whether the thresholds are passed as number or percent value. Defaults to false (percent values).
 swap_allswaps   | **Optional.** Conduct comparisons for all swap partitions, one by one. Defaults to false.
-swap_noswap     | **Optional.** Resulting state when there is no swap regardless of thresholds. Possible values are "ok", "warning", "critical", "unknown". Defaults to "critical".
 
 
 ### tcp <a id="plugin-check-command-tcp"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1657,10 +1657,6 @@ object CheckCommand "swap" {
 			set_if = "$swap_allswaps$"
 			description = "Conduct comparisons for all swap partitions, one by one"
 		}
-		"-n" = {
-			value = "$swap_noswap$"
-			description = "Resulting state when there is no swap regardless of thresholds. Possible values are \"ok\", \"warning\", \"critical\", \"unknown\". Defaults to \"critical\""
-		}
 	}
 
 	vars.swap_wfree = 50


### PR DESCRIPTION
Remove '-n' option from check_swap cause the option did not exist within the check.