### PR TITLE
Increase header size to 8KB for HTTP requests

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -83,6 +83,8 @@ All requests apart from `GET` require that the following `Accept` header is set:
 
 Each URL is prefixed with the API version (currently "/v1").
 
+HTTP header size is limited to 8KB.
+
 ### Responses <a id="icinga2-api-responses"></a>
 
 Successful requests will send back a response body containing a `results`

--- a/lib/remote/httprequest.cpp
+++ b/lib/remote/httprequest.cpp
@@ -46,14 +46,20 @@ bool HttpRequest::ParseHeaders(StreamReadContext& src, bool may_wait)
 	StreamReadStatus srs = m_Stream->ReadLine(&line, src, may_wait);
 
 	if (srs != StatusNewItem) {
-		if (src.Size > 512)
+		if (src.Size > 8 * 1024)
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Line length for HTTP header exceeded"));
 
 		return false;
 	}
 
-	if (line.GetLength() > 512)
+	if (line.GetLength() > 8 * 1024) {
+#ifdef I2_DEBUG /* I2_DEBUG */
+		Log(LogDebug, "HttpRequest")
+			<< "Header size: " << line.GetLength() << " content: '" << line << "'.";
+#endif /* I2_DEBUG */
+
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Line length for HTTP header exceeded"));
+	}
 
 	if (m_State == HttpRequestStart) {
 		/* ignore trailing new-lines */


### PR DESCRIPTION
This is the default for Tomcat and Apache too
and avoids problems with cookies and long URLs.

fixes #6355