### PR TITLE
Use I/O engine in debug console CLI command

### DIFF
--- a/lib/cli/consolecommand.hpp
+++ b/lib/cli/consolecommand.hpp
@@ -6,6 +6,9 @@
 #include "cli/clicommand.hpp"
 #include "base/exception.hpp"
 #include "base/scriptframe.hpp"
+#include "base/tlsstream.hpp"
+#include "remote/url.hpp"
+
 
 namespace icinga
 {
@@ -29,7 +32,7 @@ public:
 		boost::program_options::options_description& hiddenDesc) const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 
-	static int RunScriptConsole(ScriptFrame& scriptFrame, const String& addr = String(),
+	static int RunScriptConsole(ScriptFrame& scriptFrame, const String& connectAddr = String(),
 		const String& session = String(), const String& commandOnce = String(), const String& commandOnceFileName = String(),
 		bool syntaxOnly = false);
 
@@ -37,11 +40,12 @@ private:
 	mutable boost::mutex m_Mutex;
 	mutable boost::condition_variable m_CV;
 
-	static void ExecuteScriptCompletionHandler(boost::mutex& mutex, boost::condition_variable& cv,
-		bool& ready, const boost::exception_ptr& eptr, const Value& result, Value& resultOut,
-		boost::exception_ptr& eptrOut);
-	static void AutocompleteScriptCompletionHandler(boost::mutex& mutex, boost::condition_variable& cv,
-		bool& ready, const boost::exception_ptr& eptr, const Array::Ptr& result, Array::Ptr& resultOut);
+	static std::shared_ptr<AsioTlsStream> Connect();
+
+	static Value ExecuteScript(const String& session, const String& command, bool sandboxed);
+	static Array::Ptr AutoCompleteScript(const String& session, const String& command, bool sandboxed);
+
+	static Dictionary::Ptr SendRequest();
 
 #ifdef HAVE_EDITLINE
 	static char *ConsoleCompleteHelper(const char *word, int state);


### PR DESCRIPTION
# Tests

## Fetch global keys (including user configured constants)

```
michi@mbpmif ~/dev/icinga/icinga2 (feature/boost-asio-debug-console *<>) $ icinga2 console --connect 'https://root:icinga@localhost/'
Icinga 2 (version: v2.10.4-687-gf7c94330a)
Type $help to view available commands.
<1> => keys(globals)
[ "ActiveStages", "Icinga", "Internal", "ManubulonPluginDir", "MaxConcurrentChecks", "NodeName", "NscpPath", "PluginContribDir", "PluginDir", "ReloadTimeout", "StatsFunctions", "System", "TicketSalt", "Types", "UserDefinedConst", "Win10", "ZoneName", "countHosts", "countNotifications", "countServices" ]
```

```
[2019-05-22 12:40:39 +0200] information/ApiListener: New client connection from [::1]:55423 (no client certificate)
[2019-05-22 12:40:39 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/execute-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=keys%28globals%29&sandboxed=0 (from [::1]:55423), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:39 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55423)
```

## Autocomplete search for "No"
```
<2> => No
NodeName              Notification          NotificationCommand   NotificationComponent NotificationResult
```

```
[2019-05-22 12:40:41 +0200] information/ApiListener: New client connection from [::1]:55424 (no client certificate)
[2019-05-22 12:40:41 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/auto-complete-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=No&sandboxed=0 (from [::1]:55424), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:41 +0200] information/Console: Auto-completing expression: No
[2019-05-22 12:40:41 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55424)
[2019-05-22 12:40:41 +0200] information/ApiListener: New client connection from [::1]:55425 (no client certificate)
[2019-05-22 12:40:41 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/auto-complete-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=No&sandboxed=0 (from [::1]:55425), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:41 +0200] information/Console: Auto-completing expression: No
[2019-05-22 12:40:41 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55425)
```

## NodeName complete and result

```
<2> => NodeName
"mbpmif.int.netways.de"
```

```
[2019-05-22 12:40:50 +0200] information/ApiListener: New client connection from [::1]:55428 (no client certificate)
[2019-05-22 12:40:50 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/auto-complete-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=NodeN&sandboxed=0 (from [::1]:55428), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:50 +0200] information/Console: Auto-completing expression: NodeN
[2019-05-22 12:40:50 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55428)
```

```
[2019-05-22 12:40:50 +0200] information/ApiListener: New client connection from [::1]:55429 (no client certificate)
[2019-05-22 12:40:50 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/execute-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=NodeName&sandboxed=0 (from [::1]:55429), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:50 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55429)
```


## get functions autocomplete

```
<3> => get_
get_check_command        get_host                 get_notification_command get_objects              get_service_group        get_time                 get_user
get_event_command        get_host_group           get_object               get_service              get_services             get_time_period          get_user_group
```

```
[2019-05-22 12:40:55 +0200] information/ApiListener: New client connection from [::1]:55433 (no client certificate)
[2019-05-22 12:40:55 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/auto-complete-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=get_&sandboxed=0 (from [::1]:55433), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:55 +0200] information/Console: Auto-completing expression: get_
[2019-05-22 12:40:55 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55433)
[2019-05-22 12:40:55 +0200] information/ApiListener: New client connection from [::1]:55434 (no client certificate)
[2019-05-22 12:40:55 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/auto-complete-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=get_&sandboxed=0 (from [::1]:55434), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:40:55 +0200] information/Console: Auto-completing expression: get_
[2019-05-22 12:40:55 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55434)
```

## get_host autocompleted, NodeName autocompleted

```
<3> => get_host(NodeName)
{
	__name = "mbpmif.int.netways.de"
	acknowledgement = 0.000000
	acknowledgement_expiry = 0.000000
	action_url = ""
	active = true
	address = "127.0.0.1"
	address6 = "::1"
	check_attempt = 1.000000
	check_command = "hostalive"
	check_interval = 60.000000
	check_period = ""
	check_timeout = null
	command_endpoint = ""
	display_name = "mbpmif.int.netways.de"
	downtime_depth = 0.000000
	enable_active_checks = true
	enable_event_handler = true
	enable_flapping = false
	enable_notifications = true
	enable_passive_checks = true
	enable_perfdata = true
	event_command = ""
	extensions = {
		DbObject = {
			type = "Object"
		}
	}
	flapping = false
	flapping_buffer = 0.000000
	flapping_current = 0.000000
	flapping_index = 12.000000
	flapping_last_change = 0.000000
	flapping_threshold = 0.000000
	flapping_threshold_high = 30.000000
	flapping_threshold_low = 25.000000
	force_next_check = false
	force_next_notification = false
	groups = [ "linux-servers" ]
	ha_mode = 0.000000
	handled = false
	icon_image = ""
	icon_image_alt = ""
	last_check = 1558521626.745726
	last_check_result = {
		active = true
		check_source = "mbpmif.int.netways.de"
		command = [ "/usr/local/sbin/check_ping", "-H", "127.0.0.1", "-c", "5000,100%", "-w", "3000,80%" ]
		execution_end = 1558521626.745605
		execution_start = 1558521626.729294
		exit_status = 3.000000
		output = "/sbin/ping6 -n -c 5 127.0.0.1\nCRITICAL - Could not interpret output from ping command"
		performance_data = [ ]
		schedule_end = 1558521626.745726
		schedule_start = 1558521626.728291
		state = 3.000000
		ttl = 0.000000
		type = "CheckResult"
		vars_after = {
			attempt = 1.000000
			reachable = true
			state = 3.000000
			state_type = 1.000000
		}
		vars_before = {
			attempt = 1.000000
			reachable = true
			state = 3.000000
			state_type = 1.000000
		}
	}
	last_hard_state = 1.000000
	last_hard_state_change = 1557323847.339983
	last_hard_state_raw = 3.000000
	last_reachable = true
	last_state = 1.000000
	last_state_change = 1557323809.649515
	last_state_down = 0.000000
	last_state_raw = 3.000000
	last_state_type = 1.000000
	last_state_unreachable = 0.000000
	last_state_up = 0.000000
	max_check_attempts = 3.000000
	name = "mbpmif.int.netways.de"
	next_check = 1558521683.875786
	notes = ""
	notes_url = ""
	original_attributes = null
	package = "_etc"
	pause_called = false
	paused = false
	previous_state_change = 1557323809.649515
	problem = true
	resume_called = true
	retry_interval = 30.000000
	severity = 136.000000
	source_location = {
		first_column = 1.000000
		first_line = 18.000000
		last_column = 20.000000
		last_line = 18.000000
		path = "/usr/local/icinga/icinga2/etc/icinga2/conf.d/hosts.conf"
	}
	start_called = true
	state = 1.000000
	state_loaded = true
	state_raw = 3.000000
	state_type = 1.000000
	stop_called = false
	templates = [ "mbpmif.int.netways.de", "generic-host" ]
	type = "Host"
	vars = {
		disks = {
			disk = {
			}
			"disk /" = {
				disk_partitions = "/"
			}
		}
		http_vhosts = {
			http = {
				http_uri = "/"
			}
		}
		notification = {
			mail = {
				groups = [ "icingaadmins" ]
			}
		}
		os = "Linux"
	}
	version = 0.000000
	volatile = false
	zone = ""
}
```

```
[2019-05-22 12:41:00 +0200] information/ApiListener: New client connection from [::1]:55438 (no client certificate)
[2019-05-22 12:41:00 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/auto-complete-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=Node&sandboxed=0 (from [::1]:55438), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:41:00 +0200] information/Console: Auto-completing expression: Node
[2019-05-22 12:41:00 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55438)
```

```
[2019-05-22 12:41:02 +0200] information/ApiListener: New client connection from [::1]:55440 (no client certificate)
[2019-05-22 12:41:02 +0200] information/HttpServerConnection: Request: POST https://localhost:5665/v1/console/execute-script?session=bf62cffb-75e6-4f85-83ed-043e12a0b2f8&command=get_host%28NodeName%29&sandboxed=0 (from [::1]:55440), user: root, agent: Icinga/DebugConsole/v2.10.4-687-gf7c94330a).
[2019-05-22 12:41:02 +0200] information/HttpServerConnection: HTTP client disconnected (from [::1]:55440)
```













