### PR TITLE
Strip '\r' in notification messages to avoid 'Content-Type: application/octet-stream'

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -157,13 +157,15 @@ if [ -n "$MAILFROM" ] ; then
 
   ## Debian/Ubuntu use mailutils which requires `-a` to append the header
   if [ -f /etc/debian_version ]; then
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
   ## Other distributions (RHEL/SUSE/etc.) prefer mailx which sets a sender address with `-r`
   else
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -r "$MAILFROM" -s "$SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -r "$MAILFROM" -s "$SUBJECT" $USEREMAIL
   fi
 
 else
-  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" \
+  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
   | $MAILBIN -s "$SUBJECT" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -162,13 +162,15 @@ if [ -n "$MAILFROM" ] ; then
 
   ## Debian/Ubuntu use mailutils which requires `-a` to append the header
   if [ -f /etc/debian_version ]; then
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
   ## Other distributions (RHEL/SUSE/etc.) prefer mailx which sets a sender address with `-r`
   else
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -r "$MAILFROM" -s "$SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -r "$MAILFROM" -s "$SUBJECT" $USEREMAIL
   fi
 
 else
-  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" \
+  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
   | $MAILBIN -s "$SUBJECT" $USEREMAIL
 fi


### PR DESCRIPTION
Without this patch, an accidential `\r` in e.g. `$NOTIFICATIONCOMMENT` leads to a `Content-Type: application/octet-stream` header in e-mails. The accidential `\r` might slip in usually using Icinga/Nagios apps...

```
#!/bin/bash

NOTIFICATION_MESSAGE=`cat << EOF
***** Service Monitoring on icinga2.example.net *****

CPU Load on tux.example.net is CRITICAL!

Info:    CRITICAL - load average: 812.35, 553.01, 269.48

When:    2019-05-16 07:39:05 +0200
Service: CPU Load
Host:    tux.example.net
IPv4:    192.0.2.42

Comment by Beastie:
  ACK
EOF
`

# Append accidential '\r' manually
NOTIFICATION_MESSAGE=${NOTIFICATION_MESSAGE}$'\r'

# Bashism to remove '\r'
#NOTIFICATION_MESSAGE=${NOTIFICATION_MESSAGE//[$'\r']}

# Issue reproducer (RHEL/SUSE/etc.)
/usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" \
| mailx -r "monitoring@example.net" -s "[ACKNOWLEDGEMENT] CPU Load on tux.example.net is CRITICAL!" root@localhost

# Bashishm-free '\r' removal (RHEL/SUSE/etc.)
/usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
| mailx -r "monitoring@example.net" -s "[ACKNOWLEDGEMENT] CPU Load on tux.example.net is CRITICAL!" root@localhost
```