### PR TITLE
CLI: Return non-zero on unknown sub commands

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -327,8 +327,13 @@ static int Main()
 	po::variables_map vm;
 
 	try {
-		CLICommand::ParseCommand(argc, argv, visibleDesc, hiddenDesc, positionalDesc,
-			vm, cmdname, command, autocomplete);
+		if (!CLICommand::ParseCommand(argc, argv, visibleDesc, hiddenDesc, positionalDesc,
+			vm, cmdname, command, autocomplete)) {
+
+			Log(LogCritical, "icinga-app")
+				<< "Command parsing error. Try '--help'.";
+			return EXIT_FAILURE;
+		}
 	} catch (const std::exception& ex) {
 		Log(LogCritical, "icinga-app")
 			<< "Error while parsing command-line options: " << ex.what();

--- a/lib/cli/clicommand.cpp
+++ b/lib/cli/clicommand.cpp
@@ -200,8 +200,11 @@ found_command:
 		visibleDesc.add(vdesc);
 	}
 
-	if (autocomplete || (tried_command && !command))
+	if (autocomplete)
 		return true;
+
+	if (tried_command && !command)
+		return false;
 
 	po::options_description adesc;
 	adesc.add(visibleDesc);


### PR DESCRIPTION
# Tests
```
michi@mbpmif ~/dev/icinga/icinga2 (master *=) $ icinga2 sdfsdfsdf; echo "Status Code:$?"
[2019-05-07 12:40:54 +0200] critical/icinga-app: Command parsing error. Try '--help'.
Status Code:1
michi@mbpmif ~/dev/icinga/icinga2 (master *=) $ icinga2 daemon -C; echo "Status Code:$?"
[2019-05-07 12:41:08 +0200] information/cli: Icinga application loader (version: v2.10.4-643-gaa88271d5; debug)
[2019-05-07 12:41:08 +0200] information/cli: Loading configuration file(s).
[2019-05-07 12:41:08 +0200] information/ConfigItem: Committing config item(s).
[2019-05-07 12:41:08 +0200] information/ApiListener: My API identity: mbpmif.int.netways.de
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 2 Hosts.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 HostGroup.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 Endpoint.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 IcingaApplication.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 CheckerComponent.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 3 Zones.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 IdoMysqlConnection.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 NotificationComponent.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 ApiListener.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 7 CheckCommands.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 FileLogger.
[2019-05-07 12:41:08 +0200] information/ConfigItem: Instantiated 1 ApiUser.
[2019-05-07 12:41:08 +0200] information/ScriptGlobal: Dumping variables to file '/usr/local/icinga/icinga2/var/cache/icinga2/icinga2.vars'
[2019-05-07 12:41:08 +0200] information/cli: Finished validating the configuration file(s).
Status Code:0
michi@mbpmif ~/dev/icinga/icinga2 (master *=) $ icinga2 daemon --bumsti; echo "Status Code:$?"
[2019-05-07 12:41:22 +0200] critical/icinga-app: Error while parsing command-line options: unrecognised option '--bumsti'
Status Code:1
```

Auto-completion.

```
michi@mbpmif ~/dev/icinga/icinga2 (master *=) $ icinga2 daemon --
--close-stdio      --config           --define           --help             --log-level        --script-debugger  --version
--color            --daemonize        --errorlog         --include          --no-config        --validate
michi@mbpmif ~/dev/icinga/icinga2 (master *=) $ icinga2
api           ca            console       daemon        feature       node          object        pki           troubleshoot  variable
```


fixes #6585