### PR TITLE
Fix check_swap percentage calculation

### DIFF
--- a/plugins/check_swap.cpp
+++ b/plugins/check_swap.cpp
@@ -229,7 +229,10 @@ static int check_swap(printInfoStruct& printInfo)
 		printInfo.aSwap += round(pageFiles.at(i).availableSpwap / pow(1024.0, printInfo.unit));
 	}
 
-	printInfo.percentFree = 100.0 * printInfo.aSwap / printInfo.tSwap;
+	if (printInfo.aSwap > 0 && printInfo.tSwap > 0)
+		printInfo.percentFree = 100.0 * printInfo.aSwap / printInfo.tSwap;
+	else
+		printInfo.percentFree = 0;
 
 	return -1;
 }


### PR DESCRIPTION
This fixes the check_swap percentage calculation. When the pagefile is
turned off the available swap and total swap are 0 which leads to a
wrong calculation and misformatted output.

before:
```
SWAP OK - -nan(ind)% free | 'swap'=0MB;;;0;0
```

now:
```
SWAP OK - 0% free | 'swap'=0MB;;;0;0
```
fixes #6913 