### PR TITLE
influxdbwriter: support for json encoded PD labels

### DIFF
--- a/lib/perfdata/influxdbwriter.hpp
+++ b/lib/perfdata/influxdbwriter.hpp
@@ -49,6 +49,9 @@ private:
 	void FlushTimeoutWQ();
 	void Flush();
 
+public:
+	static String IXBuildMetric(const String& str);
+private:
 	static String EscapeKeyOrTagValue(const String& str);
 	static String EscapeValue(const Value& value);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(base_test_SOURCES
   base-value.cpp
   config-ops.cpp
   icinga-checkresult.cpp
+  icinga-influxdbwriter.cpp
   icinga-legacytimeperiod.cpp
   icinga-macros.cpp
   icinga-notification.cpp
@@ -34,6 +35,7 @@ set(base_test_SOURCES
   $<TARGET_OBJECTS:config>
   $<TARGET_OBJECTS:remote>
   $<TARGET_OBJECTS:icinga>
+  $<TARGET_OBJECTS:perfdata>
 )
 
 if(ICINGA2_UNITY_BUILD)
@@ -124,6 +126,7 @@ add_boost_test(base
     icinga_checkresult/service_3attempts
     icinga_checkresult/host_flapping_notification
     icinga_checkresult/service_flapping_notification
+    icinga_influxdbwriter/json_label
     icinga_notification/state_filter
     icinga_notification/type_filter
     icinga_macros/simple
@@ -138,6 +141,7 @@ add_boost_test(base
     icinga_perfdata/ignore_invalid_warn_crit_min_max
     icinga_perfdata/invalid
     icinga_perfdata/multi
+    icinga_perfdata/json_label
     remote_url/id_and_path
     remote_url/parameters
     remote_url/get_and_set

--- a/test/icinga-influxdbwriter.cpp
+++ b/test/icinga-influxdbwriter.cpp
@@ -1,0 +1,19 @@
+/* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
+
+#include "base/perfdatavalue.hpp"
+#include "icinga/pluginutility.hpp"
+#include "lib/perfdata/influxdbwriter.hpp"
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+BOOST_AUTO_TEST_SUITE(icinga_influxdbwriter)
+
+BOOST_AUTO_TEST_CASE(json_label)
+{
+	BOOST_CHECK(InfluxdbWriter::IXBuildMetric("not-a-json-label") == ",metric=not-a-json-label");
+	BOOST_CHECK(InfluxdbWriter::IXBuildMetric("{\"metric\":\"test-metric\",\"label\":\"test-label\"}") == ",label=test-label,metric=test-metric");
+	BOOST_CHECK(InfluxdbWriter::IXBuildMetric("{\"metric\":\"test-metric\",\"label\":\"test-label\",\"foo\":\"bar\"}") == ",foo=bar,label=test-label,metric=test-metric");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -123,4 +123,18 @@ BOOST_AUTO_TEST_CASE(multi)
 	BOOST_CHECK(pd->Get(1) == "test::b=4");
 }
 
+BOOST_AUTO_TEST_CASE(json_label)
+{
+	PerfdataValue::Ptr pv = PerfdataValue::Parse("{\"metric\":\"test-metric\",\"label\":\"test-label\"}=123456B;;;;");
+	BOOST_CHECK(pv);
+	BOOST_CHECK(pv->GetValue() == 123456);
+	BOOST_CHECK(!pv->GetCounter());
+	BOOST_CHECK(pv->GetWarn() == Empty);
+	BOOST_CHECK(pv->GetCrit() == Empty);
+	BOOST_CHECK(pv->GetMin() == Empty);
+	BOOST_CHECK(pv->GetMax() == Empty);
+
+	BOOST_CHECK(pv->Format() == "{\"metric\":\"test-metric\",\"label\":\"test-label\"}=123456B");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request implements a custom extension to the influxdbwriter that allows check plugins to return a JSON encoded performance data label. Each key/value pair is interpreted as a tag, i.e., the set of all key/value pairs decribe the series in which the performance data is stored.

We needed this extension because otherwise there is only a single tag named 'metric' which turned out insufficient for our use case and forced us to encode several information into one tag (which should be avoided when using InfluxDB). With the proposed changes we could circumvent this limitation of the influxdbwriter.