### PR TITLE
API Actions: Add downtime for all host services (child objects)

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1381,6 +1381,7 @@ Send a `POST` request to the URL endpoint `/v1/actions/schedule-downtime`.
   end\_time     | Timestamp | **Required.** Timestamp marking the end of the downtime.
   fixed         | Boolean   | **Optional.** Defaults to `true`. If true, the downtime is `fixed` otherwise `flexible`. See [downtimes](08-advanced-topics.md#downtimes) for more information.
   duration      | Number    | **Required for flexible downtimes.** Duration of the downtime in seconds if `fixed` is set to false.
+  all\_services | Boolean   | **Optional for host downtimes.** Sets downtime for [all services](12-icinga2-api.md#icinga2-api-actions-schedule-downtime-host-all-services) for the matched host objects. Defaults to `false`.
   trigger\_name | String    | **Optional.** Sets the trigger for a triggered downtime. See [downtimes](08-advanced-topics.md#downtimes) for more information on triggered downtimes.
   child\_options| String    | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. Defaults to `DowntimeNoChildren`.
 
@@ -1415,6 +1416,17 @@ like this:
 
 ```
 "filter": "host.name==\"icinga2-satellite1.localdomain\" && service.name==\"ping4\""
+```
+
+#### Schedule Host Downtime(s) with all Services <a id="icinga2-api-actions-schedule-downtime-host-all-services"></a>
+
+Schedule a downtime for one (or multiple) hosts and all of their services.
+Note the `all_services` attribute.
+
+```
+$ curl -k -s -u root:icinga -H 'Accept: application/json' \
+ -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
+ -d "$(jo -p pretty=true type=Host filter="match(\"*satellite*\", host.name)" all_services=true author=icingaadmin comment="Cluster upgrade maintenance" fixed=true start_time=$(date +%s -d "+0 hour") end_time=$(date +%s -d "+1 hour"))"
 ```
 
 ### remove-downtime <a id="icinga2-api-actions-remove-downtime"></a>

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1381,7 +1381,7 @@ Send a `POST` request to the URL endpoint `/v1/actions/schedule-downtime`.
   end\_time     | Timestamp | **Required.** Timestamp marking the end of the downtime.
   fixed         | Boolean   | **Optional.** Defaults to `true`. If true, the downtime is `fixed` otherwise `flexible`. See [downtimes](08-advanced-topics.md#downtimes) for more information.
   duration      | Number    | **Required for flexible downtimes.** Duration of the downtime in seconds if `fixed` is set to false.
-  all\_services | Boolean   | **Optional for host downtimes.** Sets downtime for [all services](12-icinga2-api.md#icinga2-api-actions-schedule-downtime-host-all-services) for the matched host objects. Defaults to `false`.
+  all\_services | Boolean   | **Optional for host downtimes.** Sets downtime for [all services](12-icinga2-api.md#icinga2-api-actions-schedule-downtime-host-all-services) for the matched host objects. If `child_options` are set, all child hosts and their services will schedule a downtime too. Defaults to `false`.
   trigger\_name | String    | **Optional.** Sets the trigger for a triggered downtime. See [downtimes](08-advanced-topics.md#downtimes) for more information on triggered downtimes.
   child\_options| String    | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. Defaults to `DowntimeNoChildren`.
 

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -172,6 +172,11 @@ constant in [constants.conf](04-configuring-icinga-2.md#constants-conf) instead.
 
 ### REST API <a id="upgrading-to-2-11-api"></a>
 
+#### Actions <a id="upgrading-to-2-11-api-config-packages"></a>
+
+The [schedule-downtime](12-icinga2-api.md#icinga2-api-actions-schedule-downtime-host-all-services)
+action supports the `all_services` parameter for Host types. Defaults to false.
+
 #### Config Packages <a id="upgrading-to-2-11-api-config-packages"></a>
 
 Deployed configuration packages require an active stage, with many previous

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -338,6 +338,10 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 	double startTime = HttpUtility::GetLastParameter(params, "start_time");
 	double endTime = HttpUtility::GetLastParameter(params, "end_time");
 
+	Host::Ptr host;
+	Service::Ptr service;
+	tie(host, service) = GetHostService(checkable);
+
 	DowntimeChildOptions childOptions = DowntimeNoChildren;
 	if (params->Contains("child_options")) {
 		try {
@@ -389,6 +393,33 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 		}
 
 		additional->Set("child_downtimes", new Array(std::move(childDowntimes)));
+	}
+
+	/* Schedule downtime for all services for the host type. */
+	bool allServices = false;
+
+	if (params->Contains("all_services"))
+		allServices = HttpUtility::GetLastParameter(params, "all_services");
+
+	if (allServices && !service) {
+		ArrayData serviceDowntimes;
+
+		for (const Service::Ptr& hostService : host->GetServices()) {
+			Log(LogNotice, "ApiActions")
+				<< "Creating downtime for service " << hostService->GetName() << " on host " << host->GetName();
+
+			String serviceDowntimeName = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
+				fixed, triggerName, duration);
+
+			Downtime::Ptr serviceDowntime = Downtime::GetByName(serviceDowntimeName);
+
+			serviceDowntimes.push_back(new Dictionary({
+				{ "name", serviceDowntimeName },
+				{ "legacy_id", serviceDowntime->GetLegacyId() }
+			}));
+		}
+
+		additional->Set("service_downtimes", new Array(std::move(serviceDowntimes)));
 	}
 
 	return ApiActions::CreateResult(200, "Successfully scheduled downtime '" +


### PR DESCRIPTION
# Hosts with all services

`all_services` = true/false

This avoids a secondary roundtrip for a typical host maintenance.

## child_options with all services

Also implemented, dependent hosts will also schedule a service downtime if `all_services` is enabled.

## Delete downtimes created through this action (all_services, child_options)

Create a runtime sequence id for this action call and store it inside the downtime objects. This is returned to the caller and as well available via GET query.

The client can use this `sequence_id` in order to filter on `remove-downtime` actions. This deletes any matching downtime object.

# Tests

Below, since this feature was enhanced quite a bit over multiple iterations.