### PR TITLE
WIP: Don't allow to view/modify the ApiListener's ticket salt via REST API

### DIFF
--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -60,7 +60,7 @@ class ApiListener : ConfigObject
 		default {{{ return Configuration::TlsHandshakeTimeout; }}}
 	};
 
-	[config] String ticket_salt;
+	[no_user_view, no_user_modify] String ticket_salt;
 
 	[config] Array::Ptr access_control_allow_origin;
 	[config, deprecated] bool access_control_allow_credentials;

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -105,6 +105,9 @@ bool VariableQueryHandler::HandleRequest(const ApiUser::Ptr& user, HttpRequest& 
 	ArrayData results;
 
 	for (const Dictionary::Ptr& var : objs) {
+		if (var->Get("name") == "TicketSalt")
+			continue;
+
 		results.emplace_back(new Dictionary({
 			{ "name", var->Get("name") },
 			{ "type", var->Get("type") },


### PR DESCRIPTION
This exposes too many sensitive details, especially the private key
for signing requests.

The Director currently relies on this object attribute. For this reason
we've implemented /v1/actions/generate-ticket in Icinga 2 v2.5 which only needs
a hostname and hides the ticket salt from the caller.

Needs icinga/icingaweb2-module-director#401