### PR TITLE
Stash notifications until object authority has been updated once

### DIFF
--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -80,6 +80,10 @@ class Notification : CustomVarObject < NotificationNameComposer
 		default {{{ return false; }}}
 	};
 
+	[state, no_user_view, no_user_modify] Array::Ptr stashed_notifications {
+		default {{{ return new Array(); }}}
+	};
+
 	[state] Timestamp last_notification;
 	[state] Timestamp next_notification;
 	[state] int notification_number;

--- a/lib/remote/apilistener-authority.cpp
+++ b/lib/remote/apilistener-authority.cpp
@@ -8,6 +8,8 @@
 
 using namespace icinga;
 
+std::atomic<bool> ApiListener::m_UpdatedObjectAuthority (false);
+
 void ApiListener::UpdateObjectAuthority()
 {
 	/* Always run this, even if there is no 'api' feature enabled. */
@@ -77,4 +79,6 @@ void ApiListener::UpdateObjectAuthority()
 			object->SetAuthority(authority);
 		}
 	}
+
+	m_UpdatedObjectAuthority.store(true);
 }

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -15,6 +15,7 @@
 #include "base/tcpsocket.hpp"
 #include "base/tlsstream.hpp"
 #include "base/threadpool.hpp"
+#include <atomic>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/ssl/context.hpp>
@@ -104,6 +105,12 @@ public:
 	static String GetDefaultKeyPath();
 	static String GetDefaultCaPath();
 
+	static inline
+	bool UpdatedObjectAuthority()
+	{
+		return m_UpdatedObjectAuthority.load();
+	}
+
 	double GetTlsHandshakeTimeout() const override;
 	void SetTlsHandshakeTimeout(double value, bool suppress_events, const Value& cookie) override;
 
@@ -133,6 +140,7 @@ private:
 	Endpoint::Ptr m_LocalEndpoint;
 
 	static ApiListener::Ptr m_Instance;
+	static std::atomic<bool> m_UpdatedObjectAuthority;
 
 	void ApiTimerHandler();
 	void ApiReconnectTimerHandler();


### PR DESCRIPTION
... into the per-node state `Notification#stashed_notifications`. Once object authority has been updated, these notifications are either send (not paused anymore) or dropped (still paused).

fixes #7086