### PR TITLE
API: Automatically repair broken _api package

### DIFF
--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -840,7 +840,7 @@ echo "dbe0bef8-c72c-4cc9-9779-da7c4527c5b2" > active-stage
 like this. Note: This is deep down in the code, use with care!
 
 ```
-sed -i 's/ActiveStages\["_api"\].*/ActiveStages\["_api"\] = "dbe0bef8-c72c-4cc9-9779-da7c4527c5b2"/g' /var/lib/icinga2/api/packages/_api/active.conf
+sed -i 's/ActiveStages\["_api"\] = .*/ActiveStages\["_api"\] = "dbe0bef8-c72c-4cc9-9779-da7c4527c5b2"/g' /var/lib/icinga2/api/packages/_api/active.conf
 ```
 
 Restart Icinga 2.

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -123,12 +123,13 @@ directory path, because the active-stage file was empty/truncated/unreadable at
 this point.
 
 2.11 makes this mechanism more stable and detects broken config packages.
+It will also attempt to fix them, the following log entry is perfectly fine.
 
 ```
-[2019-04-26 12:58:14 +0200] critical/ApiListener: Cannot detect active stage for package '_api'. Broken config package, check the troubleshooting documentation.
+[2019-05-10 12:12:09 +0200] information/ConfigObjectUtility: Repairing config package '_api' with stage 'dbe0bef8-c72c-4cc9-9779-da7c4527c5b2'.
 ```
 
