### PR TITLE
Windows: Conform to the Plugin API spec for performance label quoting

### DIFF
--- a/plugins/check_disk.cpp
+++ b/plugins/check_disk.cpp
@@ -382,7 +382,7 @@ static int printOutput(printInfoStruct& printInfo, std::vector<drive>& vDrives)
 			wsDrives.push_back(it->name + L" " + removeZero(it->free) + L" " + unit + L" (" +
 				removeZero(std::round(it->free / it->cap * 100.0)) + L"%); ");
 
-			wsPerf.push_back(L" " + it->name + L"=" + removeZero(it->free) + unit + L";" +
+			wsPerf.push_back(L" '" + it->name + L"'=" + removeZero(it->free) + unit + L";" +
 				printInfo.warn.pString(it->cap) + L";" + printInfo.crit.pString(it->cap) + L";0;"
 				+ removeZero(it->cap));
 

--- a/plugins/check_load.cpp
+++ b/plugins/check_load.cpp
@@ -171,7 +171,7 @@ static int printOutput(printInfoStruct& printInfo)
 		break;
 	}
 
-	std::wcout << " " << printInfo.load << L"% | load=" << printInfo.load << L"%;"
+	std::wcout << " " << printInfo.load << L"% | 'load'=" << printInfo.load << L"%;"
 		<< printInfo.warn.pString() << L";"
 		<< printInfo.crit.pString() << L";0;100" << '\n';
 

--- a/plugins/check_memory.cpp
+++ b/plugins/check_memory.cpp
@@ -187,7 +187,7 @@ static int printOutput(printInfoStruct& printInfo)
 	else
 		std::wcout << " - " << 100 - printInfo.percentFree << L"% used";
 
-	std::wcout << "| memory=" << currentValue << BunitStr(printInfo.unit) << L";"
+	std::wcout << "| 'memory'=" << currentValue << BunitStr(printInfo.unit) << L";"
 		<< printInfo.warn.pString(printInfo.tRam) << L";" << printInfo.crit.pString(printInfo.tRam)
 		<< L";0;" << printInfo.tRam;
 

--- a/plugins/check_network.cpp
+++ b/plugins/check_network.cpp
@@ -190,7 +190,7 @@ static int printOutput(printInfoStruct& printInfo, const std::vector<nInterface>
 			continue;
 		} else {
 			boost::algorithm::replace_all(wsFriendlyName, "'", "''");
-			tss << L"\'" << wsFriendlyName << L"_in\'=" << it->BytesInSec << L"B \'" << wsFriendlyName << L"_out\'=" << it->BytesOutSec << L"B ";
+			tss << L"'" << wsFriendlyName << L"_in'=" << it->BytesInSec << L"B '" << wsFriendlyName << L"_out'=" << it->BytesOutSec << L"B ";
 		}
 	}
 
@@ -214,7 +214,7 @@ static int printOutput(printInfoStruct& printInfo, const std::vector<nInterface>
 	}
 
 	std::wcout << " " << tIn + tOut << L"B/s | "
-		<< L"network=" << tIn + tOut << L"B;" << printInfo.warn.pString() << L";" << printInfo.crit.pString() << L";" << L"0; "
+		<< L"'network'=" << tIn + tOut << L"B;" << printInfo.warn.pString() << L";" << printInfo.crit.pString() << L";" << L"0; "
 		<< tss.str() << '\n';
 
 	return state;

--- a/plugins/check_perfmon.cpp
+++ b/plugins/check_perfmon.cpp
@@ -352,26 +352,27 @@ static int printOutput(const po::variables_map& vm, printInfoStruct& pi)
 	std::wstringstream wssPerfData;
 
 	if (vm.count("perf-syntax"))
-		wssPerfData << "\"" << vm["perf-syntax"].as<std::wstring>() << "\"=";
+		wssPerfData << "'" << vm["perf-syntax"].as<std::wstring>() << "'=";
 	else
-		wssPerfData << "\"" << pi.wsFullPath << "\"=";
+		wssPerfData << "'" << pi.wsFullPath << "'=";
 
 	wssPerfData << pi.dValue << ';' << pi.tWarn.pString() << ';' << pi.tCrit.pString() << ";;";
 
 	if (pi.tCrit.rend(pi.dValue)) {
-		std::wcout << "PERFMON CRITICAL \"" << (vm.count("perf-syntax") ? vm["perf-syntax"].as<std::wstring>() : pi.wsFullPath)
-			<< "\" = " << pi.dValue << " | " << wssPerfData.str() << '\n';
+		std::wcout << "PERFMON CRITICAL for '" << (vm.count("perf-syntax") ? vm["perf-syntax"].as<std::wstring>() : pi.wsFullPath)
+			<< "' = " << pi.dValue << " | " << wssPerfData.str() << "\n";
 		return 2;
 	}
 
 	if (pi.tWarn.rend(pi.dValue)) {
-		std::wcout << "PERFMON WARNING \"" << (vm.count("perf-syntax") ? vm["perf-syntax"].as<std::wstring>() : pi.wsFullPath)
-			<< "\" = " << pi.dValue << " | " << wssPerfData.str() << '\n';
+		std::wcout << "PERFMON WARNING for '" << (vm.count("perf-syntax") ? vm["perf-syntax"].as<std::wstring>() : pi.wsFullPath)
+			<< "' = " << pi.dValue << " | " << wssPerfData.str() << "\n";
 		return 1;
 	}
 
