### PR TITLE
Update lsi-raid ITL command

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2546,8 +2546,29 @@ Custom attributes passed as [command parameters](03-monitoring-basics.md#command
 
 Name                            | Description
 --------------------------------|-----------------------------------------------------------------------
-lsi_controller_number           | **Required.** Controller number to monitor.
-storcli_path                    | **Required.** Path to the `storcli` binary, e.g. "/usr/sbin/storcli".
+lsi_controller_number           | **Optional.** Controller number to monitor.
+storcli_path                    | **Optional.** Path to the `storcli` binary, e.g. "/usr/sbin/storcli". 
+lsi_enclosure_id                | **Optional.** Enclosure numbers to be checked, comma-separated.
+lsi_ld_id                       | **Optional.** Logical devices to be checked, comma-separated.
+lsi_pd_id                       | **Optional.** Physical devices to be checked, comma-separated.
+lsi_temp_warning                | **Optional.** RAID controller warning temperature.
+lsi_temp_critical               | **Optional.** RAID controller critical temperature.
+lsi_pd_temp_warning             | **Optional.** Disk warning temperature.
+lsi_pd_temp_critical            | **Optional.** Disk critical temperature.
+lsi_bbu_temp_warning            | **Optional.** Battery warning temperature.
+lsi_bbu_temp_critical           | **Optional.** Battery critical temperature.
+lsi_cv_temp_warning             | **Optional.** CacheVault warning temperature.
+lsi_cv_temp_critical            | **Optional.** CacheVault critical temperature.
+lsi_ignored_media_errors        | **Optional.** Warning threshold for media errors.
+lsi_ignored_other_errors        | **Optional.** Warning threshold for other errors.
+lsi_ignored_predictive_fails    | **Optional.** Warning threshold for predictive failures.
+lsi_ignored_shield_counters     | **Optional.** Warning threshold for shield counter.
+lsi_ignored_bbm_counters        | **Optional.** Warning threshold for BBM counter.
+lsi_bbu                         | **Optional.** Define if BBU is present and it's state should be checked.
+lsi_noenclosures                | **Optional.** If set to true, does not check enclosures.
+lsi_nosudo                      | **Optional.** If set to true, does not use sudo when running storcli.
+lsi_nocleanlogs                 | **Optional.** If set to true, does not clean up the log files after executing storcli checks.
+
 
 #### smart-attributes <a id="plugin-contrib-command-smart-attributes"></a>
 

--- a/itl/plugins-contrib.d/raid-controller.conf
+++ b/itl/plugins-contrib.d/raid-controller.conf
@@ -31,16 +31,92 @@ object CheckCommand "lsi-raid" {
 
 	arguments = {
 		"-C" = {
-			required = true
 			value = "$lsi_controller_number$"
 			description = "Insert the controller number to be checked."
 		}
 		"-p" = {
-			required = true
 			value = "$storcli_path$"
 			description = "Insert the path to storcli (e.g. /usr/sbin/storcli)."
 		}
+		"-EID" = {
+			value = "$lsi_enclosure_id$"
+			description = "Enclosure numbers to be checked, comma-separated."
+		}
+		"-LD" = {
+			value = "$lsi_ld_id$"
+			description = "Logical devices to be checked, comma-separated."
+		}
+		"-PD" = {
+			value = "$lsi_pd_id$"
+			description = "Physical devices to be checked, comma-separated."
+		}
+		"-Tw" = {
+			value = "$lsi_temp_warning$"
+			description = "RAID controller warning temperature."
+		}
+		"-Tc" = {
+			value = "$lsi_temp_critical$"
+			description = "RAID controller critical temperature."
+		}
+		"-PDTw" = {
+			value = "$lsi_pd_temp_warning$"
+			description = "Disk warning temperature."
+		}
+		"-PDTc" = {
+			value = "$lsi_pd_temp_critical$"
+			description = "Disk critical temperature."
+		}
+		"-BBUTw" = {
+			value = "$lsi_bbu_temp_warning$"
+			description = "Battery warning temperature."
+		}
+		"-BBUTc" = {
+			value = "$lsi_bbu_temp_critical$"
+			description = "Battery critical temperature."
+		}
+		"-CVTw" = {
+			value = "$lsi_cv_temp_warning$"
+			description = "CacheVault warning temperature."
+		}
+		"-CVTc" = {
+			value = "$lsi_cv_temp_critical$"
+			description = "CacheVault critical temperature."
+		}
+		"-Im" = {
+			value = "$lsi_ignored_media_errors$"
+			description = "Warning threshold for media errors."
+		}
+		"-Io" = {
+			value = "$lsi_ignored_other_errors$"
+			description = "Warning threshold for other errors."
+		}
+		"-Ip" = {
+			value = "$lsi_ignored_predictive_fails$"
+			description = "Warning threshold for predictive failures."
+		}
+		"-Is" = {
+			value = "$lsi_ignored_shield_counters$"
+			description = "Warning threshold for shield counter."
+		}
+		"-Ib" = {
+			value = "$lsi_ignored_bbm_counters$"
+			description = "Warning threshold for BBM counter."
+		}
+		"-b" = {
+			value = "$lsi_bbu$"
+			description = "Define if BBU is present and it's state should be checked."
+		}
+		"--noenclosures" = {
+			set_if = "$lsi_noenclosures$"
+			description = "Define if enclosures are present."
+		}
+		"--nosudo" = {
+			set_if = "$lsi_nosudo$"
+			description = "Do not use sudo when running storcli."
+		}
+		"--nocleanlogs" = {
+			set_if = "$lsi_nocleanlogs$"
+			description = "Do not clean up the log files after executing storcli checks."
+		}
 	}
-
-	vars.storcli_path = "/usr/sbin/storcli"
 }


### PR DESCRIPTION
Hi,

Currently lsi-raid command in ITL has only two arguments, but actually the check command allows much more to be provided. Apart from that, controller number & storcli path are not required arguments as they are pre-defined in check command already.