### PR TITLE
Restore 'Connection: close' behaviour in HTTP responses

### DIFF
--- a/lib/remote/httpresponse.cpp
+++ b/lib/remote/httpresponse.cpp
@@ -112,6 +112,12 @@ void HttpResponse::Finish()
 
 	m_State = HttpResponseEnd;
 
+	/* Close the connection on
+	 * a) HTTP/1.0
+	 * b) Connection: close in the sent header.
+	 *
+	 * Do this here and not in DataAvailableHandler - there might still be incoming data in there.
+	 */
 	if (m_Request->ProtocolVersion == HttpVersion10 || m_Request->Headers->Get("connection") == "close")
 		m_Stream->Shutdown();
 }

--- a/lib/remote/httpresponse.cpp
+++ b/lib/remote/httpresponse.cpp
@@ -111,6 +111,9 @@ void HttpResponse::Finish()
 	}
 
 	m_State = HttpResponseEnd;
+
+	if (m_Request->ProtocolVersion == HttpVersion10 || m_Request->Headers->Get("connection") == "close")
+		m_Stream->Shutdown();
 }
 
 bool HttpResponse::Parse(StreamReadContext& src, bool may_wait)

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -362,13 +362,6 @@ void HttpServerConnection::DataAvailableHandler()
 
 			close = true;
 		}
-
-		/* Request finished, decide whether to explicitly close the connection. */
-		if (m_CurrentRequest.ProtocolVersion == HttpVersion10 ||
-			m_CurrentRequest.Headers->Get("connection") == "close") {
-			m_Stream->Shutdown();
-			close = true;
-		}
 	} else
 		close = true;
 


### PR DESCRIPTION
Analysis and tests: https://github.com/Icinga/icinga2/issues/6799#issuecomment-443710338

fixes #6799