### PR TITLE
API: Improve error handling for 'schedule-downtime' action

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -337,6 +337,16 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 	String comment = HttpUtility::GetLastParameter(params, "comment");
 	double startTime = HttpUtility::GetLastParameter(params, "start_time");
 	double endTime = HttpUtility::GetLastParameter(params, "end_time");
+	double now = Utility::GetTime();
+
+	if (author.IsEmpty() || comment.IsEmpty())
+		return ApiActions::CreateResult(400, "Options 'author' and 'comment' must not be empty");
+
+	if (startTime < now || endTime < now)
+		return ApiActions::CreateResult(400, "Options 'start_time' and 'end_time' must be greater than current timestamp");
+
+	if (endTime < startTime)
+		return ApiActions::CreateResult(400, "Option 'end_time' must be greater than 'start_time'");
 
 	Host::Ptr host;
 	Service::Ptr service;


### PR DESCRIPTION
Empty `comment`:

```
$ curl -k -s -u root:icinga -H 'Accept: application/json'  -X POST 'https://localhost:5665/v1/actions/schedule-downtime'  -d "$(jo -p pretty=true type=Service filter=true author=icingaadmin comment="" fixed=true start_time=$(gdate +%s -d "+0 hour") end_time=$(gdate +%s -d "+1 hour"))"
{
    "results": [
        {
            "code": 400.0,
            "status": "Options 'author' and 'comment' must not be empty"
        },
```

`start_time` in the past:

```
$ curl -k -s -u root:icinga -H 'Accept: application/json' \
>  -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
>  -d "$(jo -p pretty=true type=Service filter=true author=icingaadmin comment="abc" fixed=true start_time=$(gdate +%s -d "-1 hour") end_time=$(gdate +%s -d "+1 hour"))"
{
    "results": [
        {
            "code": 400.0,
            "status": "Options 'start_time' and 'end_time' must be greater than current timestamp"
        },
```

`start_time` > `end_time`:

```
$ curl -k -s -u root:icinga -H 'Accept: application/json' \
>  -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
>  -d "$(jo -p pretty=true type=Service filter=true author=icingaadmin comment="abc" fixed=true start_time=$(gdate +%s -d "+2 hour") end_time=$(gdate +%s -d "+1 hour"))"
{
    "results": [
        {
            "code": 400.0,
            "status": "Option 'end_time' must be greater than 'start_time'"
        },
```