### PR TITLE
Timer::TimerThreadProc(): use C++11 lambda instead of bind()

### DIFF
--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -310,6 +310,6 @@ void Timer::TimerThreadProc()
 		lock.unlock();
 
 		/* Asynchronously call the timer. */
-		Utility::QueueAsyncCallback(std::bind(&Timer::Call, timer));
+		Utility::QueueAsyncCallback([timer]() { timer->Call(); });
 	}
 }


### PR DESCRIPTION
fixes #6737