### PR TITLE
Activate downtimes before any checkable object

### DIFF
--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -37,6 +37,8 @@ public:
 
 class Downtime : ConfigObject < DowntimeNameComposer
 {
+	activation_priority -10;
+
 	load_after Host;
 	load_after Service;
 


### PR DESCRIPTION
(cherry picked from commit 7936a147ba82ce7e19de43ccb5f4c830edd8d235)