### PR TITLE
Fix that check_timeout was used for Event/Notification commands too

### DIFF
--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -32,7 +32,7 @@ using namespace icinga;
 
 void PluginUtility::ExecuteCommand(const Command::Ptr& commandObj, const Checkable::Ptr& checkable,
 	const CheckResult::Ptr& cr, const MacroProcessor::ResolverList& macroResolvers,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros,
+	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros, int timeout,
 	const std::function<void(const Value& commandLine, const ProcessResult&)>& callback)
 {
 	Value raw_command = commandObj->GetCommandLine();
@@ -86,11 +86,7 @@ void PluginUtility::ExecuteCommand(const Command::Ptr& commandObj, const Checkab
 
 	Process::Ptr process = new Process(Process::PrepareCommand(command), envMacros);
 
-	if (checkable->GetCheckTimeout().IsEmpty())
-		process->SetTimeout(commandObj->GetTimeout());
-	else
-		process->SetTimeout(checkable->GetCheckTimeout());
-
+	process->SetTimeout(timeout);
 	process->SetAdjustPriority(true);
 
 	process->Run(std::bind(callback, command, _1));

--- a/lib/icinga/pluginutility.hpp
+++ b/lib/icinga/pluginutility.hpp
@@ -41,7 +41,7 @@ class PluginUtility
 public:
 	static void ExecuteCommand(const Command::Ptr& commandObj, const Checkable::Ptr& checkable,
 		const CheckResult::Ptr& cr, const MacroProcessor::ResolverList& macroResolvers,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros,
+		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros, int timeout,
 		const std::function<void(const Value& commandLine, const ProcessResult&)>& callback = std::function<void(const Value& commandLine, const ProcessResult&)>());
 
 	static ServiceState ExitStatusToState(int exitStatus);

--- a/lib/methods/pluginchecktask.cpp
+++ b/lib/methods/pluginchecktask.cpp
@@ -52,8 +52,13 @@ void PluginCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	resolvers.emplace_back("command", commandObj);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
+	int timeout = commandObj->GetTimeout();
+
+	if (!checkable->GetCheckTimeout().IsEmpty())
+		timeout = checkable->GetCheckTimeout();
+
 	PluginUtility::ExecuteCommand(commandObj, checkable, checkable->GetLastCheckResult(),
-		resolvers, resolvedMacros, useResolvedMacros,
+		resolvers, resolvedMacros, useResolvedMacros, timeout,
 		std::bind(&PluginCheckTask::ProcessFinishedHandler, checkable, cr, _1, _2));
 
 	if (!resolvedMacros || useResolvedMacros)

--- a/lib/methods/plugineventtask.cpp
+++ b/lib/methods/plugineventtask.cpp
@@ -51,8 +51,10 @@ void PluginEventTask::ScriptFunc(const Checkable::Ptr& checkable,
 	resolvers.emplace_back("command", commandObj);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
+	int timeout = commandObj->GetTimeout();
+
 	PluginUtility::ExecuteCommand(commandObj, checkable, checkable->GetLastCheckResult(),
-		resolvers, resolvedMacros, useResolvedMacros,
+		resolvers, resolvedMacros, useResolvedMacros, timeout,
 		std::bind(&PluginEventTask::ProcessFinishedHandler, checkable, _1, _2));
 }
 

--- a/lib/methods/pluginnotificationtask.cpp
+++ b/lib/methods/pluginnotificationtask.cpp
@@ -68,8 +68,10 @@ void PluginNotificationTask::ScriptFunc(const Notification::Ptr& notification,
 	resolvers.emplace_back("command", commandObj);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
+	int timeout = commandObj->GetTimeout();
+
 	PluginUtility::ExecuteCommand(commandObj, checkable, cr, resolvers,
-		resolvedMacros, useResolvedMacros,
+		resolvedMacros, useResolvedMacros, timeout,
 		std::bind(&PluginNotificationTask::ProcessFinishedHandler, checkable, _1, _2));
 }
 


### PR DESCRIPTION
We may add specific timeouts for event/notification commands
later, for now the original timeout inside the EventCommand/NotificationCommand
is used.

fixes #6304