### PR TITLE
Acknowledgment notifications should only be send if problem notification has been send

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -1553,6 +1553,14 @@ send notifications to all group members.
 > Only users who have been notified of a problem before  (`Warning`, `Critical`, `Unknown`
 states for services, `Down` for hosts) will receive `Recovery` notifications.
 
+Icinga 2 v2.10 allows you to configure `Acknowledgement` and/or `Recovery`
+without a `Problem` notification. These notifications will be sent without
+any problem notifications beforehand, and can be used for e.g. ticket systems.
+
+```
+  types = [ Acknowledgement, Recovery ]
+```
+
 ### Notifications: Users from Host/Service <a id="alert-notifications-users-host-service"></a>
 
 A common pattern is to store the users and user groups

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -62,6 +62,31 @@ are counted as connected endpoints. A similar change is there for the performanc
 The attribute `child_options` was previously accepting 0,1,2 for specific child downtime settings.
 This behaviour stays intact, but the new proposed way are specific constants as values (`DowntimeNoChildren`, `DowntimeTriggeredChildren`, `DowntimeNonTriggeredChildren`).
 
+### Notifications: Recovery and Acknowledgement <a id="upgrading-to-2-10-notifications"></a>
+
+When a user should be notified on `Problem` and `Acknowledgement`, v2.10 now checks during
+the `Acknowledgement` notification event whether this user has been notified about a problem before.
+
+```
+  types = [ Problem, Acknowledgement, Recovery ]
+```
+
+If **no** `Problem` notification was sent, and the types filter includes problems for this user,
+the `Acknowledgement` notification is **not** sent.
+
+In contrast to that, the following configuration always sends `Acknowledgement` notifications.
+
+```
+  types = [ Acknowledgement, Recovery ]
+```
+
+This change also restores the old behaviour for `Recovery` notifications. The above configuration
+leaving out the `Problem` type can be used to only receive recovery notifications. If `Problem`
+is added to the types again, Icinga 2 checks whether it has notified a user of a problem when
+sending the recovery notification.
+
+More details can be found in [this PR](https://github.com/Icinga/icinga2/pull/6527).
+
 ## Upgrading to v2.9 <a id="upgrading-to-2-9"></a>
 
 ### Deprecation and Removal Notes <a id="upgrading-to-2-9-deprecation-removal-notes"></a>

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -402,7 +402,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		/* on recovery, check if user was notified before */
 		if (type == NotificationRecovery) {
-			if (!notifiedProblemUsers->Contains(userName)) {
+			if (!notifiedProblemUsers->Contains(userName) && CheckNotificationUserFilters(NotificationProblem, user, false, false)) {
 				Log(LogNotice, "Notification")
 					<< "We did not notify user '" << userName << "' for a problem before. Not sending recovery notification.";
 				continue;
@@ -411,7 +411,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		/* on acknowledgement, check if user was notified before */
 		if (type == NotificationAcknowledgement) {
-			if (!notifiedProblemUsers->Contains(userName)) {
+			if (!notifiedProblemUsers->Contains(userName) && CheckNotificationUserFilters(NotificationProblem, user, false, false)) {
 				Log(LogNotice, "Notification")
 						<< "We did not notify user '" << userName << "' for a problem before. Not sending acknowledgement notification.";
 				continue;

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -409,6 +409,15 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			}
 		}
 
+		/* on acknowledgement, check if user was notified before */
+		if (type == NotificationAcknowledgement) {
+			if (!notifiedProblemUsers->Contains(userName)) {
+				Log(LogNotice, "Notification")
+						<< "We did not notify user '" << userName << "' for a problem before. Not sending acknowledgement notification.";
+				continue;
+			}
+		}
+
 		Log(LogInformation, "Notification")
 			<< "Sending " << (reminder ? "reminder " : "") << "'" << NotificationTypeToStringInternal(type) << "' notification '"
 			<< GetName() << "' for user '" << userName << "'";

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -402,18 +402,20 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		/* on recovery, check if user was notified before */
 		if (type == NotificationRecovery) {
-			if (!notifiedProblemUsers->Contains(userName) && CheckNotificationUserFilters(NotificationProblem, user, false, false)) {
+			if (!notifiedProblemUsers->Contains(userName) && (NotificationProblem & user->GetTypeFilter())) {
 				Log(LogNotice, "Notification")
-					<< "We did not notify user '" << userName << "' for a problem before. Not sending recovery notification.";
+					<< "We did not notify user '" << userName
+					<< "' (Problem types enabled) for a problem before. Not sending recovery notification.";
 				continue;
 			}
 		}
 
 		/* on acknowledgement, check if user was notified before */
 		if (type == NotificationAcknowledgement) {
-			if (!notifiedProblemUsers->Contains(userName) && CheckNotificationUserFilters(NotificationProblem, user, false, false)) {
+			if (!notifiedProblemUsers->Contains(userName) && (NotificationProblem & user->GetTypeFilter())) {
 				Log(LogNotice, "Notification")
-						<< "We did not notify user '" << userName << "' for a problem before. Not sending acknowledgement notification.";
+					<< "We did not notify user '" << userName
+					<< "' (Problem types enabled) for a problem before. Not sending acknowledgement notification.";
 				continue;
 			}
 		}


### PR DESCRIPTION
I'm not really sure, if `always_send_acknowledgements` should default to `true`. 
@dnsmichi what's your opinion on that?

Update @dnsmichi: We'll go without a configuration option. Check the upgrading docs.

fixes #6047 
fixes #6611 