### PR TITLE
Enable HA for features: Elasticsearch, Gelf, Graphite, InfluxDB, OpenTSDB, Perfdata

### DIFF
--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -2434,6 +2434,12 @@ By default, the following features provide advanced HA functionality:
 * [Checks](06-distributed-monitoring.md#distributed-monitoring-high-availability-checks) (load balanced, automated failover).
 * [Notifications](06-distributed-monitoring.md#distributed-monitoring-high-availability-notifications) (load balanced, automated failover).
 * [DB IDO](06-distributed-monitoring.md#distributed-monitoring-high-availability-db-ido) (Run-Once, automated failover).
+* [Elasticsearch](09-object-types.md#objecttype-elasticsearchwriter)
+* [Gelf](09-object-types.md#objecttype-gelfwriter)
+* [Graphite](09-object-types.md#objecttype-graphitewriter)
+* [InfluxDB](09-object-types.md#objecttype-influxdbwriter)
+* [OpenTsdb](09-object-types.md#objecttype-opentsdbwriter)
+* [Perfdata](09-object-types.md#objecttype-perfdatawriter) (for PNP)
 
 #### High-Availability with Checks <a id="distributed-monitoring-high-availability-checks"></a>
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -517,6 +517,7 @@ Configuration Attributes:
   ca\_path                  | String                | **Optional.** Path to CA certificate to validate the remote host. Requires `enable_tls` set to `true`.
   cert\_path                | String                | **Optional.** Path to host certificate to present to the remote host for mutual verification. Requires `enable_tls` set to `true`.
   key\_path                 | String                | **Optional.** Path to host key to accompany the cert\_path. Requires `enable_tls` set to `true`.
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `true`.
 
 Note: If `flush_threshold` is set too low, this will force the feature to flush all data to Elasticsearch too often.
 Experiment with the setting, if you are processing more than 1024 metrics per second or similar.
@@ -655,6 +656,7 @@ Configuration Attributes:
   port                      | Number                | **Optional.** GELF receiver port. Defaults to `12201`.
   source                    | String                | **Optional.** Source name for this instance. Defaults to `icinga2`.
   enable\_send\_perfdata    | Boolean               | **Optional.** Enable performance data for 'CHECK RESULT' events.
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `true`.
 
 
 ## GraphiteWriter <a id="objecttype-graphitewriter"></a>
@@ -682,6 +684,7 @@ Configuration Attributes:
   service\_name\_template   | String                | **Optional.** Metric prefix for service name. Defaults to `icinga2.$host.name$.services.$service.name$.$service.check_command$`.
   enable\_send\_thresholds  | Boolean               | **Optional.** Send additional threshold metrics. Defaults to `false`.
   enable\_send\_metadata    | Boolean               | **Optional.** Send additional metadata metrics. Defaults to `false`.
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `true`.
 
 Additional usage examples can be found [here](14-features.md#graphite-carbon-cache-writer).
 
@@ -868,7 +871,7 @@ Configuration Attributes:
   table\_prefix             | String                | **Optional.** MySQL database table prefix. Defaults to `icinga_`.
   instance\_name            | String                | **Optional.** Unique identifier for the local Icinga 2 instance. Defaults to `default`.
   instance\_description     | String                | **Optional.** Description for the Icinga 2 instance.
-  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-db-ido). Defaults to "true".
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-db-ido). Defaults to `true`.
   failover\_timeout         | Duration              | **Optional.** Set the failover timeout in a [HA cluster](06-distributed-monitoring.md#distributed-monitoring-high-availability-db-ido). Must not be lower than 60s. Defaults to `60s`.
   cleanup                   | Dictionary            | **Optional.** Dictionary with items for historical table cleanup.
   categories                | Array                 | **Optional.** Array of information types that should be written to the database.
@@ -1057,6 +1060,7 @@ Configuration Attributes:
   enable\_send\_metadata    | Boolean               | **Optional.** Whether to send check metadata e.g. states, execution time, latency etc.
   flush\_interval           | Duration              | **Optional.** How long to buffer data points before transferring to InfluxDB. Defaults to `10s`.
   flush\_threshold          | Number                | **Optional.** How many data points to buffer before forcing a transfer to InfluxDB.  Defaults to `1024`.
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `true`.
 
 Note: If `flush_threshold` is set too low, this will always force the feature to flush all data
 to InfluxDB. Experiment with the setting, if you are processing more than 1024 metrics per second
@@ -1303,7 +1307,7 @@ Example:
 object OpenTsdbWriter "opentsdb" {
   host = "127.0.0.1"
   port = 4242
-
+}
 ```
 
 Configuration Attributes:
@@ -1312,6 +1316,7 @@ Configuration Attributes:
   --------------------------|-----------------------|----------------------------------
   host            	    | String                | **Optional.** OpenTSDB host address. Defaults to `127.0.0.1`.
   port            	    | Number                | **Optional.** OpenTSDB port. Defaults to `4242`.
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `true`.
 
 
 ## PerfdataWriter <a id="objecttype-perfdatawriter"></a>
@@ -1346,6 +1351,7 @@ Configuration Attributes:
   host\_format\_template    | String                | **Optional.** Host Format template for the performance data file. Defaults to a template that's suitable for use with PNP4Nagios.
   service\_format\_template | String                | **Optional.** Service Format template for the performance data file. Defaults to a template that's suitable for use with PNP4Nagios.
   rotation\_interval        | Duration              | **Optional.** Rotation interval for the files specified in `{host,service}_perfdata_path`. Defaults to `30s`.
+  enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `true`.
 
 When rotating the performance data file the current UNIX timestamp is appended to the path specified
 in `host_perfdata_path` and `service_perfdata_path` to generate a unique filename.

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -7,6 +7,26 @@ Specific version upgrades are described below. Please note that version
 updates are incremental. An upgrade from v2.6 to v2.8 requires to
 follow the instructions for v2.7 too.
 
+## Upgrading to v2.11 <a id="upgrading-to-2-11"></a>
+
+### HA-aware Features <a id="upgrading-to-2-11-ha-aware-features"></a>
+
+v2.11 introduces additional HA functionality similar to the DB IDO feature.
+This enables the feature being active only on one endpoint while the other
+endpoint is paused. When one endpoint is shut down, automatic failover happens.
+
+This feature is turned on by default. If you need one of the features twice,
+please use `enable_ha = false` to restore the old behaviour.
+
+This affects the following features:
+
+* [Elasticsearch](09-object-types.md#objecttype-elasticsearchwriter)
+* [Gelf](09-object-types.md#objecttype-gelfwriter)
+* [Graphite](09-object-types.md#objecttype-graphitewriter)
+* [InfluxDB](09-object-types.md#objecttype-influxdbwriter)
+* [OpenTsdb](09-object-types.md#objecttype-opentsdbwriter)
+* [Perfdata](09-object-types.md#objecttype-perfdatawriter) (for PNP)
+
 ## Upgrading to v2.10 <a id="upgrading-to-2-10"></a>
 
 ### Path Constant Changes <a id="upgrading-to-2-10-path-constant-changes"></a>

--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -190,10 +190,12 @@ The GraphiteWriter feature calls the registered function and processes
 the received data. Features which connect Icinga 2 to external interfaces
 normally parse and reformat the received data into an applicable format.
 
+Since this check result signal is blocking, many of the features include a work queue
+with asynchronous task handling.
+
 The GraphiteWriter uses a TCP socket to communicate with the carbon cache
 daemon of Graphite. The InfluxDBWriter is instead writing bulk metric messages
-to InfluxDB's HTTP API.
-
+to InfluxDB's HTTP API, similar to Elasticsearch.
 
 
 ## Cluster <a id="technical-concepts-cluster"></a>
@@ -322,10 +324,10 @@ The update procedure works the same way as above.
 
 ### High Availability <a id="technical-concepts-cluster-ha"></a>
 
-High availability is automatically enabled between two nodes in the same
+General high availability is automatically enabled between two endpoints in the same
 cluster zone.
 
-This requires the same configuration and enabled features on both nodes.
+**This requires the same configuration and enabled features on both nodes.**
 
 HA zone members trust each other and share event updates as cluster messages.
 This includes for example check results, next check timestamp updates, acknowledgements
@@ -334,18 +336,52 @@ or notifications.
 This ensures that both nodes are synchronized. If one node goes away, the
 remaining node takes over and continues as normal.
 
+#### High Availability: Object Authority <a id="technical-concepts-cluster-ha-object-authority"></a>
 
 Cluster nodes automatically determine the authority for configuration
-objects. This results in activated but paused objects. You can verify
+objects. By default, all config objects are set to `HARunEverywhere` and
+as such the object authority is true for any config object on any instance.
+
+Specific objects can override and influence this setting, e.g. with `HARunOnce`
+instead prior to config object activation.
+
+This is done when the daemon starts and in a regular interval inside
+the ApiListener class, specifically calling `ApiListener::UpdateObjectAuthority()`.
+
+The algorithm works like this:
+
+* Determine whether this instance is assigned to a local zone and endpoint.
+* Collects all endpoints in this zone if they are connected.
+* If there's two endpoints, but only us seeing ourselves and the application start is less than 60 seconds in the past, do nothing (wait for cluster reconnect to take place, grace period).
+* Sort the collected endpoints by name.
+* Iterate over all config types and their respective objects
+ * Ignore !active objects
+ * Ignore objects which are !HARunOnce. This means, they can run multiple times in a zone and don't need an authority update.
+ * If this instance doesn't have a local zone, set authority to true. This is for non-clustered standalone environments where everything belongs to this instance.
+ * Calculate the object authority based on the connected endpoint names.
+ * Set the authority (true or false)
+
+The object authority calculation works "offline" without any message exchange.
+Each instance alculates the SDBM hash of the config object name, puts that in contrast
+modulo the connected endpoints size.
+This index is used to lookup the corresponding endpoint in the connected endpoints array,
+including the local endpoint. Whether the local endpoint is equal to the selected endpoint,
+or not, this sets the authority to `true` or `false`.
+
+```
+authority = endpoints[Utility::SDBM(object->GetName()) % endpoints.size()] == my_endpoint;
+```
+
+`ConfigObject::SetAuthority(bool authority)` triggers the following events:
+
+* Authority is true and object now paused: Resume the object and set `paused` to `false`.
+* Authority is false, object not paused: Pause the object and set `paused` to true.
+
+**This results in activated but paused objects on one endpoint.** You can verify
 that by querying the `paused` attribute for all objects via REST API
-or debug console.
+or debug console on both endpoints.
 
-Nodes inside a HA zone calculate the object authority independent from each other.
-
-The number of endpoints in a zone is defined through the configuration. This number
-is used inside a local modulo calculation to determine whether the node feels
-responsible for this object or not.
-
+Endpoints inside a HA zone calculate the object authority independent from each other.
 This object authority is important for selected features explained below.
 
 Since features are configuration objects too, you must ensure that all nodes
@@ -353,6 +389,36 @@ inside the HA zone share the same enabled features. If configured otherwise,
 one might have a checker feature on the left node, nothing on the right node.
 This leads to late check results because one half is not executed by the right
 node which holds half of the object authorities.
+
+By default, features are enabled to "Run-Everywhere". Specific features which
+support HA awareness, provide the `enable_ha` configuration attribute. When `enable_ha`
+is set to `true` (usually the default), "Run-Once" is set and the feature pauses on one side.
+
+```
+vim /etc/icinga2/features-enabled/graphite.conf
+
+object GraphiteWriter "graphite" {
+  ...
+  enable_ha = true
+}
+```
+
+Once such a feature is paused, there won't be any more event handling, e.g. the Elasticsearch
+feature won't process any checkresults nor write to the Elasticsearch REST API.
+
+When the cluster connection drops, the feature configuration object is updated with
+the new object authority by the ApiListener timer and resumes its operation. You can see
+that by grepping the log file for `resumed` and `paused`.
+
+```
+[2018-10-24 13:28:28 +0200] information/GraphiteWriter: 'g-ha' paused.
+```
+
+```
+[2018-10-24 13:28:28 +0200] information/GraphiteWriter: 'g-ha' resumed.
+```
+
+Specific features with HA capabilities are explained below.
 
 ### High Availability: Checker <a id="technical-concepts-cluster-ha-checker"></a>
 

--- a/lib/perfdata/elasticsearchwriter.hpp
+++ b/lib/perfdata/elasticsearchwriter.hpp
@@ -41,8 +41,8 @@ public:
 
 protected:
 	void OnConfigLoaded() override;
-	void Start(bool runtimeCreated) override;
-	void Stop(bool runtimeRemoved) override;
+	void Resume() override;
+	void Pause() override;
 
 private:
 	String m_EventPrefix;

--- a/lib/perfdata/elasticsearchwriter.ti
+++ b/lib/perfdata/elasticsearchwriter.ti
@@ -37,6 +37,9 @@ class ElasticsearchWriter : ConfigObject
 	[config] int flush_threshold {
 		default {{{ return 1024; }}}
 	};
+	[config] bool enable_ha {
+		default {{{ return true; }}}
+	};
 };
 
 }

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -46,8 +46,8 @@ public:
 
 protected:
 	void OnConfigLoaded() override;
-	void Start(bool runtimeCreated) override;
-	void Stop(bool runtimeRemoved) override;
+	void Resume() override;
+	void Pause() override;
 
 private:
 	Stream::Ptr m_Stream;

--- a/lib/perfdata/gelfwriter.ti
+++ b/lib/perfdata/gelfwriter.ti
@@ -45,6 +45,9 @@ class GelfWriter : ConfigObject
 	[no_user_modify] bool should_connect {
 		default {{{ return true; }}}
 	};
+	[config] bool enable_ha {
+		default {{{ return true; }}}
+	};
 };
 
 }

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -49,8 +49,8 @@ public:
 
 protected:
 	void OnConfigLoaded() override;
-	void Start(bool runtimeCreated) override;
-	void Stop(bool runtimeRemoved) override;
+	void Resume() override;
+	void Pause() override;
 
 private:
 	Stream::Ptr m_Stream;

--- a/lib/perfdata/graphitewriter.ti
+++ b/lib/perfdata/graphitewriter.ti
@@ -47,6 +47,9 @@ class GraphiteWriter : ConfigObject
 	[no_user_modify] bool should_connect {
 		default {{{ return true; }}}
 	};
+	[config] bool enable_ha {
+		default {{{ return true; }}}
+	};
 };
 
 }

--- a/lib/perfdata/influxdbwriter.hpp
+++ b/lib/perfdata/influxdbwriter.hpp
@@ -49,8 +49,8 @@ public:
 
 protected:
 	void OnConfigLoaded() override;
-	void Start(bool runtimeCreated) override;
-	void Stop(bool runtimeRemoved) override;
+	void Resume() override;
+	void Pause() override;
 
 private:
 	WorkQueue m_WorkQueue{10000000, 1};

--- a/lib/perfdata/influxdbwriter.ti
+++ b/lib/perfdata/influxdbwriter.ti
@@ -88,6 +88,9 @@ class InfluxdbWriter : ConfigObject
 	[config] int flush_threshold {
 		default {{{ return 1024; }}}
 	};
+	[config] bool enable_ha {
+		default {{{ return true; }}}
+	};
 };
 
 validator InfluxdbWriter {

--- a/lib/perfdata/opentsdbwriter.hpp
+++ b/lib/perfdata/opentsdbwriter.hpp
@@ -44,8 +44,9 @@ public:
 	static void StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata);
 
 protected:
-	void Start(bool runtimeCreated) override;
-	void Stop(bool runtimeRemoved) override;
+	void OnConfigLoaded() override;
+	void Resume() override;
+	void Pause() override;
 
 private:
 	Stream::Ptr m_Stream;

--- a/lib/perfdata/opentsdbwriter.ti
+++ b/lib/perfdata/opentsdbwriter.ti
@@ -34,6 +34,9 @@ class OpenTsdbWriter : ConfigObject
 	[config] String port {
 		default {{{ return "4242"; }}}
 	};
+	[config] bool enable_ha {
+		default {{{ return true; }}}
+	};
 };
 
 }

--- a/lib/perfdata/perfdatawriter.hpp
+++ b/lib/perfdata/perfdatawriter.hpp
@@ -46,8 +46,9 @@ public:
 	void ValidateServiceFormatTemplate(const Lazy<String>& lvalue, const ValidationUtils& utils) override;
 
 protected:
-	void Start(bool runtimeCreated) override;
-	void Stop(bool runtimeRemoved) override;
+	void OnConfigLoaded() override;
+	void Resume() override;
+	void Pause() override;
 
 private:
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);

--- a/lib/perfdata/perfdatawriter.ti
+++ b/lib/perfdata/perfdatawriter.ti
@@ -70,6 +70,9 @@ class PerfdataWriter : ConfigObject
 	[config] double rotation_interval {
 		default {{{ return 30; }}}
 	};
+	[config] bool enable_ha {
+		default {{{ return true; }}}
+	};
 };
 
 }


### PR DESCRIPTION
This PR implements the basic HA functionality with Run-Once or Run-Everywhere
provided by the cluster's object authority mechanism and `paused` objects.

The HA functionality is enabled by default, following the same principle
as with the IDO DB feature. This note was adding to the upgrading docs too.

fixes #2941