### PR TITLE
 Implement TLS support for the GelfWriter feature

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1344,7 +1344,10 @@ Configuration Attributes:
   source                    | String                | **Optional.** Source name for this instance. Defaults to `icinga2`.
   enable\_send\_perfdata    | Boolean               | **Optional.** Enable performance data for 'CHECK RESULT' events.
   enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `false`.
-
+  enable\_tls               | Boolean               | **Optional.** Whether to use a TLS stream. Defaults to `false`.
+  ca\_path                  | String                | **Optional.** Path to CA certificate to validate the remote host. Requires `enable_tls` set to `true`.
+  cert\_path                | String                | **Optional.** Path to host certificate to present to the remote host for mutual verification. Requires `enable_tls` set to `true`.
+  key\_path                 | String                | **Optional.** Path to host key to accompany the cert\_path. Requires `enable_tls` set to `true`.
 
 ### GraphiteWriter <a id="objecttype-graphitewriter"></a>
 

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -22,6 +22,11 @@
 #include "base/statsfunction.hpp"
 #include <boost/algorithm/string/replace.hpp>
 #include <utility>
+#include "base/io-engine.hpp"
+#include <boost/asio/write.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/asio/error.hpp>
 
 using namespace icinga;
 
@@ -126,11 +131,7 @@ void GelfWriter::ExceptionHandler(boost::exception_ptr exp)
 	Log(LogDebug, "GelfWriter")
 		<< "Exception during Graylog Gelf operation: " << DiagnosticInformation(std::move(exp));
 
-	if (GetConnected()) {
-		m_Stream->Close();
-
-		SetConnected(false);
-	}
+	DisconnectInternal();
 }
 
 void GelfWriter::Reconnect()
@@ -156,43 +157,46 @@ void GelfWriter::ReconnectInternal()
 	if (GetConnected())
 		return;
 
-	TcpSocket::Ptr socket = new TcpSocket();
-
 	Log(LogNotice, "GelfWriter")
 		<< "Reconnecting to Graylog Gelf on host '" << GetHost() << "' port '" << GetPort() << "'.";
 
-	try {
-		socket->Connect(GetHost(), GetPort());
-	} catch (const std::exception& ex) {
-		Log(LogCritical, "GelfWriter")
-			<< "Can't connect to Graylog Gelf on host '" << GetHost() << "' port '" << GetPort() << "'.";
-		throw ex;
-	}
+	bool ssl = GetEnableTls();
 
-	if (GetEnableTls()) {
-		std::shared_ptr<SSL_CTX> sslContext;
+	if (ssl) {
+		std::shared_ptr<boost::asio::ssl::context> sslContext;
 
-		try  {
-			sslContext = MakeSSLContext(GetCertPath(), GetKeyPath(), GetCaPath());
+		try {
+			sslContext = MakeAsioSslContext(GetCertPath(), GetKeyPath(), GetCaPath());
 		} catch (const std::exception& ex) {
 			Log(LogWarning, "GelfWriter")
 				<< "Unable to create SSL context.";
-			throw ex;
+			throw;
 		}
 
-		TlsStream::Ptr tlsStream = new TlsStream(socket, GetHost(), RoleClient, sslContext);
+		m_Stream.first = std::make_shared<AsioTlsStream>(IoEngine::Get().GetIoService(), *sslContext, GetHost());
+	} else {
+		m_Stream.second = std::make_shared<AsioTcpStream>(IoEngine::Get().GetIoService());
+	}
+
+	try {
+		icinga::Connect(ssl ? m_Stream.first->lowest_layer() : m_Stream.second->lowest_layer(), GetHost(), GetPort());
+	} catch (const std::exception& ex) {
+		Log(LogWarning, "GelfWriter")
+			<< "Can't connect to Graylog Gelf on host '" << GetHost() << "' port '" << GetPort() << ".'";
+		throw;
+	}
+
+	if (ssl) {
+		auto& tlsStream (m_Stream.first->next_layer());
 
 		try {
-			tlsStream->Handshake();
+			tlsStream.handshake(tlsStream.client);
 		} catch (const std::exception& ex) {
 			Log(LogWarning, "GelfWriter")
-				<< "TLS handshake with host'" << GetHost() << "' on port '" << GetPort() << "' failed.'";
-			throw ex;
+				<< "TLS handshake with host '" << GetHost() << " failed.'";
+			throw;
 		}
-
-		m_Stream = tlsStream;
-	} else
-		m_Stream = new NetworkStream(socket);
+	}
 
 	SetConnected(true);
 
@@ -217,9 +221,22 @@ void GelfWriter::DisconnectInternal()
 	if (!GetConnected())
 		return;
 
-	m_Stream->Close();
+	if (m_Stream.first) {
+		boost::system::error_code ec;
+		m_Stream.first->next_layer().shutdown(ec);
+
+		// https://stackoverflow.com/a/25703699
+		// As long as the error code's category is not an SSL category, then the protocol was securely shutdown
+		if (ec.category() == boost::asio::error::get_ssl_category()) {
+			Log(LogCritical, "GelfWriter")
+				<< "TLS shutdown with host '" << GetHost() << "' could not be done securely.";
+		}
+	} else if (m_Stream.second) {
+		m_Stream.second->close();
+	}
 
 	SetConnected(false);
+
 }
 
 void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
