### PR TITLE
Fix unnecessary blank in log message

### DIFF
--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -277,7 +277,7 @@ bool NodeUtility::UpdateConfiguration(const String& value, bool include, bool re
 	String configurationFile = Application::GetSysconfDir() + "/icinga2/icinga2.conf";
 
 	Log(LogInformation, "cli")
-		<< "Updating ' " << value << "' include in '" << configurationFile << "'.";
+		<< "Updating '" << value << "' include in '" << configurationFile << "'.";
 
 	NodeUtility::CreateBackupFile(configurationFile);
 


### PR DESCRIPTION
This fixes an unnecessary blank in the updating configuraiton log message.

```
information/cli: Updating ' "conf.d"' include in '/etc/icinga2/icinga2.conf'.
```

Should be:

```
information/cli: Updating '"conf.d"' include in '/etc/icinga2/icinga2.conf'.
```