### PR TITLE
Revert "Fix Windows reload"

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -416,8 +416,7 @@ pid_t Application::StartReloadProcess()
 	args.push_back("--reload-internal");
 	args.push_back(Convert::ToString(Utility::GetPid()));
 #else /* _WIN32 */
-	args.push_back("--restart-service");
-	args.push_back("icinga2");
+	args.push_back("--validate");
 #endif /* _WIN32 */
 
 	Process::Ptr process = new Process(Process::PrepareCommand(new Array(std::move(args))));


### PR DESCRIPTION
This reverts commit 691e3cfd576e09d28f1da0df3f112d5c56980362.

The current (problematic) state of the windows reload introduced by #6116, which was tested and and seen as working, but from revisiting the code - could not have. This reverts those changes and goes back to the old behavior of having Icinga2 manage its processes itself.

I have tested this and it does work. We should get snapshot packages asap to further test in any case.