### PR TITLE
Fix wrong UOM in check_uptime windows plugin

### DIFF
--- a/plugins/check_uptime.cpp
+++ b/plugins/check_uptime.cpp
@@ -33,6 +33,7 @@ struct printInfoStruct
 	threshold warn;
 	threshold crit;
 	long long time;
+	long long timeInSeconds;
 	Tunit unit;
 };
 
@@ -166,19 +167,19 @@ static int printOutput(printInfoStruct& printInfo)
 
 	switch (state) {
 	case OK:
-		std::wcout << L"UPTIME OK " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.time
-			<< TunitStr(printInfo.unit) << L";" << printInfo.warn.pString() << L";"
-			<< printInfo.crit.pString() << L";0;" << '\n';
+		std::wcout << L"UPTIME OK " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.timeInSeconds
+			<< "s" << L";" << printInfo.warn.toSeconds(printInfo.unit).pString() << L";"
+			<< printInfo.crit.toSeconds(printInfo.unit).pString() << L";0;" << '\n';
 		break;
 	case WARNING:
-		std::wcout << L"UPTIME WARNING " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.time
-			<< TunitStr(printInfo.unit) << L";" << printInfo.warn.pString() << L";"
-			<< printInfo.crit.pString() << L";0;" << '\n';
+		std::wcout << L"UPTIME WARNING " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.timeInSeconds
+			<< "s" << L";" << printInfo.warn.toSeconds(printInfo.unit).pString() << L";"
+			<< printInfo.crit.toSeconds(printInfo.unit).pString() << L";0;" << '\n';
 		break;
 	case CRITICAL:
-		std::wcout << L"UPTIME CRITICAL " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.time
-			<< TunitStr(printInfo.unit) << L";" << printInfo.warn.pString() << L";"
-			<< printInfo.crit.pString() << L";0;" << '\n';
+		std::wcout << L"UPTIME CRITICAL " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.timeInSeconds
+			<< "s" << L";" << printInfo.warn.toSeconds(printInfo.unit).pString() << L";"
+			<< printInfo.crit.toSeconds(printInfo.unit).pString() << L";0;" << '\n';
 		break;
 	}
 
@@ -209,6 +210,9 @@ static void getUptime(printInfoStruct& printInfo)
 		printInfo.time = uptime.count();
 		break;
 	}
+
+	// For the Performance Data we need the time in seconds
+	printInfo.timeInSeconds = boost::chrono::duration_cast<boost::chrono::seconds>(uptime).count();
 }
 
 int wmain(int argc, WCHAR **argv)

--- a/plugins/thresholds.cpp
+++ b/plugins/thresholds.cpp
@@ -28,6 +28,13 @@ threshold::threshold()
 	: set(false)
 {}
 
+threshold::threshold(const double v, const double c, bool l , bool p ) {
+	lower = v;
+	upper = c;
+	legal = l;
+	perc = p;
+}
+
 threshold::threshold(const std::wstring& stri)
 {
 	if (stri.empty())
@@ -124,6 +131,35 @@ std::wstring threshold::pString(const double max)
 		s.append(lowerStr);
 
 	return s;
+}
+
+threshold threshold::toSeconds(const Tunit& fromUnit) {
+	if (!set)
+		return *this;
+
+	double lowerAbs = lower;
+	double upperAbs = upper;
+
+	switch (fromUnit) {
+	case TunitMS:
+		lowerAbs = lowerAbs / 1000;
+		upperAbs = upperAbs / 1000;
+		break;
+	case TunitS:
+		lowerAbs = lowerAbs ;
+		upperAbs = upperAbs ;
+		break;
+	case TunitM:
+		lowerAbs = lowerAbs * 60;
+		upperAbs = upperAbs * 60;
+		break;
+	case TunitH:
+		lowerAbs = lowerAbs * 60 * 60;
+		upperAbs = upperAbs * 60 * 60;
+		break;
+	}
+
+	return threshold(lowerAbs, upperAbs, legal, perc);
 }
 
 std::wstring removeZero(double val)

--- a/plugins/thresholds.hpp
+++ b/plugins/thresholds.hpp
@@ -62,6 +62,7 @@ public:
 	// returns a printable string of the threshold
 	std::wstring pString(const double max = 100.0);
 
+	threshold toSeconds(const Tunit& fromUnit);
 };
 
 std::wstring removeZero(double);


### PR DESCRIPTION
This fixes the usage of invalid unit of measurement in the check_uptime windows plugin.

The performance data will now be provided without any UOM.

fixes #6406