### PR TITLE
Fix check_memory thresholds in 'used' mode

### DIFF
--- a/plugins/check_memory.cpp
+++ b/plugins/check_memory.cpp
@@ -150,7 +150,11 @@ static int parseArguments(int ac, WCHAR ** av, po::variables_map& vm, printInfoS
 		}
 	}
 
-	printInfo.showUsed = vm.count("show-used") > 0;
+	if (vm.count("show-used")) {
+		printInfo.showUsed = true;
+		printInfo.warn.legal = true;
+		printInfo.crit.legal = true;
+	}
 
 	return -1;
 }


### PR DESCRIPTION
The thresholds in the used mode now breaks if the value is bigger than
the threshold.

## Current behavior 
```
.\check_memory.exe -U -w 90% -c 95%
MEMORY WARNING - 50.2983% used| 'memory'=2059.99MB;3685.9950000000003;3890.7725;0;4095.55
```

I expected that the threshold breaks if it where above 90%/95% . Currently the threshold breaks if it is below 90%/95%

```
 .\check_memory.exe -U -w 48% -c 30%
MEMORY OK - 49.2309% used| 'memory'=2016.28MB;1965.864;1228.665;0;4095.55

 .\check_memory.exe -U -w 50% -c 30%
MEMORY WARNING - 49.1621% used| 'memory'=2013.46MB;2047.7750000000001;1228.665;0;4095.55
```

## Fixed behavior

```
.\check_memory.exe -U -w 90% -c 95%
MEMORY OK - 49.8562% used| 'memory'=2041.89MB;3685.9950000000003;3890.7725;0;4095.55
```

The threshold is correctly respected and breaks if it is above 90%/95%.

```
 .\check_memory.exe -U -w 50% -c 95%
MEMORY OK - 48.0606% used| 'memory'=1968.35MB;2047.7750000000001;3890.7725;0;4095.55

 .\check_memory.exe -U -w 47% -c 95%
MEMORY WARNING - 48.0603% used| 'memory'=1968.34MB;1924.9085;3890.7725;0;4095.55
```