### PR TITLE
Fix check_perfmon to support non-localized names

### DIFF
--- a/plugins/check_perfmon.cpp
+++ b/plugins/check_perfmon.cpp
@@ -297,7 +297,11 @@ bool QueryPerfData(printInfoStruct& pI)
 	if (FAILED(status))
 		goto die;
 
-	status = PdhAddCounter(hQuery, pI.wsFullPath.c_str(), NULL, &hCounter);
+	status = PdhAddEnglishCounter(hQuery, pI.wsFullPath.c_str(), NULL, &hCounter);
+
+	if (FAILED(status))
+		status = PdhAddCounter(hQuery, pI.wsFullPath.c_str(), NULL, &hCounter);
+
 	if (FAILED(status))
 		goto die;
 


### PR DESCRIPTION
This fixes check_perfmon to support non-localized names on localized
Windows machines. The fix handles the given performance counter by
default as non-localized name, if none is found it falls back to the
localized name.

Example:

```
.\check_perfmon.exe -P "\Processor(_Total)\% Processor Time"
PERFMON OK for '\Processor(_Total)\% Processor Time' = 37.7655 | '\Processor(_Total)\% Processor Time'=37.7655;;;;

.\check_perfmon.exe -P"\Prozessor(*)\Prozessorzeit (%)"
PERFMON OK for '\Prozessor(*)\Prozessorzeit (%)' = 31.5661 | '\Prozessor(*)\Prozessorzeit (%)'=31.5661;;;;
```

Both names (localized and non-localized) are working. Currently I only have a German localized Windows at hand, maybe someone can test this on other localization as well.

fixes #6418 
fixes #5546