### PR TITLE
Use --description instead of -d for check_service.exe

### DIFF
--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -222,7 +222,7 @@ object CheckCommand "service-windows" {
 			required = true
 			description = "Service to check"
 		}
-		"-d" = {
+		"--description" = {
 			set_if = "$service_win_description$"
 			description = "Use service description instead of name"
 		}


### PR DESCRIPTION
This fix is for issue #7188

The problem seems to be that the CLI parser on Windows ignores the casing of parameters passed to external commands such as `check_service.exe` and since there are both `-d` and `-D` options for this plugin it complains about the ambiguity instead of executing the check. 

Fixed by replacing the short form `-d` by `--description` in the CheckCommand.