### PR TITLE
Fix nested hostgroup example

### DIFF
--- a/doc/23-migrating-from-icinga-1x.md
+++ b/doc/23-migrating-from-icinga-1x.md
@@ -116,11 +116,11 @@ This can be migrated to Icinga 2 and [using group assign](17-language-reference.
 
 
     object HostGroup "hg1" {
+      groups = [ "hg2" ]
       assign where host.name in [ "host1", "host2" ]
     }
 
     object HostGroup "hg2" {
-      groups = [ "hg1" ]
       assign where host.name == "host3"
     }
 


### PR DESCRIPTION
In Icinga 1.x the list of members was set on the group object, in Icinga 2 the list of groups is set on the member objects (when not using assign).