### PR TITLE
Doc: Add .NET 3.5 to the windows build stack

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -845,6 +845,12 @@ Choose the following minimal set:
 
 After a while, Visual Studio will be ready.
 
+#### .NET Framework 3.5
+
+Windows 10 only have .NET Framework >= 4.6 installed by default, the Icinga Agent Wizard is built on .NET Framework 2.0 which is not included in .NET Framework 4.6. Thankfully Windows 10 have .NET Framework 3.5 (which includes .NET Framework 2.0) as a component on board, you just need to activate it.
+
+Go to `Control Panel` -> `Programs` -> `Turn Windows features on or off`. Tick `.NET Framework 3.5 (includes .NET 2.0 and 3.0)` and wait until the installation process succseded.
+
 #### Flex and Bison
 
 Install it using [chocolatey](https://www.wireshark.org/docs/wsdg_html_chunked/ChSetupWin32.html):


### PR DESCRIPTION
The Windows Agent Wizard is currently build on .NET Framework 2.0, which
is not installed by default on Windows 10. This adds a note to the
development documentation to install the .NET Framework 3.5 (which
includes .NET Framework 2.0) component on Windows 10.

**Context:**

I recreated my Windows development environment and noticed the following message after I open the Icinga 2 project without .NET Framework 3.5 installed: 

![auswahl_002](https://user-images.githubusercontent.com/18580278/52214918-2eae7700-2893-11e9-8ffd-32b7e6d3afac.png)

After I installed .NET Framework 3.5 and I reopened the project the message was no longer shown.
