### PR TITLE
InfluxDB/Elasticsearch: Flush only if there's data in the buffer

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -398,6 +398,10 @@ void ElasticsearchWriter::FlushTimeout()
 
 void ElasticsearchWriter::Flush()
 {
+	/* Flush can be called from 1) Timeout 2) Threshold 3) on shutdown/reload. */
+	if (m_DataBuffer.empty())
+		return;
+
 	/* Ensure you hold a lock against m_DataBuffer so that things
 	 * don't go missing after creating the body and clearing the buffer.
 	 */

--- a/lib/perfdata/influxdbwriter.cpp
+++ b/lib/perfdata/influxdbwriter.cpp
@@ -421,10 +421,6 @@ void InfluxdbWriter::FlushTimeoutWQ()
 {
 	AssertOnWorkQueue();
 
-	// Flush if there are any data available
-	if (m_DataBuffer.empty())
-		return;
-
 	Log(LogDebug, "InfluxdbWriter")
 		<< "Timer expired writing " << m_DataBuffer.size() << " data points";
 
@@ -433,6 +429,10 @@ void InfluxdbWriter::FlushTimeoutWQ()
 
 void InfluxdbWriter::Flush()
 {
+	/* Flush can be called from 1) Timeout 2) Threshold 3) on shutdown/reload. */
+	if (m_DataBuffer.empty())
+		return;
+
 	Log(LogDebug, "InfluxdbWriter")
 		<< "Flushing data buffer to InfluxDB.";
 


### PR DESCRIPTION
Regression from 2.10.4