### PR TITLE
service and host mail-notifications, add line-breaks to very long out…

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -92,12 +92,32 @@ shift $((OPTIND - 1))
 
 ## Keep formatting in sync with mail-service-notification.sh
 for P in LONGDATETIME HOSTNAME HOSTDISPLAYNAME HOSTOUTPUT HOSTSTATE USEREMAIL NOTIFICATIONTYPE ; do
-	eval "PAR=\$${P}"
+  eval "PAR=\$${P}"
 
-	if [ ! "$PAR" ] ; then
-		Error "Required parameter '$P' is missing."
-	fi
+  if [ ! "$PAR" ] ; then
+    Error "Required parameter '$P' is missing."
+  fi
 done
+
+## Add line-breaks to very long host-outputs to avoid
+## mail servers rejecting the message because of hitting
+## a max. message line limit (RFC821 max. 1000b per line)
+##
+## but move on, if the strings seems to take care of its
+## own formating (containing \n or \r)
+if [ ! -z "${HOSTOUTPUT}" ] \
+   && [ "${#HOSTOUTPUT}" -ge 900 ] \
+   && ! [[ "${HOSTOUTPUT}" =~ ($'\n'|$'\r') ]]; then
+  TMP_OUTPUT=''
+  STR_CNT=0
+  STR_STEPS=600
+  while [ $STR_CNT -lt ${#HOSTOUTPUT} ]; do
+    TMP_OUTPUT+="${HOSTOUTPUT:$STR_CNT:$STR_STEPS}\\n"
+    ((STR_CNT+=STR_STEPS)) || true
+  done
+  HOSTOUTPUT="${TMP_OUTPUT}"
+  unset TMP_OUTPUT STR_CNT
+fi
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] Host $HOSTDISPLAYNAME is $HOSTSTATE!"

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -96,12 +96,32 @@ shift $((OPTIND - 1))
 
 ## Keep formatting in sync with mail-host-notification.sh
 for P in LONGDATETIME HOSTNAME HOSTDISPLAYNAME SERVICENAME SERVICEDISPLAYNAME SERVICEOUTPUT SERVICESTATE USEREMAIL NOTIFICATIONTYPE ; do
-        eval "PAR=\$${P}"
+  eval "PAR=\$${P}"
 
-        if [ ! "$PAR" ] ; then
-                Error "Required parameter '$P' is missing."
-        fi
+  if [ ! "$PAR" ] ; then
+    Error "Required parameter '$P' is missing."
+  fi
 done
+
+## Add line-breaks to very long service-outputs to avoid
+## mail servers rejecting the message because of hitting
+## a max. message line limit (RFC821 max. 1000b per line)
+##
+## but move on, if the strings seems to take care of its
+## own formating (containing \n or \r)
+if [ ! -z "${SERVICEOUTPUT}" ] \
+   && [ "${#SERVICEOUTPUT}" -ge 900 ] \
+   && ! [[ "${SERVICEOUTPUT}" =~ ($'\n'|$'\r') ]]; then
+   TMP_OUTPUT=''
+   STR_CNT=0
+   STR_STEPS=600
+   while [ $STR_CNT -lt ${#SERVICEOUTPUT} ]; do
+      TMP_OUTPUT+="${SERVICEOUTPUT:$STR_CNT:$STR_STEPS}\\n"
+      ((STR_CNT+=STR_STEPS)) || true
+   done
+   SERVICEOUTPUT="${TMP_OUTPUT}"
+   unset TMP_OUTPUT STR_CNT
+fi
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE!"


### PR DESCRIPTION
In case of `service.output` or `host.output` contain very long strings (lets say >= 1000 characters) it happens that mail-servers rejecting those mails generated by `mail-host-notification.sh` and `mail-service-notification.sh`.

[RFC821](https://tools.ietf.org/html/rfc821)
```
            text line

               The maximum total length of a text line including the
               <CRLF> is 1000 characters (but not counting the leading
               dot duplicated for transparency).
```

As an example, Exim4 enforces this limit and rejects the message with `message is too big 
(transport limit = 1)`.

One could argue, thats this is the responsibility of plugins to submit well-formated output.

But on the other hand, not receiving a notification at all - because of a misbehaving plugin - is IMHO even more worse :)

So I've adapted `mail-host-notification.sh` and `mail-service-notification.sh` to take of strings that are longer than 900 characters and add some newline-characters in between.

But only if it seems, that the plugin itself has not taken care of formating the output itself (not containing `\r` or `\n`). Otherwise it leaves the output untouched.