### PR TITLE
Remove #include for deprecated header file

### DIFF
--- a/test/base-object-packer.cpp
+++ b/test/base-object-packer.cpp
@@ -26,7 +26,7 @@
 #include <climits>
 #include <initializer_list>
 #include <iomanip>
-#include <strstream>
+#include <sstream>
 
 using namespace icinga;
 


### PR DESCRIPTION
This fixes the following build warning:

```
[ 99%] Building CXX object test/CMakeFiles/boosttest-test-base.dir/base_unity.cpp.o
In file included from /usr/include/c++/4.8/backward/strstream:51:0,
                 from /home/travis/build/Icinga/icinga2/test/base-object-packer.cpp:29,
                 from /home/travis/build/Icinga/icinga2/build/test/base_unity.cpp:11:
/usr/include/c++/4.8/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
 #warning \
  ^
```

(https://travis-ci.org/Icinga/icinga2/builds/415412321)