### PR TITLE
Overridden path constants not passed to config validation in /v1/config/stages API call

### DIFF
--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -217,11 +217,16 @@ void ConfigPackageUtility::AsyncTryActivateStage(const String& packageName, cons
 	// prepare arguments
 	Array::Ptr args = new Array({
 		Application::GetExePath(Application::GetArgV()[0]),
-		"daemon",
-		"--validate",
-		"--define",
-		"ActiveStageOverride=" + packageName + ":" + stageName
 	});
+
+	// copy all arguments of parent process
+	for (int i=1; i < Application::GetArgC(); i++) {
+		args->Add(Application::GetArgV()[i]);
+	}
+	// add arguments for validation
+	args->Add("--validate");
+	args->Add("--define");
+	args->Add("ActiveStageOverride=" + packageName + ":" + stageName);
 
 	Process::Ptr process = new Process(Process::PrepareCommand(args));
 	process->SetTimeout(300);

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -220,9 +220,15 @@ void ConfigPackageUtility::AsyncTryActivateStage(const String& packageName, cons
 	});
 
 	// copy all arguments of parent process
-	for (int i=1; i < Application::GetArgC(); i++) {
-		args->Add(Application::GetArgV()[i]);
+	for (int i = 1; i < Application::GetArgC(); i++) {
+		String argV = Application::GetArgV()[i];
+
+		if (argV == "-d" || argV == "--daemonize")
+			continue;
+
+		args->Add(argV);
 	}
+
 	// add arguments for validation
 	args->Add("--validate");
 	args->Add("--define");


### PR DESCRIPTION
<!--- Provide a general summary of the issue in the Title above -->
Hi,
when overriding SysconfDir, LocalStateDir, RunDir variables at start time icinga2 failes to validate the configuration (startup.log) after posting a new configuration via the API call.

<!-- If you are reporting a problem or a bug, please ensure to read https://github.com/Icinga/icinga2/blob/master/doc/15-troubleshooting.md first. -->

<!-- Formatting tips:

GitHub supports Markdown: https://guides.github.com/features/mastering-markdown/
Multi-line code blocks either with three back ticks, or four space indent.

```
object Host "myhost" {
  ...
}
```
-->

## Expected Behavior
<!--- If you're describing a bug, tell us what should happen -->
By posting a wrong/inconsistent configuration through the Icinga2 API, the startup.log should always contain the validation error.
<!--- If you're suggesting a change/improvement, tell us how it should work -->


## Current Behavior
<!--- If describing a bug, tell us what happens instead of the expected behavior -->
When overriding LocalStateDir/ConfigDir during startup (--define), the validation of new configurations is not done correctly.
Posting a wrong configuration through the API results to a false positive validation check if in the default path resides a valid configuration. In fact, you will find a succesful validation check inside the generated startup.log.
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
By posting a wrong/inconsistent configuration through the Icinga2 API, the startup.log should always contain the validation error even when overriding LocalStateDir/ConfigDir with command line parameters during startup.

## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
Propagate --define and -D command line arguments during the validation check.
<!--- or ideas how to implement:  the addition or change -->

## Steps to Reproduce (for bugs)
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include configuration, logs, etc. to reproduce, if relevant -->
1. Run icinga2 overriding SysconfDir/LocalStateDir
```
/usr/sbin/icinga2 daemon -d -e ${ICINGA2_ERROR_LOG} -D SysconfDir=/shared/icinga2/conf/ -D LocalStateDir=/shared/icinga2/data/ -D RunDir=/run/icinga2-master/
```
2. Deploy a working configuration (e.g. with director)
3. try to deploy an inconsistent configuration
```
curl -k -s -u root:XXXX -H 'Accept: application/json' -X POST -d '{"files":{"zones.d\/director-global\/001-director-basics.conf":"\nconst DirectorStageDir = dirname(dirname(current_filename))\n\nconst DirectorOverrideVars = \"_override_servicevars\"\nconst DirectorOverrideTemplate = \"host var overrides (Director)\"\n\ntemplate Service DirectorOverrideTemplate {\n  \/**\n   * Seems that host is missing when used in a service object, works fine for\n   * apply rules\n   *\/\n  if (! host) {\n    var host = get_host(host_name)\n  }\n\n  if (vars) {\n    vars += host.vars[DirectorOverrideVars][name]\n  } else {\n    vars = host.vars[DirectorOverrideVars][name]\n  }\n}\n","zones.d\/director-global\/host_templates.conf":"template Host \"wrongtemplate\" {\n}\n\n","zones.d\/master\/hosts.conf":"object Host \"TEST\" {\n    import \"wrongtemplate\"\n\n}\n\n","zones.d\/director-global\/commands.conf":"library \"methods\"\n\n"}}' 'https://localhost:5665/v1/config/stages/director'
{"results":[{"code":200.0,"package":"director","stage":"77fc923b890d-1534257981-2","status":"Created stage.  Icinga2 will reload."}]}
```
4. Verify that the startup.log confirms a valid configuration:
```
cat /neteye/shared/icinga2/data/lib/icinga2/api/packages/director/77fc923b890d-1534257981-2/startup.log
information/cli: Icinga application loader (version: r2.8.4-1)
information/cli: Loading configuration file(s).
information/ConfigItem: Committing config item(s).
information/ConfigItem: Instantiated 2 Zones.
information/ConfigItem: Instantiated 1 FileLogger.
information/ConfigItem: Instantiated 2 NotificationCommands.
information/ConfigItem: Instantiated 209 CheckCommands.
information/ConfigItem: Instantiated 1 IcingaApplication.
information/ConfigItem: Instantiated 1 CheckerComponent.
information/ConfigItem: Instantiated 1 IdoMysqlConnection.
information/ConfigItem: Instantiated 1 NotificationComponent.
information/ScriptGlobal: Dumping variables to file '/local/icinga2/data/cache/icinga2/icinga2.vars'
information/cli: Finished validating the configuration file(s).
```

### Expected result:
```
cat /neteye/shared/icinga2/data/lib/icinga2/api/packages/director/77fc923b890d-1534257981-2/startup.log 
information/cli: Icinga application loader (version: r2.8.4-1)
information/cli: Loading configuration file(s).
information/ConfigItem: Committing config item(s).
information/ApiListener: My API identity: icinga2-master.neteyelocal
critical/config: Error: Validation failed for object 'TEST' of type 'Host'; Attribute 'check_command': Attribute must not be empty.
Location: in /neteye/shared/icinga2/data//lib/icinga2/api/packages/director/77fc923b890d-1534257981-2/zones.d/master/hosts.conf: 1:0-1:17
/neteye/shared/icinga2/data//lib/icinga2/api/packages/director/77fc923b890d-1534257981-2/zones.d/master/hosts.conf(1): object Host "TEST" {
                                                                                                                       ^^^^^^^^^^^^^^^^^^
/neteye/shared/icinga2/data//lib/icinga2/api/packages/director/77fc923b890d-1534257981-2/zones.d/master/hosts.conf(2):     import "wrongtemplate"
/neteye/shared/icinga2/data//lib/icinga2/api/packages/director/77fc923b890d-1534257981-2/zones.d/master/hosts.conf(3): 

critical/config: 1 error
[root@77fc923b890d ~]#
```

## Context
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
Multiple independend Icinga2 instances are running on the same system. In order to accomplish this you need to specify different paths for configuration, logs, etc. The validation should inherit the override of the paths/dirs specified on command line.

## Your Environment
<!--- Include as many relevant details about the environment you experienced the problem in -->
* Version used (`icinga2 --version`):
```
icinga2 - The Icinga 2 network monitoring daemon (version: r2.8.4-1)

Copyright (c) 2012-2017 Icinga Development Team (https://www.icinga.com/)
License GPLv2+: GNU GPL version 2 or later <http://gnu.org/licenses/gpl2.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Application information:
  Installation root: /usr
  Sysconf directory: /local/icinga2/conf
  Run directory: /run
  Local state directory: /local/icinga2/data
  Package data directory: /usr/share/icinga2
  State path: /local/icinga2/data/lib/icinga2/icinga2.state
  Modified attributes path: /local/icinga2/data/lib/icinga2/modified-attributes.conf
  Objects path: /local/icinga2/data/cache/icinga2/icinga2.debug
  Vars path: /local/icinga2/data/cache/icinga2/icinga2.vars
  PID path: /run/icinga2/icinga2.pid

System information:
  Platform: CentOS Linux
  Platform version: 7 (Core)
  Kernel: Linux
  Kernel version: 4.16.3-301.fc28.x86_64
  Architecture: x86_64

Build information:
  Compiler: GNU 4.8.5
  Build host: a620ad6de6a5
```
* Operating System and version:
```
cat /etc/redhat-release 
CentOS Linux release 7.5.1804 (Core)
```
* Enabled features (`icinga2 feature list`):
```
Disabled features: command compatlog debuglog elasticsearch gelf graphite notification opentsdb perfdata statusdata syslog
Enabled features: api checker ido-mysql influxdb livestatus mainlog
```
* Icinga Web 2 version and modules (System - About):
n/a
* Config validation (`icinga2 daemon -C`):
```
information/cli: Icinga application loader (version: r2.8.4-1)
information/cli: Loading configuration file(s).
information/ConfigItem: Committing config item(s).
information/ConfigItem: Instantiated 2 Zones.
information/ConfigItem: Instantiated 1 FileLogger.
information/ConfigItem: Instantiated 2 NotificationCommands.
information/ConfigItem: Instantiated 209 CheckCommands.
information/ConfigItem: Instantiated 1 IcingaApplication.
information/ConfigItem: Instantiated 1 CheckerComponent.
information/ConfigItem: Instantiated 1 IdoMysqlConnection.
information/ConfigItem: Instantiated 1 NotificationComponent.
information/ScriptGlobal: Dumping variables to file '/neteye/local/icinga2/data/cache/icinga2/icinga2.vars'
information/cli: Finished validating the configuration file(s).
```
* If you run multiple Icinga 2 instances, the `zones.conf` file (or `icinga2 object list --type Endpoint` and `icinga2 object list --type Zone`) from all affected nodes.
