### PR TITLE
ClusterEvents::AcknowledgementSet event should forward 'persistent' attribute

### DIFF
--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -445,6 +445,7 @@ void ClusterEvents::AcknowledgementSetHandler(const Checkable::Ptr& checkable,
 	params->Set("comment", comment);
 	params->Set("acktype", type);
 	params->Set("notify", notify);
+	params->Set("persistent", persistent);
 	params->Set("expiry", expiry);
 
 	Dictionary::Ptr message = new Dictionary();


### PR DESCRIPTION
Discovered while writing cluster message docs.