### PR TITLE
Elasticsearch: Change Content-Type header to 'application/x-ndjson' for bulk streams

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -27,6 +27,7 @@ This affects the following features:
 * [OpenTsdb](09-object-types.md#objecttype-opentsdbwriter)
 * [Perfdata](09-object-types.md#objecttype-perfdatawriter) (for PNP)
 
+
 ### Package Dependencies <a id="upgrading-to-2-11-package-dependencies"></a>
 
 #### Removed: YAJL

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -456,7 +456,12 @@ void ElasticsearchWriter::SendRequest(const String& body)
 
 	/* Specify required headers by Elasticsearch. */
 	req.AddHeader("Accept", "application/json");
-	req.AddHeader("Content-Type", "application/json");
+
+	/* Use application/x-ndjson for bulk streams. While ES
+	 * is able to handle application/json, the newline separator
+	 * causes problems with Logstash (#6609).
+	 */
+	req.AddHeader("Content-Type", "application/x-ndjson");
 
 	/* Send authentication if configured. */
 	String username = GetUsername();


### PR DESCRIPTION
fixes #6609