### PR TITLE
Fix state conditions in check_memory and check_swap

### DIFF
--- a/plugins/check_memory.cpp
+++ b/plugins/check_memory.cpp
@@ -164,7 +164,7 @@ static int printOutput(printInfoStruct& printInfo)
 	if (l_Debug)
 		std::wcout << L"Constructing output string" << '\n';
 
-	state state;
+	state state = OK;
 
 	std::wcout << L"MEMORY ";
 
@@ -175,16 +175,13 @@ static int printOutput(printInfoStruct& printInfo)
 	else
 		currentValue = printInfo.tRam - printInfo.aRam;
 
-	if (printInfo.warn.rend(currentValue, printInfo.tRam)) {
+	if (printInfo.warn.rend(currentValue, printInfo.tRam))
 		state = WARNING;
-		std::wcout << L"WARNING";
-	} else if (printInfo.crit.rend(currentValue, printInfo.tRam)) {
+
+	if (printInfo.crit.rend(currentValue, printInfo.tRam))
 		state = CRITICAL;
-		std::wcout << L"CRITICAL";
-	} else {
-		state = OK;
-		std::wcout << L"OK";
-	}
+
+	std::wcout << stateToString(state);
 
 	if (!printInfo.showUsed)
 		std::wcout << " - " << printInfo.percentFree << L"% free";

--- a/plugins/check_swap.cpp
+++ b/plugins/check_swap.cpp
@@ -194,16 +194,13 @@ static int printOutput(printInfoStruct& printInfo)
 	else
 		currentValue = printInfo.tSwap - printInfo.aSwap;
 
-	if (printInfo.warn.rend(currentValue, printInfo.tSwap)) {
+	if (printInfo.warn.rend(currentValue, printInfo.tSwap))
 		state = WARNING;
-		std::wcout << L"WARNING - ";
-	} else if (printInfo.crit.rend(currentValue, printInfo.tSwap)) {
+
+	if (printInfo.crit.rend(currentValue, printInfo.tSwap))
 		state = CRITICAL;
-		std::wcout << L"CRITICAL - ";
-	} else {
-		state = OK;
-		std::wcout << L"OK - ";
-	}
+
+	std::wcout << stateToString(state) << " ";
 
 	if (!printInfo.showUsed)
 		std::wcout << printInfo.percentFree << L"% free ";

--- a/plugins/thresholds.cpp
+++ b/plugins/thresholds.cpp
@@ -282,3 +282,12 @@ std::wstring formatErrorInfo(unsigned long err) {
 
 	return out.str();
 }
+
+std::wstring stateToString(const state& state) {
+	switch (state) {
+		case OK: return L"OK";
+		case WARNING: return L"WARNING";
+		case CRITICAL: return L"CRITICAL";
+		default: return L"UNKNOWN";
+	}
+}

--- a/plugins/thresholds.hpp
+++ b/plugins/thresholds.hpp
@@ -76,4 +76,6 @@ std::wstring TunitStr(const Tunit&);
 void printErrorInfo(unsigned long err = 0);
 std::wstring formatErrorInfo(unsigned long err);
 
+std::wstring stateToString(const state&);
+
 #endif /* THRESHOLDS_H */


### PR DESCRIPTION
This fixes the state conditions in check_memory and check_swap. This
turns the if/else if/else statements in simple if statements, since they
won't work properly when both thresholds are broken.

This also implements a new function to get a given state as wstring. 

# Tests

check_memory

```
.\check_memory.exe -u mb -w 55%
MEMORY WARNING - 13.467% free| 'memory'=551.55MB;2252.5525000000002;;0;4095.55

.\check_memory.exe -u mb -w 55% -c 60%
MEMORY CRITICAL - 10.4848% free| 'memory'=429.41MB;2252.5525000000002;2457.3299999999999;0;4095.55

.\check_memory.exe -u mb -w 80%  -U
MEMORY WARNING - 89.184% used| 'memory'=3652.57MB;3276.4400000000005;;0;4095.55

.\check_memory.exe -u mb -w 80% -c 85% -U
MEMORY CRITICAL - 89.0834% used| 'memory'=3648.46MB;3276.4400000000005;3481.2175000000002;0;4095.55
```

check_swap

```
 .\check_swap.exe -u mb -w 90%
SWAP OK 90.0452% free | 'swap'=1990MB;1989;;0;2210

.\check_swap.exe -u mb -w 91%
SWAP WARNING 90.0452% free | 'swap'=1990MB;2011.1000000000001;;0;2210

.\check_swap.exe -u mb -w 91% -c 92%
SWAP CRITICAL 90.0452% free | 'swap'=1990MB;2011.1000000000001;2033.2;0;2210

.\check_swap.exe -u mb -w 8% -U
SWAP WARNING 9.68326% used | 'swap'=214MB;176.80000000000001;;0;2210

.\check_swap.exe -u mb -w 8% -c 9% -U
SWAP CRITICAL 9.68326% used | 'swap'=214MB;176.80000000000001;198.90000000000001;0;2210
```

fixes #6810