### PR TITLE
 Fix the Icinga2 version check for versions with more than 5 characters

### DIFF
--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -175,9 +175,10 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	}
 
 	/* Extract the version number of the running Icinga2 instance.
-	 * We assume that appVersion will allways be something like 'v2.10.1-8-gaebe6da' and we want to extract '2.10.1'. */
+	 * We assume that appVersion will allways be something like 'v2.10.1-8-gaebe6da' and we want to extract '2.10.1'.
+	 */
 	int endOfVersionNumber = appVersion.FindFirstOf("-") - 1;
-	String parsedAppVersion = appVersion.SubStr(1,endOfVersionNumber);
+	String parsedAppVersion = appVersion.SubStr(1, endOfVersionNumber);
 
 	/* Return an error if the version is less than specified (optional). */
 	if (missingIcingaMinVersion.IsEmpty() && !icingaMinVersion.IsEmpty() && Utility::CompareVersion(icingaMinVersion, parsedAppVersion) < 0) {

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -174,9 +174,12 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		cr->SetState(ServiceWarning);
 	}
 
-	/* Return an error if the version is less than specified (optional). */
-	String parsedAppVersion = appVersion.SubStr(1,5);
+	/* Extract the version number of the running Icinga2 instance.
+	 * We assume that appVersion will allways be something like 'v2.10.1-8-gaebe6da' and we want to extract '2.10.1'. */
+	int endOfVersionNumber = appVersion.FindFirstOf("-") - 1;
+	String parsedAppVersion = appVersion.SubStr(1,endOfVersionNumber);
 
+	/* Return an error if the version is less than specified (optional). */
 	if (missingIcingaMinVersion.IsEmpty() && !icingaMinVersion.IsEmpty() && Utility::CompareVersion(icingaMinVersion, parsedAppVersion) < 0) {
 		output += "; Minimum version " + icingaMinVersion + " is not installed.";
 		cr->SetState(ServiceCritical);


### PR DESCRIPTION
The previous implementation assumed that every version number will have
5 characters. With the release of 2.10.0 this does not work anymore.
The new implementation extracts everything from the second character to
the first dash. This should work as long as the version string is in a
format like 'v2.10.1-8-gaebe6da'.

fixes Icinga#6703

Edit: I never really wrote C++ code before. So I am looking forward for any kind of feedback ;)