### PR TITLE
Ensure that icinga_min_version parameter is optional

### DIFF
--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -55,8 +55,10 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	resolvers.emplace_back("command", commandObj);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
+	String missingIcingaMinVersion;
+
 	String icingaMinVersion = MacroProcessor::ResolveMacros("$icinga_min_version$", resolvers, checkable->GetLastCheckResult(),
-		nullptr, MacroProcessor::EscapeCallback(), resolvedMacros, useResolvedMacros);
+		&missingIcingaMinVersion, MacroProcessor::EscapeCallback(), resolvedMacros, useResolvedMacros);
 
 	if (resolvedMacros && !useResolvedMacros)
 		return;
@@ -175,7 +177,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	/* Return an error if the version is less than specified (optional). */
 	String parsedAppVersion = appVersion.SubStr(1,5);
 
-	if (!icingaMinVersion.IsEmpty() && Utility::CompareVersion(icingaMinVersion, parsedAppVersion) < 0) {
+	if (missingIcingaMinVersion.IsEmpty() && !icingaMinVersion.IsEmpty() && Utility::CompareVersion(icingaMinVersion, parsedAppVersion) < 0) {
 		output += "; Minimum version " + icingaMinVersion + " is not installed.";
 		cr->SetState(ServiceCritical);
 	}


### PR DESCRIPTION
Seen that here: https://github.com/Icinga/icinga2/issues/6319#issuecomment-390195058

The fix in #5960 doesn't entirely solve it for only command
endpoint clients being updated, the parent node doesn't send
in the value.

```
[2018-05-18 14:29:57 +0200] warning/MacroProcessor: Macro 'icinga_min_version' is not defined.
Context:
	(0) Resolving macros for string '$icinga_min_version$'
	(1) Executing remote check for object 'agent001'
```

refs #5960
refs #3998