### PR TITLE
Revert "Fix obsolete parameter in Systemd script"

### DIFF
--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -5,10 +5,10 @@ After=syslog.target network-online.target postgresql.service mariadb.service car
 [Service]
 Type=notify
 EnvironmentFile=@ICINGA2_SYSCONFIGFILE@
-ExecStartPre=@CMAKE_INSTALL_PREFIX@/lib/icinga2/prepare-dirs
+ExecStartPre=@CMAKE_INSTALL_PREFIX@/lib/icinga2/prepare-dirs @ICINGA2_SYSCONFIGFILE@
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/icinga2 daemon -e ${ICINGA2_ERROR_LOG}
 PIDFile=@ICINGA2_RUNDIR@/icinga2/icinga2.pid
-ExecReload=@CMAKE_INSTALL_PREFIX@/lib/icinga2/safe-reload
+ExecReload=@CMAKE_INSTALL_PREFIX@/lib/icinga2/safe-reload @ICINGA2_SYSCONFIGFILE@
 TimeoutStartSec=30m
 
 # Systemd >228 enforces a lower process number for services.


### PR DESCRIPTION
This reverts commit 592fb22c7fe4d291e630a2b6126312d088ce60d7.

We have the problem that Systemd doesn't expand shell variables
into our environment.

During the upgrade cycle this would maybe render a wrong PID file
location, thus resulting in wrong 'safe-reload' behaviour.

This is only for a clean upgrade path from 2.8.x to 2.9.0,
the proper fix is to ensure that the sysconfig file is empty
and keep our own defaults, or modified from the user.

refs #6434