### PR TITLE
Use std::to_string for Convert::ToString()

### DIFF
--- a/lib/base/configtype.cpp
+++ b/lib/base/configtype.cpp
@@ -53,8 +53,8 @@ void ConfigType::RegisterObject(const ConfigObject::Ptr& object)
 
 			auto *type = dynamic_cast<Type *>(this);
 
-			BOOST_THROW_EXCEPTION(ScriptError("An object with type '" + type->GetName() + "' and name '" + name + "' already exists (" +
-				it->second->GetDebugInfo().Path + "), new declaration: " + object->GetDebugInfo().Path,
+			BOOST_THROW_EXCEPTION(ScriptError("An object with type '" + type->GetName() + "' and name '" + name + "' already exists (in " +
+				it->second->GetDebugInfo().ToString() + "), new declaration: in " + object->GetDebugInfo().ToString(),
 				object->GetDebugInfo()));
 		}
 

--- a/lib/base/configtype.cpp
+++ b/lib/base/configtype.cpp
@@ -53,8 +53,8 @@ void ConfigType::RegisterObject(const ConfigObject::Ptr& object)
 
 			auto *type = dynamic_cast<Type *>(this);
 
-			BOOST_THROW_EXCEPTION(ScriptError("An object with type '" + type->GetName() + "' and name '" + name + "' already exists (in " +
-				it->second->GetDebugInfo().ToString() + "), new declaration: in " + object->GetDebugInfo().ToString(),
+			BOOST_THROW_EXCEPTION(ScriptError("An object with type '" + type->GetName() + "' and name '" + name + "' already exists (" +
+				Convert::ToString(it->second->GetDebugInfo()) + "), new declaration: " + Convert::ToString(object->GetDebugInfo()),
 				object->GetDebugInfo()));
 		}
 

--- a/lib/base/configtype.cpp
+++ b/lib/base/configtype.cpp
@@ -54,7 +54,7 @@ void ConfigType::RegisterObject(const ConfigObject::Ptr& object)
 			auto *type = dynamic_cast<Type *>(this);
 
 			BOOST_THROW_EXCEPTION(ScriptError("An object with type '" + type->GetName() + "' and name '" + name + "' already exists (" +
-				Convert::ToString(it->second->GetDebugInfo()) + "), new declaration: " + Convert::ToString(object->GetDebugInfo()),
+				it->second->GetDebugInfo().Path + "), new declaration: " + object->GetDebugInfo().Path,
 				object->GetDebugInfo()));
 		}
 

--- a/lib/base/convert.cpp
+++ b/lib/base/convert.cpp
@@ -19,7 +19,7 @@
 
 #include "base/convert.hpp"
 #include "base/datetime.hpp"
-#include <boost/lexical_cast.hpp>
+#include "base/debuginfo.hpp"
 
 using namespace icinga;
 
@@ -41,6 +41,13 @@ String Convert::ToString(double val)
 	if (fractional == 0)
 		return Convert::ToString(static_cast<long long>(val));
 
+	std::ostringstream msgbuf;
+	msgbuf << std::fixed << val;
+	return msgbuf.str();
+}
+
+String Convert::ToString(const DebugInfo& val)
+{
 	std::ostringstream msgbuf;
 	msgbuf << std::fixed << val;
 	return msgbuf.str();

--- a/lib/base/convert.hpp
+++ b/lib/base/convert.hpp
@@ -23,6 +23,7 @@
 #include "base/i2-base.hpp"
 #include "base/value.hpp"
 #include <boost/lexical_cast.hpp>
+#include <string>
 
 namespace icinga
 {
@@ -82,12 +83,18 @@ public:
 	template<typename T>
 	static String ToString(const T& val)
 	{
-		return boost::lexical_cast<std::string>(val);
+		return std::to_string(val);
 	}
 
 	static String ToString(const String& val);
 	static String ToString(const Value& val);
 	static String ToString(double val);
+
+	template<size_t S>
+	static String ToString(const char (&val)[S])
+	{
+		return std::string(val);
+	}
 
 	static double ToDateTimeValue(double val);
 	static double ToDateTimeValue(const Value& val);

--- a/lib/base/convert.hpp
+++ b/lib/base/convert.hpp
@@ -89,6 +89,7 @@ public:
 	static String ToString(const String& val);
 	static String ToString(const Value& val);
 	static String ToString(double val);
+	static String ToString(const DebugInfo& val);
 
 	template<size_t S>
 	static String ToString(const char (&val)[S])

--- a/lib/base/debuginfo.hpp
+++ b/lib/base/debuginfo.hpp
@@ -41,10 +41,6 @@ struct DebugInfo
 
 	int LastLine{0};
 	int LastColumn{0};
-
-	std::string ToString() {
-		return std::string(Convert::ToString(Path) + ": " + Convert::ToString(FirstLine) + ":" + Convert::ToString(FirstColumn) + "-" + Convert::ToString(LastLine) + ":" + Convert::ToString(LastColumn));
-	}
 };
 
 std::ostream& operator<<(std::ostream& out, const DebugInfo& val);

--- a/lib/base/debuginfo.hpp
+++ b/lib/base/debuginfo.hpp
@@ -22,6 +22,7 @@
 
 #include "base/i2-base.hpp"
 #include "base/string.hpp"
+#include "base/convert.hpp"
 
 namespace icinga
 {
@@ -40,6 +41,10 @@ struct DebugInfo
 
 	int LastLine{0};
 	int LastColumn{0};
+
+	std::string ToString() {
+		return std::string(Convert::ToString(Path) + ": " + Convert::ToString(FirstLine) + ":" + Convert::ToString(FirstColumn) + "-" + Convert::ToString(LastLine) + ":" + Convert::ToString(LastColumn));
+	}
 };
 
 std::ostream& operator<<(std::ostream& out, const DebugInfo& val);


### PR DESCRIPTION
This uses `std::to_string` in `Convert::ToString` instead of
`boost::lexical_cast<std::string>`. This also adds a special handling for
a char array.

refs #5842