### PR TITLE
WIP: Replace boost/std::bind with C++11 lambdas

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -379,7 +379,8 @@ static void ReloadProcessCallback(const ProcessResult& pr)
 {
 	l_Restarting = false;
 
-	std::thread t(std::bind(&ReloadProcessCallbackInternal, pr));
+	auto lambdaReloadProcessCallbackInternal = [&, pr](){return ReloadProcessCallbackInternal(pr);};
+	std::thread t(lambdaReloadProcessCallbackInternal);
 	t.detach();
 }
 

--- a/lib/base/array-script.cpp
+++ b/lib/base/array-script.cpp
@@ -88,7 +88,8 @@ static Array::Ptr ArraySort(const std::vector<Value>& args)
 			BOOST_THROW_EXCEPTION(ScriptError("Sort function must be side-effect free."));
 
 		ObjectLock olock(arr);
-		std::sort(arr->Begin(), arr->End(), std::bind(ArraySortCmp, args[0], _1, _2));
+		auto lambdaArraySortCmp = [=](const Value& a, const Value& b){return ArraySortCmp(args[0], a, b);};
+        std::sort(arr->Begin(), arr->End(), lambdaArraySortCmp);
 	}
 
 	return arr;

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -559,7 +559,8 @@ void ConfigObject::RestoreObjects(const String& filename, int attributeTypes)
 		if (srs != StatusNewItem)
 			continue;
 
-		upq.Enqueue(std::bind(&ConfigObject::RestoreObject, message, attributeTypes));
+		auto lambdaRestoreObject = [&, message, attributeTypes](){return ConfigObject::RestoreObject(message, attributeTypes);};
+		upq.Enqueue(lambdaRestoreObject);
 		restored++;
 	}
 

--- a/lib/base/filelogger.cpp
+++ b/lib/base/filelogger.cpp
@@ -31,8 +31,8 @@ void FileLogger::Start(bool runtimeCreated)
 {
 	ReopenLogFile();
 
-	Application::OnReopenLogs.connect(std::bind(&FileLogger::ReopenLogFile, this));
-
+	auto lambdaReopenLogFile = [&](){return FileLogger::ReopenLogFile();};
+	Application::OnReopenLogs.connect(lambdaReopenLogFile);
 	ObjectImpl<FileLogger>::Start(runtimeCreated);
 
 	Log(LogInformation, "FileLogger")

--- a/lib/base/functionwrapper.hpp
+++ b/lib/base/functionwrapper.hpp
@@ -39,7 +39,8 @@ inline std::function<Value (const std::vector<Value>&)> WrapFunction(void (*func
 template<typename Return>
 std::function<Value (const std::vector<Value>&)> WrapFunction(Return (*function)(const std::vector<Value>&))
 {
-	return std::bind(function, _1);
+	auto lambdaFunction = [=](const std::vector<Value> wrap){return function(wrap);};
+	return lambdaFunction;
 }
 
 template <std::size_t... Indices>

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -491,7 +491,8 @@ Value ScriptUtils::Glob(const std::vector<Value>& args)
 		type = args[1];
 
 	std::vector<String> paths;
-	Utility::Glob(pathSpec, std::bind(&GlobCallbackHelper, std::ref(paths), _1), type);
+	auto lambdaGlobCallbackHelper = [&](const String& path){return GlobCallbackHelper(paths, path);};
+	Utility::Glob(pathSpec, lambdaGlobCallbackHelper, type);
 
 	return Array::FromVector(paths);
 }
@@ -510,7 +511,8 @@ Value ScriptUtils::GlobRecursive(const std::vector<Value>& args)
 		type = args[2];
 
 	std::vector<String> paths;
-	Utility::GlobRecursive(path, pattern, std::bind(&GlobCallbackHelper, std::ref(paths), _1), type);
+	auto lambdaGlobCallbackHelper = [&](const String& path){return GlobCallbackHelper(paths, path);};
+	Utility::GlobRecursive(path, pattern, lambdaGlobCallbackHelper, type);
 
 	return Array::FromVector(paths);
 }

--- a/lib/base/stream.cpp
+++ b/lib/base/stream.cpp
@@ -83,7 +83,8 @@ void Stream::Close()
 
 	/* Force signals2 to remove the slots, see https://stackoverflow.com/questions/2049291/force-deletion-of-slot-in-boostsignals2
 	 * for details. */
-	OnDataAvailable.connect(std::bind(&StreamDummyCallback));
+	//OnDataAvailable.connect(std::bind(&StreamDummyCallback));
+	//TODO:: Replace SteamDummyCallback with something more purposeful
 }
 
 StreamReadStatus Stream::ReadLine(String *line, StreamReadContext& context, bool may_wait)

