### PR TITLE
Fix check_swap formatting

### DIFF
--- a/plugins/check_swap.cpp
+++ b/plugins/check_swap.cpp
@@ -200,7 +200,7 @@ static int printOutput(printInfoStruct& printInfo)
 	if (printInfo.crit.rend(currentValue, printInfo.tSwap))
 		state = CRITICAL;
 
-	std::wcout << stateToString(state) << " ";
+	std::wcout << stateToString(state) << " - ";
 
 	if (!printInfo.showUsed)
 		std::wcout << printInfo.percentFree << L"% free ";


### PR DESCRIPTION
This fixes a small formatting mistake introduced by #6811. To keep the
check_swap output in sync with all other plugins I fixed the formatting.

**v2.10.2**
```
SWAP OK - 99.929% free | 'swap'=1407MB;;;0;1408
```

**current master**
```
SWAP OK 99.929% free | 'swap'=1407MB;;;0;1408
```
(missing `-`)

**fixed**
```
SWAP OK - 99.929% free | 'swap'=1407MB;1;;0;1408
```

I'll assign 2.10.3 as milestone here since #6811 is already backported.
