### PR TITLE
Fix api setup to automatically create the conf.d directory

### DIFF
--- a/lib/cli/apisetuputility.cpp
+++ b/lib/cli/apisetuputility.cpp
@@ -152,6 +152,15 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 
 bool ApiSetupUtility::SetupMasterApiUser()
 {
+	if (!Utility::PathExists(GetConfdPath())) {
+		Log(LogWarning, "cli")
+			<< "Path '" << GetConfdPath() << "' do not exist.";
+		Log(LogInformation, "cli")
+			<< "Creating path '" << GetConfdPath() << "'.";
+
+		Utility::MkDirP(GetConfdPath(), 0755);
+	}
+
 	String api_username = "root"; // TODO make this available as cli parameter?
 	String api_password = RandomString(8);
 	String apiUsersPath = GetConfdPath() + "/api-users.conf";


### PR DESCRIPTION
This patch creates the conf.d directory automatically when it is not present during api setup.

fixes #6553 