### PR TITLE
Use SSL_pending() for remaining TLS stream data

### DIFF
--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -186,7 +186,26 @@ void TlsStream::OnEvent(int revents)
 
 					readTotal += rc;
 				}
-			} while (rc > 0 && readTotal < 64 * 1024);
+
+#ifdef I2_DEBUG /* I2_DEBUG */
+				Log(LogDebug, "TlsStream")
+					<< "Read bytes: " << rc << " Total read bytes: " << readTotal;
+#endif /* I2_DEBUG */
+				/* Limit read size. We cannot do this check inside the while loop
+				 * since below should solely check whether OpenSSL has more data
+				 * or not. */
+				if (readTotal >= 64 * 1024) {
+#ifdef I2_DEBUG /* I2_DEBUG */
+					Log(LogWarning, "TlsStream")
+						<< "Maximum read bytes exceeded: " << readTotal;
+#endif /* I2_DEBUG */
+					break;
+				}
+
+			/* Use OpenSSL's state machine here to determine whether we need
+			 * to read more data. SSL_has_pending() is available with 1.1.0.
+			 */
+			} while (SSL_pending(m_SSL.get()));
 
 			if (success)
 				m_CV.notify_all();


### PR DESCRIPTION
We've used this previously, and according to the OpenSSL
docs we should just use it. From our experience everything
done different to the API functions from OpenSSL causes
undefined behaviour in the worst case.

This commit also breaks the packet size limit into a more
readable version, including logs for development debug builds.

refs #6242