### PR TITLE
Add haproxy-status CheckCommand definition

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5466,7 +5466,7 @@ haproxy_timeout         | **Optional.** Seconds before plugin times out (default
 haproxy_warning         | **Optional.** Warning request time threshold (in seconds)
 haproxy_critical        | **Optional.** Critical request time threshold (in seconds)
 
-#### haproxy-status <a id="plugin-contrib-command-haproxy-status"></a>
+#### haproxy_status <a id="plugin-contrib-command-haproxy_status"></a>
 
 The [check_haproxy_status](https://github.com/jonathanio/monitoring-nagios-haproxy) plugin,
 uses the `haproxy` statistics socket to monitor [haproxy](http://www.haproxy.org/) frontends/backends.

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5466,6 +5466,30 @@ haproxy_timeout         | **Optional.** Seconds before plugin times out (default
 haproxy_warning         | **Optional.** Warning request time threshold (in seconds)
 haproxy_critical        | **Optional.** Critical request time threshold (in seconds)
 
+#### haproxy-status <a id="plugin-contrib-command-haproxy-status"></a>
+
+The [check_haproxy_status](https://github.com/jonathanio/monitoring-nagios-haproxy) plugin,
+uses the `haproxy` statistics socket to monitor [haproxy](http://www.haproxy.org/) frontends/backends.
+
+This plugin need read/write access to the statistics socket with an operator level. You can configure it in the global section of haproxy to allow icinga user to use it:
+```
+stats socket /run/haproxy/admin.sock user haproxy group icinga mode 660 level operator
+```
+
+Custom attributes passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
+
+Name                        | Description
+----------------------------|----------------------------------------------------------------------------------
+haproxy\_status\_default    | **Optional.** Set/Override the defaults which will be applied to all checks (unless specifically set by --overrides).
+haproxy\_status\_frontends  | **Optional.** Enable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached).
+haproxy\_status\_nofrontends| **Optional.** Disable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached).
+haproxy\_status\_backends   | **Optional.** Enable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached).
+haproxy\_status\_nobackends | **Optional.** Disable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached).
+haproxy\_status\_servers    | **Optional.** Enable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues).
+haproxy\_status\_noservers  | **Optional.** Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues).
+haproxy\_status\_overrides  | **Optional.** Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above.
+haproxy\_status\_socket     | **Required.** Path to the socket check_haproxy should connect to
+
 #### phpfpm_status <a id="plugin-contrib-command-phpfpm_status"></a>
 
 The [check_phpfpm_status](http://github.com/regilero/check_phpfpm_status) plugin,

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -619,6 +619,51 @@ object CheckCommand "haproxy" {
 	}
 }
 
+object CheckCommand "haproxy_status" {
+	import "plugin-check-command"
+	command = [ PluginDir + "/check_haproxy_status" ]
+
+	arguments = {
+		"--defaults" = {
+			value = "$haproxy_status_default$"
+			description = "Set/Override the defaults which will be applied to all checks (unless specifically set by --overrides)."
+		}
+		"--frontends" = {
+			set_if = "$haproxy_status_frontends$"
+			description = "Enable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached)."
+		}
+		"--nofrontends" = {
+			set_if = "$haproxy_status_nofrontends$"
+			description = "Disable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached)."
+		}
+		"--backends" = {
+			set_if = "$haproxy_status_backends$"
+			description = "Enable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached)."
+		}
+		"--nobackends" = {
+			set_if = "$haproxy_status_nobackends$"
+			description = "Disable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached)."
+		}
+		"--servers" = {
+			set_if = "$haproxy_status_servers$"
+			description = "Enable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
+		}
+		"--noservers" = {
+			set_if = "$haproxy_status_noservers$"
+			description = "Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
+		}
+		"--overrides" = {
+			value = "$haproxy_status_overrides$"
+			description = "Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above."
+		}
+		"--socket" = {
+			value = "$haproxy_status_socket$"
+			description = "Path to the socket check_haproxy should connect to"
+			required = true
+		}
+	}
+}
+
 object CheckCommand "phpfpm_status" {
 	import "plugin-check-command"
 	command = [ PluginDir + "/check_phpfpm_status" ]


### PR DESCRIPTION
Another haproxy CheckCommand. This plugin uses haproxy stat socket to
check for all or specific frontend/backend status.