### PR TITLE
Improve logging for disconnected HTTP clients

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -83,7 +83,8 @@ void HttpServerConnection::Disconnect()
 		return;
 	}
 
-	Log(LogDebug, "HttpServerConnection", "Http client disconnected");
+	Log(LogInformation, "HttpServerConnection")
+		<< "HTTP client disconnected (from " << m_Stream->GetSocket()->GetPeerAddress() << ")";
 
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 	listener->RemoveHttpClient(this);


### PR DESCRIPTION
Previously this was inside the debug log, with the
new socket printers we can enhance checking for proper
connects and disconnects.

refs #6514