### PR TITLE
Add new "-us" option to ipmi-sensor CheckCommand

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2752,6 +2752,7 @@ ipmi_no_sel_checking             | **Optional.** Turn off system event log check
 ipmi_no_thresholds               | **Optional.** Turn off performance data thresholds from output-sensor-thresholds.
 ipmi_verbose                     | **Optional.** Be Verbose multi line output, also with additional details for warnings.
 ipmi_debug                       | **Optional.** Be Verbose debugging output, followed by normal multi line output.
+ipmi_unify_file                  | **Optional.** Path to the unify file to unify sensor names.
 
 #### ipmi-alive <a id="plugin-contrib-command-ipmi-alive"></a>
 

--- a/itl/plugins-contrib.d/ipmi.conf
+++ b/itl/plugins-contrib.d/ipmi.conf
@@ -103,6 +103,10 @@ object CheckCommand "ipmi-sensor" {
 			set_if = "$ipmi_debug$"
 			description = "Be Verbose debugging output, followed by normal multi line output"
 		}
+		"-us" = {
+			value = "$ipmi_unify_file$"
+			description = "Path to the unify file to unify sensor names."
+		}
 	}
 
 	vars.ipmi_address = "$check_address$"


### PR DESCRIPTION
This will add a new option which was introduced in the monitoring plugin.

Fixes #6892