### PR TITLE
Fix using full path in prepare-dirs/safe-reload scripts

### DIFF
--- a/etc/initsystem/prepare-dirs.cmake
+++ b/etc/initsystem/prepare-dirs.cmake
@@ -17,9 +17,9 @@ fi
 : ${ICINGA2_USER:="@ICINGA2_USER@"}
 : ${ICINGA2_GROUP:="@ICINGA2_GROUP@"}
 : ${ICINGA2_COMMAND_GROUP:="@ICINGA2_COMMAND_GROUP@"}
-: ${ICINGA2_INIT_RUN_DIR:="@ICINGA2_INITRUNDIR@"}
-: ${ICINGA2_LOG_DIR:="@ICINGA2_LOGDIR@"}
-: ${ICINGA2_CACHE_DIR:="@ICINGA2_CACHEDIR@"}
+: ${ICINGA2_INIT_RUN_DIR:="@ICINGA2_FULL_INITRUNDIR@"}
+: ${ICINGA2_LOG_DIR:="@ICINGA2_FULL_LOGDIR@"}
+: ${ICINGA2_CACHE_DIR:="@ICINGA2_FULL_CACHEDIR@"}
 
 getent passwd $ICINGA2_USER >/dev/null 2>&1 || (echo "Icinga user '$ICINGA2_USER' does not exist. Exiting." && exit 6)
 getent group $ICINGA2_GROUP >/dev/null 2>&1 || (echo "Icinga group '$ICINGA2_GROUP' does not exist. Exiting." && exit 6)

--- a/etc/initsystem/safe-reload.cmake
+++ b/etc/initsystem/safe-reload.cmake
@@ -11,7 +11,7 @@ fi
 
 # Set defaults, to overwrite see "@ICINGA2_SYSCONFIGFILE@"
 
-: ${ICINGA2_PID_FILE:="@ICINGA2_INITRUNDIR@/icinga2.pid"}
+: ${ICINGA2_PID_FILE:="@ICINGA2_FULL_INITRUNDIR@/icinga2.pid"}
 : ${DAEMON:="@CMAKE_INSTALL_FULL_SBINDIR@/icinga2"}
 
 printf "Validating config files: "


### PR DESCRIPTION
This won't be visible with packages and overridden paths,
just source builds which invoke the scripts manually.

refs #6506