### PR TITLE
Fix output formatting in windows plugins

### DIFF
--- a/plugins/check_memory.cpp
+++ b/plugins/check_memory.cpp
@@ -189,7 +189,7 @@ static int printOutput(printInfoStruct& printInfo)
 
 	std::wcout << "| memory=" << currentValue << BunitStr(printInfo.unit) << L";"
 		<< printInfo.warn.pString(printInfo.tRam) << L";" << printInfo.crit.pString(printInfo.tRam)
-		<< L";0;" << printInfo.tRam;
+		<< L";0;" << printInfo.tRam << '\n';
 
 	return state;
 }

--- a/plugins/check_ping.cpp
+++ b/plugins/check_ping.cpp
@@ -264,7 +264,7 @@ static bool resolveHostname(const std::wstring& hostname, bool ipv6, std::wstrin
 	DWORD ret = GetAddrInfoW(hostname.c_str(), NULL, &hints, &result);
 
 	if (ret) {
-		std::cout << "Failed to resolve hostname. Winsock Error Code: " << ret << '\n';
+		std::wcout << L"Failed to resolve hostname. Error " << ret << L": " << formatErrorInfo(ret) << L"\n";
 		return false;
 	}
 

--- a/plugins/thresholds.cpp
+++ b/plugins/thresholds.cpp
@@ -223,7 +223,26 @@ void printErrorInfo(unsigned long err)
 	LPWSTR mBuf = NULL;
 	if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 		NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&mBuf, 0, NULL))
-			std::wcout << "Failed to format error message, last error was: " << err << '\n';
-	else
+		std::wcout << "Failed to format error message, last error was: " << err << '\n';
+	else {
+		boost::trim_right(std::wstring(mBuf));
 		std::wcout << mBuf << std::endl;
+	}
+}
+
+std::wstring formatErrorInfo(unsigned long err) {
+	std::wostringstream out;
+	if (!err)
+		err = GetLastError();
+	LPWSTR mBuf = NULL;
+	if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&mBuf, 0, NULL))
+		out << "Failed to format error message, last error was: " << err;
+	else {
+		std::wstring tempOut = std::wstring(mBuf);
+		boost::trim_right(tempOut);
+		out << tempOut;
+	}
+
+	return out.str();
 }

--- a/plugins/thresholds.hpp
+++ b/plugins/thresholds.hpp
@@ -73,5 +73,6 @@ Tunit parseTUnit(const std::wstring&);
 std::wstring TunitStr(const Tunit&);
 
 void printErrorInfo(unsigned long err = 0);
+std::wstring formatErrorInfo(unsigned long err);
 
 #endif /* THRESHOLDS_H */


### PR DESCRIPTION
Adds a newline to check_memory and check_ping now looks up and prints
error messages when host resolution fails.

refs #6411