### PR TITLE
Throw config error when using global zones as parent

### DIFF
--- a/lib/remote/zone.cpp
+++ b/lib/remote/zone.cpp
@@ -33,6 +33,9 @@ void Zone::OnAllConfigLoaded()
 
 	m_Parent = Zone::GetByName(GetParentRaw());
 
+	if (m_Parent && m_Parent->IsGlobal())
+		BOOST_THROW_EXCEPTION(ScriptError("Zone '" + GetName() + "' can not have a global zone as parent.", GetDebugInfo()));
+
 	Zone::Ptr zone = m_Parent;
 	int levels = 0;
 


### PR DESCRIPTION
Disallow global zones as parent
```
object Endpoint "foo" {
}

object Zone "fooz" {
	endpoints = [ "foo" ]
	parent = "global-templates"
}

object Zone "director-global" {
	global = true
}
```

used to be allowed, now this output is expected:

```
$ icinga2 daemon -C
[2018-06-15 14:43:03 +0200] information/cli: Icinga application loader (version: v2.8.4-748-gee9be90fa)
[2018-06-15 14:43:03 +0200] information/cli: Loading configuration file(s).
[2018-06-15 14:43:04 +0200] information/ConfigItem: Committing config item(s).
[2018-06-15 14:43:04 +0200] information/ApiListener: My API identity: jfws
[2018-06-15 14:43:05 +0200] critical/config: Error: Zone 'fooz' can not have a global zone as parent.
Location: in /home/jflach/i2/etc/icinga2/zones.conf: 33:1-33:18
/home/jflach/i2/etc/icinga2/zones.conf(31): }
/home/jflach/i2/etc/icinga2/zones.conf(32): 
/home/jflach/i2/etc/icinga2/zones.conf(33): object Zone "fooz" {
                                            ^^^^^^^^^^^^^^^^^^
/home/jflach/i2/etc/icinga2/zones.conf(34):  endpoints = [ "foo" ]
/home/jflach/i2/etc/icinga2/zones.conf(35):  parent = "global-templates"

[2018-06-15 14:43:05 +0200] critical/config: 1 error
```