### PR TITLE
Fix negative 'empty in' value in WorkQueue log message

### DIFF
--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -24,6 +24,7 @@
 #include "base/application.hpp"
 #include "base/exception.hpp"
 #include <boost/thread/tss.hpp>
+#include <math.h>
 
 using namespace icinga;
 
@@ -221,7 +222,7 @@ void WorkQueue::StatusTimerHandler()
 
 	if (pending > GetTaskCount(5)) {
 		timeInfo = " empty in ";
-		if (timeToZero < 0)
+		if (timeToZero < 0 || std::isinf(timeToZero))
 			timeInfo += "infinite time, your task handler isn't able to keep up";
 		else
 			timeInfo += Utility::FormatDuration(timeToZero);


### PR DESCRIPTION
This fixes a negative 'empty in' value in WorkQueue log messages.

```
[2018-07-10 18:40:42 +0200] information/WorkQueue: #5 (IdoPgsqlConnection, ido-pgsql) items: 1000000, rate: 564.85/s (33891/min 162508/5min 162508/15min); empty in -2147483648 days
```
**Problem:**

The problematic log message occurs when you have a heavy load on your IDO database and the task handler can't keep up. 

The 'empty in' value is negative due to a division by zero in workqueue.cpp:218.

```
double gradient = (pending - m_PendingTasks) / (now - m_PendingTasksTimestamp);
double timeToZero = pending / gradient;
```

In some cases `pending` and `m_PendingTasks` are equal, which leads to an infinite `timeToZero` variable.

```
Thread 63 "icinga2" hit Breakpoint 2, icinga::WorkQueue::StatusTimerHandler (this=0x7fffd007d470) at /srv/icinga2/lib/base/workqueue.cpp:222
222		if (pending > GetTaskCount(5)) {
(gdb) l 
217		double gradient = (pending - m_PendingTasks) / (now - m_PendingTasksTimestamp);
218		double timeToZero = pending / gradient;
219	
220		String timeInfo;
221	
222		if (pending > GetTaskCount(5)) {
223			timeInfo = " empty in ";
224			if (timeToZero < 0)
225				timeInfo += "infinite time, your task handler isn't able to keep up";
226			else
(gdb) p gradient
$1 = 0
(gdb) p timeToZero
$2 = inf
(gdb) p pending 
$3 = 1000000
(gdb) p m_PendingTasks
$4 = 1000000
```  
**Fix:**

This fix handle a infinite `timeToZero` variable and output's the appropriate log message. 

```
[2018-07-10 18:54:39 +0200] information/WorkQueue: #5 (IdoPgsqlConnection, ido-pgsql) items: 1000000, rate: 1531/s (91860/min 306716/5min 306716/15min); empty in infinite time, your task handler isn't able to keep up
```