### PR TITLE
ApiListener#RelayMessageOne(): fix wrong condition

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -988,7 +988,7 @@ bool ApiListener::RelayMessageOne(const Zone::Ptr& targetZone, const MessageOrig
 		}
 
 		/* only relay message to the master if we're not currently the master */
-		if (currentMaster != myEndpoint && currentMaster != endpoint) {
+		if (currentMaster == myEndpoint && currentMaster == endpoint) {
 			skippedEndpoints.push_back(endpoint);
 			continue;
 		}


### PR DESCRIPTION
The changed condition now behaves as described by the comment above it.

Especially the cases a and d (show below) aren't swapped anymore.

 input                                                                      | a | b | c | d
 ---------------------------------------------------------------------------|---|---|---|--
 `currentMaster == myEndpoint`                                              | 0 | 0 | 1 | 1
 `currentMaster == endpoint`                                                | 0 | 1 | 0 | 1
 `currentMaster != myEndpoint && currentMaster != endpoint`                 | 1 | 0 | 0 | 0
 `/* only relay message to the master if we're not currently the master */` | 0 | 0 | 0 | 1