### PR TITLE
Fix checkresults from the future breaking checks

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -170,8 +170,8 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 	long old_attempt = GetCheckAttempt();
 	bool recovery = false;
 
-	/* Ignore check results older than the current one. */
-	if (old_cr && cr->GetExecutionStart() < old_cr->GetExecutionStart())
+	/* Ignore check results older than the current one, except if the previous check result is from the future. */
+	if (old_cr && cr->GetExecutionStart() < old_cr->GetExecutionStart() && old_cr->GetExecutionStart() < now)
 		return;
 
 	/* The ExecuteCheck function already sets the old state, but we need to do it again

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -170,9 +170,34 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 	long old_attempt = GetCheckAttempt();
 	bool recovery = false;
 
-	/* Ignore check results older than the current one, except if the previous check result is from the future. */
-	if (old_cr && cr->GetExecutionStart() < old_cr->GetExecutionStart() && old_cr->GetExecutionStart() < now)
-		return;
+	/* When we have an check result already (not after fresh start),
+	 * prevent to accept old check results and allow overrides for
+	 * CRs happened in the future.
+	 */
+	if (old_cr) {
+		double currentCRTimestamp = old_cr->GetExecutionStart();
+		double newCRTimestamp = cr->GetExecutionStart();
+
+		/* Our current timestamp may be from the future (wrong server time adjusted again). Allow overrides here. */
+		if (currentCRTimestamp > now) {
+			/* our current CR is from the future, let the new CR override it. */
+			Log(LogDebug, "Checkable")
+				<< std::fixed << std::setprecision(6) << "Processing check result for checkable '" << GetName() << "' from "
+				<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", newCRTimestamp) << " (" << newCRTimestamp
+				<< "). Overriding since ours is from the future at "
+				<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", currentCRTimestamp) << " (" << currentCRTimestamp << ").";
+		} else {
+			/* Current timestamp is from the past, but the new timestamp is even more in the past. Skip it. */
+			if (newCRTimestamp < currentCRTimestamp) {
+				Log(LogDebug, "Checkable")
+					<< std::fixed << std::setprecision(6) << "Skipping check result for checkable '" << GetName() << "' from "
+					<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", newCRTimestamp) << " (" << newCRTimestamp
+					<< "). It is in the past compared to ours at "
+					<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", currentCRTimestamp) << " (" << currentCRTimestamp << ").";
+				return;
+			}
+		}
+	}
 
 	/* The ExecuteCheck function already sets the old state, but we need to do it again
 	 * in case this was a passive check result. */


### PR DESCRIPTION
More info can be found in #6797 

Test protocol:

1. Have a check_result with execution_time well in the future
```
$ curl -k -s -u root:icinga -H 'Accept: application/json' -X GET 'https://localhost:5665/v1/objects/hosts/timesplitter?attrs=next_check&attrs=last_check' |jq
{
  "results": [
    {
      "attrs": {
        "last_check": 1736586079.960443,
        "next_check": 1547219178.13
      },
      "joins": {},
      "meta": {},
      "name": "timesplitter",
      "type": "Host"
    }
  ]
}
```
2. All checks will be discarded as they are 'old'
3. Install Icinga2 with this patch
4. Check results will be accepted again as the previous check_result is in the future
```
curl -k -s -u root:icinga -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/actions/reschedule-check?type=Host'
{
  "results": [
    {
      "attrs": {
        "last_check": 1547219627.718529,
        "next_check": 1547219686.138539
      },
      "joins": {},
      "meta": {},
      "name": "timesplitter",
      "type": "Host"
    }
  ]
}
```

fixes #6797 