### PR TITLE
Implement support for template strings

### DIFF
--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -72,6 +72,7 @@ REGISTER_SCRIPTFUNCTION_NS(System, sleep, &Utility::Sleep, "interval");
 REGISTER_SCRIPTFUNCTION_NS(System, path_exists, &Utility::PathExists, "path");
 REGISTER_SCRIPTFUNCTION_NS(System, glob, &ScriptUtils::Glob, "pathspec:callback:type");
 REGISTER_SCRIPTFUNCTION_NS(System, glob_recursive, &ScriptUtils::GlobRecursive, "pathspec:callback:type");
+REGISTER_SAFE_SCRIPTFUNCTION_NS(System, default_tag_func, &ScriptUtils::DefaultTagFunc, "strings:args");
 
 INITIALIZE_ONCE(&ScriptUtils::StaticInitialize);
 
@@ -502,4 +503,21 @@ Value ScriptUtils::GlobRecursive(const std::vector<Value>& args)
 	Utility::GlobRecursive(path, pattern, std::bind(&GlobCallbackHelper, std::ref(paths), _1), type);
 
 	return Array::FromVector(paths);
+}
+
+Value ScriptUtils::DefaultTagFunc(const Array::Ptr& strings, const Array::Ptr& args)
+{
+	if (!strings || strings->GetLength() == 0)
+		BOOST_THROW_EXCEPTION(std::invalid_argument("'strings' must not be empty."));
+
+	if (!args || strings->GetLength() != args->GetLength() + 1)
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid length for 'args'."));
+
+	String result = strings->Get(0);
+
+	for (size_t i = 1; i < strings->GetLength(); i++) {
+		result += Convert::ToString(args->Get(i - 1)) + strings->Get(i);
+	}
+
+	return result;
 }

--- a/lib/base/scriptutils.hpp
+++ b/lib/base/scriptutils.hpp
@@ -58,6 +58,7 @@ public:
 	static double Ptr(const Object::Ptr& object);
 	static Value Glob(const std::vector<Value>& args);
 	static Value GlobRecursive(const std::vector<Value>& args);
+	static Value DefaultTagFunc(const Array::Ptr& strings, const Array::Ptr& args);
 
 private:
 	ScriptUtils();

--- a/lib/config/configcompiler.hpp
+++ b/lib/config/configcompiler.hpp
@@ -49,7 +49,7 @@ struct CompilerDebugInfo
 	operator DebugInfo() const
 	{
 		DebugInfo di;
-		di.Path = Path;
+		di.Path = Path ? Path : "";
 		di.FirstLine = FirstLine;
 		di.FirstColumn = FirstColumn;
 		di.LastLine = LastLine;

--- a/lib/config/expression.hpp
+++ b/lib/config/expression.hpp
@@ -938,6 +938,21 @@ private:
 	std::unique_ptr<Expression> m_ExceptBody;
 };
 
+class TemplateStringExpression final : public DebuggableExpression
+{
+public:
+	TemplateStringExpression(std::unique_ptr<Expression> tagFunc, std::vector<String> strings, std::vector<std::unique_ptr<Expression>> exprs, const DebugInfo& debugInfo = DebugInfo())
+		: DebuggableExpression(debugInfo), m_TagFunc(std::move(tagFunc)), m_Strings(std::move(strings)), m_Expressions(std::move(exprs))
+	{ }
+
+protected:
+	ExpressionResult DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const override;
+
+private:
+	std::unique_ptr<Expression> m_TagFunc;
+	std::vector<String> m_Strings;
+	std::vector<std::unique_ptr<Expression>> m_Expressions;
+};
 }
 
 #endif /* EXPRESSION_H */


### PR DESCRIPTION
This PR implements template strings - in a fashion similar to what's available in JavaScript (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).

Multi-line template strings are supported (which somewhat obsoletes \`\`\`).

Example: https://asciinema.org/a/xWZRfBKY9xPkHA5fJydMwrNxP

TODOs:
* [ ] Documentation
* [ ] Support for expressions which contain `}` and `` ` ``.
* [ ] Multi-line support for `icinga2 console`