### PR TITLE
Add new -r parameter for esxi_hardware command

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -3303,7 +3303,7 @@ This category includes all plugins for various virtualization technologies.
 
 #### esxi_hardware <a id="plugin-contrib-command-esxi-hardware"></a>
 
-The [check_esxi_hardware.py](https://www.claudiokuenzler.com/nagios-plugins/check_esxi_hardware.php) plugin
+The [check_esxi_hardware.py](https://www.claudiokuenzler.com/monitoring-plugins/check_esxi_hardware.php) plugin
 uses the [pywbem](https://pywbem.github.io/pywbem/) Python library to monitor the hardware of ESXi servers
 through the [VMWare API](https://www.vmware.com/support/pubs/sdk_pubs.html) and CIM service.
 
@@ -3317,7 +3317,8 @@ esxi_hardware_pass      | **Required.** Password of the user. Can also be provid
 esxi_hardware_port      | **Optional.** Specifies the CIM port to connect to. Defaults to 5989.
 esxi_hardware_vendor    | **Optional.** Defines the vendor of the server: "auto", "dell", "hp", "ibm", "intel", "unknown" (default).
 esxi_hardware_html      | **Optional.** Add web-links to hardware manuals for Dell servers (use your country extension). Only useful with **esxi_hardware_vendor** = dell.
-esxi_hardware_ignore    | **Optional.** Comma separated list of elements to ignore.
+esxi_hardware_ignore    | **Optional.** Comma separated list of CIM elements to ignore.
+esxi_hardware_regex     | **Optional.** Allow regular expression lookups of elements in ignore list. Defaults to false.
 esxi_hardware_perfdata  | **Optional.** Add performcedata for graphers like PNP4Nagios to the output. Defaults to false.
 esxi_hardware_nopower   | **Optional.** Do not collect power performance data, when **esxi_hardware_perfdata** is set to true. Defaults to false.
 esxi_hardware_novolts   | **Optional.** Do not collect voltage performance data, when **esxi_hardware_perfdata** is set to true. Defaults to false.

--- a/itl/plugins-contrib.d/virtualization.conf
+++ b/itl/plugins-contrib.d/virtualization.conf
@@ -32,6 +32,10 @@ object CheckCommand "esxi_hardware" {
 			value = "$esxi_hardware_ignore$"
 			description = "comma-separated list of elements to ignore"
 		}
+		"-r" = {
+			set_if = "$esxi_hardware_regex$"
+			description = "Allow regular expression lookups of elements in ignore list"
+		}
 		"-p" = {
 			set_if = "$esxi_hardware_perfdata$"
 			description = "collect performance data for pnp4nagios"
@@ -64,6 +68,7 @@ object CheckCommand "esxi_hardware" {
 
 	vars.esxi_hardware_host = "$address$"
 	vars.esxi_hardware_port = 5989
+	vars.esxi_hardware_regex = false
 	vars.esxi_hardware_perfdata = false
 	vars.esxi_hardware_nopower = false
 	vars.esxi_hardware_novolts = false


### PR DESCRIPTION
Update ITL command definition of check_esxi_hardware plugin with the new "-r" parameter.
See https://www.claudiokuenzler.com/blog/851/check_esxi_hardware-supports-regular-expression-elements-ignore-list for more info. 