### PR TITLE
Bugfix: integer overflow when converting large integer Values to String

### DIFF
--- a/lib/base/convert.cpp
+++ b/lib/base/convert.cpp
@@ -42,14 +42,12 @@ String Convert::ToString(double val)
 
 	if (fractional == 0) {
 		if (val < UINT64_MAX) {
-			if (val >= 0) {
+			if (val >= 0)
 				return Convert::ToString(static_cast<unsigned long long>(val));
-			} else {
+			else
 				return Convert::ToString(static_cast<long long>(val));
-			}
-		} else {
+		} else
 			msgbuf << std::setprecision(0);
-		}
 	}
 
 	msgbuf << std::fixed << val;

--- a/lib/base/convert.cpp
+++ b/lib/base/convert.cpp
@@ -38,10 +38,20 @@ String Convert::ToString(double val)
 	double integral;
 	double fractional = std::modf(val, &integral);
 
-	if (fractional == 0)
-		return Convert::ToString(static_cast<long long>(val));
-
 	std::ostringstream msgbuf;
+
+	if (fractional == 0) {
+		if (val < UINT64_MAX) {
+			if (val >= 0) {
+				return Convert::ToString(static_cast<unsigned long long>(val));
+			} else {
+				return Convert::ToString(static_cast<long long>(val));
+			}
+		} else {
+			msgbuf << std::setprecision(0);
+		}
+	}
+
 	msgbuf << std::fixed << val;
 	return msgbuf.str();
 }

--- a/lib/base/value-operators.cpp
+++ b/lib/base/value-operators.cpp
@@ -80,6 +80,8 @@ std::ostream& icinga::operator<<(std::ostream& stream, const Value& value)
 {
 	if (value.IsBoolean())
 		stream << static_cast<int>(value);
+	else if (value.IsNumber())
+		stream << Convert::ToString(double(value));
 	else
 		stream << static_cast<String>(value);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,6 +123,8 @@ add_boost_test(base
     base_value/scalar
     base_value/convert
     base_value/format
+    base_value/floatValues
+    base_value/largeValues
     config_ops/simple
     config_ops/advanced
     icinga_checkresult/host_1attempt
@@ -146,6 +148,7 @@ add_boost_test(base
     icinga_perfdata/ignore_invalid_warn_crit_min_max
     icinga_perfdata/invalid
     icinga_perfdata/multi
+    icinga_perfdata/format_large_values
     remote_url/id_and_path
     remote_url/parameters
     remote_url/get_and_set

--- a/test/base-convert.cpp
+++ b/test/base-convert.cpp
@@ -58,6 +58,7 @@ BOOST_AUTO_TEST_CASE(tostring)
 	BOOST_CHECK(Convert::ToString(Value(7.5)) == "7.500000");
 	BOOST_CHECK(Convert::ToString(Value("hello")) == "hello");
 	BOOST_CHECK(Convert::ToString(Value("hello hello")) == "hello hello");
+	BOOST_CHECK(Convert::ToString(Value(UINT64_MAX)) == "18446744073709551616");
 }
 
 BOOST_AUTO_TEST_CASE(tobool)

--- a/test/base-value.cpp
+++ b/test/base-value.cpp
@@ -66,4 +66,31 @@ BOOST_AUTO_TEST_CASE(format)
 	BOOST_CHECK(v != 3);
 }
 
+BOOST_AUTO_TEST_CASE(floatValues)
+{
+	Value v = 3.1415;
+
+	std::ostringstream obuf;
+	obuf << v;
+
+	BOOST_CHECK(obuf.str() == "3.141500");
+}
+
+BOOST_AUTO_TEST_CASE(largeValues)
+{
+	// note that Value internally stores the number as double, so the actual
+	// value is 18446744073709551616.0 due to floating point imprecision
+	Value v = UINT64_MAX;
+
+	BOOST_CHECK(v != Value(INT64_MIN));
+	BOOST_CHECK(v == Value(UINT64_MAX));
+	BOOST_CHECK(v == 18446744073709551616.0);
+
+	std::ostringstream obuf;
+	obuf << v;
+
+	BOOST_CHECK(obuf.str() != "-9223372036854775808");
+	BOOST_CHECK(obuf.str() == "18446744073709551616");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -140,4 +140,14 @@ BOOST_AUTO_TEST_CASE(multi)
 	BOOST_CHECK(pd->Get(1) == "test::b=4");
 }
 
+BOOST_AUTO_TEST_CASE(format_large_values)
+{
+	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=18446744073709551615");
+	BOOST_CHECK(pv);
+	BOOST_CHECK(pv->GetValue() == UINT64_MAX);
+
+	BOOST_CHECK(pv->Format() != "test=-9223372036854775808");
+	BOOST_CHECK(pv->Format() == "test=18446744073709551616");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Unit test to demonstrate the issue + fix in Convert::ToString() to prevent integer overflow of Values near UINT64_MAX

fixes #6936