### PR TITLE
Cache the peer address in the HTTP server

### DIFF
--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -59,6 +59,7 @@ private:
 	boost::recursive_mutex m_DataHandlerMutex;
 	WorkQueue m_RequestQueue;
 	int m_PendingRequests;
+	String m_PeerAddress;
 
 	StreamReadContext m_Context;
 


### PR DESCRIPTION
Later socket calls are expensive and might lead
into a race condition on close when logging it.

refs #6655