### PR TITLE
TcpSocket#Bind(): reuse socket addresses on Windows, too

### DIFF
--- a/lib/base/tcpsocket.cpp
+++ b/lib/base/tcpsocket.cpp
@@ -89,10 +89,8 @@ void TcpSocket::Bind(const String& node, const String& service, int family)
 		const int optFalse = 0;
 		setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast<const char *>(&optFalse), sizeof(optFalse));
 
-#ifndef _WIN32
 		const int optTrue = 1;
 		setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&optTrue), sizeof(optTrue));
-#endif /* _WIN32 */
 
 		int rc = bind(fd, info->ai_addr, info->ai_addrlen);
 


### PR DESCRIPTION
fixes #6378