### PR TITLE
Service: don't rely on the own host being already set during derivative state calculation

### DIFF
--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -125,7 +125,7 @@ int Service::GetSeverity() const
 		severity |= SeverityFlagDowntime;
 	else if (IsAcknowledged())
 		severity |= SeverityFlagAcknowledgement;
-	else if (m_Host->GetProblem())
+	else if (m_Host && m_Host->GetProblem())
 		severity |= SeverityFlagHostDown;
 	else
 		severity |= SeverityFlagUnhandled;
@@ -137,7 +137,7 @@ int Service::GetSeverity() const
 
 bool Service::GetHandled() const
 {
-	return Checkable::GetHandled() || m_Host->GetProblem();
+	return Checkable::GetHandled() || (m_Host && m_Host->GetProblem());
 }
 
 bool Service::IsStateOK(ServiceState state) const


### PR DESCRIPTION
fixes #7284