### PR TITLE
Fix program option parsing

### DIFF
--- a/lib/cli/clicommand.cpp
+++ b/lib/cli/clicommand.cpp
@@ -186,7 +186,7 @@ bool CLICommand::ParseCommand(int argc, char **argv, po::options_description& vi
 		std::vector<String>::size_type i;
 		int k;
 		for (i = 0, k = 1; i < vname.size() && k < argc; i++, k++) {
-			if (strncmp(argv[k], "--", 2) == 0) {
+			if (strncmp(argv[k], "-", 1) == 0 || strncmp(argv[k], "--", 2) == 0) {
 				i--;
 				continue;
 			}


### PR DESCRIPTION
This fixes the program option parsing for short options like `icinga2 -V`.

**Tests**

```
# /tmp/icinga2/sbin/icinga2 -V
icinga2 - The Icinga 2 network monitoring daemon (version: v2.8.4-744-ge885cf71c)

Copyright (c) 2012-2018 Icinga Development Team (https://www.icinga.com/)
License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl2.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Application information:
  Installation root: /tmp/icinga2
  Sysconf directory: /tmp/icinga2/etc
  Run directory: /tmp/icinga2/var/run
  Local state directory: /tmp/icinga2/var
  Package data directory: /tmp/icinga2/share/icinga2
  State path: /tmp/icinga2/var/lib/icinga2/icinga2.state
  Modified attributes path: /tmp/icinga2/var/lib/icinga2/modified-attributes.conf
  Objects path: /tmp/icinga2/var/cache/icinga2/icinga2.debug
  Vars path: /tmp/icinga2/var/cache/icinga2/icinga2.vars
  PID path: /tmp/icinga2/var/run/icinga2/icinga2.pid

System information:
  Platform: Ubuntu
  Platform version: 18.04 LTS (Bionic Beaver)
  Kernel: Linux
  Kernel version: 4.15.0-20-generic
  Architecture: x86_64

Build information:
  Compiler: Clang 6.0.0
  Build host: metis
```
The short options are now working.

```
# /tmp/icinga2/sbin/icinga2 daemon -C
[2018-06-12 19:13:37 +0200] information/cli: Icinga application loader (version: v2.8.4-744-ge885cf71c)
[2018-06-12 19:13:37 +0200] information/cli: Loading configuration file(s).
[2018-06-12 19:13:37 +0200] information/ConfigItem: Committing config item(s).
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 NotificationComponent.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 CheckerComponent.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 UserGroup.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 11 Services.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 ScheduledDowntime.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 User.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 3 ServiceGroups.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 3 TimePeriods.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 3 Zones.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 Host.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 2 NotificationCommands.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 12 Notifications.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 2 HostGroups.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 IcingaApplication.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 Endpoint.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 1 FileLogger.
[2018-06-12 19:13:37 +0200] information/ConfigItem: Instantiated 212 CheckCommands.
[2018-06-12 19:13:37 +0200] information/ScriptGlobal: Dumping variables to file '/tmp/icinga2/var/cache/icinga2/icinga2.vars'
[2018-06-12 19:13:37 +0200] information/cli: Finished validating the configuration file(s).
```
Commands with short options like `daemon -C` continue to work.

Is there anything else to test?

fixes #6365 