### PR TITLE
Initialize ICINGA2_ERROR_LOG inside the systemd environment

### DIFF
--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -5,6 +5,7 @@ After=syslog.target network-online.target postgresql.service mariadb.service car
 
 [Service]
 Type=notify
+Environment="ICINGA2_ERROR_LOG=@ICINGA2_LOGDIR@/error.log"
 EnvironmentFile=@ICINGA2_SYSCONFIGFILE@
 ExecStartPre=@CMAKE_INSTALL_PREFIX@/lib/icinga2/prepare-dirs @ICINGA2_SYSCONFIGFILE@
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/icinga2 daemon --close-stdio -e ${ICINGA2_ERROR_LOG}


### PR DESCRIPTION
The initscript uses a local default, which is not here for Systemd.