### PR TITLE
Disable stack traces for WQ exceptions (used in config compiler)

### DIFF
--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -169,13 +169,13 @@ std::vector<boost::exception_ptr> WorkQueue::GetExceptions() const
 	return m_Exceptions;
 }
 
-void WorkQueue::ReportExceptions(const String& facility) const
+void WorkQueue::ReportExceptions(const String& facility, bool verbose) const
 {
 	std::vector<boost::exception_ptr> exceptions = GetExceptions();
 
 	for (const auto& eptr : exceptions) {
 		Log(LogCritical, facility)
-			<< DiagnosticInformation(eptr);
+			<< DiagnosticInformation(eptr, verbose);
 	}
 
 	Log(LogCritical, facility)

--- a/lib/base/workqueue.hpp
+++ b/lib/base/workqueue.hpp
@@ -103,7 +103,7 @@ public:
 
 	bool HasExceptions() const;
 	std::vector<boost::exception_ptr> GetExceptions() const;
-	void ReportExceptions(const String& facility) const;
+	void ReportExceptions(const String& facility, bool verbose = false) const;
 
 protected:
 	void IncreaseTaskCount();


### PR DESCRIPTION
The ConfigItem class collects exceptions and reports them.
In contrast to our other DiagnosticInformation() calls,
verbosity is enabled any time.

This patch allows to re-enable the verbose output including
the stack traces, but disables this by default.