### PR TITLE
Add support for -q argument to Manubulon snmp-storage commmand

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2067,6 +2067,7 @@ snmp_privpass           | **Required.** SNMP version 3 priv password. No value d
 snmp_warn               | **Optional.** The warning threshold.
 snmp_crit               | **Optional.** The critical threshold.
 snmp_storage_name       | **Optional.** Storage name. Default to regex "^/$$". More options available in the [snmp storage](http://nagios.manubulon.com/snmp_storage.html) documentation.
+snmp_storage_type       | **Optional.** Filter by storage type. Valid options are Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk. No value defined as default.
 snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
 snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 snmp_storage_olength	| **Optional.** Max-size of the SNMP message, usefull in case of Too Long responses.

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -216,7 +216,7 @@ object CheckCommand "snmp-storage" {
 			description = "Max-size of the SNMP message, usefull in case of Too Long responses."
 		}
 		"-q" = {
-			value = "$storage_type$"
+			value = "$snmp_storage_type$"
 			description = "Storage type: Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk"
 		}
 	}

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -215,6 +215,10 @@ object CheckCommand "snmp-storage" {
 			value = "$snmp_storage_olength$"
 			description = "Max-size of the SNMP message, usefull in case of Too Long responses."
 		}
+    "-q" = {
+      value = "$storage_type$"
+      description = "Storage type: Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk"
+    }
 	}
 
 	vars.snmp_storage_name = "^/$$"
@@ -396,6 +400,6 @@ object CheckCommand "snmp-service" {
 			description = "Do not use regexp to match NAME in service description."
 		}
 	}
-	
+
 	vars.snmp_service_name = ".*"
 }

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -215,10 +215,10 @@ object CheckCommand "snmp-storage" {
 			value = "$snmp_storage_olength$"
 			description = "Max-size of the SNMP message, usefull in case of Too Long responses."
 		}
-    "-q" = {
-      value = "$storage_type$"
-      description = "Storage type: Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk"
-    }
+		"-q" = {
+			value = "$storage_type$"
+			description = "Storage type: Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk"
+		}
 	}
 
 	vars.snmp_storage_name = "^/$$"


### PR DESCRIPTION
The -q argument specifies the storage type. Setting this to parameter to FixedDisk makes it easy to create a single service which monitors all fixed disks, ignoring NFS mounts for example.

