### PR TITLE
Fix spelling errors.

### DIFF
--- a/lib/base/socket.cpp
+++ b/lib/base/socket.cpp
@@ -94,7 +94,7 @@ void Socket::Close()
 }
 
 /**
- * Retrieves the last error that occured for the socket.
+ * Retrieves the last error that occurred for the socket.
  *
  * @returns An error code.
  */

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -221,7 +221,7 @@ void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable)
 		CheckResult::Ptr cr = new CheckResult();
 		cr->SetState(ServiceUnknown);
 
-		String output = "Exception occured while checking '" + checkable->GetName() + "': " + DiagnosticInformation(ex);
+		String output = "Exception occurred while checking '" + checkable->GetName() + "': " + DiagnosticInformation(ex);
 		cr->SetOutput(output);
 
 		double now = Utility::GetTime();

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -262,7 +262,7 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 			NodeUtility::UpdateConfiguration("\"conf.d/api-users.conf\"", true, false);
 		} else {
 			Log(LogWarning, "cli")
-				<< "Included file dosen't exist " << apiUsersFilePath;
+				<< "Included file doesn't exist " << apiUsersFilePath;
 		}
 	}
 

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -293,7 +293,7 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 	bool send_notification = false;
 
 	if (notification_reachable && !in_downtime && !IsAcknowledged()) {
-		/* Send notifications whether when a hard state change occured. */
+		/* Send notifications whether when a hard state change occurred. */
 		if (hardChange && !(old_stateType == StateTypeSoft && IsStateOK(new_state)))
 			send_notification = true;
 		/* Or if the checkable is volatile and in a HARD state. */

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -76,7 +76,7 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 				notification->BeginExecuteNotification(type, cr, force, false, author, text);
 		} catch (const std::exception& ex) {
 			Log(LogWarning, "Checkable")
-				<< "Exception occured during notification for service '"
+				<< "Exception occurred during notification for service '"
 				<< GetName() << "': " << DiagnosticInformation(ex);
 		}
 	}

--- a/lib/icinga/clusterevents-check.cpp
+++ b/lib/icinga/clusterevents-check.cpp
@@ -179,7 +179,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 			CheckResult::Ptr cr = new CheckResult();
 			cr->SetState(ServiceUnknown);
 
-			String output = "Exception occured while checking '" + host->GetName() + "': " + DiagnosticInformation(ex);
+			String output = "Exception occurred while checking '" + host->GetName() + "': " + DiagnosticInformation(ex);
 			cr->SetOutput(output);
 
 			double now = Utility::GetTime();

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -524,7 +524,7 @@ void Notification::ExecuteNotificationHelper(NotificationType type, const User::
 			<< "' and user '" << user->GetName() << "'.";
 	} catch (const std::exception& ex) {
 		Log(LogWarning, "Notification")
-			<< "Exception occured during notification for checkable '"
+			<< "Exception occurred during notification for checkable '"
 			<< GetCheckable()->GetName() << "': " << DiagnosticInformation(ex);
 	}
 }

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -130,7 +130,7 @@ void NotificationComponent::NotificationTimerHandler()
 			notification->BeginExecuteNotification(NotificationProblem, checkable->GetLastCheckResult(), false, true);
 		} catch (const std::exception& ex) {
 			Log(LogWarning, "NotificationComponent")
-				<< "Exception occured during notification for object '"
+				<< "Exception occurred during notification for object '"
 				<< GetName() << "': " << DiagnosticInformation(ex);
 		}
 	}

--- a/third-party/yajl/src/api/yajl_parse.h
+++ b/third-party/yajl/src/api/yajl_parse.h
@@ -35,7 +35,7 @@ extern "C" {
         yajl_status_ok,
         /** a client callback returned zero, stopping the parse */
         yajl_status_client_canceled,
-        /** An error occured during the parse.  Call yajl_get_error for
+        /** An error occurred during the parse.  Call yajl_get_error for
          *  more information about the encountered error */
         yajl_status_error
     } yajl_status;
@@ -192,7 +192,7 @@ extern "C" {
      *  parse.
      *
      *  If verbose is non-zero, the message will include the JSON
-     *  text where the error occured, along with an arrow pointing to
+     *  text where the error occurred, along with an arrow pointing to
      *  the specific char.
      *
      *  \returns A dynamically allocated string will be returned which should
@@ -211,7 +211,7 @@ extern "C" {
      *
      * In the event an error is encountered during parsing, this function
      * affords the client a way to get the offset into the most recent
-     * chunk where the error occured.  0 will be returned if no error
+     * chunk where the error occurred.  0 will be returned if no error
      * was encountered.
      */
     YAJL_API size_t yajl_get_bytes_consumed(yajl_handle hand);


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the 2.9.0 Debian package build:

 * occured -> occurred
 * dosen't -> doesn't