### PR TITLE
Extend 09-object-types.md with argument array

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -230,6 +230,12 @@ Argument order:
 ..., -3, -2, -1, <un-ordered keys>, 1, 2, 3, ...
 ```
 
+Define argument array:
+
+```
+value = "[ 'one', 'two', 'three' ]"
+```
+
 Argument array with `repeat_key = true`:
 
 ```


### PR DESCRIPTION
*Since I just spent quite a bit of time figuring this one out, I'd thought I'd it to the docs:*

Add a small snippet demonstrating how to define an argument array instead of a simple string.

