### PR TITLE
Fix wrong facility in GelfWriter log message

### DIFF
--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -108,7 +108,7 @@ void GelfWriter::Pause()
 	m_WorkQueue.Join();
 	DisconnectInternal();
 
-	Log(LogInformation, "GraphiteWriter")
+	Log(LogInformation, "GelfWriter")
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<GelfWriter>::Pause();


### PR DESCRIPTION
This fixes a wrong facility in GelfWriter log message (paused message).