### PR TITLE
Added snmp_exclude option to manubulon snmp-storage check

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2071,6 +2071,7 @@ snmp_crit               | **Optional.** The critical threshold.
 snmp_storage_name       | **Optional.** Storage name. Default to regex "^/$$". More options available in the [snmp storage](http://nagios.manubulon.com/snmp_storage.html) documentation.
 snmp_storage_type       | **Optional.** Filter by storage type. Valid options are Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk. No value defined as default.
 snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
+snmp_exclude            | **Optional.** Select all storages except the one(s) selected by -m. No action on storage type selection.
 snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 snmp_storage_olength	| **Optional.** Max-size of the SNMP message, usefull in case of Too Long responses.
 

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -211,6 +211,10 @@ object CheckCommand "snmp-storage" {
 			set_if = "$snmp_perf$"
 			description = "Perfparse compatible output"
 		}
+		"-e" = {
+			set_if = "$snmp_exclude$"
+			description = "Select all storages except the one(s) selected by -m. No action on storage type selection."
+		}
 		"-o" = {
 			value = "$snmp_storage_olength$"
 			description = "Max-size of the SNMP message, usefull in case of Too Long responses."
@@ -225,6 +229,7 @@ object CheckCommand "snmp-storage" {
 	vars.snmp_warn = 80
 	vars.snmp_crit = 90
 	vars.snmp_perf = true
+	vars.snmp_exclude = false
 }
 
 


### PR DESCRIPTION
This adds the -e option to the manublulon smnp-storage check command.