### PR TITLE
Make the NSCP CheckDisk --exclude option available to Icinga 2

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1877,7 +1877,8 @@ Check command object for the `check_drivesize` NSClient++ plugin.
 
 Name                   | Description
 -----------------------|------------------
-nscp_disk_drive        | **Optional.** Drive character, default to all drives.
+nscp_disk_drive        | **Optional.** Drive character, default to all drives. Can be an array if multiple drives should be monitored.
+nscp_disk_exclude      | **Optional.** Drive character, default to none. Can be an array of drive characters if multiple drives should be excluded.
 nscp_disk_free         | **Optional.** Switch between checking free space (free=true) or used space (free=false), default to false.
 nscp_disk_warning      | **Optional.** Threshold for WARNING in percent or absolute (use MB, GB, ...), default to 80 (used) or 20 percent (free).
 nscp_disk_critical     | **Optional.** Threshold for CRITICAL in percent or absolute (use MB, GB, ...), default to 90 (used) or 10 percent (free).

--- a/itl/command-nscp-local.conf
+++ b/itl/command-nscp-local.conf
@@ -222,6 +222,10 @@ object CheckCommand "nscp-local-disk" {
 			value = "$nscp_disk_drive$"
 			repeat_key = true
 		}
+		"--exclude" = {
+			value = "$nscp_disk_exclude$"
+			repeat_key = true
+		}
 		"--warning" = {
 			value = "$nscp_disk_op$ $nscp_disk_warning$"
 		}


### PR DESCRIPTION
This PR makes the --exclude option that NSCP provides accessible by Icinga 2. 

I was rather surprised to find that while --drive works fine, --exclude does not have an interface in Icinga 2. 

My usual scenario is to provide a default monitoring covering all cases, except specific ones that need to be handled separately and excluded from the general catch-all monitoring. For this the availability of --exclude is essential.