### PR TITLE
account for adjusted interface of mysql8

### DIFF
--- a/lib/mysql_shim/mysqlinterface.cpp
+++ b/lib/mysql_shim/mysqlinterface.cpp
@@ -92,7 +92,7 @@ struct MysqlInterfaceImpl final : public MysqlInterface
 		return mysql_real_escape_string(mysql, to, from, length);
 	}
 
-	my_bool ssl_set(MYSQL *mysql, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher) const override
+	bool ssl_set(MYSQL *mysql, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher) const override
 	{
 		return mysql_ssl_set(mysql, key, cert, ca, capath, cipher);
 	}

--- a/lib/mysql_shim/mysqlinterface.hpp
+++ b/lib/mysql_shim/mysqlinterface.hpp
@@ -35,7 +35,7 @@ struct MysqlInterface
 	virtual MYSQL *real_connect(MYSQL *mysql, const char *host, const char *user, const char *passwd,
 		const char *db, unsigned int port, const char *unix_socket, unsigned long clientflag) const = 0;
 	virtual unsigned long real_escape_string(MYSQL *mysql, char *to, const char *from, unsigned long length) const = 0;
-	virtual my_bool ssl_set(MYSQL *mysql, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher) const = 0;
+	virtual bool ssl_set(MYSQL *mysql, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher) const = 0;
 	virtual MYSQL_RES *store_result(MYSQL *mysql) const = 0;
 	virtual unsigned int thread_safe() const = 0;
 


### PR DESCRIPTION
mysql8 utilizes c99 bools instead of my_bool labelled chars

as the upcoming generation of enterprise linux systems comes with mysql v8 as default (and some like me are already using such systems like redhat el8 beta for tests) - and the change is compatible with v5 and recommended by MySQL team this should implemented in code base asap...