### PR TITLE
DSL: Implement getenv()

### DIFF
--- a/doc/18-library-reference.md
+++ b/doc/18-library-reference.md
@@ -425,6 +425,22 @@ Example:
     	warn = null
     }
 
+### getenv <a id="global-functions-getenv"></a>
+
+Signature:
+
+    function getenv(key)
+
+Returns the value from the specified environment variable key.
+
+Example:
+
+    $ MY_ENV_VAR=icinga2 icinga2 console
+    Icinga 2 (version: v2.11.0)
+    Type $help to view available commands.
+    <1> => getenv("MY_ENV_VAR")
+    "icinga2"
+
 ### dirname <a id="global-functions-dirname"></a>
 
 Signature:

--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -925,7 +925,8 @@ static VOID WINAPI ServiceMain(DWORD argc, LPSTR *argv)
 int main(int argc, char **argv)
 {
 #ifndef _WIN32
-	if (!getenv("ICINGA2_KEEP_FDS")) {
+	String keepFDs = Utility::GetFromEnvironment("ICINGA2_KEEP_FDS");
+	if (keepFDs.IsEmpty()) {
 		rlimit rl;
 		if (getrlimit(RLIMIT_NOFILE, &rl) >= 0) {
 			rlim_t maxfds = rl.rlim_max;

--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -491,8 +491,8 @@ String Application::GetExePath(const String& argv0)
 	}
 
 	if (!foundSlash) {
-		const char *pathEnv = getenv("PATH");
-		if (pathEnv) {
+		String pathEnv = Utility::GetFromEnvironment("PATH");
+		if (!pathEnv.IsEmpty()) {
 			std::vector<String> paths = String(pathEnv).Split(":");
 
 			bool foundPath = false;

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -61,6 +61,7 @@ REGISTER_SAFE_FUNCTION(System, bool, &ScriptUtils::CastBool, "value");
 REGISTER_SAFE_FUNCTION(System, get_time, &Utility::GetTime, "");
 REGISTER_SAFE_FUNCTION(System, basename, &Utility::BaseName, "path");
 REGISTER_SAFE_FUNCTION(System, dirname, &Utility::DirName, "path");
+REGISTER_SAFE_FUNCTION(System, getenv, &ScriptUtils::GetEnv, "value");
 REGISTER_SAFE_FUNCTION(System, msi_get_component_path, &ScriptUtils::MsiGetComponentPathShim, "component");
 REGISTER_SAFE_FUNCTION(System, track_parents, &ScriptUtils::TrackParents, "child");
 REGISTER_SAFE_FUNCTION(System, escape_shell_cmd, &Utility::EscapeShellCmd, "cmd");
@@ -529,4 +530,9 @@ Value ScriptUtils::GlobRecursive(const std::vector<Value>& args)
 	Utility::GlobRecursive(path, pattern, std::bind(&GlobCallbackHelper, std::ref(paths), _1), type);
 
 	return Array::FromVector(paths);
+}
+
+String ScriptUtils::GetEnv(const String& key)
+{
+	return Utility::GetFromEnvironment(key);
 }

--- a/lib/base/scriptutils.hpp
+++ b/lib/base/scriptutils.hpp
@@ -58,6 +58,7 @@ public:
 	static double Ptr(const Object::Ptr& object);
 	static Value Glob(const std::vector<Value>& args);
 	static Value GlobRecursive(const std::vector<Value>& args);
+	static String GetEnv(const String& key);
 
 private:
 	ScriptUtils();

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -36,6 +36,7 @@
 #include <ios>
 #include <fstream>
 #include <iostream>
+#include <stdlib.h>
 #include <future>
 
 #ifdef __FreeBSD__
@@ -1936,16 +1937,18 @@ String Utility::GetIcingaDataPath()
 
 #endif /* _WIN32 */
 
+/**
+ * Retrieve the environment variable value by given key.
+ *
+ * @param env Environment variable name.
+ */
+
 String Utility::GetFromEnvironment(const String& env)
 {
-#ifndef _WIN32
 	const char *envValue = getenv(env.CStr());
+
 	if (envValue == NULL)
 		return String();
 	else
 		return String(envValue);
-#else /* _WIN32 */
-	// While getenv exists on Windows, we don't set them. Therefore there is no reason to read them.
-	return String();
-#endif /* _WIN32 */
 }

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -69,6 +69,8 @@ public:
 	static String DirName(const String& path);
 	static String BaseName(const String& path);
 
+	static String GetEnv(const String& key);
+
 	static void NullDeleter(void *);
 
 	static double GetTime();

--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -245,8 +245,8 @@ int ConsoleCommand::Run(const po::variables_map& vm, const std::vector<std::stri
 			<< "Type $help to view available commands.\n";
 
 
-	const char *addrEnv = getenv("ICINGA2_API_URL");
-	if (addrEnv)
+	String addrEnv = Utility::GetFromEnvironment("ICINGA2_API_URL");
+	if (!addrEnv.IsEmpty())
 		addr = addrEnv;
 
 	if (vm.count("connect"))
@@ -290,12 +290,12 @@ int ConsoleCommand::RunScriptConsole(ScriptFrame& scriptFrame, const String& add
 	int next_line = 1;
 
 #ifdef HAVE_EDITLINE
-	char *homeEnv = getenv("HOME");
+	String homeEnv = Utility::GetFromEnvironment("HOME");
 
 	String historyPath;
 	std::fstream historyfp;
 
-	if (homeEnv) {
+	if (!homeEnv.IsEmpty()) {
 		historyPath = String(homeEnv) + "/.icinga2_history";
 
 		historyfp.open(historyPath.CStr(), std::fstream::in);
@@ -321,12 +321,12 @@ int ConsoleCommand::RunScriptConsole(ScriptFrame& scriptFrame, const String& add
 			return EXIT_FAILURE;
 		}
 
-		const char *usernameEnv = getenv("ICINGA2_API_USERNAME");
-		const char *passwordEnv = getenv("ICINGA2_API_PASSWORD");
+		String usernameEnv = Utility::GetFromEnvironment("ICINGA2_API_USERNAME");
+		String passwordEnv = Utility::GetFromEnvironment("ICINGA2_API_PASSWORD");
 
-		if (usernameEnv)
+		if (!usernameEnv.IsEmpty())
 			url->SetUsername(usernameEnv);
-		if (passwordEnv)
+		if (!passwordEnv.IsEmpty())
 			url->SetPassword(passwordEnv);
 
 		if (url->GetPort().IsEmpty())


### PR DESCRIPTION
This patch also restores Utility::GetFromEnvironment()
and replaces the hardcoded `getenv()` calls.