### PR TITLE
Ensure that runtime created API objects survive a restart

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -102,6 +102,28 @@ The deprecated `concurrent_checks` attribute in the [checker feature](09-object-
 has no effect anymore if set. Please use the [MaxConcurrentChecks](17-language-reference.md#icinga-constants-global-config)
 constant in [constants.conf](04-configuring-icinga-2.md#constants-conf) instead.
 
+### REST API <a id="upgrading-to-2-11-api"></a>
+
+#### Config Packages <a id="upgrading-to-2-11-api-config-packages"></a>
+
+Deployed configuration packages require an active stage, with many previous
+allowed. This mechanism is used by the Icinga Director as external consumer,
+and Icinga itself for storing runtime created objects inside the `_api`
+package.
+
+This includes downtimes and comments, which where sometimes stored in the wrong
+directory path, because the active-stage file was empty/truncated/unreadable at
+this point.
+
+2.11 makes this mechanism more stable and detects broken config packages.
+
+```
+[2019-04-26 12:58:14 +0200] critical/ApiListener: Cannot detect active stage for package '_api'. Broken config package, check the troubleshooting documentation.
+```
+
+In order to fix this, please follow [this troubleshooting entry](15-troubleshooting.md#troubleshooting-api-missing-runtime-objects).
+
+
 ## Upgrading to v2.10 <a id="upgrading-to-2-10"></a>
 
 ### Path Constant Changes <a id="upgrading-to-2-10-path-constant-changes"></a>

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -289,7 +289,13 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 	}
 
 	/* Remove ignored Downtime/Comment objects. */
-	ConfigItem::RemoveIgnoredItems(ConfigObjectUtility::GetConfigDir());
+	try {
+		String configDir = ConfigObjectUtility::GetConfigDir();
+		ConfigItem::RemoveIgnoredItems(configDir);
+	} catch (const std::exception& ex) {
+		Log(LogNotice, "cli")
+			<< "Cannot clean ignored downtimes/comments: " << ex.what();
+	}
 
 #ifndef _WIN32
 	struct sigaction sa;

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -282,7 +282,15 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 	params->Set("version", object->GetVersion());
 
 	if (object->GetPackage() == "_api") {
-		String file = ConfigObjectUtility::GetObjectConfigPath(object->GetReflectionType(), object->GetName());
+		String file;
+
+		try {
+			file = ConfigObjectUtility::GetObjectConfigPath(object->GetReflectionType(), object->GetName());
+		} catch (const std::exception& ex) {
+			Log(LogNotice, "ApiListener")
+				<< "Cannot sync object '" << object->GetName() << "': " << ex.what();
+			return;
+		}
 
 		std::ifstream fp(file.CStr(), std::ifstream::binary);
 		if (!fp)

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1578,7 +1578,12 @@ void ApiListener::CheckApiPackageIntegrity()
 			activeStage = ConfigPackageUtility::GetActiveStageFromFile(package);
 		} catch (const std::exception& ex) {
 			/* An error means that the stage is broken, try to repair it. */
-			String activeStageCached = m_ActivePackageStages[package];
+			auto it = m_ActivePackageStages.find(package);
+
+			if (it == m_ActivePackageStages.end())
+				continue;
+
+			String activeStageCached = it->second;
 
 			Log(LogInformation, "ApiListener")
 				<< "Repairing broken API config package '" << package

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -124,6 +124,8 @@ private:
 	Timer::Ptr m_ReconnectTimer;
 	Timer::Ptr m_AuthorityTimer;
 	Timer::Ptr m_CleanupCertificateRequestsTimer;
+	Timer::Ptr m_ApiPackageIntegrityTimer;
+
 	Endpoint::Ptr m_LocalEndpoint;
 
 	static ApiListener::Ptr m_Instance;
@@ -131,6 +133,7 @@ private:
 	void ApiTimerHandler();
 	void ApiReconnectTimerHandler();
 	void CleanupCertificateRequestsTimerHandler();
+	void CheckApiPackageIntegrity();
 
 	bool AddListener(const String& node, const String& service);
 	void AddConnection(const Endpoint::Ptr& endpoint);

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -84,6 +84,11 @@ public:
 	static Value ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 	static Value ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
+	/* API config packages */
+	void SetActivePackageStage(const String& package, const String& stage);
+	String GetActivePackageStage(const String& package);
+	void RemoveActivePackageStage(const String& package);
+
 	static Value HelloAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
 	static void UpdateObjectAuthority();
@@ -175,6 +180,12 @@ private:
 	void SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient);
 
 	void SyncClient(const JsonRpcConnection::Ptr& aclient, const Endpoint::Ptr& endpoint, bool needSync);
+
+	/* API Config Packages */
+	mutable boost::mutex m_ActivePackageStagesLock;
+	std::map<String, String> m_ActivePackageStages;
+
+	void UpdateActivePackageStagesCache();
 };
 
 }

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -269,6 +269,17 @@ String ConfigPackageUtility::GetActiveStageFromFile(const String& packageName)
 	return stage.Trim();
 }
 
