### PR TITLE
Revert "Initialize Socket Event Engine on application startup"

### DIFF
--- a/lib/base/socketevents.cpp
+++ b/lib/base/socketevents.cpp
@@ -35,8 +35,6 @@ static SocketEventEngine *l_SocketIOEngine;
 
 int SocketEvents::m_NextID = 0;
 
-INITIALIZE_ONCE(&SocketEvents::InitializeEngine);
-
 void SocketEventEngine::Start()
 {
 	for (int tid = 0; tid < SOCKET_IOTHREADS; tid++) {
@@ -116,6 +114,8 @@ void SocketEvents::InitializeEngine()
 SocketEvents::SocketEvents(const Socket::Ptr& socket, Object *lifesupportObject)
 	: m_ID(m_NextID++), m_FD(socket->GetFD()), m_EnginePrivate(nullptr)
 {
+	boost::call_once(l_SocketIOOnceFlag, &SocketEvents::InitializeEngine);
+
 	Register(lifesupportObject);
 }
 

--- a/lib/base/socketevents.hpp
+++ b/lib/base/socketevents.hpp
@@ -53,8 +53,6 @@ public:
 	void *GetEnginePrivate() const;
 	void SetEnginePrivate(void *priv);
 
-	static void InitializeEngine();
-
 protected:
 	SocketEvents(const Socket::Ptr& socket, Object *lifesupportObject);
 
@@ -65,6 +63,8 @@ private:
 	void *m_EnginePrivate;
 
 	static int m_NextID;
+
+	static void InitializeEngine();
 
 	void WakeUpThread(bool wait = false);
 


### PR DESCRIPTION
This reverts commit c8dcd1297f6d0be8685c5a3079e40fc44e779add.

We cannot do this during application startup, since Daemonize()
kills the threads again.

refs #6514
refs #6630