### PR TITLE
Don't throw an error when namespace indexers don't find a valid key

### DIFF
--- a/lib/base/namespace.cpp
+++ b/lib/base/namespace.cpp
@@ -108,7 +108,7 @@ Value Namespace::GetFieldByName(const String& field, bool, const DebugInfo& debu
 	if (nsVal)
 		return nsVal->Get(debugInfo);
 	else
-		return GetPrototypeField(const_cast<Namespace *>(this), field, true, debugInfo);
+		return GetPrototypeField(const_cast<Namespace *>(this), field, false, debugInfo); /* Ignore indexer not found errors similar to the Dictionary class. */
 }
 
 void Namespace::SetFieldByName(const String& field, const Value& value, bool overrideFrozen, const DebugInfo& debugInfo)


### PR DESCRIPTION
Examples:

```
globals["abc"]
globals.def
```

The patch for the Icinga Director unfortunately only solves the
master, and as discussed with @lippserd we need to ensure that
satellites and clients with 2.10 can be restarted without any errors
from deployed configuration.

refs #6509
refs icinga/icingaweb2-module-director#1654