-	std::wcout << "PERFMON OK \"" << (vm.count("perf-syntax") ? vm["perf-syntax"].as<std::wstring>() : pi.wsFullPath)
-		<< "\" = " << pi.dValue << " | " << wssPerfData.str() << '\n';
+	std::wcout << "PERFMON OK for '" << (vm.count("perf-syntax") ? vm["perf-syntax"].as<std::wstring>() : pi.wsFullPath)
+		<< "' = " << pi.dValue << " | " << wssPerfData.str() << "\n";
+
 	return 0;
 }
 

--- a/plugins/check_service.cpp
+++ b/plugins/check_service.cpp
@@ -124,7 +124,7 @@ static int printOutput(const printInfoStruct& printInfo)
 	state state = OK;
 
 	if (!printInfo.ServiceState) {
-		std::wcout << L"SERVICE CRITICAL NOTFOUND | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
+		std::wcout << L"SERVICE CRITICAL NOT FOUND | 'service'=" << printInfo.ServiceState << ";;;1;7" << '\n';
 		return 3;
 	}
 
@@ -133,13 +133,13 @@ static int printOutput(const printInfoStruct& printInfo)
 
 	switch (state) {
 	case OK:
-		std::wcout << L"SERVICE \"" << printInfo.service << "\" OK RUNNING | service=4;;;1;7" << '\n';
+		std::wcout << L"SERVICE \"" << printInfo.service << "\" OK RUNNING | 'service'=4;;;1;7" << '\n';
 		break;
 	case WARNING:
-		std::wcout << L"SERVICE \"" << printInfo.service << "\" WARNING NOT RUNNING | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
+		std::wcout << L"SERVICE \"" << printInfo.service << "\" WARNING NOT RUNNING | 'service'=" << printInfo.ServiceState << ";;;1;7" << '\n';
 		break;
 	case CRITICAL:
-		std::wcout << L"SERVICE \"" << printInfo.service << "\" CRITICAL NOT RUNNING | service=" << printInfo.ServiceState << ";;;1;7" << '\n';
+		std::wcout << L"SERVICE \"" << printInfo.service << "\" CRITICAL NOT RUNNING | 'service'=" << printInfo.ServiceState << ";;;1;7" << '\n';
 		break;
 	}
 

--- a/plugins/check_swap.cpp
+++ b/plugins/check_swap.cpp
@@ -166,17 +166,17 @@ static int printOutput(printInfoStruct& printInfo)
 
 	switch (state) {
 	case OK:
-		std::wcout << L"SWAP OK - " << printInfo.percentFree << L"% free | swap=" << printInfo.aSwap << BunitStr(printInfo.unit) << L";"
+		std::wcout << L"SWAP OK - " << printInfo.percentFree << L"% free | 'swap'=" << printInfo.aSwap << BunitStr(printInfo.unit) << L";"
 			<< printInfo.warn.pString(printInfo.tSwap) << L";" << printInfo.crit.pString(printInfo.tSwap)
 			<< L";0;" << printInfo.tSwap << '\n';
 		break;
 	case WARNING:
-		std::wcout << L"SWAP WARNING - " << printInfo.percentFree << L"% free | swap=" << printInfo.aSwap << BunitStr(printInfo.unit) << L";"
+		std::wcout << L"SWAP WARNING - " << printInfo.percentFree << L"% free | 'swap'=" << printInfo.aSwap << BunitStr(printInfo.unit) << L";"
 			<< printInfo.warn.pString(printInfo.tSwap) << L";" << printInfo.crit.pString(printInfo.tSwap)
 			<< L";0;" << printInfo.tSwap << '\n';
 		break;
 	case CRITICAL:
-		std::wcout << L"SWAP CRITICAL - " << printInfo.percentFree << L"% free | swap=" << printInfo.aSwap << BunitStr(printInfo.unit) << L";"
+		std::wcout << L"SWAP CRITICAL - " << printInfo.percentFree << L"% free | 'swap'=" << printInfo.aSwap << BunitStr(printInfo.unit) << L";"
 			<< printInfo.warn.pString(printInfo.tSwap) << L";" << printInfo.crit.pString(printInfo.tSwap)
 			<< L";0;" << printInfo.tSwap << '\n';
 		break;

--- a/plugins/check_update.cpp
+++ b/plugins/check_update.cpp
@@ -149,7 +149,7 @@ static int printOutput(const printInfoStruct& printInfo)
 		break;
 	}
 
