### PR TITLE
Add missing shutdown/program state dumps for SIGUSR2 reload handler

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -751,6 +751,13 @@ void Application::SigUsr2Handler(int)
 
 	instance->ClosePidFile(false);
 
+	/* Ensure to dump the program state on reload. */
+	ConfigObject::StopObjects();
+	instance->OnShutdown();
+
+	Log(LogInformation, "Application")
+		<< "Reload done, parent process shutting down. Child process with PID '" << m_ReloadProcess << "' is taking over.";
+
 	Exit(0);
 }
 


### PR DESCRIPTION
Credits to @west0rmann finding the issue and providing the initial fix.

Test protocol: https://github.com/Icinga/icinga2/issues/6689#issuecomment-430174765

fixes #6689
fixes #6592