### PR TITLE
Deprecate ExternalCommandListener feature ('command') and adjust log warnings to the roadmap

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -270,6 +270,11 @@ Configuration Attributes:
 Reads Icinga 1.x check result files from a directory. This functionality is provided
 to help existing Icinga 1.x users and might be useful for migration scenarios.
 
+> **Note**
+>
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
+
 Example:
 
 ```
@@ -318,6 +323,11 @@ Configuration Attributes:
 
 Writes log files in a format that's compatible with Icinga 1.x.
 This configuration object is available as [compatlog feature](14-features.md#compat-logging).
+
+> **Note**
+>
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
 
 Example:
 
@@ -598,6 +608,11 @@ More advanced examples for event command usage can be found [here](03-monitoring
 
 Implements the Icinga 1.x command pipe which can be used to send commands to Icinga.
 This configuration object is available as [command feature](14-features.md#external-commands).
+
+> **Note**
+>
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
 
 Example:
 
@@ -1557,6 +1572,11 @@ Configuration Attributes:
 
 Periodically writes status and configuration data files which are used by third-party tools.
 This configuration object is available as [statusdata feature](14-features.md#status-data).
+
+> **Note**
+>
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
 
 Example:
 

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -165,6 +165,11 @@ VACUUM
 > Please use the [REST API](12-icinga2-api.md#icinga2-api) as modern and secure alternative
 > for external actions.
 
+> **Note**
+>
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
+
 Icinga 2 provides an external command pipe for processing commands
 triggering specific actions (for example rescheduling a service check
 through the web interface).
@@ -817,7 +822,8 @@ A detailed list on the available table attributes can be found in the [Livestatu
 
 > **Note**
 >
-> This feature is DEPRECATED and will be removed in Icinga 2 v2.11.
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
 
 Icinga 1.x writes object configuration data and status data in a cyclic
 interval to its `objects.cache` and `status.dat` files. Icinga 2 provides
@@ -835,7 +841,8 @@ you can safely disable this feature.
 
 > **Note**
 >
-> This feature is DEPRECATED and will be removed in Icinga 2 v2.11.
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
 
 The Icinga 1.x log format is considered being the `Compat Log`
 in Icinga 2 provided with the `CompatLogger` object.
@@ -860,7 +867,8 @@ in `/var/log/icinga2/compat`. Rotated log files are moved into
 
 > **Note**
 >
-> This feature is DEPRECATED and will be removed in Icinga 2 v2.11.
+> This feature is DEPRECATED and will be removed in future releases.
+> Check the [roadmap](https://github.com/Icinga/icinga2/milestones).
 
 Icinga 1.x writes its check result files to a temporary spool directory
 where they are processed in a regular interval.

--- a/lib/compat/checkresultreader.cpp
+++ b/lib/compat/checkresultreader.cpp
@@ -45,7 +45,7 @@ void CheckResultReader::Start(bool runtimeCreated)
 		<< "'" << GetName() << "' started.";
 
 	Log(LogWarning, "CheckResultReader")
-		<< "The CheckResultReader feature is DEPRECATED and will be removed in Icinga v2.11.";
+		<< "This feature is DEPRECATED and will be removed in future releases. Check the roadmap at https://github.com/Icinga/icinga2/milestones";
 
 #ifndef _WIN32
 	m_ReadTimer = new Timer();

--- a/lib/compat/compatlogger.cpp
+++ b/lib/compat/compatlogger.cpp
@@ -47,7 +47,7 @@ void CompatLogger::Start(bool runtimeCreated)
 		<< "'" << GetName() << "' started.";
 
 	Log(LogWarning, "CompatLogger")
-		<< "The CompatLogger feature is DEPRECATED and will be removed in Icinga v2.11.";
+		<< "This feature is DEPRECATED and will be removed in future releases. Check the roadmap at https://github.com/Icinga/icinga2/milestones";
 
 	Checkable::OnNewCheckResult.connect(std::bind(&CompatLogger::CheckResultHandler, this, _1, _2));
 	Checkable::OnNotificationSentToUser.connect(std::bind(&CompatLogger::NotificationSentHandler, this, _1, _2, _3, _4, _5, _6, _7, _8));

--- a/lib/compat/externalcommandlistener.cpp
+++ b/lib/compat/externalcommandlistener.cpp
@@ -36,6 +36,8 @@ void ExternalCommandListener::Start(bool runtimeCreated)
 	Log(LogInformation, "ExternalCommandListener")
 		<< "'" << GetName() << "' started.";
 
+	Log(LogWarning, "ExternalCommandListener")
+		<< "This feature is DEPRECATED and will be removed in future releases. Check the roadmap at https://github.com/Icinga/icinga2/milestones";
 #ifndef _WIN32
 	m_CommandThread = std::thread(std::bind(&ExternalCommandListener::CommandPipeThread, this, GetCommandPath()));
 	m_CommandThread.detach();

--- a/lib/compat/statusdatawriter.cpp
+++ b/lib/compat/statusdatawriter.cpp
@@ -61,7 +61,7 @@ void StatusDataWriter::Start(bool runtimeCreated)
 		<< "'" << GetName() << "' started.";
 
 	Log(LogWarning, "StatusDataWriter")
-		<< "The StatusDataWriter feature is DEPRECATED and will be removed in Icinga v2.11.";
+		<< "This feature is DEPRECATED and will be removed in future releases. Check the roadmap at https://github.com/Icinga/icinga2/milestones";
 
 	m_ObjectsCacheOutdated = true;
 


### PR DESCRIPTION
They won't be removed with 2.11 thus far. Users should
be guided to the roadmap which holds all details instead
of hardcoding a version in the code.