### PR TITLE
Debug: Log calls to ConfigObject::Deactivate()

### DIFF
--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -631,6 +631,10 @@ void ConfigObject::StopObjects()
 			continue;
 
 		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+#ifdef I2_DEBUG
+			Log(LogDebug, "ConfigObject")
+				<< "Deactivate() called for config object '" << object->GetName() << "' with type '" << type->GetName() << "'.";
+#endif /* I2_DEBUG */
 			object->Deactivate();
 		}
 	}


### PR DESCRIPTION
Only available in debug builds.