--- a/lib/base/typetype-script.cpp
+++ b/lib/base/typetype-script.cpp
@@ -21,7 +21,8 @@ static void TypeRegisterAttributeHandler(const String& fieldName, const Function
 	REQUIRE_NOT_NULL(self);
 
 	int fid = self->GetFieldId(fieldName);
-	self->RegisterAttributeHandler(fid, std::bind(&InvokeAttributeHandlerHelper, callback, _1, _2));
+	auto lambdaInvokeAttributeHandlerHelper = [&](const Object::Ptr& object, const Value& cookie){return InvokeAttributeHandlerHelper(callback, object, cookie);};
+	self->RegisterAttributeHandler(fid, lambdaInvokeAttributeHandlerHelper);
 }
 
 Object::Ptr TypeType::GetPrototype()

--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -60,7 +60,8 @@ void WorkQueue::EnqueueUnlocked(boost::mutex::scoped_lock& lock, std::function<v
 			<< "Spawning WorkQueue threads for '" << m_Name << "'";
 
 		for (int i = 0; i < m_ThreadCount; i++) {
-			m_Threads.create_thread(std::bind(&WorkQueue::WorkerThreadProc, this));
+			auto lambdaWorkerThreadProc = [&](){return WorkQueue::WorkerThreadProc();};
+			m_Threads.create_thread(lambdaWorkerThreadProc);
 		}
 
 		m_Spawned = true;

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -58,7 +58,8 @@ void CheckerComponent::Start(bool runtimeCreated)
 		<< "'" << GetName() << "' started.";
 
 
-	m_Thread = std::thread(std::bind(&CheckerComponent::CheckThreadProc, this));
+	auto lambdaCheckThreadProc = [&](){return CheckerComponent::CheckThreadProc();};
+	m_Thread = std::thread(lambdaCheckThreadProc);
 
 	m_ResultTimer = new Timer();
 	m_ResultTimer->SetInterval(5);
@@ -222,7 +223,8 @@ void CheckerComponent::CheckThreadProc()
 
 		Checkable::IncreasePendingChecks();
 
-		Utility::QueueAsyncCallback(std::bind(&CheckerComponent::ExecuteCheckHelper, CheckerComponent::Ptr(this), checkable));
+		auto lambdaExecuteCheckHelper = [&, checkable](){return CheckerComponent::ExecuteCheckHelper(checkable);};
+		Utility::QueueAsyncCallback(lambdaExecuteCheckHelper);
 
 		lock.lock();
 	}

