### PR TITLE
Ensure to _unlink before renaming replay log on Windows

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1046,6 +1046,13 @@ void ApiListener::RotateLogFile()
 
 	String oldpath = GetApiDir() + "log/current";
 	String newpath = GetApiDir() + "log/" + Convert::ToString(static_cast<int>(ts)+1);
+
+
+#ifdef _WIN32
+	_unlink(newpath.CStr());
+#endif /* _WIN32 */
+
+
 	(void) rename(oldpath.CStr(), newpath.CStr());
 }
 


### PR DESCRIPTION
fixes #5052