### PR TITLE
Ensure that HTTP/1.0 or 'Connection: close' headers are properly disconnecting the client

### DIFF
--- a/lib/remote/httpresponse.cpp
+++ b/lib/remote/httpresponse.cpp
@@ -111,9 +111,6 @@ void HttpResponse::Finish()
 	}
 
 	m_State = HttpResponseEnd;
-
-	if (m_Request->ProtocolVersion == HttpVersion10 || m_Request->Headers->Get("connection") == "close")
-		m_Stream->Shutdown();
 }
 
 bool HttpResponse::Parse(StreamReadContext& src, bool may_wait)

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -357,6 +357,13 @@ void HttpServerConnection::DataAvailableHandler()
 		}
 
 		m_RequestQueue.Enqueue(std::bind(&Stream::SetCorked, m_Stream, false));
+
+		/* Request finished, decide whether to explicitly close the connection. */
+		if (m_CurrentRequest.ProtocolVersion == HttpVersion10 ||
+			m_CurrentRequest.Headers->Get("connection") == "close") {
+			m_Stream->Shutdown();
+			close = true;
+		}
 	} else
 		close = true;
 


### PR DESCRIPTION
Test results: https://github.com/Icinga/icinga2/issues/6514#issuecomment-428155731

fixes #6514