### PR TITLE
Quality: Prefer BOOST_{,UN}LIKELY gcc optimizer macros over our own

### DIFF
--- a/lib/base/i2-base.hpp
+++ b/lib/base/i2-base.hpp
@@ -72,14 +72,6 @@
 #	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-#if defined(__GNUC__)
-#	define likely(x) __builtin_expect(!!(x), 1)
-#	define unlikely(x) __builtin_expect(!!(x), 0)
-#else
-#	define likely(x) (x)
-#	define unlikely(x) (x)
-#endif
-
 #define BOOST_BIND_NO_PLACEHOLDERS
 
 #include <functional>

--- a/lib/config/vmops.hpp
+++ b/lib/config/vmops.hpp
@@ -235,10 +235,10 @@ public:
 
 	static inline Value GetField(const Value& context, const String& field, bool sandboxed = false, const DebugInfo& debugInfo = DebugInfo())
 	{
-		if (unlikely(context.IsEmpty() && !context.IsString()))
+		if (BOOST_UNLIKELY(context.IsEmpty() && !context.IsString()))
 			return Empty;
 
-		if (unlikely(!context.IsObject()))
+		if (BOOST_UNLIKELY(!context.IsObject()))
 			return GetPrototypeField(context, field, true, debugInfo);
 
 		Object::Ptr object = context;


### PR DESCRIPTION
Our macro collides with Boost::DateTime and the gregorian classes
and I don't see any reason why we shouldn't use Boost::Config
being already there.

Note: These macros are used for branch prediction optimization
in GCC, worth a read: https://stackoverflow.com/questions/109710/how-do-the-likely-unlikely-macros-in-the-linux-kernel-work-and-what-is-their-ben