### PR TITLE
fixes #6758

### DIFF
--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -1,5 +1,6 @@
 [Unit]
 Description=Icinga host/service/network monitoring system
+Requires=network-online.target
 After=syslog.target network-online.target postgresql.service mariadb.service carbon-cache.service carbon-relay.service
 
 [Service]


### PR DESCRIPTION
Add target network-online.target as requirement.
Service Icinga2 won't start before target is finally reached.
This prevents Icinga2 from failing if no entry for hostname.domain
is set in /etc/hosts