### PR TITLE
Quality: Replace deprecated get_io_service() with get_executor().context() for Boost ASIO

### DIFF
--- a/lib/base/tcpsocket.hpp
+++ b/lib/base/tcpsocket.hpp
@@ -32,7 +32,7 @@ void Connect(Socket& socket, const String& node, const String& service)
 {
 	using boost::asio::ip::tcp;
 
-	tcp::resolver resolver (socket.get_io_service());
+	tcp::resolver resolver (socket.get_executor().context());
 	tcp::resolver::query query (node, service);
 	auto result (resolver.resolve(query));
 	auto current (result.begin());
@@ -61,7 +61,7 @@ void Connect(Socket& socket, const String& node, const String& service, boost::a
 {
 	using boost::asio::ip::tcp;
 
-	tcp::resolver resolver (socket.get_io_service());
+	tcp::resolver resolver (socket.get_executor().context());
 	tcp::resolver::query query (node, service);
 	auto result (resolver.async_resolve(query, yc));
 	auto current (result.begin());

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -417,7 +417,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const std
 {
 	namespace asio = boost::asio;
 
-	auto& io (server->get_io_service());
+	auto& io (server->get_executor().context());
 
 	for (;;) {
 		try {
@@ -641,7 +641,7 @@ void ApiListener::NewClientHandlerInternal(boost::asio::yield_context yc, const 
 
 			endpoint->AddClient(aclient);
 
-			asio::spawn(client->get_io_service(), [this, aclient, endpoint, needSync](asio::yield_context yc) {
+			asio::spawn(client->get_executor().context(), [this, aclient, endpoint, needSync](asio::yield_context yc) {
 				CpuBoundWork syncClient (yc);
 
 				SyncClient(aclient, endpoint, needSync);

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -31,7 +31,7 @@ using namespace icinga;
 auto const l_ServerHeader ("Icinga/" + Application::GetAppVersion());
 
 HttpServerConnection::HttpServerConnection(const String& identity, bool authenticated, const std::shared_ptr<AsioTlsStream>& stream)
-	: m_Stream(stream), m_Seen(Utility::GetTime()), m_IoStrand(stream->get_io_service()), m_ShuttingDown(false), m_HasStartedStreaming(false)
+	: m_Stream(stream), m_Seen(Utility::GetTime()), m_IoStrand(stream->get_executor().context()), m_ShuttingDown(false), m_HasStartedStreaming(false)
 {
 	if (authenticated) {
 		m_ApiUser = ApiUser::GetByClientCN(identity);
@@ -529,7 +529,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 
 void HttpServerConnection::CheckLiveness(boost::asio::yield_context yc)
 {
-	boost::asio::deadline_timer timer (m_Stream->get_io_service());
+	boost::asio::deadline_timer timer (m_Stream->get_executor().context());
 
 	for (;;) {
 		timer.expires_from_now(boost::posix_time::seconds(5));

--- a/lib/remote/jsonrpcconnection-heartbeat.cpp
+++ b/lib/remote/jsonrpcconnection-heartbeat.cpp
@@ -17,7 +17,7 @@ REGISTER_APIFUNCTION(Heartbeat, event, &JsonRpcConnection::HeartbeatAPIHandler);
 
 void JsonRpcConnection::HandleAndWriteHeartbeats(boost::asio::yield_context yc)
 {
-	boost::asio::deadline_timer timer (m_Stream->get_io_service());
+	boost::asio::deadline_timer timer (m_Stream->get_executor().context());
 
 	for (;;) {
 		timer.expires_from_now(boost::posix_time::seconds(10));

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -31,8 +31,8 @@ static RingBuffer l_TaskStats (15 * 60);
 JsonRpcConnection::JsonRpcConnection(const String& identity, bool authenticated,
 	const std::shared_ptr<AsioTlsStream>& stream, ConnectionRole role)
 	: m_Identity(identity), m_Authenticated(authenticated), m_Stream(stream),
-	m_Role(role), m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_NextHeartbeat(0), m_IoStrand(stream->get_io_service()),
-	m_OutgoingMessagesQueued(stream->get_io_service()), m_WriterDone(stream->get_io_service()), m_ShuttingDown(false)
+	m_Role(role), m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_NextHeartbeat(0), m_IoStrand(stream->get_executor().context()),
+	m_OutgoingMessagesQueued(stream->get_executor().context()), m_WriterDone(stream->get_executor().context()), m_ShuttingDown(false)
 {
 	if (authenticated)
 		m_Endpoint = Endpoint::GetByName(identity);
@@ -310,7 +310,7 @@ Value SetLogPositionHandler(const MessageOrigin::Ptr& origin, const Dictionary::
 
 void JsonRpcConnection::CheckLiveness(boost::asio::yield_context yc)
 {
-	boost::asio::deadline_timer timer (m_Stream->get_io_service());
+	boost::asio::deadline_timer timer (m_Stream->get_executor().context());
 
 	for (;;) {
 		timer.expires_from_now(boost::posix_time::seconds(30));


### PR DESCRIPTION
refs #7041