### PR TITLE
WIP: Bugfixing Timeperiods

### DIFF
--- a/lib/icinga/timeperiod.cpp
+++ b/lib/icinga/timeperiod.cpp
@@ -142,12 +142,12 @@ void TimePeriod::RemoveSegment(double begin, double end)
 	for (const Dictionary::Ptr& segment : segments) {
 		/* Fully contained in the specified range? */
 		if (segment->Get("begin") >= begin && segment->Get("end") <= end)
+			// Don't add the old segment, because the segment is fully contained into our range
 			continue;
 
 		/* Not overlapping at all? */
 		if (segment->Get("end") < begin || segment->Get("begin") > end) {
 			newSegments->Add(segment);
-
 			continue;
 		}
 
@@ -162,6 +162,8 @@ void TimePeriod::RemoveSegment(double begin, double end)
 				{ "begin", end },
 				{ "end", segment->Get("end") }
 			}));
+			// Don't add the old segment, because we have now two new segments and a gap between
+			continue;
 		}
 
 		/* Adjust the begin/end timestamps so as to not overlap with the specified range. */


### PR DESCRIPTION
Hi @dnsmichi,
I think I found a bug in timeperiods - missing "continue". Please take a look.

Do we have a possibility to wait for initialization of included or excluded timeperiods? Because in the moment of start the included or excluded timeperiod is empty.

PR for fixing https://github.com/Icinga/icinga2/issues/6282

Best Regards
Reamer