### PR TITLE
Fix that no_more_notifications gets reset when Recovery notifications are filtered away

### DIFF
--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -317,6 +317,16 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 				<< "Not sending " << (reminder ? "reminder " : " ") << "notifications for notification object '" << GetName() << "': type '"
 				<< NotificationTypeToStringInternal(type) << "' does not match type filter: "
 				<< NotificationFilterToString(GetTypeFilter(), GetTypeFilterMap()) << ".";
+
+			/* Ensure to reset no_more_notifications on Recovery notifications,
+			 * even if the admin did not configure them in the filter.
+			 */
+			{
+				ObjectLock olock(this);
+				if (type == NotificationRecovery && GetInterval() <= 0)
+					SetNoMoreNotifications(false);
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Hello from the OSMC hackathon :)

## Description

Combination of notification interval = 0, times.begin = 1h and filtered recovery notificadtions.

The problem arises with the first critical/down notification which delays the notification to 3h hours in the future, and sets `no_more_notifications` to `true`.

Once a recovery notification is triggered, this does not reach the point where it actually evaluates users to notify. It also does not reset `no_more_notifications` to `false` again, allowing our NOTOK-OK-NOTOK state transition logic to kick in.

We've analysed the problem with @jschanz and created a possible fix for it. A workaround for the problem is to add the `Recovery` type again to the notification objects and send a dummy OK check results to also reset the `no_more_notifications` flag to false again.

![img_2461](https://user-images.githubusercontent.com/382049/48196149-f1008780-e351-11e8-9022-f106c6341873.jpg)
![img_2462](https://user-images.githubusercontent.com/382049/48196150-f1008780-e351-11e8-94a1-39267e773ef0.jpg)
![img_2463](https://user-images.githubusercontent.com/382049/48196154-f1991e00-e351-11e8-9413-aca42bde6ad4.jpg)
![img_2464](https://user-images.githubusercontent.com/382049/48196155-f231b480-e351-11e8-9078-a4bc1b4c2c9f.jpg)