-In order to fix this, please follow [this troubleshooting entry](15-troubleshooting.md#troubleshooting-api-missing-runtime-objects).
+If you still encounter problems, please follow [this troubleshooting entry](15-troubleshooting.md#troubleshooting-api-missing-runtime-objects).
 
 
 ## Upgrading to v2.10 <a id="upgrading-to-2-10"></a>

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -288,6 +288,9 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 		Logger::DisableConsoleLog();
 	}
 
+	/* Create the internal API object storage. Do this here too with setups without API. */
+	ConfigObjectUtility::CreateStorage();
+
 	/* Remove ignored Downtime/Comment objects. */
 	try {
 		String configDir = ConfigObjectUtility::GetConfigDir();

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -7,6 +7,7 @@
 #include "remote/jsonrpc.hpp"
 #include "remote/apifunction.hpp"
 #include "remote/configpackageutility.hpp"
+#include "remote/configobjectutility.hpp"
 #include "base/convert.hpp"
 #include "base/defer.hpp"
 #include "base/io-engine.hpp"
@@ -134,6 +135,9 @@ void ApiListener::OnConfigLoaded()
 	if (!oldCertPath.IsEmpty() && !oldKeyPath.IsEmpty() && !oldCaPath.IsEmpty()) {
 		Log(LogWarning, "ApiListener", "Please read the upgrading documentation for v2.8: https://icinga.com/docs/icinga2/latest/doc/16-upgrading-icinga-2/");
 	}
+
+	/* Create the internal API object storage. */
+	ConfigObjectUtility::CreateStorage();
 
 	/* Cache API packages and their active stage name. */
 	UpdateActivePackageStagesCache();

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -44,9 +44,12 @@ void ConfigObjectUtility::RepairPackage(const String& package)
 	/* Try to fix the active stage, whenever we find a directory in there.
 	 * This automatically heals packages < 2.11 which remained broken.
 	 */
+	String dir = ConfigPackageUtility::GetPackageDir() + "/" + package + "/";
+
 	namespace fs = boost::filesystem;
 
-	fs::path path(ConfigPackageUtility::GetPackageDir() + "/" + package + "/");
+	/* Use iterators to workaround VS builds on Windows. */
+	fs::path path(dir.Begin(), dir.End());
 
 	fs::recursive_directory_iterator end;
 

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -10,15 +10,21 @@
 #include "base/dependencygraph.hpp"
 #include "base/utility.hpp"
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/system/error_code.hpp>
 #include <fstream>
 
 using namespace icinga;
 
 String ConfigObjectUtility::GetConfigDir()
 {
-	/* This may throw an exception the caller above must handle. */
-	return ConfigPackageUtility::GetPackageDir() + "/_api/" +
-		ConfigPackageUtility::GetActiveStage("_api");
+	String prefix = ConfigPackageUtility::GetPackageDir() + "/_api/";
+	String activeStage = ConfigPackageUtility::GetActiveStage("_api");
+
+	if (activeStage.IsEmpty())
+		RepairPackage("_api");
+
+	return prefix + activeStage;
 }
 
 String ConfigObjectUtility::GetObjectConfigPath(const Type::Ptr& type, const String& fullName)
@@ -31,6 +37,59 @@ String ConfigObjectUtility::GetObjectConfigPath(const Type::Ptr& type, const Str
 
 	return prefix + "/conf.d/" + typeDir +
 		"/" + EscapeName(fullName) + ".conf";
+}
+
+void ConfigObjectUtility::RepairPackage(const String& package)
+{
+	/* Try to fix the active stage, whenever we find a directory in there.
+	 * This automatically heals packages < 2.11 which remained broken.
+	 */
+	namespace fs = boost::filesystem;
+
+	fs::path path(ConfigPackageUtility::GetPackageDir() + "/" + package + "/");
+
+	fs::recursive_directory_iterator end;
+
+	String foundActiveStage;
+
+	for (fs::recursive_directory_iterator it(path); it != end; it++) {
+		boost::system::error_code ec;
+
+		const fs::path d = *it;
+		if (fs::is_directory(d, ec)) {
+			/* Extract the relative directory name. */
+			foundActiveStage = d.stem().string();
+
+			break; // Use the first found directory.
+		}
+	}
+
+	if (!foundActiveStage.IsEmpty()) {
+		Log(LogInformation, "ConfigObjectUtility")
+			<< "Repairing config package '" << package << "' with stage '" << foundActiveStage << "'.";
+
+		ConfigPackageUtility::ActivateStage(package, foundActiveStage);
+	} else {
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot repair package '" + package + "', please check the troubleshooting docs."));
+	}
+}
+
+void ConfigObjectUtility::CreateStorage()
+{
+	boost::mutex::scoped_lock lock(ConfigPackageUtility::GetStaticPackageMutex());
+
+	/* For now, we only use _api as our creation target. */
+	String package = "_api";
+
+	if (!ConfigPackageUtility::PackageExists(package)) {
+		Log(LogNotice, "ConfigObjectUtility")
+			<< "Package " << package << " doesn't exist yet, creating it.";
+
+		ConfigPackageUtility::CreatePackage(package);
+
+		String stage = ConfigPackageUtility::CreateStage(package);
+		ConfigPackageUtility::ActivateStage(package, stage);
+	}
 }
 
 String ConfigObjectUtility::EscapeName(const String& name)
@@ -88,16 +147,7 @@ String ConfigObjectUtility::CreateObjectConfig(const Type::Ptr& type, const Stri
 bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& fullName,
 	const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation)
 {
-	{
-		boost::mutex::scoped_lock lock(ConfigPackageUtility::GetStaticPackageMutex());
-
-		if (!ConfigPackageUtility::PackageExists("_api")) {
-			ConfigPackageUtility::CreatePackage("_api");
-
-			String stage = ConfigPackageUtility::CreateStage("_api");
-			ConfigPackageUtility::ActivateStage("_api", stage);
-		}
-	}
+	CreateStorage();
 
 	ConfigItem::Ptr item = ConfigItem::GetByTypeAndName(type, fullName);
 

--- a/lib/remote/configobjectutility.hpp
+++ b/lib/remote/configobjectutility.hpp
@@ -23,6 +23,8 @@ class ConfigObjectUtility
 public:
 	static String GetConfigDir();
 	static String GetObjectConfigPath(const Type::Ptr& type, const String& fullName);
+	static void RepairPackage(const String& package);
+	static void CreateStorage();
 
 	static String CreateObjectConfig(const Type::Ptr& type, const String& fullName,
 		bool ignoreOnError, const Array::Ptr& templates, const Dictionary::Ptr& attrs);


### PR DESCRIPTION
This partially reverts #7150 and avoids exceptions
inside the flow. Each time an empty active stage
is detected, Icinga tries to repair it from the
the given directory tree.

Also, the code now takes into account that it should
create the package storage on startup, whether within
the API object, or if disabled, inside the application.

Caching the active stages for packages in memory
only is in effect with the API feature being enabled.
This is useful for other deployed config packages,
not only the internal one.

fixes #7173
refs #7150
refs #7119
fixes #6959