+void ConfigPackageUtility::SetActiveStageToFile(const String& packageName, const String& stageName)
+{
+	boost::mutex::scoped_lock lock(GetStaticMutex());
+
+	String activeStagePath = GetPackageDir() + "/" + packageName + "/active-stage";
+
+	std::ofstream fpActiveStage(activeStagePath.CStr(), std::ofstream::out | std::ostream::binary | std::ostream::trunc); //TODO: fstream exceptions
+	fpActiveStage << stageName;
+	fpActiveStage.close();
+}
+
 String ConfigPackageUtility::GetActiveStage(const String& packageName)
 {
 	ApiListener::Ptr listener = ApiListener::GetInstance();
@@ -307,11 +318,7 @@ void ConfigPackageUtility::SetActiveStage(const String& packageName, const Strin
 	listener->SetActivePackageStage(packageName, stageName);
 
 	/* Also update the marker on disk for restarts. */
-	String activeStagePath = GetPackageDir() + "/" + packageName + "/active-stage";
-
-	std::ofstream fpActiveStage(activeStagePath.CStr(), std::ofstream::out | std::ostream::binary | std::ostream::trunc); //TODO: fstream exceptions
-	fpActiveStage << stageName;
-	fpActiveStage.close();
+	SetActiveStageToFile(packageName, stageName);
 }
 
 std::vector<std::pair<String, bool> > ConfigPackageUtility::GetFiles(const String& packageName, const String& stageName)

--- a/lib/remote/configpackageutility.hpp
+++ b/lib/remote/configpackageutility.hpp
@@ -32,7 +32,9 @@ public:
 	static String CreateStage(const String& packageName, const Dictionary::Ptr& files = nullptr);
 	static void DeleteStage(const String& packageName, const String& stageName);
 	static std::vector<String> GetStages(const String& packageName);
+	static String GetActiveStageFromFile(const String& packageName);
 	static String GetActiveStage(const String& packageName);
+	static void SetActiveStage(const String& packageName, const String& stageName);
 	static void ActivateStage(const String& packageName, const String& stageName);
 	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool reload);
 

--- a/lib/remote/configpackageutility.hpp
+++ b/lib/remote/configpackageutility.hpp
@@ -35,6 +35,7 @@ public:
 	static String GetActiveStageFromFile(const String& packageName);
 	static String GetActiveStage(const String& packageName);
 	static void SetActiveStage(const String& packageName, const String& stageName);
+	static void SetActiveStageToFile(const String& packageName, const String& stageName);
 	static void ActivateStage(const String& packageName, const String& stageName);
 	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool reload);
 


### PR DESCRIPTION
Story: #7119

- Runtime created objects exist after restart (downtimes, comments, hosts, services, etc.)
- Reduce file I/O with active-stage reads, cache the details in memory
- Improve error handling, add exceptions and avoid wrong reads/writes
- Log config package errors on startup
- Repair missing active-stage files from a 5min timer, if they get deleted (brute force user action, the code uses lock guards now).

fixes #7119