### PR TITLE
Add 'used' feature to check_swap

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1632,12 +1632,12 @@ The data collection is instant.
 
 Custom attributes:
 
-Name            | Description
-:---------------|:------------
-swap\_win\_warn | **Optional**. The warning threshold. Defaults to "10%".
-swap\_win\_crit | **Optional**. The critical threshold. Defaults to "5%".
-swap\_win\_unit | **Optional**. The unit to display the received value in, thresholds are interpreted in this unit. Defaults to "mb" (megabyte).
-
+Name             | Description
+:--------------- | :------------
+swap\_win\_warn  | **Optional**. The warning threshold. Defaults to "10%".
+swap\_win\_crit  | **Optional**. The critical threshold. Defaults to "5%".
+swap\_win\_unit  | **Optional**. The unit to display the received value in, thresholds are interpreted in this unit. Defaults to "mb" (megabyte).
+swap\_win\_show\_used | **Optional**. Show used swap instead of the free swap.
 
 ### update-windows <a id="windows-plugins-update-windows"></a>
 

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -258,6 +258,10 @@ object CheckCommand "swap-windows" {
 			value = "$swap_win_unit$"
 			description = "Unit to display swap in"
 		}
+		"-U" = {
+			set_if = "$swap_win_show_used$"
+			description = "Show used swap instead of the free swap"
+		}
 	}
 
 	// Default


### PR DESCRIPTION
This implements the _used_ feature to check_swap to print the used swap
instead of the default available swap.