--- a/lib/cli/featureutility.cpp
+++ b/lib/cli/featureutility.cpp
@@ -184,11 +184,17 @@ bool FeatureUtility::GetFeatures(std::vector<String>& features, bool get_disable
 		/* disable = available-enabled */
 		String available_pattern = GetFeaturesAvailablePath() + "/*.conf";
 		std::vector<String> available;
-		Utility::Glob(available_pattern, std::bind(&FeatureUtility::CollectFeatures, _1, std::ref(available)), GlobFile);
+		auto lambdaCollectFeatures = [&](const String& feature_file){
+			return FeatureUtility::CollectFeatures(feature_file, available);
+		};
+		Utility::Glob(available_pattern, lambdaCollectFeatures, GlobFile);
 
 		String enabled_pattern = GetFeaturesEnabledPath() + "/*.conf";
 		std::vector<String> enabled;
-		Utility::Glob(enabled_pattern, std::bind(&FeatureUtility::CollectFeatures, _1, std::ref(enabled)), GlobFile);
+		auto lambdaEnableFeatures = [&](const String& feature_file){
+			return FeatureUtility::CollectFeatures(feature_file, enabled);
+		};
+		Utility::Glob(enabled_pattern, lambdaEnableFeatures, GlobFile);
 
 		std::sort(available.begin(), available.end());
 		std::sort(enabled.begin(), enabled.end());
@@ -201,7 +207,10 @@ bool FeatureUtility::GetFeatures(std::vector<String>& features, bool get_disable
 		/* all enabled features */
 		String enabled_pattern = GetFeaturesEnabledPath() + "/*.conf";
 
-		Utility::Glob(enabled_pattern, std::bind(&FeatureUtility::CollectFeatures, _1, std::ref(features)), GlobFile);
+		auto lambdaCollectFeatures = [&](const String& feature_file){
+			return FeatureUtility::CollectFeatures(feature_file, features);
+		};
+		Utility::Glob(enabled_pattern, lambdaCollectFeatures, GlobFile);
 	}
 
 	return true;

--- a/lib/compat/checkresultreader.cpp
+++ b/lib/compat/checkresultreader.cpp
@@ -73,7 +73,8 @@ void CheckResultReader::ReadTimerHandler() const
 {
 	CONTEXT("Processing check result files in '" + GetSpoolDir() + "'");
 
-	Utility::Glob(GetSpoolDir() + "/c??????.ok", std::bind(&CheckResultReader::ProcessCheckResultFile, this, _1), GlobFile);
+	auto lambdaProcessCheckResultFile = [&](const String& path){return CheckResultReader::ProcessCheckResultFile(path);};
+	Utility::Glob(GetSpoolDir() + "/c??????.ok", lambdaProcessCheckResultFile, GlobFile);
 }
 
 void CheckResultReader::ProcessCheckResultFile(const String& path) const

--- a/lib/compat/externalcommandlistener.cpp
+++ b/lib/compat/externalcommandlistener.cpp
@@ -39,7 +39,8 @@ void ExternalCommandListener::Start(bool runtimeCreated)
 	Log(LogWarning, "ExternalCommandListener")
 		<< "This feature is DEPRECATED and will be removed in future releases. Check the roadmap at https://github.com/Icinga/icinga2/milestones";
 #ifndef _WIN32
-	m_CommandThread = std::thread(std::bind(&ExternalCommandListener::CommandPipeThread, this, GetCommandPath()));
+	auto lambdaCommandPipeThread = [&](){return ExternalCommandListener::CommandPipeThread(GetCommandPath());};
+	m_CommandThread = std::thread(lambdaCommandPipeThread);
 	m_CommandThread.detach();
 #endif /* _WIN32 */
 }

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -19,11 +19,20 @@ boost::signals2::signal<void (const Checkable::Ptr&, const MessageOrigin::Ptr&)>
 void Checkable::StaticInitialize()
 {
 	/* fixed downtime start */
-	Downtime::OnDowntimeStarted.connect(std::bind(&Checkable::NotifyFixedDowntimeStart, _1));
+	auto lambdaNotifyFixedDowntimeStart = [&](const Downtime::Ptr& downtime){
+	    return Checkable::NotifyFixedDowntimeStart(downtime);
+	};
+	Downtime::OnDowntimeStarted.connect(lambdaNotifyFixedDowntimeStart);
 	/* flexible downtime start */
-	Downtime::OnDowntimeTriggered.connect(std::bind(&Checkable::NotifyFlexibleDowntimeStart, _1));
+	auto lambdaNotifyFlexibleDowntimeStart = [&](const Downtime::Ptr& downtime){
+	    return Checkable::NotifyFixedDowntimeStart(downtime);
+	};
+	Downtime::OnDowntimeTriggered.connect(lambdaNotifyFlexibleDowntimeStart);
 	/* fixed/flexible downtime end */
-	Downtime::OnDowntimeRemoved.connect(std::bind(&Checkable::NotifyDowntimeEnd, _1));
+	auto lambdaNotifyDowntimeEnd = [&](const Downtime::Ptr& downtime){
+	    return Checkable::NotifyDowntimeEnd(downtime);
+	};
+	Downtime::OnDowntimeRemoved.connect(lambdaNotifyDowntimeEnd);
 }
 
 Checkable::Checkable()

--- a/lib/icinga/clusterevents-check.cpp
+++ b/lib/icinga/clusterevents-check.cpp
@@ -66,7 +66,8 @@ void ClusterEvents::EnqueueCheck(const MessageOrigin::Ptr& origin, const Diction
 		return;
 	}
 
