### PR TITLE
Make mail-{host,service}-notification.sh as POSIX-compliant as possible.

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright (C) 2012-2018 Icinga Development Team (https://icinga.com/)
 # Except of function urlencode which is Copyright (C) by Brian White (brian@aljex.com) used under MIT license 
@@ -51,11 +51,14 @@ Error() {
 }
 
 urlencode() {
-  local LANG=C i c e=''
-  for ((i=0;i<${#1};i++)); do
-    c=${1:$i:1}
-    [[ "$c" =~ [a-zA-Z0-9\.\~\_\-] ]] || printf -v c '%%%02X' "'$c"
-    e+="$c"
+  local LANG=C i=0 c e s="$1"
+
+  while [ $i -lt ${#1} ]; do
+    [ "$i" -eq 0 ] || s="${s#?}"
+    c=${s%"${s#?}"}
+    [ -z "${c#[[:alnum:].~_-]}" ] || c=$(printf '%%%02X' "'$c")
+    e="${e}${c}"
+    i=$((i + 1))
   done
   echo "$e"
 }

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright (C) 2012-2018 Icinga Development Team (https://icinga.com/)
 # Except of function urlencode which is Copyright (C) by Brian White (brian@aljex.com) used under MIT license
@@ -53,11 +53,14 @@ Error() {
 }
 
 urlencode() {
-  local LANG=C i c e=''
-  for ((i=0;i<${#1};i++)); do
-    c=${1:$i:1}
-    [[ "$c" =~ [a-zA-Z0-9\.\~\_\-] ]] || printf -v c '%%%02X' "'$c"
-    e+="$c"
+  local LANG=C i=0 c e s="$1"
+
+  while [ $i -lt ${#1} ]; do
+    [ "$i" -eq 0 ] || s="${s#?}"
+    c=${s%"${s#?}"}
+    [ -z "${c#[[:alnum:].~_-]}" ] || c=$(printf '%%%02X' "'$c")
+    e="${e}${c}"
+    i=$((i + 1))
   done
   echo "$e"
 }


### PR DESCRIPTION
When setting up a test-environment on OpenBSD I found that the mail-{host,service}-notification.sh scripts don't work anymore since the commit of urlencode, because OpenBSD changes the shebang from #!/usr/bin/env bash to #!/bin/ksh, which breaks compatibility.

I just committed the diff below to OpenBSD.[0][1][2] Would it be possible to allow something similar to be included in icinga2 itself?

I changed the shebang here, so that future alterations would be more inclined to also check for plain sh-compatibility. Diff lightly tested with bash, dash, OpenBSD ksh/sh.

[0] https://marc.info/?l=openbsd-ports-cvs&m=154237326925540&w=2
[1] http://cvsweb.openbsd.org/ports/net/icinga/core2/patches/patch-etc_icinga2_scripts_mail-host-notification_sh
[2] http://cvsweb.openbsd.org/ports/net/icinga/core2/patches/patch-etc_icinga2_scripts_mail-service-notification_sh