### PR TITLE
Add support for config validation log timestamps

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -476,7 +476,7 @@ static int Main()
 			&GlobalArgumentCompletion, true, autoindex);
 		rc = 0;
 	} else if (command) {
-		Logger::DisableTimestamp(true);
+		Logger::DisableTimestamp();
 #ifndef _WIN32
 		if (command->GetImpersonationLevel() == ImpersonateRoot) {
 			if (getuid() != 0) {

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -173,9 +173,14 @@ LogSeverity Logger::GetConsoleLogSeverity()
 	return m_ConsoleLogSeverity;
 }
 
-void Logger::DisableTimestamp(bool disable)
+void Logger::DisableTimestamp()
 {
-	m_TimestampEnabled = !disable;
+	m_TimestampEnabled = false;
+}
+
+void Logger::EnableTimestamp()
+{
+	m_TimestampEnabled = true;
 }
 
 bool Logger::IsTimestampEnabled()

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -84,7 +84,8 @@ public:
 	static void DisableConsoleLog();
 	static void EnableConsoleLog();
 	static bool IsConsoleLogEnabled();
-	static void DisableTimestamp(bool);
+	static void DisableTimestamp();
+	static void EnableTimestamp();
 	static bool IsTimestampEnabled();
 
 	static void SetConsoleLogSeverity(LogSeverity logSeverity);

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -183,8 +183,7 @@ std::vector<String> DaemonCommand::GetArgumentSuggestions(const String& argument
  */
 int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::string>& ap) const
 {
-	if (!vm.count("validate"))
-		Logger::DisableTimestamp(false);
+	Logger::EnableTimestamp();
 
 	Log(LogInformation, "cli")
 		<< "Icinga application loader (version: " << Application::GetAppVersion()


### PR DESCRIPTION
This also adds implicit support for the startup.log
generated from API config package validation, e.g. used by
the Icinga Director.

fixes #3455