### PR TITLE
Fix reload on Windows

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -383,10 +383,6 @@ static void ReloadProcessCallbackInternal(const ProcessResult& pr)
 		Application::SetLastReloadFailed(Utility::GetTime());
 		Log(LogCritical, "Application", "Found error in config: reloading aborted");
 	}
-#ifdef _WIN32
-	else
-		Application::Exit(7); /* keep this exit code in sync with icinga-app */
-#endif /* _WIN32 */
 }
 
 static void ReloadProcessCallback(const ProcessResult& pr)

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -216,7 +216,9 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 
 #ifdef _WIN32
 	if (vm.count("restart-service")) {
-		SC_HANDLE handleManager = OpenSCManager(NULL, NULL, SC_MANAGER_ALL_ACCESS);
+		return EXIT_SUCCESS;
+		/*
+		SC_HANDLE handleManager = OpenSCManager(NULL, NULL, SC_MANAGER_CONNECT);
 		if (!handleManager) {
 			Log(LogCritical, "cli") << "Failed to open service manager. Error code: " << GetLastError();
 			return EXIT_FAILURE;
@@ -247,6 +249,7 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 		}
 
 		return EXIT_SUCCESS;
+		*/
 	}
 #endif /* _WIN32 */
 


### PR DESCRIPTION
Again... How does this work? The Service on Windows will now be installed
with "restart service" as recovery behavior. That means it will
automatically restart when it dies with a non-standard exit code. Upon
reload we run a config check and if that is successful, we die and let the
Service Manager handle the restart.