### PR TITLE
Require TLS 1.2 for Cluster & REST API

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1122,7 +1122,7 @@ Configuration Attributes:
   accept\_commands                      | Boolean               | **Optional.** Accept remote commands. Defaults to `false`.
   max\_anonymous\_clients               | Number                | **Optional.** Limit the number of anonymous client connections (not configured endpoints and signing requests).
   cipher\_list                          | String                | **Optional.** Cipher list that is allowed. For a list of available ciphers run `openssl ciphers`. Defaults to `ALL:!LOW:!WEAK:!MEDIUM:!EXP:!NULL`.
-  tls\_protocolmin                      | String                | **Optional.** Minimum TLS protocol version. Must be one of `TLSv1`, `TLSv1.1` or `TLSv1.2`. Defaults to `TLSv1`.
+  tls\_protocolmin                      | String                | **Optional.** Minimum TLS protocol version. Since v2.11, only `TLSv1.2` is supported. Defaults to `TLSv1.2`.
   tls\_handshake\_timeout               | Number                | **Optional.** TLS Handshake timeout. Defaults to `10s`.
   access\_control\_allow\_origin        | Array                 | **Optional.** Specifies an array of origin URLs that may access the API. [(MDN docs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Origin)
   access\_control\_allow\_credentials   | Boolean               | **Deprecated.** Indicates whether or not the actual request can be made using credentials. Defaults to `true`. [(MDN docs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Credentials)

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -53,6 +53,17 @@ and compiled into the binary as header only include. It helps our way to C++11 a
 to fix additional UTF8 issues more easily. Read more about its [design goals](https://github.com/nlohmann/json#design-goals)
 and [benchmarks](https://github.com/miloyip/nativejson-benchmark#parsing-time).
 
+### TLS 1.2 <a id="upgrading-to-2-11-tls-1-2"></a>
+
+v2.11 raises the minimum required TLS version to 1.2.
+This is available since OpenSSL 1.0.1 (EL6 & Debian Jessie).
+
+Older Icinga satellites/agents need to support TLS 1.2 during the TLS
+handshake.
+
+The `api` feature attribute `tls_protocolmin` now only supports the
+value `TLSv1.2` being the default.
+
 ### HA-aware Features <a id="upgrading-to-2-11-ha-aware-features"></a>
 
 v2.11 introduces additional HA functionality similar to the DB IDO feature.

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -162,7 +162,7 @@ std::shared_ptr<boost::asio::ssl::context> MakeAsioSslContext(const String& pubk
 
 	InitializeOpenSSL();
 
-	auto context (std::make_shared<ssl::context>(ssl::context::sslv23));
+	auto context (std::make_shared<ssl::context>(ssl::context::tlsv12));
 
 	SetupSslContext(context->native_handle(), pubkey, privkey, cakey);
 
@@ -200,24 +200,15 @@ void SetCipherListToSSLContext(const std::shared_ptr<boost::asio::ssl::context>&
  */
 void SetTlsProtocolminToSSLContext(const std::shared_ptr<boost::asio::ssl::context>& context, const String& tlsProtocolmin)
 {
-	long flags = SSL_CTX_get_options(context->native_handle());
+	// tlsProtocolmin has no effect since we enforce TLS 1.2 since 2.11.
 
-	flags |= SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
-
-#ifdef SSL_TXT_TLSV1_1
-	if (tlsProtocolmin == SSL_TXT_TLSV1_1)
-		flags |= SSL_OP_NO_TLSv1;
-	else
-#endif /* SSL_TXT_TLSV1_1 */
-#ifdef SSL_TXT_TLSV1_2
-	if (tlsProtocolmin == SSL_TXT_TLSV1_2)
-		flags |= SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
-	else
-#endif /* SSL_TXT_TLSV1_2 */
-	if (tlsProtocolmin != SSL_TXT_TLSV1)
-		BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid TLS protocol version specified."));
-
-	SSL_CTX_set_options(context->native_handle(), flags);
+	context->set_options(
+		boost::asio::ssl::context::default_workarounds |
+		boost::asio::ssl::context::no_sslv2 |
+		boost::asio::ssl::context::no_sslv3 |
+		boost::asio::ssl::context::no_tlsv1 |
+		boost::asio::ssl::context::no_tlsv1_1
+	);
 }
 
 /**

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1631,16 +1631,8 @@ void ApiListener::ValidateTlsProtocolmin(const Lazy<String>& lvalue, const Valid
 {
 	ObjectImpl<ApiListener>::ValidateTlsProtocolmin(lvalue, utils);
 
-	if (lvalue() != SSL_TXT_TLSV1
-#ifdef SSL_TXT_TLSV1_1
-		&& lvalue() != SSL_TXT_TLSV1_1 &&
-		lvalue() != SSL_TXT_TLSV1_2
-#endif /* SSL_TXT_TLSV1_1 */
-		) {
-		String message = "Invalid TLS version. Must be one of '" SSL_TXT_TLSV1 "'";
-#ifdef SSL_TXT_TLSV1_1
-		message += ", '" SSL_TXT_TLSV1_1 "' or '" SSL_TXT_TLSV1_2 "'";
-#endif /* SSL_TXT_TLSV1_1 */
+	if (lvalue() != SSL_TXT_TLSV1_2) {
+		String message = "Invalid TLS version. Must be '" SSL_TXT_TLSV1_2 "'";
 
 		BOOST_THROW_EXCEPTION(ValidationError(this, { "tls_protocolmin" }, message));
 	}

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -21,7 +21,7 @@ class ApiListener : ConfigObject
 		default {{{ return "ALL:!LOW:!WEAK:!MEDIUM:!EXP:!NULL"; }}}
 	};
 	[config] String tls_protocolmin {
-		default {{{ return "TLSv1"; }}}
+		default {{{ return "TLSv1.2"; }}}
 	};
 
 	[config] String bind_host {


### PR DESCRIPTION
Rationale: https://github.com/Icinga/icinga2/issues/7041#issuecomment-496955389

refs #7041