### PR TITLE
Feature/extended influx perfdata

### DIFF
--- a/lib/perfdata/influxdbwriter.cpp
+++ b/lib/perfdata/influxdbwriter.cpp
@@ -338,8 +338,8 @@ void InfluxdbWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable, const
 		fields->Set("acknowledgement", new InfluxdbInteger(checkable->GetAcknowledgement()));
 		fields->Set("latency", cr->CalculateLatency());
 		fields->Set("execution_time", cr->CalculateExecutionTime());
-		fields->Set("short_message", CompatUtility::GetCheckResultOutput(cr));
-		fields->Set("full_message", cr->GetOutput());
+		//fields->Set("short_message", CompatUtility::GetCheckResultOutput(cr));
+		//fields->Set("full_message", cr->GetOutput());
 		fields->Set("check_source", cr->GetCheckSource());
 
 		SendMetric(checkable, tmpl, Empty, fields, ts);


### PR DESCRIPTION
The influxdbwriter does not store certain properties of the performance data values which are stored by other performance data writers.

This pull request adds the following data to the influxdbwriter output:
* check source
* unit
* counter
* last_state + last_hard_state

Furthermore it increases the timestamp precision to ns.