### PR TITLE
ITL: Add default thresholds to windows check commands

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1508,8 +1508,8 @@ Custom attributes:
 
 Name                  | Description
 :---------------------|:------------
-disk\_win\_warn       | **Optional**. The warning threshold.
-disk\_win\_crit       | **Optional**. The critical threshold.
+disk\_win\_warn       | **Optional**. The warning threshold. Defaults to "20%".
+disk\_win\_crit       | **Optional**. The critical threshold. Defaults to "10%".
 disk\_win\_path       | **Optional**. Check only these paths, default checks all.
 disk\_win\_unit       | **Optional**. Use this unit to display disk space, thresholds are interpreted in this unit. Defaults to "mb", possible values are: b, kb, mb, gb and tb.
 disk\_win\_exclude    | **Optional**. Exclude these drives from check.
@@ -1543,8 +1543,8 @@ Custom attributes:
 
 Name              | Description
 :-----------------|:------------
-memory\_win\_warn | **Optional**. The warning threshold.
-memory\_win\_crit | **Optional**. The critical threshold.
+memory\_win\_warn | **Optional**. The warning threshold. Defaults to "10%".
+memory\_win\_crit | **Optional**. The critical threshold. Defaults to "5%".
 memory\_win\_unit | **Optional**. The unit to display the received value in, thresholds are interpreted in this unit. Defaults to "mb" (megabyte), possible values are: b, kb, mb, gb and tb.
 
 
@@ -1634,8 +1634,8 @@ Custom attributes:
 
 Name            | Description
 :---------------|:------------
-swap\_win\_warn | **Optional**. The warning threshold.
-swap\_win\_crit | **Optional**. The critical threshold.
+swap\_win\_warn | **Optional**. The warning threshold. Defaults to "10%".
+swap\_win\_crit | **Optional**. The critical threshold. Defaults to "5%".
 swap\_win\_unit | **Optional**. The unit to display the received value in, thresholds are interpreted in this unit. Defaults to "mb" (megabyte).
 
 

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -47,8 +47,11 @@ object CheckCommand "disk-windows" {
 			description = "Work with used instead of free space"
 		}
 	}
-	vars.disk_win_unit = "mb"
+
 	//The default
+	vars.disk_win_unit = "mb"
+	vars.disk_win_warn = "20%"
+	vars.disk_win_crit = "10%"
 }
 
 object CheckCommand "load-windows" {
@@ -83,8 +86,11 @@ object CheckCommand "memory-windows" {
 			description = "Use this unit to display memory"
 		}
 	}
-	vars.memory_win_unit = "mb"
+
 	//The default
+	vars.memory_win_unit = "mb"
+	vars.memory_win_warn = "10%"
+	vars.memory_win_crit = "5%"
 }
 
 object CheckCommand "network-windows" {
@@ -254,7 +260,10 @@ object CheckCommand "swap-windows" {
 		}
 	}
 
+	// Default
 	vars.swap_win_unit = "mb"
+	vars.swap_win_warn = "10%"
+	vars.swap_win_crit = "5%"
 }
 
 object CheckCommand "update-windows" {


### PR DESCRIPTION
This adds default thresholds to the windows check commands:

* disk-windows:		warn: 20%, crit: 10%
* memory-windows:	        warn: 10%, crit: 5%
* swap-windows:		warn: 10%, crit: 5%

https://monitoring-portal.org/t/icinga2-disk-usage-not-sending-critical-notifications/2143/11

