### PR TITLE
Fix connection error handling in Elasticsearch and InfluxDB features

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -428,7 +428,19 @@ void ElasticsearchWriter::SendRequest(const String& body)
 
 	url->SetPath(path);
 
-	Stream::Ptr stream = Connect();
+	Stream::Ptr stream;
+
+	try {
+		stream = Connect();
+	} catch (const std::exception& ex) {
+		Log(LogWarning, "ElasticsearchWriter")
+			<< "Flush failed, cannot connect to Elasticsearch.";
+		return;
+	}
+
+	if (!stream)
+		return;
+
 	HttpRequest req(stream);
 
 	/* Specify required headers by Elasticsearch. */

--- a/lib/perfdata/influxdbwriter.cpp
+++ b/lib/perfdata/influxdbwriter.cpp
@@ -419,7 +419,15 @@ void InfluxdbWriter::Flush()
 	String body = boost::algorithm::join(m_DataBuffer, "\n");
 	m_DataBuffer.clear();
 
-	Stream::Ptr stream = Connect();
+	Stream::Ptr stream;
+
+	try {
+		stream = Connect();
+	} catch (const std::exception& ex) {
+		Log(LogWarning, "InfluxDbWriter")
+			<< "Flush failed, cannot connect to InfluxDB.";
+		return;
+	}
 
 	if (!stream)
 		return;


### PR DESCRIPTION
Previously this would just throw the entire exception stack trace
which is not needed here.

fixes #6394