### PR TITLE
Keep notes for immediately log flushing

### DIFF
--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -238,6 +238,11 @@ Log::~Log()
 
 		if (entry.Severity >= logger->GetMinSeverity())
 			logger->ProcessLogEntry(entry);
+
+#ifdef I2_DEBUG /* I2_DEBUG */
+		/* Always flush, don't depend on the timer. Enable this for development sprints. */
+		//logger->Flush();
+#endif /* I2_DEBUG */
 	}
 
 	if (Logger::IsConsoleLogEnabled() && entry.Severity >= Logger::GetConsoleLogSeverity())


### PR DESCRIPTION
Disabled, but kept for future debugging sessions.
Helps with things like #6455