### PR TITLE
Initialize Socket Event Engine on application startup

### DIFF
--- a/lib/base/socketevents.cpp
+++ b/lib/base/socketevents.cpp
@@ -35,6 +35,8 @@ static SocketEventEngine *l_SocketIOEngine;
 
 int SocketEvents::m_NextID = 0;
 
+INITIALIZE_ONCE(&SocketEvents::InitializeEngine);
+
 void SocketEventEngine::Start()
 {
 	for (int tid = 0; tid < SOCKET_IOTHREADS; tid++) {
@@ -114,8 +116,6 @@ void SocketEvents::InitializeEngine()
 SocketEvents::SocketEvents(const Socket::Ptr& socket, Object *lifesupportObject)
 	: m_ID(m_NextID++), m_FD(socket->GetFD()), m_EnginePrivate(nullptr)
 {
-	boost::call_once(l_SocketIOOnceFlag, &SocketEvents::InitializeEngine);
-
 	Register(lifesupportObject);
 }
 

--- a/lib/base/socketevents.hpp
+++ b/lib/base/socketevents.hpp
@@ -53,6 +53,8 @@ public:
 	void *GetEnginePrivate() const;
 	void SetEnginePrivate(void *priv);
 
+	static void InitializeEngine();
+
 protected:
 	SocketEvents(const Socket::Ptr& socket, Object *lifesupportObject);
 
@@ -63,8 +65,6 @@ private:
 	void *m_EnginePrivate;
 
 	static int m_NextID;
-
-	static void InitializeEngine();
 
 	void WakeUpThread(bool wait = false);
 


### PR DESCRIPTION
Previously this happened inside the TlsStream constructor
during the first connection attempt.

refs #6517 