### PR TITLE
Implement sleep CheckCommand

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -160,6 +160,15 @@ Check command for the built-in `exception` check. This check throws an exception
 For test and demo purposes only. The `exception` check command does not support
 any vars.
 
+### sleep <a id="itl-sleep"></a>
+
+Check command for the built-in `sleep` check. This allows to use sleep for testing
+and debugging only.
+
+Name            | Description
+----------------|--------------
+sleep\_time     | **Optional.** The duration of the sleep in seconds. Defaults to 1s.
+
 <!-- keep this anchor for URL link history only -->
 <a id="plugin-check-commands"></a>
 

--- a/itl/command-icinga.conf
+++ b/itl/command-icinga.conf
@@ -35,3 +35,7 @@ object CheckCommand "random" {
 object CheckCommand "exception" {
 	import "exception-check-command"
 }
+
+object CheckCommand "sleep" {
+    import "sleep-check-command"
+}

--- a/lib/methods/CMakeLists.txt
+++ b/lib/methods/CMakeLists.txt
@@ -16,6 +16,7 @@ set(methods_SOURCES
   pluginnotificationtask.cpp pluginnotificationtask.hpp
   randomchecktask.cpp randomchecktask.hpp
   timeperiodtask.cpp timeperiodtask.hpp
+  sleepchecktask.cpp sleepchecktask.hpp
 )
 
 if(ICINGA2_UNITY_BUILD)

--- a/lib/methods/methods-itl.conf
+++ b/lib/methods/methods-itl.conf
@@ -54,6 +54,12 @@ System.assert(Internal.run_with_activation_context(function() {
 	template TimePeriod "even-minutes-timeperiod" use (EvenMinutesTimePeriod = Internal.EvenMinutesTimePeriod) {
 		update = EvenMinutesTimePeriod
 	}
+
+	template CheckCommand "sleep-check-command" use (SleepCheck = Internal.SleepCheck) {
+	    execute = SleepCheck
+
+	    vars.sleep_time = 1s
+	}
 }))
 
 var methods = [
@@ -70,7 +76,8 @@ var methods = [
 	"NullCheck",
 	"NullEvent",
 	"EmptyTimePeriod",
-	"EvenMinutesTimePeriod"
+	"EvenMinutesTimePeriod",
+	"SleepCheck"
 ]
 
 for (method in methods) {

--- a/lib/methods/sleepchecktask.cpp
+++ b/lib/methods/sleepchecktask.cpp
@@ -1,0 +1,51 @@
+/* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
+
+#include "methods/sleepchecktask.hpp"
+#include "icinga/icingaapplication.hpp"
+#include "icinga/pluginutility.hpp"
+#include "base/utility.hpp"
+#include "base/convert.hpp"
+#include "base/function.hpp"
+#include "base/logger.hpp"
+
+using namespace icinga;
+
+REGISTER_FUNCTION_NONCONST(Internal, SleepCheck, &SleepCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+
+void SleepCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
+        const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+{
+    REQUIRE_NOT_NULL(checkable);
+    REQUIRE_NOT_NULL(cr);
+
+    CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
+
+    Host::Ptr host;
+    Service::Ptr service;
+    tie(host, service) = GetHostService(checkable);
+
+    MacroProcessor::ResolverList resolvers;
+    if (service)
+        resolvers.emplace_back("service", service);
+    resolvers.emplace_back("host", host);
+    resolvers.emplace_back("command", commandObj);
+    resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
+
+    double sleepTime = MacroProcessor::ResolveMacros("$sleep_time$", resolvers, checkable->GetLastCheckResult(),
+            nullptr, MacroProcessor::EscapeCallback(), resolvedMacros, useResolvedMacros);
+
+    if (resolvedMacros && !useResolvedMacros)
+        return;
+
+    Utility::Sleep(sleepTime);
+
+    String output = "Slept for " + Convert::ToString(sleepTime) + " seconds.";
+
+    double now = Utility::GetTime();
+
+    cr->SetOutput(output);
+    cr->SetExecutionStart(now);
+    cr->SetExecutionEnd(now);
+
+    checkable->ProcessCheckResult(cr);
+}

--- a/lib/methods/sleepchecktask.hpp
+++ b/lib/methods/sleepchecktask.hpp
@@ -1,0 +1,30 @@
+/* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
+
+#ifndef SLEEPCHECKTASK_H
+#define SLEEPCHECKTASK_H
+
+#include "methods/i2-methods.hpp"
+#include "icinga/service.hpp"
+#include "base/dictionary.hpp"
+
+namespace icinga
+{
+
+/**
+ * Test class for additional check types. Implements the "sleep" check type.
+ *
+ * @ingroup methods
+ */
+class SleepCheckTask
+{
+public:
+    static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
+            const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+
+private:
+    SleepCheckTask();
+};
+
+}
+
+#endif /* SLEEPCHECKTASK_H */


### PR DESCRIPTION
Implements a sleep CheckCommand in the Icinga Template Library. Offers the option of a custom var parameter named `sleep_time`, which defaults to 1 second. 

fixes #6964 