### PR TITLE
Implement the Dictionary#clear script function

### DIFF
--- a/doc/18-library-reference.md
+++ b/doc/18-library-reference.md
@@ -1428,6 +1428,14 @@ Signature:
 Removes the item with the specified `key`. Trying to remove an item which does not exist
 is a no-op.
 
+### Dictionary#clear <a id="dictionary-clear"></a>
+
+Signature:
+
+    function clear();
+
+Removes all items from the dictionary.
+
 ### Dictionary#set <a id="dictionary-set"></a>
 
 Signature:

--- a/lib/base/dictionary-script.cpp
+++ b/lib/base/dictionary-script.cpp
@@ -57,6 +57,14 @@ static void DictionaryRemove(const String& key)
 	self->Remove(key);
 }
 
+static void DictionaryClear()
+{
+	ScriptFrame *vframe = ScriptFrame::GetCurrentFrame();
+	Dictionary::Ptr self = static_cast<Dictionary::Ptr>(vframe->Self);
+	REQUIRE_NOT_NULL(self);
+	self->Clear();
+}
+
 static bool DictionaryContains(const String& key)
 {
 	ScriptFrame *vframe = ScriptFrame::GetCurrentFrame();
@@ -115,6 +123,7 @@ Object::Ptr Dictionary::GetPrototype()
 		{ "set", new Function("Dictionary#set", DictionarySet, { "key", "value" }) },
 		{ "get", new Function("Dictionary#get", DictionaryGet, { "key" }) },
 		{ "remove", new Function("Dictionary#remove", DictionaryRemove, { "key" }) },
+		{ "clear", new Function("Dictionary#clear", DictionaryClear, {}) },
 		{ "contains", new Function("Dictionary#contains", DictionaryContains, { "key" }, true) },
 		{ "shallow_clone", new Function("Dictionary#shallow_clone", DictionaryShallowClone, {}, true) },
 		{ "keys", new Function("Dictionary#keys", DictionaryKeys, {}, true) },


### PR DESCRIPTION
This adds a new user-accessible method to the Dictionary class: `clear`

Like the name suggests this method removes all items from a dictionary.