### PR TITLE
Fixed opentsdb metric name with colon chars

### DIFF
--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -254,6 +254,7 @@ String OpenTsdbWriter::EscapeMetric(const String& str)
 	boost::replace_all(result, " ", "_");
 	boost::replace_all(result, ".", "_");
 	boost::replace_all(result, "\\", "_");
+	boost::replace_all(result, ":", "_");
 
 	return result;
 }


### PR DESCRIPTION
Fixed opentsdb metric name with colon chars.

refs #4723 
