### PR TITLE
Add timestamp to all messages sent out via JSON-RPC

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -896,6 +896,11 @@ void ApiListener::SyncSendMessage(const Endpoint::Ptr& endpoint, const Dictionar
 {
 	ObjectLock olock(endpoint);
 
+	if (!message->Contains("ts")) {
+		double ts = Utility::GetTime();
+		message->Set("ts", ts);
+	}
+
 	if (!endpoint->GetSyncing()) {
 		Log(LogNotice, "ApiListener")
 			<< "Sending message '" << message->Get("method") << "' to '" << endpoint->GetName() << "'";


### PR DESCRIPTION
This PR serves as an attempt to fix #6932.

The fix adds a ts key with the current time as the value to all JSON-RPC messages sent out to other endpoints. As a result, the endpoints update their local/remote log position as they already do for messages that have been relayed to them. 

I'm not sure of any side effects that might hide somewhere in the code I did not look at, but in my tests this partially solved #6932 and did not have any adversary effects on my test environment. It will certainly require some scrutiny, though.

Unfortunately, the solution is only partial so far. In a setup 

    master cluster -> satellite cluster -> agent

the agent properly receives timestamped messages and sets its remote log position accordingly, and it also emits `SetLogPosition` messages to the satellites, but they do not relay them further to their parent zone and so on the masters the `GetLocalLogPosition()` method still returns 0 for the agent:

```
[2019-02-10 18:41:11 +0000] debug/ApiListener: Considering log deletion for endpoint 'repo.dev.hindenburgring.com': 1549823579 > 0; Log must be kept for replay
[2019-02-10 18:41:11 +0000] debug/ApiListener: Considering log deletion for endpoint 'repo.dev.hindenburgring.com': 1549823580 > 0; Log must be kept for replay
[2019-02-10 18:41:11 +0000] debug/ApiListener: Considering log deletion for endpoint 'repo.dev.hindenburgring.com': 1549823586 > 0; Log must be kept for replay
[2019-02-10 18:41:11 +0000] debug/ApiListener: Considering log deletion for endpoint 'repo.dev.hindenburgring.com': 1549823587 > 0; Log must be kept for replay
[2019-02-10 18:41:11 +0000] debug/ApiListener: Considering log deletion for endpoint 'repo.dev.hindenburgring.com': 1549823897 > 0; Log must be kept for replay
```

So while the satellites properly clean up their replay logs, the master still keeps them around. 

I'll look into this later on.