### PR TITLE
Fix static initializer priority for namespaces in LTO builds

### DIFF
--- a/lib/base/function.hpp
+++ b/lib/base/function.hpp
@@ -72,6 +72,7 @@ private:
 		bool side_effect_free, bool deprecated);
 };
 
+/* Ensure that the priority is lower than the basic namespace initialization in scriptframe.cpp. */
 #define REGISTER_FUNCTION(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \

--- a/lib/base/objecttype.cpp
+++ b/lib/base/objecttype.cpp
@@ -23,6 +23,7 @@
 
 using namespace icinga;
 
+/* Ensure that the priority is lower than the basic namespace initialization in scriptframe.cpp. */
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	Type::Ptr type = new ObjectType();
 	type->SetPrototype(Object::GetPrototype());

--- a/lib/base/primitivetype.hpp
+++ b/lib/base/primitivetype.hpp
@@ -48,6 +48,7 @@ private:
 	ObjectFactory m_Factory;
 };
 
+/* Ensure that the priority is lower than the basic namespace initialization in scriptframe.cpp. */
 #define REGISTER_BUILTIN_TYPE(type, prototype)					\
 	INITIALIZE_ONCE_WITH_PRIORITY([]() {					\
 		icinga::Type::Ptr t = new PrimitiveType(#type, "None"); 	\

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -29,6 +29,10 @@ boost::thread_specific_ptr<std::stack<ScriptFrame *> > ScriptFrame::m_ScriptFram
 
 static auto l_InternalNSBehavior = new ConstNamespaceBehavior();
 
+/* Ensure that this gets called with highest priority
+ * and wins against other static initializers in lib/icinga, etc.
+ * LTO-enabled builds will cause trouble otherwise, see GH #6575.
+ */
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 
@@ -51,7 +55,7 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 
 	Namespace::Ptr internalNS = new Namespace(l_InternalNSBehavior);
 	globalNS->SetAttribute("Internal", std::make_shared<ConstEmbeddedNamespaceValue>(internalNS));
-}, 50);
+}, 1000);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_InternalNSBehavior->Freeze();

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -26,6 +26,7 @@ using namespace icinga;
 
 Type::Ptr Type::TypeInstance;
 
+/* Ensure that the priority is lower than the basic namespace initialization in scriptframe.cpp. */
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	Type::Ptr type = new TypeType();
 	type->SetPrototype(TypeType::GetPrototype());

--- a/lib/base/type.hpp
+++ b/lib/base/type.hpp
@@ -138,6 +138,7 @@ class TypeImpl
 {
 };
 
+/* Ensure that the priority is lower than the basic namespace initialization in scriptframe.cpp. */
 #define REGISTER_TYPE(type) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		icinga::Type::Ptr t = new TypeImpl<type>(); \

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -21,10 +21,10 @@
 #include "base/utility.hpp"
 #include "base/logger.hpp"
 #include "base/application.hpp"
+#include "base/scriptglobal.hpp"
 #include "config/configcompiler.hpp"
 #include "config/configcompilercontext.hpp"
 #include "config/configitembuilder.hpp"
-
 
 using namespace icinga;
 
@@ -146,6 +146,9 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 		return false;
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
+	VERIFY(systemNS);
+
+	/* This is initialized inside the IcingaApplication class. */
 	Value vAppType;
 	VERIFY(systemNS->Get("ApplicationType", &vAppType));
 

--- a/lib/config/configfragment.hpp
+++ b/lib/config/configfragment.hpp
@@ -26,6 +26,7 @@
 #include "base/exception.hpp"
 #include "base/application.hpp"
 
+/* Ensure that the priority is lower than the basic namespace initialization in scriptframe.cpp. */
 #define REGISTER_CONFIG_FRAGMENT(name, fragment) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		std::unique_ptr<icinga::Expression> expression = icinga::ConfigCompiler::CompileText(name, fragment); \


### PR DESCRIPTION
Tested with both `ICINGA2_LTO_BUILD=OFF/ON`.

fixes #6575