### PR TITLE
Fix out-of-bounds crash with Array#remove

### DIFF
--- a/lib/base/array.cpp
+++ b/lib/base/array.cpp
@@ -175,6 +175,9 @@ void Array::Remove(SizeType index, bool overrideFrozen)
 	if (m_Frozen && !overrideFrozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Array must not be modified."));
 
+	if (index >= m_Data.size())
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Index to remove must be within bounds."));
+
 	m_Data.erase(m_Data.begin() + index);
 }
 


### PR DESCRIPTION
Fixes Icinga 2 crashing when calling array.remove with negative integers. If preferred we can just not do anything if the index is out of bounds.

Without this patch:
```
<1> => x = [0,1]
null
<2> => x.remove(-2)
Caught SIGABRT.
Current time: 2019-06-28 15:52:27 +0200

critical/Application: Icinga 2 has terminated unexpectedly. Additional information can be found in '/home/jflach/i2/var/log/icinga2/crash/report.1561729947.786670'
```

With this patch:
```
<2> => x = [0,1]
null
<3> => x.remove(5)
       ^^^^^^^^^^^
Error while evaluating expression: Index to remove must be within bounds.
<4> => x.remove(-1)
       ^^^^^^^^^^^^
Error while evaluating expression: Index to remove must be within bounds.
<5> => x.remove(0)
null
<6> => x
[ 1.000000 ]
<7> => x.remove(1)
       ^^^^^^^^^^^
Error while evaluating expression: Index to remove must be within bounds.
```

fixes #7265