### PR TITLE
avoid incrementing Ptr which could be already be in destruction-phase

### DIFF
--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -110,7 +110,7 @@ void Timer::UninitializeThread()
 void Timer::Call()
 {
 	try {
-		OnTimerExpired(Timer::Ptr(this));
+		OnTimerExpired(this);
 	} catch (...) {
 		InternalReschedule(true);
 
@@ -301,8 +301,6 @@ void Timer::TimerThreadProc()
 			continue;
 		}
 
-		Timer::Ptr ptimer = timer;
-
 		/* Remove the timer from the list so it doesn't get called again
 		 * until the current call is completed. */
 		l_Timers.erase(timer);
@@ -312,6 +310,6 @@ void Timer::TimerThreadProc()
 		lock.unlock();
 
 		/* Asynchronously call the timer. */
-		Utility::QueueAsyncCallback(std::bind(&Timer::Call, ptimer));
+		Utility::QueueAsyncCallback(std::bind(&Timer::Call, timer));
 	}
 }

--- a/lib/base/timer.hpp
+++ b/lib/base/timer.hpp
@@ -39,7 +39,7 @@ public:
 	void Reschedule(double next = -1);
 	double GetNext() const;
 
-	boost::signals2::signal<void(const Timer::Ptr&)> OnTimerExpired;
+	boost::signals2::signal<void(const Timer * const&)> OnTimerExpired;
 
 private:
 	double m_Interval{0}; /**< The interval of the timer. */

--- a/test/base-timer.cpp
+++ b/test/base-timer.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(interval)
 
 int counter = 0;
 
-static void Callback(const Timer::Ptr&)
+static void Callback(const Timer * const&)
 {
 	counter++;
 }


### PR DESCRIPTION
possible verified/proven fix for double-free (and possibly other memory-corruption related) crashes at logrotate time (issue #6737)

this is a direct fix of the issue revealing the problem that leads to crash

verification done with a patched icinga2 where the execution-order of the code lines of counter-parts involved in re-incrementing/decrementing Timer:Ptr is forced to be the one that leads to the obeserverd segfaults

Faulty race condition can be enforced with a patch like https://github.com/Elias481/icinga2/commit/359f45e24837ce9d9fcf6ffebfca8666e06cc884 (for verification)

P.S. the design of Timer module prevents completion of destruction of Timer object before the Timer got released from TimerThreadProc and finished it's possible last Call so it does no harm to not get a owning-reference on the time within TimerThreadProc() and Call().