### PR TITLE
Doc fix: update apache section

### DIFF
--- a/doc/05-service-monitoring.md
+++ b/doc/05-service-monitoring.md
@@ -226,7 +226,7 @@ Instead, choose a plugin and configure its parameters and thresholds. The follow
 * [ftp](10-icinga-template-library.md#plugin-check-command-ftp)
 * [webinject](10-icinga-template-library.md#plugin-contrib-command-webinject)
 * [squid](10-icinga-template-library.md#plugin-contrib-command-squid)
-* [apache_status](10-icinga-template-library.md#plugin-contrib-command-apache_status)
+* [apache-status](10-icinga-template-library.md#plugin-contrib-command-apache-status)
 * [nginx_status](10-icinga-template-library.md#plugin-contrib-command-nginx_status)
 * [kdc](10-icinga-template-library.md#plugin-contrib-command-kdc)
 * [rbl](10-icinga-template-library.md#plugin-contrib-command-rbl)

--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -521,7 +521,7 @@ Database	| MySQL				| [mysql_health](10-icinga-template-library.md#plugin-contri
 Database	| PostgreSQL			| [postgres](10-icinga-template-library.md#plugin-contrib-command-postgres)
 Database	| Housekeeping			| Check the database size and growth and analyse metrics to examine trends.
 Database	| DB IDO			| [ido](10-icinga-template-library.md#itl-icinga-ido) (more below)
-Webserver	| Apache2, Nginx, etc.		| [http](10-icinga-template-library.md#plugin-check-command-http), [apache_status](10-icinga-template-library.md#plugin-contrib-command-apache_status), [nginx_status](10-icinga-template-library.md#plugin-contrib-command-nginx_status)
+Webserver	| Apache2, Nginx, etc.		| [http](10-icinga-template-library.md#plugin-check-command-http), [apache-status](10-icinga-template-library.md#plugin-contrib-command-apache-status), [nginx_status](10-icinga-template-library.md#plugin-contrib-command-nginx_status)
 Webserver	| Certificates			| [http](10-icinga-template-library.md#plugin-check-command-http)
 Webserver	| Authorization			| [http](10-icinga-template-library.md#plugin-check-command-http)
 Notifications	| Mail (queue)			| [smtp](10-icinga-template-library.md#plugin-check-command-smtp), [mailq](10-icinga-template-library.md#plugin-check-command-mailq)

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1667,8 +1667,8 @@ Unless the `ignore_reboot` flag is set, if any updates require a reboot the plug
 
 > **Note**
 >
-> If they are enabled, performance data will be shown in the web interface.  
-> If run without the optional parameters, the plugin will output critical if any important updates are available.  
+> If they are enabled, performance data will be shown in the web interface.
+> If run without the optional parameters, the plugin will output critical if any important updates are available.
 
 
 ### uptime-windows <a id="windows-plugins-uptime-windows"></a>
@@ -5139,7 +5139,7 @@ vmware_multiline        | **Optional.** Multiline output in overview. This mean 
 
 This category includes all plugins for web-based checks.
 
-#### apache_status <a id="plugin-contrib-command-apache_status"></a>
+#### apache-status <a id="plugin-contrib-command-apache-status"></a>
 
 The [check_apache_status.pl](https://github.com/lbetz/check_apache_status) plugin
 uses the [/server-status](https://httpd.apache.org/docs/current/mod/mod_status.html)


### PR DESCRIPTION
Updates `apache_status` to `apache-status` to be identical according the [itl](https://github.com/Icinga/icinga2/blob/master/itl/plugins-contrib.d/web.conf#L329).
Fixes some possible copy & paste mistakes:
`Attribute 'check_command': Object 'apache_status' of type 'CheckCommand' does not exist.`