### PR TITLE
Implement scheduling_endpoint attribute

### DIFF
--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -1180,6 +1180,7 @@ to represent its internal state. The following types are exposed via the [API](1
   output                    | String                | The check output.
   performance\_data         | Array                 | Array of [performance data values](08-advanced-topics.md#advanced-value-types-perfdatavalue).
   check\_source             | String                | Name of the node executing the check.
+  scheduling\_source        | String                | Name of the node scheduling the check.
   state                     | Number                | The current state (0 = OK, 1 = WARNING, 2 = CRITICAL, 3 = UNKNOWN).
   command                   | Value                 | Array of command with shell-escaped arguments or command line string.
   execution\_start          | Timestamp             | Check execution start time (as a UNIX timestamp).

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -104,6 +104,7 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 		cr->SetExecutionEnd(HttpUtility::GetLastParameter(params, "execution_end"));
 
 	cr->SetCheckSource(HttpUtility::GetLastParameter(params, "check_source"));
+	cr->SetSchedulingSource(HttpUtility::GetLastParameter(params, "scheduling_source"));
 
 	Value perfData = params->Get("performance_data");
 

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -118,6 +118,12 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 	if (cr->GetExecutionEnd() == 0)
 		cr->SetExecutionEnd(now);
 
+	if (!origin || origin->IsLocal())
+		cr->SetCheckSource(IcingaApplication::GetInstance()->GetNodeName());
+
+	if (!origin || origin->IsLocal())
+		cr->SetSchedulingSource(IcingaApplication::GetInstance()->GetNodeName());
+
 	Endpoint::Ptr command_endpoint = GetCommandEndpoint();
 
 	if (cr->GetCheckSource().IsEmpty()) {

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -119,9 +119,6 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		cr->SetExecutionEnd(now);
 
 	if (!origin || origin->IsLocal())
-		cr->SetCheckSource(IcingaApplication::GetInstance()->GetNodeName());
-
-	if (!origin || origin->IsLocal())
 		cr->SetSchedulingSource(IcingaApplication::GetInstance()->GetNodeName());
 
 	Endpoint::Ptr command_endpoint = GetCommandEndpoint();

--- a/lib/icinga/checkresult.ti
+++ b/lib/icinga/checkresult.ti
@@ -61,6 +61,7 @@ class CheckResult
 	};
 
 	[state] String check_source;
+	[state] String scheduling_source;
 	[state] double ttl;
 
 	[state] Dictionary::Ptr vars_before;

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -320,6 +320,9 @@ bool Host::ResolveMacro(const String& macro, const CheckResult::Ptr&, Value *res
 		} else if (macro == "check_source") {
 			*result = cr->GetCheckSource();
 			return true;
+		} else if (macro == "scheduling_source") {
+			*result = cr->GetSchedulingSource();
+			return true;
 		}
 	}
 

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -267,6 +267,9 @@ bool Service::ResolveMacro(const String& macro, const CheckResult::Ptr& cr, Valu
 		} else if (macro == "check_source") {
 			*result = cr->GetCheckSource();
 			return true;
+		} else if (macro == "scheduling_source") {
+			*result = cr->GetSchedulingSource();
+			return true;
 		}
 	}
 
@@ -282,4 +285,3 @@ std::pair<Host::Ptr, Service::Ptr> icinga::GetHostService(const Checkable::Ptr& 
 	else
 		return std::make_pair(static_pointer_cast<Host>(checkable), nullptr);
 }
-


### PR DESCRIPTION
This implements the attribute `scheduling_endpoint` for hosts and services to show which endpoint is running the scheduler for the check.

fixes #4814