-	m_CheckRequestQueue.push_back(std::bind(ClusterEvents::ExecuteCheckFromQueue, origin, params));
+	auto lambdaExecuteCheckFromQueue = [=](){return ClusterEvents::ExecuteCheckFromQueue(origin, params);};
+	m_CheckRequestQueue.push_back(lambdaExecuteCheckFromQueue);
 
 	if (!m_CheckSchedulerRunning) {
 		std::thread t(ClusterEvents::RemoteCheckThreadProc);

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -168,7 +168,10 @@ void IcingaApplication::DumpModifiedAttributes()
 	fp.exceptions(std::ofstream::failbit | std::ofstream::badbit);
 
 	ConfigObject::Ptr previousObject;
-	ConfigObject::DumpModifiedAttributes(std::bind(&PersistModAttrHelper, std::ref(fp), std::ref(previousObject), _1, _2, _3));
+	auto lambdaPersistModAttrHelper = [&](const ConfigObject::Ptr& object, const String& attr, const Value& value){
+	    return PersistModAttrHelper(fp, previousObject, object, attr, value);
+	};
+	ConfigObject::DumpModifiedAttributes(lambdaPersistModAttrHelper);
 
 	if (previousObject) {
 		ConfigWriter::EmitRaw(fp, "\tobj.version = ");

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -422,7 +422,11 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			<< "Sending " << (reminder ? "reminder " : "") << "'" << NotificationTypeToStringInternal(type) << "' notification '"
 			<< notificationName << "' for user '" << userName << "'";
 
-		Utility::QueueAsyncCallback(std::bind(&Notification::ExecuteNotificationHelper, this, type, user, cr, force, author, text));
+		auto lambdaExecuteNotificationHelper = [&, type, user, cr, force, author, text](){
+		    return Notification::ExecuteNotificationHelper(type, user, cr, force, author, text);
+		};
+		Utility::QueueAsyncCallback(lambdaExecuteNotificationHelper);
+
 
 		/* collect all notified users */
 		allNotifiedUsers.insert(user);

--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -79,7 +79,8 @@ void PluginUtility::ExecuteCommand(const Command::Ptr& commandObj, const Checkab
 	process->SetTimeout(timeout);
 	process->SetAdjustPriority(true);
 
-	process->Run(std::bind(callback, command, _1));
+	auto lambdaCallback = [=](const ProcessResult& pr){return callback(command, pr);};
+	process->Run(lambdaCallback);
 }
 
 ServiceState PluginUtility::ExitStatusToState(int exitStatus)

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -80,8 +80,10 @@ void ScheduledDowntime::Start(bool runtimeCreated)
 		l_Timer->Start();
 	});
 
-	if (!IsPaused())
-		Utility::QueueAsyncCallback(std::bind(&ScheduledDowntime::CreateNextDowntime, this));
+	if (!IsPaused()) {
+	    auto lambdaCreateNextDowntime = [&](){return ScheduledDowntime::CreateNextDowntime();};
+        Utility::QueueAsyncCallback(lambdaCreateNextDowntime);
+    }
 }
 
 void ScheduledDowntime::TimerProc()

--- a/lib/methods/pluginchecktask.cpp
+++ b/lib/methods/pluginchecktask.cpp
@@ -40,9 +40,11 @@ void PluginCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	if (!checkable->GetCheckTimeout().IsEmpty())
 		timeout = checkable->GetCheckTimeout();
 
+	auto lambdaProcessFinishedHandler = [&, checkable, cr](const Value& commandLine, const ProcessResult& pr){
+		return PluginCheckTask::ProcessFinishedHandler(checkable, cr, commandLine, pr);
+	};
 	PluginUtility::ExecuteCommand(commandObj, checkable, checkable->GetLastCheckResult(),
-		resolvers, resolvedMacros, useResolvedMacros, timeout,
-		std::bind(&PluginCheckTask::ProcessFinishedHandler, checkable, cr, _1, _2));
+		resolvers, resolvedMacros, useResolvedMacros, timeout, lambdaProcessFinishedHandler);
 
 	if (!resolvedMacros || useResolvedMacros)
 		Checkable::IncreasePendingChecks();

--- a/lib/methods/plugineventtask.cpp
+++ b/lib/methods/plugineventtask.cpp
@@ -36,9 +36,11 @@ void PluginEventTask::ScriptFunc(const Checkable::Ptr& checkable,
 
 	int timeout = commandObj->GetTimeout();
 
+	auto lambdaProcessFinishedHandler = [&, checkable](const Value& commandLine, const ProcessResult& pr){
+		return PluginEventTask::ProcessFinishedHandler(checkable, commandLine, pr);
+	};
 	PluginUtility::ExecuteCommand(commandObj, checkable, checkable->GetLastCheckResult(),
-		resolvers, resolvedMacros, useResolvedMacros, timeout,
-		std::bind(&PluginEventTask::ProcessFinishedHandler, checkable, _1, _2));
+		resolvers, resolvedMacros, useResolvedMacros, timeout, lambdaProcessFinishedHandler);
 }
 
 void PluginEventTask::ProcessFinishedHandler(const Checkable::Ptr& checkable, const Value& commandLine, const ProcessResult& pr)

