### PR TITLE
Don't run UpdateObjectAuthority for Comments and Downtimes

### DIFF
--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -159,7 +159,13 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 			return false;
 		}
 
-		ApiListener::UpdateObjectAuthority();
+		/* if (type != Comment::TypeInstance && type != Downtime::TypeInstance)
+		 * Does not work since this would require libicinga, which has a dependency on libremote
+		 * Would work if these libs were static.
+		 */
+		if (type->GetName() != "Comment" && type->GetName() != "Downtime")
+			ApiListener::UpdateObjectAuthority();
+
 
 		Log(LogInformation, "ConfigObjectUtility")
 			<< "Created and activated object '" << fullName << "' of type '" << type->GetName() << "'.";


### PR DESCRIPTION
This patch does not run UpdateObjectAuthority when creating Downtimes or Comments via the API. UOA takes up most of the time when creating a new object as it enumerates all objects. Downtimes are especially heavy as you often create multiple of them at a time.

In my tests creating downtimes for 15.000 Services took over 7 minutes (UOA runs 15.000 times, going over all ~30.000 objects), when not running UOA this went down to 50 seconds.

To make sure Downtimes still work without UOA, I ran the following test:
1. Have a master-master zone (M1 & M2)
2. Create Downtimes on M1s API
3. Query Downtimes on M2 and see if they are active
4. Success and Profit
 
About the implementation:
I am using type->GetName and compare Strings. This may seem ugly but is necessary in this case as type comparison would require libremote to link libicinga which means a dependency circle.