### PR TITLE
Fix problem when adding endpoint through API

### DIFF
--- a/lib/remote/endpoint.hpp
+++ b/lib/remote/endpoint.hpp
@@ -67,6 +67,7 @@ public:
 	double GetBytesReceivedPerSecond() const override;
 
 protected:
+	void Stop(bool runtimeRemoved) override;
 	void OnAllConfigLoaded() override;
 
 private:

--- a/lib/remote/zone.cpp
+++ b/lib/remote/zone.cpp
@@ -86,6 +86,62 @@ std::set<Endpoint::Ptr> Zone::GetEndpoints() const
 	return result;
 }
 
+void Zone::AddEndpoint(const Endpoint::Ptr& endpoint)
+{
+	if (IsGlobal()) {
+		BOOST_THROW_EXCEPTION(ScriptError("Endpoint '"
+			+ endpoint->GetName() + "' cannot be added to global zone '"
+			+ GetName() + "'.", GetDebugInfo()));
+	}
+
+	Array::Ptr endpoints = GetEndpointsRaw();
+
+	if (!endpoints) {
+		endpoints = new Array();
+		SetEndpointsRaw(endpoints);
+	}
+
+	{
+		ObjectLock olock(endpoints);
+
+		for (const String& name : endpoints) {
+			if (name == endpoint->GetName()) {
+				BOOST_THROW_EXCEPTION(ScriptError("Endpoint '"
+					+ endpoint->GetName() + "' already belongs to zone '"
+					+ GetName() + "'.", GetDebugInfo()));
+			}
+		}
+
+		endpoints->Add(endpoint->GetName());
+		endpoint->SetCachedZone(this);
+	}
+}
+
+void Zone::RemoveEndpoint(const Endpoint::Ptr& endpoint)
+{
+	Array::Ptr endpoints = GetEndpointsRaw();
+
+	if (!endpoints) {
+		BOOST_THROW_EXCEPTION(ScriptError("Endpoint '" + endpoint->GetName()
+			+ "' cannot be removed from because zone '" + GetName()
+			+ "' has no endpoints.", GetDebugInfo()));
+	}
+
+	{
+
+		ObjectLock olock(endpoints);
+
+		auto it = endpoints->Begin();
+		for (const String& name : endpoints) {
+			if (endpoint->GetName() == name) {
+				endpoints->Remove(it);
+				return;
+			}
+			it++;
+		}
+	}
+}
+
 std::vector<Zone::Ptr> Zone::GetAllParents() const
 {
 	return m_AllParents;

--- a/lib/remote/zone.hpp
+++ b/lib/remote/zone.hpp
@@ -42,6 +42,9 @@ public:
 	std::set<Endpoint::Ptr> GetEndpoints() const;
 	std::vector<Zone::Ptr> GetAllParents() const;
 
+	void AddEndpoint(const Endpoint::Ptr& endpoint);
+	void RemoveEndpoint(const Endpoint::Ptr& endpoint);
+
 	bool CanAccessObject(const ConfigObject::Ptr& object);
 	bool IsChildOf(const Zone::Ptr& zone);
 	bool IsGlobal() const;


### PR DESCRIPTION
Adding endpoint through API would cause exception.  Zone objects can be created through API without specifying 'endpoints' attribute.  This change, in order to allow Endpoint objects to be added through API, makes use of Endpoint 'zone' attribute to first establish Endpoint <-> Zone relationship and then set its value to proper zone.  In other words, Endpoint 'zone' attribute value is initially used to add the Endpoint to Zone with specified name (ie: Endpoint is now part of Zones 'endpoints').  Once Endpoint is added to Zone, the value of Endpoints 'zone' attribute is set to its Zone 'parent'.  This way. Endpoints (and zones) can be added to master (for use on master) or through master to configure satellite(s).


Here is an example when following conditions are met:

  - master: has master zone/endpoint, does not know about the satellite or client
  - satellite: has satellite zone/endpoint and master zone/endpoint
  - client: has satellite zone/endpoint and client zone/endpoint (no master)


* Add satellite (or client) on master:

```
curl -k -s -u $USER:$PASSWD --request PUT \
  --url https://master:5665/v1/objects/zones/satellite \
  --header 'accept: application/json' \
  --data '{"attrs": {"__name": "satellite", "parent": "master"}}'

curl -k -s -u $USER:$PASSWD --request PUT \
  --url https://master:5665/v1/objects/endpoints/satellite1 \
  --header 'accept: application/json' \
  --data '{"attrs": {"__name": "satellite1", "host": "satellite1", "port": "5665", "zone": "satellite"}}'

```

Node that Endpoint 'satellite1' zone attribute value is set to 'satellite' and not 'master'.  The Endpoint itself will be added to Zone 'satellite' as its endpoint.  Internally, Endpoint zone value will be set to 'master' (its zones parent) where it is meant to reside.

* Add client zone and endpoint(s) to satellite through master:

```
curl -k -s -u $USER:$PASSWD --request PUT \
  --url https://master:5665/v1/objects/zones/client \
  --header 'accept: application/json' \
  --data '{"attrs": {"__name": "client", "parent": "satellite", "zone": "satellite"}}'

curl -k -s -u $USER:$PASSWD --request PUT \
  --url https://master:5665/v1/objects/endpoints/client1 \
  --header 'accept: application/json' \
  --data '{"attrs": {"__name": "client1", "host": "client1", "port": "5665", "zone": "client"}}'

```

Again, Endpoint 'client1' zone value is set to 'client' and not 'satellite' (it will be added to Zone 'client' as its endpoint).  Internally, this value will be set to 'satellite' where sync() is supposed to send it to.


* Add more clients to 'client' zone which will configure satellite 'satellite1':

```
curl -k -s -u $USER:$PASSWD --request PUT \
  --url https://master:5665/v1/objects/endpoints/client2 \
  --header 'accept: application/json' \
  --data '{"attrs": {"__name": "client2", "host": "client2", "port": "5665", "zone": "client"}}'

```

refs #3823