### PR TITLE
Fix non-unity builds on CentOS 7 with std::shared_ptr

### DIFF
--- a/lib/base/namespace.hpp
+++ b/lib/base/namespace.hpp
@@ -26,6 +26,7 @@
 #include "base/debuginfo.hpp"
 #include <map>
 #include <vector>
+#include <memory>
 
 namespace icinga
 {


### PR DESCRIPTION
refs #6509