### PR TITLE
Fix regression for wrong objects.cache path overwriting icinga2.debug file

### DIFF
--- a/lib/compat/statusdatawriter.cpp
+++ b/lib/compat/statusdatawriter.cpp
@@ -559,7 +559,8 @@ void StatusDataWriter::UpdateObjectsCache()
 {
 	CONTEXT("Writing objects.cache file");
 
-	String objectsPath = Configuration::ObjectsPath;
+	/* Use the compat path here from the .ti generated class. */
+	String objectsPath = GetObjectsPath();
 
 	std::fstream objectfp;
 	String tempObjectsPath = Utility::CreateTempFile(objectsPath + ".XXXXXX", 0644, objectfp);


### PR DESCRIPTION
The 'statusdata' feature is deprecated, although it affects 'object list'.

fixes #6705