### PR TITLE
Add support for using the 'in' operator for substring checks

### DIFF
--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -179,8 +179,8 @@ Operator | Precedence | Examples (Result)                             | Descript
 >        | 6         | 3 > 5 (false)                                 | Greater than
 <=       | 6         | 3 <= 3 (true)                                 | Less than or equal
 >=       | 6         | 3 >= 3 (true)                                 | Greater than or equal
-in       | 7          | "foo" in [ "foo", "bar" ] (true)              | Element contained in array
-!in      | 7          | "foo" !in [ "bar", "baz" ] (true)             | Element not contained in array
+in       | 7          | "foo" in [ "foo", "bar" ] (true)              | Element contained in array or string
+!in      | 7          | "foo" !in [ "bar", "baz" ] (true)             | Element not contained in array or string
 ==       | 8         | "hello" == "hello" (true), 3 == 5 (false)     | Equal to
 !=       | 8         | "hello" != "world" (true), 3 != 3 (false)     | Not equal to
 &        | 9          | 7 & 3 (3)                                     | Binary AND

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -355,14 +355,21 @@ ExpressionResult InExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhint) 
 
 	if (operand2.GetValue().IsEmpty())
 		return false;
-	else if (!operand2.GetValue().IsObjectType<Array>())
+	else if (!operand2.GetValue().IsObjectType<Array>() && !operand2.GetValue().IsString())
 		BOOST_THROW_EXCEPTION(ScriptError("Invalid right side argument for 'in' operator: " + JsonEncode(operand2.GetValue()), m_DebugInfo));
 
 	ExpressionResult operand1 = m_Operand1->Evaluate(frame);
 	CHECK_RESULT(operand1)
 
-	Array::Ptr arr = operand2.GetValue();
-	return arr->Contains(operand1.GetValue());
+	Value rhs = operand2.GetValue();
+
+	if (rhs.IsObjectType<Array>()) {
+		Array::Ptr arr = rhs;
+		return arr->Contains(operand1.GetValue());
+	} else {
+		String str = rhs;
+		return str.Find(operand1.GetValue()) != String::NPos;
+	}
 }
 
 ExpressionResult NotInExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const
@@ -372,14 +379,21 @@ ExpressionResult NotInExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhin
 
 	if (operand2.GetValue().IsEmpty())
 		return true;
-	else if (!operand2.GetValue().IsObjectType<Array>())
+	else if (!operand2.GetValue().IsObjectType<Array>() && !operand2.GetValue().IsString())
 		BOOST_THROW_EXCEPTION(ScriptError("Invalid right side argument for 'in' operator: " + JsonEncode(operand2.GetValue()), m_DebugInfo));
 
 	ExpressionResult operand1 = m_Operand1->Evaluate(frame);
 	CHECK_RESULT(operand1);
 
-	Array::Ptr arr = operand2.GetValue();
-	return !arr->Contains(operand1.GetValue());
+	Value rhs = operand2.GetValue();
+
+	if (rhs.IsObjectType<Array>()) {
+		Array::Ptr arr = rhs;
+		return !arr->Contains(operand1.GetValue());
+	} else {
+		String str = rhs;
+		return str.Find(operand1.GetValue()) == String::NPos;
+	}
 }
 
 ExpressionResult LogicalAndExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const

--- a/test/config-ops.cpp
+++ b/test/config-ops.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(simple)
 	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
 
 	expr = ConfigCompiler::CompileText("<test>", R"("foo" in "bar")");
-	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
+	BOOST_CHECK(!expr->Evaluate(frame).GetValue());
 
 	expr = ConfigCompiler::CompileText("<test>", R"("foo" !in [ "bar", "baz" ])");
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(simple)
 	BOOST_CHECK(expr->Evaluate(frame).GetValue());
 
 	expr = ConfigCompiler::CompileText("<test>", R"("foo" !in "bar")");
-	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
+	BOOST_CHECK(expr->Evaluate(frame).GetValue());
 
 	expr = ConfigCompiler::CompileText("<test>", "{ a += 3 }");
 	dict = expr->Evaluate(frame).GetValue();


### PR DESCRIPTION
This implements string support for the `in` and `!in` operators:

```
gunnar@abyss ~/icinga2 (feature/operator-in-for-strings) $ icinga2 console
Icinga 2 (version: v2.8.4-797-g73f69e89d)
Type $help to view available commands.
<1> => "test" in "testtest"
true
<2> => ^D
```