### PR TITLE
Reset terminal on erroneous console exit

### DIFF
--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -533,9 +533,10 @@ void ConsoleCommand::ExecuteScriptCompletionHandler(boost::mutex& mutex, boost::
 			Log(LogCritical, "ConsoleCommand")
 				<< "HTTP query failed: " << ex.what();
 
+#ifdef HAVE_EDITLINE
 			/* Ensures that the terminal state is resetted */
 			rl_deprep_terminal();
-
+#endif /* HAVE_EDITLINE */
 
 			Application::Exit(EXIT_FAILURE);
 		}
@@ -560,8 +561,10 @@ void ConsoleCommand::AutocompleteScriptCompletionHandler(boost::mutex& mutex, bo
 			Log(LogCritical, "ConsoleCommand")
 				<< "HTTP query failed: " << ex.what();
 
+#ifdef HAVE_EDITLINE
 			/* Ensures that the terminal state is resetted */
 			rl_deprep_terminal();
+#endif /* HAVE_EDITLINE */
 
 			Application::Exit(EXIT_FAILURE);
 		}

--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -532,6 +532,11 @@ void ConsoleCommand::ExecuteScriptCompletionHandler(boost::mutex& mutex, boost::
 		} catch (const std::exception& ex) {
 			Log(LogCritical, "ConsoleCommand")
 				<< "HTTP query failed: " << ex.what();
+
+			/* Ensures that the terminal state is resetted */
+			rl_deprep_terminal();
+
+
 			Application::Exit(EXIT_FAILURE);
 		}
 	}
@@ -554,6 +559,10 @@ void ConsoleCommand::AutocompleteScriptCompletionHandler(boost::mutex& mutex, bo
 		} catch (const std::exception& ex) {
 			Log(LogCritical, "ConsoleCommand")
 				<< "HTTP query failed: " << ex.what();
+
+			/* Ensures that the terminal state is resetted */
+			rl_deprep_terminal();
+
 			Application::Exit(EXIT_FAILURE);
 		}
 	}

--- a/lib/cli/editline.hpp
+++ b/lib/cli/editline.hpp
@@ -24,6 +24,7 @@ extern "C" {
 
 char *readline(const char *prompt);
 int add_history(const char *line);
+void rl_deprep_terminal();
 
 typedef char *ELFunction(const char *, int);
 


### PR DESCRIPTION
This ensures that the terminal is reset on an erroneous exit when using the Icinga 2 console. The problematic state only occurs if Icinga 2 is compiled with `libedit` support.

## Test

1. Start the Icinga 2 console and choose an invalid port.

```
metis ~/Coding/icinga/icinga2/build_debug (fix/erroneous-console-exit) # /home/michael/bin/icinga2/sbin/icinga2 console --connect https://localhost:9999/
Icinga 2 (version: v2.9.1-50-g51b900b30)
Type $help to view available commands.
<1> =>
```

2. Now hit the _tab_ key. The console (correctly) terminates with an critical error because of the invalid port. 

```
metis ~/Coding/icinga/icinga2/build_debug (fix/erroneous-console-exit) # /home/michael/bin/icinga2/sbin/icinga2 console --connect https://localhost:9999/
Icinga 2 (version: v2.9.1-50-g51b900b30)
Type $help to view available commands.
<1> => critical/TcpSocket: Invalid socket: Connection refused
critical/ConsoleCommand: HTTP query failed: std::exception

```

3. Hit the _return_ key. 

```
metis ~/Coding/icinga/icinga2/build_debug (fix/erroneous-console-exit) # /home/michael/bin/icinga2/sbin/icinga2 console --connect https://localhost:9999/
Icinga 2 (version: v2.9.1-50-g51b900b30)
Type $help to view available commands.
<1> => critical/TcpSocket: Invalid socket: Connection refused
critical/ConsoleCommand: HTTP query failed: std::exception
metis ~/Coding/icinga/icinga2/build_debug (fix/erroneous-console-exit) #
```

4. The terminal stays intact.

fixes #6382