### PR TITLE
Remove not needed inline code tag

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -78,7 +78,7 @@ with 2.11.
 
 If you are running the commands with a different user than the
 compiled `ICINGA_USER` and `ICINGA_GROUP` CMake settings (`icinga` everywhere,
-except Debian with `nagios` for historical reasons`), ensure that this
+except Debian with `nagios` for historical reasons), ensure that this
 user has the capabilities to change to a different user.
 
 If you still encounter problems, run the aforementioned CLI commands as root,


### PR DESCRIPTION
This removes a not needed inline code tag (back-tick) in the upgrading
chapter for 2.11.