### PR TITLE
use dedicated permissions namespace for scriptframe in filterutility

### DIFF
--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -23,7 +23,8 @@ bool EventQueue::CanProcessEvent(const String& type) const
 
 void EventQueue::ProcessEvent(const Dictionary::Ptr& event)
 {
-	ScriptFrame frame(true);
+	Namespace::Ptr frameNS = new Namespace();
+	ScriptFrame frame(true, frameNS);
 	frame.Sandboxed = true;
 
 	try {

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -188,7 +188,8 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 	Expression *permissionFilter;
 	CheckPermission(user, qd.Permission, &permissionFilter);
 
-	ScriptFrame permissionFrame(true);
+	Namespace::Ptr permissionFrameNS = new Namespace();
+	ScriptFrame permissionFrame(true, permissionFrameNS);
 
 	for (const String& type : qd.Types) {
 		String attr = type;


### PR DESCRIPTION
* allow proper parallel execution of requests
  * refs #6785 where permission checks get wrong result because permissions checks are done within a shared namespaces without using only unique keys
  * refs #6874 where segmentation faults occur because of concurrent access to non threadsafe parts of namespace
* do the same for eventqueue (not certain whether events can be processed in parallel but I expect it is the case)