### PR TITLE
Allow to configure anonymous clients limit inside the ApiListener object

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -61,6 +61,7 @@ Configuration Attributes:
   bind\_port                            | Number                | **Optional.** The port the api listener should be bound to. Defaults to `5665`.
   accept\_config                        | Boolean               | **Optional.** Accept zone configuration. Defaults to `false`.
   accept\_commands                      | Boolean               | **Optional.** Accept remote commands. Defaults to `false`.
+  max\_anonymous\_clients               | Number                | **Optional.** Limit the number of anonymous client connections (not configured endpoints and signing requests).
   cipher\_list                          | String                | **Optional.** Cipher list that is allowed. For a list of available ciphers run `openssl ciphers`. Defaults to `ALL:!LOW:!WEAK:!MEDIUM:!EXP:!NULL`.
   tls\_protocolmin                      | String                | **Optional.** Minimum TLS protocol version. Must be one of `TLSv1`, `TLSv1.1` or `TLSv1.2`. Defaults to `TLSv1`.
   access\_control\_allow\_origin        | Array                 | **Optional.** Specifies an array of origin URLs that may access the API. [(MDN docs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Origin)

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -49,6 +49,14 @@ New [Icinga constants](17-language-reference.md#icinga-constants) have been adde
 The keywords `namespace` and `using` are now [reserved](17-language-reference.md#reserved-keywords) for the namespace functionality provided
 with v2.10. Read more about how it works [here](17-language-reference.md#namespaces).
 
+### Configuration: ApiListener <a id="upgrading-to-2-10-configuration-apilistener"></a>
+
+Anonymous JSON-RPC connections in the cluster can now be configured with `max_anonymous_clients`
+attribute.
+The corresponding REST API results from `/v1/status/ApiListener` in `json_rpc` have been renamed
+from `clients` to `anonymous_clients` to better reflect their purpose. Authenticated clients
+are counted as connected endpoints. A similar change is there for the performance data metrics.
+
 ### API: schedule-downtime Action <a id="upgrading-to-2-10-api-schedule-downtime-action"></a>
 
 The attribute `child_options` was previously accepting 0,1,2 for specific child downtime settings.

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -50,6 +50,9 @@ class ApiListener : ConfigObject
 
 	[config] bool accept_config;
 	[config] bool accept_commands;
+	[config] int max_anonymous_clients {
+		default {{{ return -1; }}}
+	};
 
 	[config] String ticket_salt;
 

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -248,7 +248,8 @@ void JsonRpcConnection::MessageHandler(const String& jsonString)
 
 bool JsonRpcConnection::ProcessMessage()
 {
-	ssize_t maxMessageLength = 64 * 1024;
+	/* Limit for anonymous clients (signing requests and not configured endpoints. */
+	ssize_t maxMessageLength = 1024 * 1024;
 
 	if (m_Endpoint)
 		maxMessageLength = -1; /* no limit */


### PR DESCRIPTION
Previously this was hardcoded, and for security reasons users might want
to adjust this value. This affects CSR signing requests as well as
clients which have not yet been configured as endpoints on the current
node.

refs #6566