### PR TITLE
Fix logrotate "Operation not permitted"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ if(NOT DEFINED LOGROTATE_HAS_SU)
 endif()
 if(LOGROTATE_HAS_SU)
   set(LOGROTATE_USE_SU "\n\tsu ${ICINGA2_USER} ${ICINGA2_GROUP}")
+else()
+  set(LOGROTATE_CREATE "\n\tcreate 644 ${ICINGA2_USER} ${ICINGA2_GROUP}")
 endif()
 
 find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS thread system program_options regex REQUIRED)

--- a/etc/logrotate.d/icinga2.cmake
+++ b/etc/logrotate.d/icinga2.cmake
@@ -4,8 +4,7 @@
 	compress
 	delaycompress
 	missingok
-	notifempty
-	create 644 @ICINGA2_USER@ @ICINGA2_GROUP@
+	notifempty@LOGROTATE_CREATE@
 	postrotate
 		/bin/kill -USR1 $(cat @ICINGA2_INITRUNDIR@/icinga2.pid 2> /dev/null) 2> /dev/null || true
 	endscript
@@ -17,7 +16,6 @@
 	compress
 	delaycompress
 	missingok
-	notifempty
-	create 644 @ICINGA2_USER@ @ICINGA2_GROUP@
+	notifempty@LOGROTATE_CREATE@
 	# TODO: figure out how to get Icinga to re-open this log file
 }


### PR DESCRIPTION
PR 75 (commit afb6346) added support for the 'su' directive of logrotate. However, when using 'su', we cannot chown to arbitrary file owners anymore, which means that unless the file has already been created with the same permissions we'll get an error. This happens e.g. on Debian Stretch, since log files are normally owned by the adm group:
```
/var/log/icinga2:
# ls -la
total 59724
drwxr-s--x  4 nagios adm       16384 Mär 31 20:26 .
drwxr-xr-x 14 root   root      12288 Mär 31 06:25 ..
drwxr-s---  3 nagios adm        4096 Mai 12  2018 compat
drwxr-s---  2 nagios adm        4096 Apr 25  2018 crash
-rw-r-----  1 nagios adm           0 Nov 16 18:17 error.log
-rw-r-----  1 nagios adm       66843 Mär 31 22:07 icinga2.log
# logrotate /etc/logrotate.d/icinga2 
error: error setting owner of /var/log/icinga2/icinga2.log.1.gz to uid 107 and gid 33: Operation not permitted
```
Fix this by not using chown and su together, as files will already be created with the correct permissions.