@@ -479,7 +496,13 @@ void GelfWriter::SendLogMessage(const Checkable::Ptr& checkable, const String& g
 		Log(LogDebug, "GelfWriter")
 			<< "Checkable '" << checkable->GetName() << "' sending message '" << log << "'.";
 
-		m_Stream->Write(log.CStr(), log.GetLength());
+		if (m_Stream.first) {
+			boost::asio::write(*m_Stream.first, boost::asio::buffer(msgbuf.str()));
+			m_Stream.first->flush();
+		} else {
+			boost::asio::write(*m_Stream.second, boost::asio::buffer(msgbuf.str()));
+			m_Stream.second->flush();
+		}
 	} catch (const std::exception& ex) {
 		Log(LogCritical, "GelfWriter")
 			<< "Cannot write to TCP socket on host '" << GetHost() << "' port '" << GetPort() << "'.";

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -33,7 +33,7 @@ protected:
 	void Pause() override;
 
 private:
-	Stream::Ptr m_Stream;
+	OptionalTlsStream m_Stream;
 	WorkQueue m_WorkQueue{10000000, 1};
 
 	Timer::Ptr m_ReconnectTimer;

--- a/lib/perfdata/gelfwriter.ti
+++ b/lib/perfdata/gelfwriter.ti
@@ -31,6 +31,12 @@ class GelfWriter : ConfigObject
 	[config] bool enable_ha {
 		default {{{ return false; }}}
 	};
+    [config] bool enable_tls {
+        default {{{ return false; }}}
+    };
+    [config] String ca_path;
+    [config] String cert_path;
+    [config] String key_path;
 };
 
 }


### PR DESCRIPTION
This implements TLS support for the GelfWriter feature.

# Test

I used the Icinga 2 Vagrant box with Graylog from [icinga-vagrant](https://github.com/Icinga/icinga-vagrant). But I only used the Graylog instance from there, the Icinga 2 daemon ran directly on my notebook computer.

## Create CA

```
openssl genrsa -out ca.key 4096
openssl req -x509 -new -nodes -extensions v3_ca -key ca.key -days 1024 -out ca.crt -sha512
```

## Generate certificate for Graylog (server)

```
openssl genrsa -out graylog-server.key 4096
openssl req -new -key graylog-server.key -out graylog-server.csr -sha512
openssl x509 -req -in graylog-server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out graylog-server.crt -days 365 -sha512
```

## Generate certificate for Icinga 2 (client)

```
openssl genrsa -out icinga2-client.key 4096
openssl req -new -key icinga2-client.key -out icinga2-client.csr -sha512
openssl x509 -req -in icinga2-client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out icinga2-client.crt -days 365 -sha512
```

I copied `ca.crt`,  `icinga2-client.key` and  `icinga2-client.crt` to my machine, since the Icinga 2 daemon runs there. 

## Create new Gelf Input with TLS

![graylog - inputs - chromium_005](https://user-images.githubusercontent.com/18580278/49344439-750b0e00-f677-11e8-98ea-ee1297a17339.png)

```
bind_address: 0.0.0.0
decompress_size_limit: 8388608
max_message_size: 2097152
override_source: <empty>
port: 12202
recv_buffer_size: 1048576
tcp_keepalive: false
tls_cert_file: /srv/graylog/graylog-server.crt
tls_client_auth: required
tls_client_auth_cert_file: /srv/graylog/ca.crt
tls_enable: true
tls_key_file: /srv/graylog/graylog-server-pkcs8.key
tls_key_password: ********
use_null_delimiter: true
```

## Activate and configure GelfWriter feature 

```
icinga2 feature enable gelf
```

```
vim /usr/local/icinga2/etc/icinga2/features-enabled/gelf.conf

object GelfWriter "gelf" {
  host = "192.168.33.6"
  port = 12202
  source = "icinga2"
  enable_send_perfdata = true
  enable_tls = true
  ca_path = "/srv/ca.crt"
  cert_path = "/srv/icinga2-client.crt"
  key_path = "/srv/icinga2-client.key"
}
```

## Verifying TLS usage

Start the Icinga 2 daemon, verify that the GelfWriter actually writes data.

```
[2018-12-02 21:21:57 +0100] information/GelfWriter: 'gelf' resumed.
[...]
[2018-12-02 21:22:07 +0100] information/WorkQueue: #5 (GelfWriter, gelf) items: 0, rate: 9.11667/s (547/min 547/5min 547/15min);
```

Check Graylog.

![graylog - sources - chromium_006](https://user-images.githubusercontent.com/18580278/49344551-3413f900-f679-11e8-8613-17625510e1dc.png)

Graylog receives data. 

Verify encryption.

![-any_004](https://user-images.githubusercontent.com/18580278/49344566-74737700-f679-11e8-985b-88ba8a372aa9.png)

(192.168.33.6 is the ip address of the Graylog VM).

fixes #6152