### PR TITLE
Disable program option guessing in check_service

### DIFF
--- a/plugins/check_service.cpp
+++ b/plugins/check_service.cpp
@@ -43,8 +43,10 @@ static int parseArguments(int ac, WCHAR **av, po::variables_map& vm, printInfoSt
 			parser
 			.options(desc)
 			.style(
-			po::command_line_style::unix_style |
-			po::command_line_style::allow_long_disguise)
+			po::command_line_style::unix_style &
+			~po::command_line_style::allow_guessing |
+			po::command_line_style::allow_long_disguise
+			)
 			.run(),
 			vm);
 		vm.notify();


### PR DESCRIPTION
This disables the program option guessing in check_service to avoid
ambiguous parameter parsing.

If guessing is enabled the Boost program option parser tries to guess which option could be meant. We also enabled the `allow_long_disguise` style, which provides us to use long options with a single starting character (e.g `-debug`). If now the guessing kicks in there are ambiguous parameters: `-debug` and `-d`.
 
## Tests
```
.\check_service.exe -s Work Folders
The specified service does not exist as an installed service.

.\check_service.exe -s Work Folders -d
SERVICE "workfolderssvc" CRITICAL NOT RUNNING | 'service'=1;;;1;7
```

```
.\check_service.exe -s W32Time -d
Could not find service matching description

.\check_service.exe --service W32Time --description
Could not find service matching description
```
(Which is the expected behavior.)

```
.\check_service.exe --service W32Time
SERVICE "W32Time" CRITICAL NOT RUNNING | 'service'=1;;;1;7
```

fixes #7188