### PR TITLE
Use std::stol in Convert::ToLong(const String&)

### DIFF
--- a/lib/base/convert.hpp
+++ b/lib/base/convert.hpp
@@ -69,6 +69,17 @@ public:
 		return static_cast<long>(val);
 	}
 
+	static long ToLong(const String& val)
+	{
+		try {
+			return std::stol(val, nullptr, 10);
+		} catch (const std::exception&) {
+			std::ostringstream msgbuf;
+			msgbuf << "Can't convert '" << val << "' to an integer.";
+			BOOST_THROW_EXCEPTION(std::invalid_argument(msgbuf.str()));
+		}
+	}
+
 	static double ToDouble(const Value& val)
 	{
 		return val;

--- a/test/base-convert.cpp
+++ b/test/base-convert.cpp
@@ -35,6 +35,13 @@ BOOST_AUTO_TEST_CASE(tolong)
 	BOOST_CHECK(Convert::ToLong(Value(-7)) == -7);
 
 	BOOST_CHECK(Convert::ToLong(3.141386593) == 3);
+
+	String str = "10";
+	BOOST_CHECK(Convert::ToLong(str) == 10);
+	str = " 20 with text";
+	BOOST_CHECK(Convert::ToLong(str) == 20);
+	str = "text only";
+	BOOST_CHECK_THROW(Convert::ToLong(str), boost::exception);
 }
 
 BOOST_AUTO_TEST_CASE(todouble)


### PR DESCRIPTION
This uses `std::stol` in `Convert::ToLong(const String&)` instead of
`boost::lexical_cast<long>`. This also adds tests for various String cases.

fixes #5841