### PR TITLE
Add activation priority for config object types

### DIFF
--- a/lib/base/filelogger.ti
+++ b/lib/base/filelogger.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class FileLogger : StreamLogger
 {
+	activation_priority -100;
+
 	[config, required] String path;
 };
 

--- a/lib/base/sysloglogger.ti
+++ b/lib/base/sysloglogger.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class SyslogLogger : Logger
 {
+	activation_priority -100;
+
 	[config] String facility {
 		default {{{ return "LOG_USER"; }}}
 	};

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -154,6 +154,11 @@ std::vector<String> Type::GetLoadDependencies() const
 	return std::vector<String>();
 }
 
+int Type::GetActivationPriority() const
+{
+	return 0;
+}
+
 void Type::RegisterAttributeHandler(int fieldId, const AttributeHandler& callback)
 {
 	throw std::runtime_error("Invalid field ID.");

--- a/lib/base/type.hpp
+++ b/lib/base/type.hpp
@@ -103,6 +103,7 @@ public:
 	Value GetField(int id) const override;
 
 	virtual std::vector<String> GetLoadDependencies() const;
+	virtual int GetActivationPriority() const;
 
 	typedef std::function<void (const Object::Ptr&, const Value&)> AttributeHandler;
 	virtual void RegisterAttributeHandler(int fieldId, const AttributeHandler& callback);

--- a/lib/checker/checkercomponent.ti
+++ b/lib/checker/checkercomponent.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class CheckerComponent : ConfigObject
 {
+	activation_priority 100;
+
 	[config] int concurrent_checks {
 		get {{{
 			return Application::GetMaxConcurrentChecks();

--- a/lib/compat/checkresultreader.ti
+++ b/lib/compat/checkresultreader.ti
@@ -27,6 +27,8 @@ namespace icinga
 
 class CheckResultReader : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String spool_dir {
 		default {{{ return Application::GetLocalStateDir() + "/lib/icinga2/spool/checkresults/"; }}}
 	};

--- a/lib/compat/compatlogger.ti
+++ b/lib/compat/compatlogger.ti
@@ -27,6 +27,8 @@ namespace icinga
 
 class CompatLogger : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String log_dir {
 		default {{{ return Application::GetLocalStateDir() + "/log/icinga2/compat"; }}}
 	};

--- a/lib/compat/externalcommandlistener.ti
+++ b/lib/compat/externalcommandlistener.ti
@@ -27,6 +27,8 @@ namespace icinga
 
 class ExternalCommandListener : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String command_path {
 		default {{{ return Application::GetRunDir() + "/icinga2/cmd/icinga2.cmd"; }}}
 	};

--- a/lib/compat/statusdatawriter.ti
+++ b/lib/compat/statusdatawriter.ti
@@ -27,6 +27,8 @@ namespace icinga
 
 class StatusDataWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String status_path {
 		default {{{ return Application::GetLocalStateDir() + "/cache/icinga2/status.dat"; }}}
 	};

--- a/lib/db_ido_mysql/idomysqlconnection.ti
+++ b/lib/db_ido_mysql/idomysqlconnection.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class IdoMysqlConnection : DbConnection
 {
+	activation_priority 100;
+
 	[config] String host {
 		default {{{ return "localhost"; }}}
 	};

--- a/lib/db_ido_pgsql/idopgsqlconnection.ti
+++ b/lib/db_ido_pgsql/idopgsqlconnection.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class IdoPgsqlConnection : DbConnection
 {
+	activation_priority 100;
+
 	[config] String host {
 		default {{{ return "localhost"; }}}
 	};

--- a/lib/livestatus/livestatuslistener.ti
+++ b/lib/livestatus/livestatuslistener.ti
@@ -26,6 +26,8 @@ namespace icinga
 {
 
 class LivestatusListener : ConfigObject {
+	activation_priority 100;
+
 	[config] String socket_type {
 		default {{{ return "unix"; }}}
 	};

--- a/lib/notification/notificationcomponent.ti
+++ b/lib/notification/notificationcomponent.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class NotificationComponent : ConfigObject
 {
+	activation_priority 100;
+
 	[config] bool enable_ha (EnableHA) {
 		default {{{ return true; }}}
 	};

--- a/lib/perfdata/elasticsearchwriter.ti
+++ b/lib/perfdata/elasticsearchwriter.ti
@@ -7,6 +7,8 @@ namespace icinga
 
 class ElasticsearchWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config, required] String host {
 		default {{{ return "127.0.0.1"; }}}
 	};

--- a/lib/perfdata/gelfwriter.ti
+++ b/lib/perfdata/gelfwriter.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class GelfWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String host {
 		default {{{ return "127.0.0.1"; }}}
 	};

--- a/lib/perfdata/graphitewriter.ti
+++ b/lib/perfdata/graphitewriter.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class GraphiteWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String host {
 		default {{{ return "127.0.0.1"; }}}
 	};

--- a/lib/perfdata/influxdbwriter.ti
+++ b/lib/perfdata/influxdbwriter.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class InfluxdbWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config, required] String host {
 		default {{{ return "127.0.0.1"; }}}
 	};

--- a/lib/perfdata/opentsdbwriter.ti
+++ b/lib/perfdata/opentsdbwriter.ti
@@ -26,6 +26,8 @@ namespace icinga
 
 class OpenTsdbWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String host {
 		default {{{ return "127.0.0.1"; }}}
 	};

--- a/lib/perfdata/perfdatawriter.ti
+++ b/lib/perfdata/perfdatawriter.ti
@@ -27,6 +27,8 @@ namespace icinga
 
 class PerfdataWriter : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String host_perfdata_path {
 		default {{{ return Application::GetLocalStateDir() + "/spool/icinga2/perfdata/host-perfdata"; }}}
 	};

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -28,6 +28,8 @@ namespace icinga
 
 class ApiListener : ConfigObject
 {
+	activation_priority 50;
+
 	[config, deprecated] String cert_path;
 	[config, deprecated] String key_path;
 	[config, deprecated] String ca_path;

--- a/tools/mkclass/class_lexer.ll
+++ b/tools/mkclass/class_lexer.ll
@@ -135,6 +135,7 @@ class				{ return T_CLASS; }
 namespace			{ return T_NAMESPACE; }
 code				{ return T_CODE; }
 load_after			{ return T_LOAD_AFTER; }
+activation_priority	{ return T_ACTIVATION_PRIORITY; }
 library				{ return T_LIBRARY; }
 abstract			{ yylval->num = TAAbstract; return T_CLASS_ATTRIBUTE; }
 vararg_constructor		{ yylval->num = TAVarArgConstructor; return T_CLASS_ATTRIBUTE; }
@@ -164,6 +165,7 @@ navigate			{ yylval->num = FTNavigate; return T_FIELD_ACCESSOR_TYPE; }
 \"[^\"]+\"			{ yylval->text = strdup(yytext + 1); yylval->text[strlen(yylval->text) - 1] = '\0'; return T_STRING; }
 \<[^ \>]*\>			{ yylval->text = strdup(yytext + 1); yylval->text[strlen(yylval->text) - 1] = '\0'; return T_ANGLE_STRING; }
 [a-zA-Z_][:a-zA-Z0-9\-_]*	{ yylval->text = strdup(yytext); return T_IDENTIFIER; }
+-?[0-9]+(\.[0-9]+)?		{ yylval->num = strtod(yytext, NULL); return T_NUMBER; }
 
 .				return yytext[0];
 

--- a/tools/mkclass/class_parser.yy
+++ b/tools/mkclass/class_parser.yy
@@ -61,6 +61,7 @@ using namespace icinga;
 %token T_CLASS "class (T_CLASS)"
 %token T_CODE "code (T_CODE)"
 %token T_LOAD_AFTER "load_after (T_LOAD_AFTER)"
+%token T_ACTIVATION_PRIORITY "activation_priority (T_ACTIVATION_PRIORITY)"
 %token T_LIBRARY "library (T_LIBRARY)"
 %token T_NAMESPACE "namespace (T_NAMESPACE)"
 %token T_VALIDATOR "validator (T_VALIDATOR)"
@@ -77,6 +78,7 @@ using namespace icinga;
 %token T_SET "set (T_SET)"
 %token T_DEFAULT "default (T_DEFAULT)"
 %token T_FIELD_ACCESSOR_TYPE "field_accessor_type (T_FIELD_ACCESSOR_TYPE)"
+%token T_NUMBER "number (T_NUMBER)"
 %type <text> T_IDENTIFIER
 %type <text> T_STRING
 %type <text> T_ANGLE_STRING
@@ -106,6 +108,7 @@ using namespace icinga;
 %type <rule> validator_rule
 %type <rules> validator_rules
 %type <validator> validator
+%type <num> T_NUMBER
 
 %{
 
@@ -250,6 +253,8 @@ class: class_attribute_list T_CLASS T_IDENTIFIER inherits_specifier type_base_sp
 		for (const Field& field : *$7) {
 			if (field.Attributes & FALoadDependency) {
 				$$->LoadDependencies.push_back(field.Name);
+			} else if (field.Attributes & FAActivationPriority) {
+				$$->ActivationPriority = field.Priority;
 			} else
 				$$->Fields.push_back(field);
 		}
@@ -378,6 +383,13 @@ class_field: field_attribute_list field_type identifier alternative_name_specifi
 		field->Attributes = FALoadDependency;
 		field->Name = $2;
 		std::free($2);
+		$$ = field;
+	}
+	| T_ACTIVATION_PRIORITY T_NUMBER ';'
+	{
+		auto *field = new Field();
+		field->Attributes = FAActivationPriority;
+		field->Priority = $2;
 		$$ = field;
 	}
 	;

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -408,6 +408,14 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 	m_Impl << "\t" << "return deps;" << std::endl
 		<< "}" << std::endl << std::endl;
 
+	/* GetActivationPriority */
+	m_Header << "\t" << "int GetActivationPriority() const override;" << std::endl;
+
+	m_Impl << "int TypeImpl<" << klass.Name << ">::GetActivationPriority() const" << std::endl
+		<< "{" << std::endl
+		<< "\t" << "return " << klass.ActivationPriority << ";" << std::endl
+		<< "}" << std::endl << std::endl;
+
 	/* RegisterAttributeHandler */
 	m_Header << "public:" << std::endl
 			<< "\t" << "void RegisterAttributeHandler(int fieldId, const Type::AttributeHandler& callback) override;" << std::endl;

--- a/tools/mkclass/classcompiler.hpp
+++ b/tools/mkclass/classcompiler.hpp
@@ -76,7 +76,8 @@ enum FieldAttribute
 	FANoUserView = 2048,
 	FADeprecated = 4096,
 	FAGetVirtual = 8192,
-	FASetVirtual = 16384
+	FASetVirtual = 16384,
+	FAActivationPriority = 32768
 };
 
 struct FieldType
@@ -122,6 +123,7 @@ struct Field
 	std::string NavigationName;
 	std::string NavigateAccessor;
 	bool PureNavigateAccessor{false};
+	int Priority{0};
 
 	inline std::string GetFriendlyName() const
 	{
@@ -167,6 +169,7 @@ struct Klass
 	int Attributes;
 	std::vector<Field> Fields;
 	std::vector<std::string> LoadDependencies;
+	int ActivationPriority{0};
 };
 
 enum RuleAttribute


### PR DESCRIPTION
This PR adds an `activation_priority` option to all icinga objects. Objects are activated in order of their activation, with the lowest going first and the highest last.
The default is 0.

Currently the priorities are as follows
- -100:
Loggers (FileLogger, SyslogLogger) We want these first to make sure any errors are logged
- 0:
Everything else. Mostly Config items (Hosts, Services, Downtimes...) 
- 50:
ApiListener. Stated after config but as the first feature since we want it available asap. A bit of premature optimization possibly.
- 100:
Features (CheckerComponent, CheckResultReader, CompatLogger, ExternalCommandListener, StatusDataWriter, IdoConnections, LivestatusListener, NotificationComponent, ElasticSearchWriter, GelfWriter, GraphiteWriter, InfluxdbWriter, OpenTsdbWriter) These are activated last to make sure they don't act before all config objects are there.

fixes #6057 
fixes #6231 