### PR TITLE
Avoid duplicating non-zero count message replay messages in the debug log

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1249,9 +1249,10 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 			Log(LogInformation, "ApiListener")
 				<< "Replayed " << count << " messages.";
 		}
-
-		Log(LogNotice, "ApiListener")
-			<< "Replayed " << count << " messages.";
+		else {
+			Log(LogNotice, "ApiListener")
+				<< "Replayed " << count << " messages.";
+		}
 
 		if (last_sync) {
 			{


### PR DESCRIPTION
Suggested fix for #6942