### PR TITLE
Ignore failure of unit test base_utility/comparepasswords_issafe

### DIFF
--- a/test/base-utility.cpp
+++ b/test/base-utility.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(comparepasswords_issafe)
 	auto duration2 (steady_clock::now() - start2);
 
 	double diff = (double)duration_cast<microseconds>(duration1).count() / (double)duration_cast<microseconds>(duration2).count();
-	BOOST_CHECK(0.9 <= diff && diff <= 1.1);
+	BOOST_WARN(0.9 <= diff && diff <= 1.1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
... as volatile system load may cause false negatives

fixes #6987