### PR TITLE
Improve type logging for notifications

### DIFF
--- a/lib/compat/compatlogger.cpp
+++ b/lib/compat/compatlogger.cpp
@@ -237,7 +237,7 @@ void CompatLogger::NotificationSentHandler(const Notification::Ptr& notification
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	String notification_type_str = Notification::NotificationTypeToString(notification_type);
+	String notification_type_str = Notification::NotificationTypeToStringCompat(notification_type);
 
 	/* override problem notifications with their current state string */
 	if (notification_type == NotificationProblem) {

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -1071,7 +1071,7 @@ void DbEvents::AddNotificationSentLogHistory(const Notification::Ptr& notificati
 	if (commandObj)
 		checkCommandName = commandObj->GetName();
 
-	String notificationTypeStr = Notification::NotificationTypeToString(notification_type);
+	String notificationTypeStr = Notification::NotificationTypeToStringCompat(notification_type); //TODO: Change that to our own types.
 
 	String author_comment = "";
 	if (notification_type == NotificationCustom || notification_type == NotificationAcknowledgement) {

--- a/lib/icinga/apievents.cpp
+++ b/lib/icinga/apievents.cpp
@@ -132,7 +132,7 @@ void ApiEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& notif
 	}
 
 	result->Set("users", new Array(std::move(userNames)));
-	result->Set("notification_type", Notification::NotificationTypeToString(type));
+	result->Set("notification_type", Notification::NotificationTypeToStringCompat(type)); //TODO: Change this to our own types.
 	result->Set("author", author);
 	result->Set("text", text);
 	result->Set("check_result", Serialize(cr));

--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -85,8 +85,14 @@ public:
 
 	void ProcessNotificationResult(const NotificationResult::Ptr& nr, const MessageOrigin::Ptr& origin = nullptr);
 
+	// Logging, etc.
 	static String NotificationTypeToString(NotificationType type);
+	// Compat, used for notifications, etc.
+	static String NotificationTypeToStringCompat(NotificationType type);
 	static String NotificationFilterToString(int filter, const std::map<String, int>& filterMap);
+
+	static String NotificationServiceStateToString(ServiceState state);
+	static String NotificationHostStateToString(HostState state);
 
 	static boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> OnNextNotificationChanged;
 	static boost::signals2::signal<void (const Notification::Ptr&, const NotificationResult::Ptr&, const MessageOrigin::Ptr&)> OnNewNotificationResult;
@@ -118,10 +124,6 @@ private:
 
 	static bool EvaluateApplyRuleInstance(const intrusive_ptr<Checkable>& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule);
 	static bool EvaluateApplyRule(const intrusive_ptr<Checkable>& checkable, const ApplyRule& rule);
-
-	static String NotificationTypeToStringInternal(NotificationType type);
-	static String NotificationServiceStateToString(ServiceState state);
-	static String NotificationHostStateToString(HostState state);
 
 	static std::map<String, int> m_StateFilterMap;
 	static std::map<String, int> m_TypeFilterMap;

--- a/lib/methods/pluginnotificationtask.cpp
+++ b/lib/methods/pluginnotificationtask.cpp
@@ -32,7 +32,7 @@ void PluginNotificationTask::ScriptFunc(const Notification::Ptr& notification,
 	Checkable::Ptr checkable = notification->GetCheckable();
 
 	Dictionary::Ptr notificationExtra = new Dictionary({
-		{ "type", Notification::NotificationTypeToString(type) },
+		{ "type", Notification::NotificationTypeToStringCompat(type) }, //TODO: Change that to our types.
 		{ "author", author },
 		{ "comment", comment }
 	});

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -318,7 +318,7 @@ void ElasticsearchWriter::NotificationSentToAllUsersHandlerInternal(const Notifi
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	String notificationTypeString = Notification::NotificationTypeToString(type);
+	String notificationTypeString = Notification::NotificationTypeToStringCompat(type); //TODO: Change that to our own types.
 
 	Dictionary::Ptr fields = new Dictionary();
 

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -371,7 +371,7 @@ void GelfWriter::NotificationToUserHandlerInternal(const Notification::Ptr& noti
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	String notificationTypeString = Notification::NotificationTypeToString(notificationType);
+	String notificationTypeString = Notification::NotificationTypeToStringCompat(notificationType); //TODO: Change that to our own types.
 
 	String authorComment = "";
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,6 +124,7 @@ add_boost_test(base
     icinga_checkresult/service_3attempts
     icinga_checkresult/host_flapping_notification
     icinga_checkresult/service_flapping_notification
+    icinga_notification/strings
     icinga_notification/state_filter
     icinga_notification/type_filter
     icinga_macros/simple

--- a/test/icinga-notification.cpp
+++ b/test/icinga-notification.cpp
@@ -8,6 +8,21 @@ using namespace icinga;
 
 BOOST_AUTO_TEST_SUITE(icinga_notification)
 
+BOOST_AUTO_TEST_CASE(strings)
+{
+	// States
+	BOOST_CHECK("OK" == Notification::NotificationServiceStateToString(ServiceOK));
+	BOOST_CHECK("Critical" == Notification::NotificationServiceStateToString(ServiceCritical));
+	BOOST_CHECK("Up" == Notification::NotificationHostStateToString(HostUp));
+
+	// Types
+	BOOST_CHECK("DowntimeStart" == Notification::NotificationTypeToString(NotificationDowntimeStart));
+	BOOST_CHECK("Problem" == Notification::NotificationTypeToString(NotificationProblem));
+
+	// Compat
+	BOOST_CHECK("DOWNTIMECANCELLED" == Notification::NotificationTypeToStringCompat(NotificationDowntimeRemoved));
+}
+
 BOOST_AUTO_TEST_CASE(state_filter)
 {
 	unsigned long fstate;


### PR DESCRIPTION
Additionally the type is now logged to allow better traces through the logs.

```
[2019-07-16 13:38:37 +0200] notice/Notification: Attempting to send notifications of type 'Recovery' for notification object 'many-test-0!many-test-0!many-test-0'.
[2019-07-16 13:38:37 +0200] information/Notification: Sending 'Recovery' notification 'many-test-0!many-test-0!many-test-0' for user 'many'
```

This also again hides the checkable objects without a notification object, this spams the log with useless information level logging.

Apart from that, I've added some basic unit tests for the State/Type to String methods, and renamed their function interfaces.

```
michi@mbpmif ~/dev/icinga/icinga2 (feature/notification-logging *<>) $ ./debug/Bin/Debug/boosttest-test-base --run_test=icinga_notification/strings --log_level=all
Initializing Application...
Initializing IcingaApplication...
Running 1 test case...
Entering test module "Master Test Suite"
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:9: Entering test suite "icinga_notification"
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:11: Entering test case "strings"
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:14: info: check "OK" == Notification::NotificationServiceStateToString(ServiceOK) has passed
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:15: info: check "Critical" == Notification::NotificationServiceStateToString(ServiceCritical) has passed
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:16: info: check "Up" == Notification::NotificationHostStateToString(HostUp) has passed
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:19: info: check "DowntimeStart" == Notification::NotificationTypeToString(NotificationDowntimeStart) has passed
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:20: info: check "Problem" == Notification::NotificationTypeToString(NotificationProblem) has passed
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:23: info: check "DOWNTIMECANCELLED" == Notification::NotificationTypeToStringCompat(NotificationDowntimeRemoved) has passed
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:11: Leaving test case "strings"; testing time: 114us
/Users/michi/dev/icinga/icinga2/test/icinga-notification.cpp:9: Leaving test suite "icinga_notification"; testing time: 142us
Leaving test module "Master Test Suite"; testing time: 203us

*** No errors detected
```