### PR TITLE
Cluster log replay fixes (#6932)

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -1345,6 +1345,21 @@ bool Utility::PathExists(const String& path)
 #endif /* _WIN32 */
 }
 
+bool Utility::FileIsEmpty(const String& path)
+{
+#ifndef _WIN32
+	struct stat statbuf;
+	if (stat(path.CStr(), &statbuf) < 0)
+	    return true;
+#else /* _WIN32 */
+	struct _stat statbuf;
+	if (_stat(path.CStr(), &statbuf) < 0)
+	    return true;
+#endif /* _WIN32 */
+
+    return (statbuf.st_size == 0);
+}
+
 Value Utility::LoadJsonFile(const String& path)
 {
 	std::ifstream fp;

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -110,6 +110,7 @@ public:
 	static tm LocalTime(time_t ts);
 
 	static bool PathExists(const String& path);
+	static bool FileIsEmpty(const String& path);
 
 	static void RemoveDirRecursive(const String& path);
 	static void CopyFile(const String& source, const String& target);

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -141,6 +141,7 @@ private:
 	boost::mutex m_LogLock;
 	Stream::Ptr m_LogFile;
 	size_t m_LogMessageCount{0};
+	double m_LogLastRotation{0};
 
 	bool RelayMessageOne(const Zone::Ptr& zone, const MessageOrigin::Ptr& origin, const Dictionary::Ptr& message, const Endpoint::Ptr& currentMaster);
 	void SyncRelayMessage(const MessageOrigin::Ptr& origin, const ConfigObject::Ptr& secobj, const Dictionary::Ptr& message, bool log);

--- a/lib/remote/jsonrpcconnection-heartbeat.cpp
+++ b/lib/remote/jsonrpcconnection-heartbeat.cpp
@@ -33,6 +33,9 @@ void JsonRpcConnection::HeartbeatTimerHandler()
 				}) }
 			});
 
+			if (!endpoint->GetSyncing())
+				request->Set("ts", Utility::GetTime());
+
 			client->SendMessage(request);
 		}
 	}
@@ -49,4 +52,3 @@ Value JsonRpcConnection::HeartbeatAPIHandler(const MessageOrigin::Ptr& origin, c
 
 	return Empty;
 }
-


### PR DESCRIPTION
- ApiListener::ApiTimerHandler() does not try to keep replay logs for
  endpoints that are not directly connected.

- ApiListener::ApiTimerHandler() now deletes empty replay logs (though
  this might no longer be necessary because the log will no longer
  be rotated when it is empty.

- ApiListener::RotateLogFile() will not overwrite an existing
  replay log that happens to have been created in the same second
  by another rotation.

  This will not happen as often as it used to because the log will
  only be rotated when it is not empty, but it is still possible. A
  maximum of 19 rotation attempts will be made before giving up.

- There is a new variable m_LogLastRotation for the cluster log
  that is used to determine whether the cluster log was rotated
  while the old logs were being replayed.

- ApiListenet::ReplayLog() no longer rotates the cluster log
  if it is empty, which led to excessive log rotation activity
  and a large number of empty replay log files.

- In ApiListener::ReplayLog(), the logic for updating the
  local log position for an endpoint was fixed. The position will
  be updated even if no log message was replayed to an endpoint
  so ApiListener::ApiTimerHandler() can clean up the log.

  This is not the complete solution to #6932, though, as logs
  for endpoint A created after the endpoint synchronisation
  for endpoint B has finished will not be replayed to B until
  B dis- and reconnects, so they cannot be cleaned up.

- In JsonRpcConnection::HeartbeatTimerHandler(), when an
  endpoint is not currently syncing, a 'ts' attributed is
  added to the heartbeat message.

  This causes the recipient of the heartbeat message to update
  its remote log position for the sending endpoint, and
  consequentially it will update its own local log position
  on the sender of the heartbeat by sending back a
  log::SetLogPosition message. This enables i
  ApiListener::ApiTimerHandler() to clean up replay logs
  even after an endpoint has been synchronised.

- A new Utility::FileIsEmpty() method was provided as an
  auxiliary function.