### PR TITLE
Fix Windows Agent resize behavior

### DIFF
--- a/agent/windows-setup-agent/SetupWizard.Designer.cs
+++ b/agent/windows-setup-agent/SetupWizard.Designer.cs
@@ -746,7 +746,7 @@
 			this.tabError.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)(this.picBanner)).EndInit();
 			this.ResumeLayout(false);
-
+			this.Load += new System.EventHandler(this.SetupWizard_Load);
 		}
 
 		#endregion

--- a/agent/windows-setup-agent/SetupWizard.cs
+++ b/agent/windows-setup-agent/SetupWizard.cs
@@ -576,6 +576,12 @@ namespace Icinga
 		{
 
 		}
+
+		private void SetupWizard_Load(object sender, EventArgs e)
+		{
+			this.MinimumSize = this.Size;
+			this.MaximumSize = this.Size;
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes the Windows Agent behavior when resizing.

![devel-win10-icinga2 wird ausgefuhrt - oracle vm virtualbox_002](https://user-images.githubusercontent.com/18580278/43022603-15a9ad82-8c68-11e8-97d3-f59f821f0e70.png)

![devel-win10-icinga2 wird ausgefuhrt - oracle vm virtualbox_005](https://user-images.githubusercontent.com/18580278/43022620-246bce68-8c68-11e8-803d-af67e4db1fa7.png)

![devel-win10-icinga2 wird ausgefuhrt - oracle vm virtualbox_006](https://user-images.githubusercontent.com/18580278/43022625-271f9e50-8c68-11e8-9cf1-eea4033bd18f.png)

fixes #4959