### PR TITLE
Lock all kind of Objects during serialization

### DIFF
--- a/lib/base/serializer.cpp
+++ b/lib/base/serializer.cpp
@@ -142,7 +142,7 @@ static Object::Ptr SerializeObject(const Object::Ptr& input, int attributeTypes,
 
 		Value value = input->GetField(i);
 		stack.Push(field.Name, value);
-		fields.emplace_back(field.Name, SerializeInternal(input->GetField(i), attributeTypes, stack));
+		fields.emplace_back(field.Name, SerializeInternal(value, attributeTypes, stack));
 		stack.Pop();
 	}
 

--- a/lib/base/serializer.cpp
+++ b/lib/base/serializer.cpp
@@ -129,6 +129,8 @@ static Object::Ptr SerializeObject(const Object::Ptr& input, int attributeTypes,
 	DictionaryData fields;
 	fields.reserve(type->GetFieldCount() + 1);
 
+	ObjectLock olock(input);
+
 	for (int i = 0; i < type->GetFieldCount(); i++) {
 		Field field = type->GetFieldInfo(i);
 

--- a/lib/icinga/timeperiod.cpp
+++ b/lib/icinga/timeperiod.cpp
@@ -221,6 +221,7 @@ void TimePeriod::Merge(const TimePeriod::Ptr& timeperiod, bool include)
 void TimePeriod::UpdateRegion(double begin, double end, bool clearExisting)
 {
 	if (clearExisting) {
+		ObjectLock olock(this);
 		SetSegments(new Array());
 	} else {
 		if (begin < GetValidEnd())
@@ -346,6 +347,8 @@ void TimePeriod::UpdateTimerHandler()
 
 void TimePeriod::Dump()
 {
+	ObjectLock olock(this);
+
 	Array::Ptr segments = GetSegments();
 
 	Log(LogDebug, "TimePeriod")


### PR DESCRIPTION
Perivoud behaviour was to only lock arrays, dictionaries and namespaces but not other objects.
That can lead to crashes if objects are mutating during initialization even if the Objects are locked for that mutation in the threads that mutate them.

Should fix #7003 