-	std::wcout << output << printInfo.numUpdates << L" | update=" << printInfo.numUpdates << L";"
+	std::wcout << output << printInfo.numUpdates << L" | 'update'=" << printInfo.numUpdates << L";"
 		<< printInfo.warn << L";" << printInfo.crit << L";0;" << '\n';
 
 	return state;

--- a/plugins/check_uptime.cpp
+++ b/plugins/check_uptime.cpp
@@ -166,17 +166,17 @@ static int printOutput(printInfoStruct& printInfo)
 
 	switch (state) {
 	case OK:
-		std::wcout << L"UPTIME OK " << printInfo.time << TunitStr(printInfo.unit) << L" | uptime=" << printInfo.time
+		std::wcout << L"UPTIME OK " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.time
 			<< TunitStr(printInfo.unit) << L";" << printInfo.warn.pString() << L";"
 			<< printInfo.crit.pString() << L";0;" << '\n';
 		break;
 	case WARNING:
-		std::wcout << L"UPTIME WARNING " << printInfo.time << TunitStr(printInfo.unit) << L" | uptime=" << printInfo.time
+		std::wcout << L"UPTIME WARNING " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.time
 			<< TunitStr(printInfo.unit) << L";" << printInfo.warn.pString() << L";"
 			<< printInfo.crit.pString() << L";0;" << '\n';
 		break;
 	case CRITICAL:
-		std::wcout << L"UPTIME CRITICAL " << printInfo.time << TunitStr(printInfo.unit) << L" | uptime=" << printInfo.time
+		std::wcout << L"UPTIME CRITICAL " << printInfo.time << TunitStr(printInfo.unit) << L" | 'uptime'=" << printInfo.time
 			<< TunitStr(printInfo.unit) << L";" << printInfo.warn.pString() << L";"
 			<< printInfo.crit.pString() << L";0;" << '\n';
 		break;

--- a/plugins/check_users.cpp
+++ b/plugins/check_users.cpp
@@ -151,15 +151,15 @@ static int printOutput(printInfoStruct& printInfo)
 
 	switch (state) {
 	case OK:
-		std::wcout << L"USERS OK " << printInfo.users << L" User(s) logged in | users=" << printInfo.users << L";"
+		std::wcout << L"USERS OK " << printInfo.users << L" User(s) logged in | 'users'=" << printInfo.users << L";"
 			<< printInfo.warn.pString() << L";" << printInfo.crit.pString() << L";0;" << '\n';
 		break;
 	case WARNING:
-		std::wcout << L"USERS WARNING " << printInfo.users << L" User(s) logged in | users=" << printInfo.users << L";"
+		std::wcout << L"USERS WARNING " << printInfo.users << L" User(s) logged in | 'users'=" << printInfo.users << L";"
 			<< printInfo.warn.pString() << L";" << printInfo.crit.pString() << L";0;" << '\n';
 		break;
 	case CRITICAL:
-		std::wcout << L"USERS CRITICAL " << printInfo.users << L" User(s) logged in | users=" << printInfo.users << L";"
+		std::wcout << L"USERS CRITICAL " << printInfo.users << L" User(s) logged in | 'users'=" << printInfo.users << L";"
 			<< printInfo.warn.pString() << L";" << printInfo.crit.pString() << L";0;" << '\n';
 		break;
 	}


### PR DESCRIPTION
Single quotes are allowed, double quotes are not. This is also required if one overrides perf-syntax in check_perfmon.exe

This PR modifies all Windows plugins to use single quotes, thus all of them should be tested.

# Before

```
C:\Program Files (x86)\icinga2\sbin>check_perfmon.exe -P "\prozessor(_total)\prozessorzeit (%)" --perf-syntax "processor_total_time"
PERFMON OK "processor_total_time" = 4.62368 | "processor_total_time"=4.62368;;;;
```

# After

```
C:\Users\michi\source\repos\icinga2\Bin\Debug\Debug>check_perfmon.exe -P "\prozessor(_total)\prozessorzeit (%)" --perf-syntax "processor_total_time"
PERFMON OK for 'processor_total_time' = 0.807653 | 'processor_total_time'=0.807653;;;;
```