### PR TITLE
Shuffle items before config validation

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -39,6 +39,8 @@
 #include <boost/algorithm/string/join.hpp>
 #include <sstream>
 #include <fstream>
+#include <algorithm>
+#include <random>
 
 using namespace icinga;
 
@@ -436,6 +438,10 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 
 	if (items.empty())
 		return true;
+
+	// Shuffle all items to evenly distribute them over the threads of the workqueue. This increases perfomance
+	// noticably in environments with lots of objects and available threads.
+	std::shuffle(std::begin(items), std::end(items), std::default_random_engine {});
 
 	for (const auto& ip : items)
 		newItems.push_back(ip.first);


### PR DESCRIPTION
This patch increases the performance of large installations greatly.
Previous:
```
time
real    1m42.073s
user    3m8.528s
sys     0m10.956s
```
With this patch:
```
real    0m38.717s
user    6m8.964s
sys     0m11.556s
```

Previously jobs were unevenly distributed among the worker threads, leading to situations where only 2 threads were working and 14 idling. I have tried to fix this at first by only pre-selecting the objects to work at any given step but ran into issues if pointer degradation and memory corruption (you don't want to know).