### PR TITLE
Move new downtime constants into the Icinga namespace

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -46,9 +46,9 @@ INITIALIZE_ONCE(&Downtime::StaticInitialize);
 
 void Downtime::StaticInitialize()
 {
-	ScriptGlobal::Set("DowntimeNoChildren", "DowntimeNoChildren");
-	ScriptGlobal::Set("DowntimeTriggeredChildren", "DowntimeTriggeredChildren");
-	ScriptGlobal::Set("DowntimeNonTriggeredChildren", "DowntimeNonTriggeredChildren");
+	ScriptGlobal::Set("Icinga.DowntimeNoChildren", "DowntimeNoChildren", true);
+	ScriptGlobal::Set("Icinga.DowntimeTriggeredChildren", "DowntimeTriggeredChildren", true);
+	ScriptGlobal::Set("Icinga.DowntimeNonTriggeredChildren", "DowntimeNonTriggeredChildren", true);
 }
 
 String DowntimeNameComposer::MakeName(const String& shortName, const Object::Ptr& context) const


### PR DESCRIPTION
This PR moves the new downtime constants into the Icinga namespace (see #6509).