### PR TITLE
Fix deadlock in GraphiteWriter

### DIFF
--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -299,7 +299,7 @@ void GraphiteWriter::SendMetric(const String& prefix, const String& name, double
 	msgbuf << "\n";
 	String metric = msgbuf.str();
 
-	ObjectLock olock(this);
+	boost::mutex::scoped_lock lock(m_StreamMutex);
 
 	if (!GetConnected())
 		return;

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -27,6 +27,7 @@
 #include "base/timer.hpp"
 #include "base/workqueue.hpp"
 #include <fstream>
+#include <boost/thread/mutex.hpp>
 
 namespace icinga
 {
@@ -54,6 +55,7 @@ protected:
 
 private:
 	Stream::Ptr m_Stream;
+	boost::mutex m_StreamMutex;
 	WorkQueue m_WorkQueue{10000000, 1};
 
 	Timer::Ptr m_ReconnectTimer;


### PR DESCRIPTION
This fixes a deadlock in the GraphiteWriter feature, which is visible during the reload process. The reload thread waits for the GraphiteWriter to finish, but the GraphiteWriter can't finish because it's stuck in `SendMetric()` waiting for a lock which is hold by the reload thread.

Analysis: https://github.com/Icinga/icinga2/issues/6753#issuecomment-437688546

fixes #6753 

