### PR TITLE
DB IDO: Do not deactivate objects during application reload/restart

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -353,6 +353,11 @@ bool Application::IsShuttingDown()
 	return m_ShuttingDown;
 }
 
+bool Application::IsRestarting()
+{
+	return l_Restarting;
+}
+
 void Application::OnShutdown()
 {
 	/* Nothing to do here. */

--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -58,6 +58,7 @@ public:
 	static void RequestReopenLogs();
 
 	static bool IsShuttingDown();
+	static bool IsRestarting();
 
 	static void SetDebuggingSeverity(LogSeverity severity);
 	static LogSeverity GetDebuggingSeverity();


### PR DESCRIPTION
This follows the same principle as with the shutdown handler,
and was introduced with the changed reload handling with 2.9.
Previously IsShuttingDown() was sufficient which got set at one
location.

SigUsr2 as handler introduced a new location where m_ShuttingDown
is not necessarily set yet. Since this handler gets called when
l_Restarting is enabled, we'll use this flag to avoid config update
events resulting in object deactivation (object->IsActive() always
returns false).

Full analysis and test protocol: https://github.com/Icinga/icinga2/issues/7125#issuecomment-489079446

refs #5996
refs #6691
refs #6970

fixes #7125