### PR TITLE
Impersonate as Icinga user, not root

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -67,6 +67,23 @@ The [IdoMysqlConnection](09-object-types.md#objecttype-idomysqlconnection) and [
 objects provide a new attribute named `last_failover` which shows the last failover timestamp.
 This value also is available in the [ido](10-icinga-template-library.md#itl-icinga-ido) CheckCommand output.
 
+
+### CLI Commands <a id="upgrading-to-2-11-cli-commands"></a>
+
+CLI commands such as `api setup`, `node wizard/setup`, `feature enable/disable/list`
+required root permissions previously. Since the file permissions allow
+the Icinga user to change things already, and users kept asking to
+run Icinga on their own webspace without root permissions, this is now possible
+with 2.11.
+
+If you are running the commands with a different user than the
+compiled `ICINGA_USER` and `ICINGA_GROUP` CMake settings (`icinga` everywhere,
+except Debian with `nagios` for historical reasons`), ensure that this
+user has the capabilities to change to a different user.
+
+If you still encounter problems, run the aforementioned CLI commands as root,
+or with sudo.
+
 ## Upgrading to v2.10 <a id="upgrading-to-2-10"></a>
 
 ### Path Constant Changes <a id="upgrading-to-2-10-path-constant-changes"></a>

--- a/lib/cli/apisetupcommand.cpp
+++ b/lib/cli/apisetupcommand.cpp
@@ -24,7 +24,7 @@ String ApiSetupCommand::GetShortDescription() const
 
 ImpersonationLevel ApiSetupCommand::GetImpersonationLevel() const
 {
-	return ImpersonateRoot;
+	return ImpersonateIcinga;
 }
 
 int ApiSetupCommand::GetMaxArguments() const

--- a/lib/cli/featuredisablecommand.cpp
+++ b/lib/cli/featuredisablecommand.cpp
@@ -36,7 +36,7 @@ int FeatureDisableCommand::GetMaxArguments() const
 
 ImpersonationLevel FeatureDisableCommand::GetImpersonationLevel() const
 {
-	return ImpersonateRoot;
+	return ImpersonateIcinga;
 }
 
 /**

--- a/lib/cli/featureenablecommand.cpp
+++ b/lib/cli/featureenablecommand.cpp
@@ -36,7 +36,7 @@ int FeatureEnableCommand::GetMaxArguments() const
 
 ImpersonationLevel FeatureEnableCommand::GetImpersonationLevel() const
 {
-	return ImpersonateRoot;
+	return ImpersonateIcinga;
 }
 
 /**

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -71,7 +71,7 @@ std::vector<String> NodeSetupCommand::GetArgumentSuggestions(const String& argum
 
 ImpersonationLevel NodeSetupCommand::GetImpersonationLevel() const
 {
-	return ImpersonateRoot;
+	return ImpersonateIcinga;
 }
 
 /**

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -37,7 +37,7 @@ String NodeWizardCommand::GetShortDescription() const
 
 ImpersonationLevel NodeWizardCommand::GetImpersonationLevel() const
 {
-	return ImpersonateRoot;
+	return ImpersonateIcinga;
 }
 
 int NodeWizardCommand::GetMaxArguments() const


### PR DESCRIPTION
This requires write permissions for

- etc/features-*
- etc/*.conf
- var/{lib,cache}/icinga2/*

Typically permissions are handled by prepare-dirs,
or the respective CLI commands are run as root either way.

fixes #4947