### PR TITLE
Include api user configuration file during api setup

### DIFF
--- a/lib/cli/apisetuputility.cpp
+++ b/lib/cli/apisetuputility.cpp
@@ -198,6 +198,15 @@ bool ApiSetupUtility::SetupMasterApiUser()
 
 bool ApiSetupUtility::SetupMasterEnableApi()
 {
+	/*
+	* Ensure the api-users.conf file is included, when conf.d inclusion is disabled.
+	*/
+	if (!NodeUtility::GetConfigurationIncludeState("\"conf.d\"", true))
+		NodeUtility::UpdateConfiguration("\"conf.d/api-users.conf\"", true, false);
+
+	/*
+	* Enable the API feature
+	*/
 	Log(LogInformation, "cli", "Enabling the 'api' feature.");
 
 	FeatureUtility::EnableFeatures({ "api" });

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -269,7 +269,7 @@ void NodeUtility::SerializeObject(std::ostream& fp, const Dictionary::Ptr& objec
 * Returns true if the include is found, otherwise false
 */
 bool NodeUtility::GetConfigurationIncludeState(const String& value, bool recursive) {
-	String configurationFile = Application::GetConst("ConfigDir") + "/icinga2.conf";
+	String configurationFile = Configuration::ConfigDir + "/icinga2.conf";
 
 	Log(LogInformation, "cli")
 		<< "Reading '" << configurationFile << "'.";

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -293,7 +293,7 @@ bool NodeUtility::GetConfigurationIncludeState(const String& value, bool recursi
 		* First hit breaks out of the loop.
 		*/
 
-		if (!line.compare(affectedInclude)) {
+		if (line.compare(0, affectedInclude.GetLength(), affectedInclude) == 0) {
 			isIncluded = true;
 
 			/*

--- a/lib/cli/nodeutility.hpp
+++ b/lib/cli/nodeutility.hpp
@@ -44,6 +44,7 @@ public:
 
 	static bool WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects);
 
+	static bool GetConfigurationIncludeState(const String& value, bool recursive);
 	static bool UpdateConfiguration(const String& value, bool include, bool recursive);
 	static void UpdateConstant(const String& name, const String& value);
 


### PR DESCRIPTION
This ensures that the `api-users.conf` file gets included during `api setup` when the `conf.d` directory inclusion is disabled. 

fixes #6557