--- a/lib/methods/pluginnotificationtask.cpp
+++ b/lib/methods/pluginnotificationtask.cpp
@@ -53,9 +53,11 @@ void PluginNotificationTask::ScriptFunc(const Notification::Ptr& notification,
 
 	int timeout = commandObj->GetTimeout();
 
+	auto lambdaProcessFinishedHandler = [&, checkable, notification, nr](const Value& commandLine, const ProcessResult& pr){
+		return PluginNotificationTask::ProcessFinishedHandler(checkable, notification, nr, commandLine, pr);
+	};
 	PluginUtility::ExecuteCommand(commandObj, checkable, cr, resolvers,
-		resolvedMacros, useResolvedMacros, timeout,
-		std::bind(&PluginNotificationTask::ProcessFinishedHandler, checkable, notification, nr, _1, _2));
+		resolvedMacros, useResolvedMacros, timeout, lambdaProcessFinishedHandler);
 }
 
 void PluginNotificationTask::ProcessFinishedHandler(const Checkable::Ptr& checkable,

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -56,7 +56,8 @@ ConfigDirInformation ApiListener::LoadConfigDir(const String& dir)
 	ConfigDirInformation config;
 	config.UpdateV1 = new Dictionary();
 	config.UpdateV2 = new Dictionary();
-	Utility::GlobRecursive(dir, "*", std::bind(&ApiListener::ConfigGlobHandler, std::ref(config), dir, _1), GlobFile);
+	auto lambdaConfigGlobHandler = [&, dir](const String& file){return ApiListener::ConfigGlobHandler(config, dir, file);};
+	Utility::GlobRecursive(dir, "*", lambdaConfigGlobHandler, GlobFile);
 	return config;
 }
 

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -258,16 +258,18 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 				}
 			}
 
-			provider->FindTargets(type, std::bind(&FilteredAddTarget,
-				std::ref(permissionFrame), permissionFilter,
-				std::ref(frame), &*ufilter, std::ref(result), variableName, _1));
+			auto lambdaFilteredAddTarget = [&, permissionFilter, variableName](const Object::Ptr& target){
+				return FilteredAddTarget(permissionFrame, permissionFilter, frame, &*ufilter, result, variableName, target);
+			};
+			provider->FindTargets(type, lambdaFilteredAddTarget);
 		} else {
 			/* Ensure to pass a nullptr as filter expression.
 			 * GCC 8.1.1 on F28 causes problems, see GH #6533.
 			 */
-			provider->FindTargets(type, std::bind(&FilteredAddTarget,
-				std::ref(permissionFrame), permissionFilter,
-				std::ref(frame), nullptr, std::ref(result), variableName, _1));
+			auto lambdaFilteredAddTarget = [&, permissionFilter, variableName](const Object::Ptr& target){
+				return FilteredAddTarget(permissionFrame, permissionFilter, frame, nullptr, result, variableName, target);
+			};
+			provider->FindTargets(type, lambdaFilteredAddTarget);
 		}
 	}
 

--- a/lib/remote/pkiutility.cpp
+++ b/lib/remote/pkiutility.cpp
@@ -420,8 +420,11 @@ Dictionary::Ptr PkiUtility::GetCertificateRequests()
 
 	String requestDir = ApiListener::GetCertificateRequestsDir();
 
-	if (Utility::PathExists(requestDir))
-		Utility::Glob(requestDir + "/*.json", std::bind(&CollectRequestHandler, requests, _1), GlobFile);
-
+	if (Utility::PathExists(requestDir)) {
+	    auto lambdaCollectRequestHandler = [&, requests](const String& requestFile){
+	    	return CollectRequestHandler(requests, requestFile);
+	    };
+        Utility::Glob(requestDir + "/*.json", lambdaCollectRequestHandler, GlobFile);
+    }
 	return requests;
 }


### PR DESCRIPTION
I've replaced lots of instances of boost/std::bind with C++11-conforming lambda functions. 
However, there are conflicts with my approach in replacing and boost::signals2::signal and it's connect()-function, where boost/std::bind is used. 

For example, in streamlogger.cpp I've replaced
`m_FlushLogTimer->OnTimerExpired.connect(std::bind(&StreamLogger::FlushLogTimerHandler, this));` 

with 

`auto lambdaFlushLogTimerHandler = [&](){return StreamLogger::FlushLogTimerHandler();};
		m_FlushLogTimer->OnTimerExpired.connect(lambdaFlushLogTimerHandler);`

This is the resulting error from the compiler:
![Screenshot 2019-05-28 at 17 44 41](https://user-images.githubusercontent.com/43344334/58492031-66a63680-8170-11e9-8883-dc8086e28675.png)

Any hints or tips on what I might've been doing wrong would be greatly appreciated. 

