### PR TITLE
#6749 Wrong operator on stride variable causing incorrect behaviour

### DIFF
--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -42,7 +42,7 @@ bool LegacyTimePeriod::IsInTimeRange(tm *begin, tm *end, int stride, tm *referen
 
 	int daynumber = (tsref - tsbegin) / (24 * 60 * 60);
 
-	if (stride > 1 && daynumber % stride == 0)
+	if (stride > 1 && daynumber % stride > 0)
 		return false;
 
 	return true;


### PR DESCRIPTION
This pull request resolves a [bug documented 6749](https://github.com/Icinga/icinga2/issues/6749). It is a one liner, but it resolves a big issue with Icinga ( at last big for me ).
