### PR TITLE
Change log level for failed event command execution

### DIFF
--- a/lib/methods/plugineventtask.cpp
+++ b/lib/methods/plugineventtask.cpp
@@ -60,7 +60,7 @@ void PluginEventTask::ProcessFinishedHandler(const Checkable::Ptr& checkable, co
 {
 	if (pr.ExitStatus != 0) {
 		Process::Arguments parguments = Process::PrepareCommand(commandLine);
-		Log(LogNotice, "PluginEventTask")
+		Log(LogWarning, "PluginEventTask")
 			<< "Event command for object '" << checkable->GetName() << "' (PID: " << pr.PID
 			<< ", arguments: " << Process::PrettyPrintArguments(parguments) << ") terminated with exit code "
 			<< pr.ExitStatus << ", output: " << pr.Output;


### PR DESCRIPTION
Follows the same approach as for notifications and checks.

```
[2018-05-11 15:24:13 +0200] notice/Checkable: State Change: Checkable 'testmaster2' hard state change from DOWN to UP detected.
[2018-05-11 15:24:13 +0200] notice/Checkable: Executing event handler 'testevent' for checkable 'testmaster2'
[2018-05-11 15:24:13 +0200] notice/Process: Running command 'exit' '1': PID 38023
[2018-05-11 15:24:13 +0200] notice/Process: PID 38023 ('exit' '1') terminated with exit code 128
[2018-05-11 15:24:13 +0200] warning/PluginEventTask: Event command for object 'testmaster2' (PID: 38023, arguments: 'exit' '1') terminated with exit code 128, output: execvpe(exit) failed: Permission denied
```

refs #5692 
