### PR TITLE
Silence config compiler logging for runtime created objects

### DIFF
--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -158,11 +158,11 @@ std::vector<ApplyRule>& ApplyRule::GetRules(const String& type)
 	return it->second;
 }
 
-void ApplyRule::CheckMatches()
+void ApplyRule::CheckMatches(bool silent)
 {
 	for (const RuleMap::value_type& kv : m_Rules) {
 		for (const ApplyRule& rule : kv.second) {
-			if (!rule.HasMatches())
+			if (!rule.HasMatches() && !silent)
 				Log(LogWarning, "ApplyRule")
 					<< "Apply rule '" << rule.GetName() << "' (" << rule.GetDebugInfo() << ") for type '" << kv.first << "' does not match anywhere!";
 		}

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -62,7 +62,7 @@ public:
 	static bool IsValidTargetType(const String& sourceType, const String& targetType);
 	static std::vector<String> GetTargetTypes(const String& sourceType);
 
-	static void CheckMatches();
+	static void CheckMatches(bool silent);
 
 private:
 	String m_TargetType;

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -618,7 +618,7 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 		return false;
 	}
 
-	ApplyRule::CheckMatches();
+	ApplyRule::CheckMatches(silent);
 
 	if (!silent) {
 		/* log stats for external parsers */

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -143,7 +143,8 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 
 		std::vector<ConfigItem::Ptr> newItems;
 
-		if (!ConfigItem::CommitItems(ascope.GetContext(), upq, newItems) || !ConfigItem::ActivateItems(upq, newItems, true)) {
+		/* Disable logging for object creation, but do so ourselves later on. */
+		if (!ConfigItem::CommitItems(ascope.GetContext(), upq, newItems, true) || !ConfigItem::ActivateItems(upq, newItems, true, true)) {
 			if (errors) {
 				if (unlink(path.CStr()) < 0 && errno != ENOENT) {
 					BOOST_THROW_EXCEPTION(posix_error()
@@ -164,6 +165,10 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		}
 
 		ApiListener::UpdateObjectAuthority();
+
+		Log(LogInformation, "ConfigObjectUtility")
+			<< "Created and activated object '" << fullName << "' of type '" << type->GetName() << "'.";
+
 	} catch (const std::exception& ex) {
 		if (unlink(path.CStr()) < 0 && errno != ENOENT) {
 			BOOST_THROW_EXCEPTION(posix_error()


### PR DESCRIPTION
This is especially problematic with many single creation requests,
e.g. many downtimes created via Icinga Web 2 & the REST API.

In addition to the config compiler messages, apply rule matches are
also in there which are removed by this patch.