### PR TITLE
Introduce the 'Environment' variable

### DIFF
--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -400,6 +400,7 @@ BuildCompilerVersion|**Read-only.** The version of the compiler Icinga was built
 BuildHostName       |**Read-only.** The name of the host Icinga was built on, e.g. "acheron".
 ApplicationVersion  |**Read-only.** The application version, e.g. "2.9.0".
 MaxConcurrentChecks |**Read-write**. The number of max checks run simultaneously. Defaults to 512.
+Environment         |**Read-write**. The name of the Icinga environment. Included in the SNI host name when making outbound connections. Defaults to "production".
 
 
 Advanced runtime constants. Please only use them if advised by support or developers.

--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -221,6 +221,8 @@ static int Main()
 	Application::DeclareConcurrency(std::thread::hardware_concurrency());
 	Application::DeclareMaxConcurrentChecks(Application::GetDefaultMaxConcurrentChecks());
 
+	ScriptGlobal::Set("Environment", "production");
+
 	ScriptGlobal::Set("AttachDebugger", false);
 
 	ScriptGlobal::Set("PlatformKernel", Utility::GetPlatformKernel());

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -81,7 +81,8 @@ void IcingaApplication::StatsFunc(const Dictionary::Ptr& status, const Array::Pt
 			{ "enable_perfdata", icingaapplication->GetEnablePerfdata() },
 			{ "pid", Utility::GetPid() },
 			{ "program_start", Application::GetStartTime() },
-			{ "version", Application::GetAppVersion() }
+			{ "version", Application::GetAppVersion() },
+			{ "environment", ScriptGlobal::Get("Environment", &Empty) }
 		}));
 	}
 

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -382,10 +382,16 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 
 	TcpSocket::Ptr client = new TcpSocket();
 
+	String serverName = endpoint->GetName();
+
+	String env = ScriptGlobal::Get("Environment", &Empty);
+	if (env != "" && env != "production")
+		serverName += ":" + env;
+
 	try {
 		endpoint->SetConnecting(true);
 		client->Connect(host, port);
-		NewClientHandler(client, endpoint->GetName(), RoleClient);
+		NewClientHandler(client, serverName, RoleClient);
 		endpoint->SetConnecting(false);
 	} catch (const std::exception& ex) {
 		endpoint->SetConnecting(false);


### PR DESCRIPTION
This PR adds a new global variable: Environment

Its only purpose is to allow other tools to differentiate inbound TLS connections based on the SNI extension in the ClientHello message.

The default environment name is "production". However this can be changed by setting the variable to something else.

Unless the environment is "production" or "" (i.e., an empty string) a colon (":") and the environment name are appended to the SNI host name, e.g. "agent.example.com:staging":

![screen shot 2018-05-15 at 10 32 10](https://user-images.githubusercontent.com/388571/40045697-47611908-582b-11e8-8467-7949d3949398.png)
