### PR TITLE
Rewrite tests for Timeperiods with Boost.DateTime and fix "day -X" specification

### DIFF
--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -181,6 +181,9 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			if (mday < 0) {
 				boost::gregorian::date d(GetEndOfMonthDay(reference->tm_year + 1900, mon + 1)); //TODO: Refactor this mess into full Boost.DateTime
 
+				//Depending on the number, we need to substract specific days (counting starts at 0).
+				d = d - boost::gregorian::days(mday * -1 - 1);
+
 				*begin = boost::gregorian::to_tm(d);
 				begin->tm_hour = 0;
 				begin->tm_min = 0;
@@ -199,6 +202,9 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			/* day -X: Negative days are relative to the next month. */
 			if (mday < 0) {
 				boost::gregorian::date d(GetEndOfMonthDay(reference->tm_year + 1900, mon + 1)); //TODO: Refactor this mess into full Boost.DateTime
+
+				//Depending on the number, we need to substract specific days (counting starts at 0).
+				d = d - boost::gregorian::days(mday * -1 - 1);
 
 				// End date is one day in the future, starting 00:00:00
 				d = d + boost::gregorian::days(1);

--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -113,6 +113,13 @@ int LegacyTimePeriod::MonthFromString(const String& monthdef)
 		return -1;
 }
 
+boost::gregorian::date LegacyTimePeriod::GetEndOfMonthDay(int year, int month)
+{
+	boost::gregorian::date d(boost::gregorian::greg_year(year), boost::gregorian::greg_month(month), 1);
+
+	return d.end_of_month();
+}
+
 void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end, tm *reference)
 {
 	/* Let mktime() figure out whether we're in DST or not. */
@@ -170,10 +177,14 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			begin->tm_min = 0;
 			begin->tm_sec = 0;
 
-			/* day -1: Negative days are relative to the next month. */
+			/* day -X: Negative days are relative to the next month. */
 			if (mday < 0) {
-				begin->tm_mday = mday * -1 - 1;
-				begin->tm_mon++;
+				boost::gregorian::date d(GetEndOfMonthDay(reference->tm_year + 1900, mon + 1)); //TODO: Refactor this mess into full Boost.DateTime
+
+				*begin = boost::gregorian::to_tm(d);
+				begin->tm_hour = 0;
+				begin->tm_min = 0;
+				begin->tm_sec = 0;
 			}
 		}
 
@@ -185,10 +196,17 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			end->tm_min = 0;
 			end->tm_sec = 0;
 
-			/* day -1: Negative days are relative to the next month. */
+			/* day -X: Negative days are relative to the next month. */
 			if (mday < 0) {
-				end->tm_mday = mday * -1 - 1;
-				end->tm_mon++;
+				boost::gregorian::date d(GetEndOfMonthDay(reference->tm_year + 1900, mon + 1)); //TODO: Refactor this mess into full Boost.DateTime
+
+				// End date is one day in the future, starting 00:00:00
+				d = d + boost::gregorian::days(1);
+
+				*end = boost::gregorian::to_tm(d);
+				end->tm_hour = 0;
+				end->tm_min = 0;
+				end->tm_sec = 0;
 			}
 		}
 

--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -170,7 +170,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			begin->tm_min = 0;
 			begin->tm_sec = 0;
 
-			/* Negative days are relative to the next month. */
+			/* day -1: Negative days are relative to the next month. */
 			if (mday < 0) {
 				begin->tm_mday = mday * -1 - 1;
 				begin->tm_mon++;
@@ -185,7 +185,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			end->tm_min = 0;
 			end->tm_sec = 0;
 
-			/* Negative days are relative to the next month. */
+			/* day -1: Negative days are relative to the next month. */
 			if (mday < 0) {
 				end->tm_mday = mday * -1 - 1;
 				end->tm_mon++;

--- a/lib/icinga/legacytimeperiod.hpp
+++ b/lib/icinga/legacytimeperiod.hpp
@@ -6,6 +6,7 @@
 #include "icinga/i2-icinga.hpp"
 #include "icinga/timeperiod.hpp"
 #include "base/dictionary.hpp"
+#include <boost/date_time/gregorian/gregorian.hpp>
 
 namespace icinga
 {
@@ -35,6 +36,8 @@ public:
 
 private:
 	LegacyTimePeriod();
+
+	static boost::gregorian::date GetEndOfMonthDay(int year, int month);
 };
 
 }

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -159,6 +159,26 @@ BOOST_AUTO_TEST_CASE(simple)
 	BOOST_CHECK_EQUAL(end, expectedEnd);
 
 	//-----------------------------------------------------
+	// Third last day of the month
+	timestamp = "day -3";
+	tm_ref.tm_year = 2019 - 1900;
+	tm_ref.tm_mon = 7 - 1;
+
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2019, 7, 29), boost::posix_time::time_duration(0, 0, 0));
+
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2019, 7, 30), boost::posix_time::time_duration(0, 0, 0));
+
+	// Run Tests
+	LegacyTimePeriod::ParseTimeSpec(timestamp, &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
 	// Leap year with the last day of the month
 	timestamp = "day -1";
 	tm_ref.tm_year = 2016 - 1900; // leap year

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -2,6 +2,11 @@
 
 #include "base/utility.hpp"
 #include "icinga/legacytimeperiod.hpp"
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/ptime.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/date_time/gregorian/conversion.hpp>
+#include <boost/date_time/date.hpp>
 #include <BoostTestTargetConfig.h>
 
 using namespace icinga;
@@ -44,105 +49,210 @@ BOOST_GLOBAL_FIXTURE(GlobalTimezoneFixture);
 
 BOOST_AUTO_TEST_CASE(simple)
 {
-	tm beg, end, ref;
+	tm tm_beg, tm_end, tm_ref;
+	String timestamp;
+	boost::posix_time::ptime begin;
+	boost::posix_time::ptime end;
+	boost::posix_time::ptime expectedBegin;
+	boost::posix_time::ptime expectedEnd;
 
+	//-----------------------------------------------------
 	// check parsing of "YYYY-MM-DD" specs
-	LegacyTimePeriod::ParseTimeSpec("2016-01-01", &beg, &end, &ref);
-	BOOST_CHECK_EQUAL(mktime(&beg), (time_t) 1451606400);
-	BOOST_CHECK_EQUAL(mktime(&end), (time_t) 1451692800);
+	timestamp = "2016-01-01";
 
-	LegacyTimePeriod::ParseTimeSpec("2015-12-31", &beg, &end, &ref);
-	BOOST_CHECK_EQUAL(mktime(&beg), (time_t) 1451520000);
-	BOOST_CHECK_EQUAL(mktime(&end), (time_t) 1451606400);
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2016, 1, 1), boost::posix_time::time_duration(0, 0, 0));
 
-	BOOST_CHECK_THROW(LegacyTimePeriod::ParseTimeSpec("2015-12-32", &beg, &end, &ref),
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2016, 1, 2), boost::posix_time::time_duration(0, 0, 0));
+
+	// Run test
+	LegacyTimePeriod::ParseTimeSpec(timestamp, &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	timestamp = "2015-12-31";
+
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2015, 12, 31), boost::posix_time::time_duration(0, 0, 0));
+
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2016, 1, 1), boost::posix_time::time_duration(0, 0, 0));
+
+	// Run test
+	LegacyTimePeriod::ParseTimeSpec(timestamp, &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	// Break things forcefully
+	BOOST_CHECK_THROW(LegacyTimePeriod::ParseTimeSpec("2015-12-32", &tm_beg, &tm_end, &tm_ref),
 	    std::invalid_argument);
 
-	BOOST_CHECK_THROW(LegacyTimePeriod::ParseTimeSpec("2015-28-01", &beg, &end, &ref),
+	BOOST_CHECK_THROW(LegacyTimePeriod::ParseTimeSpec("2015-28-01", &tm_beg, &tm_end, &tm_ref),
 	    std::invalid_argument);
 
+	//-----------------------------------------------------
 	// check parsing of "day X" and "day -X" specs
-	ref.tm_year = 2016 - 1900;
-	ref.tm_mon = 1;
-	LegacyTimePeriod::ParseTimeSpec("day 2", &beg, &end, &ref);
-	BOOST_CHECK_EQUAL(mktime(&beg), (time_t) 1454371200); // 2016-02-02
-	BOOST_CHECK_EQUAL(mktime(&end), (time_t) 1454457600); // 2016-02-03
+	timestamp = "day 2";
+	tm_ref.tm_year = 2016 - 1900;
+	tm_ref.tm_mon = 2 - 1;
 
-	ref.tm_year = 2018 - 1900;
-	ref.tm_mon = 11;
-	LegacyTimePeriod::ParseTimeSpec("day 31", &beg, &end, &ref);
-	BOOST_CHECK_EQUAL(mktime(&beg), (time_t) 1546214400); // 2018-12-31
-	BOOST_CHECK_EQUAL(mktime(&end), (time_t) 1546300800); // 2019-01-01
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2016, 2, 2), boost::posix_time::time_duration(0, 0, 0));
 
-	ref.tm_year = 2012 - 1900;
-	ref.tm_mon = 6;
-	LegacyTimePeriod::ParseTimeSpec("day -1", &beg, &end, &ref);
-	BOOST_CHECK_EQUAL(mktime(&beg), (time_t) 1343692800); // 2012-07-31
-	BOOST_CHECK_EQUAL(mktime(&end), (time_t) 1343779200); // 2012-08-01
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2016, 2, 3), boost::posix_time::time_duration(0, 0, 0));
 
-	ref.tm_year = 2016 - 1900; // leap year
-	ref.tm_mon = 1;
-	LegacyTimePeriod::ParseTimeSpec("day -1", &beg, &end, &ref);
-	BOOST_CHECK_EQUAL(mktime(&beg), (time_t) 1456704000); // 2016-02-29
-	BOOST_CHECK_EQUAL(mktime(&end), (time_t) 1456790400); // 2016-03-01
+	// Run Tests
+	LegacyTimePeriod::ParseTimeSpec(timestamp, &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	timestamp = "day 31";
+	tm_ref.tm_year = 2018 - 1900;
+	tm_ref.tm_mon = 12 - 1;
+
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2018, 12, 31), boost::posix_time::time_duration(0, 0, 0));
+
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2019, 1, 1), boost::posix_time::time_duration(0, 0, 0));
+
+	// Run Tests
+	LegacyTimePeriod::ParseTimeSpec(timestamp, &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	// Last day of the month
+	timestamp = "day -1";
+	tm_ref.tm_year = 2012 - 1900;
+	tm_ref.tm_mon = 7 - 1;
+
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2012, 7, 31), boost::posix_time::time_duration(0, 0, 0));
+
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2012, 8, 1), boost::posix_time::time_duration(0, 0, 0));
+
+	// Run Tests
+	LegacyTimePeriod::ParseTimeSpec(timestamp, &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	// Leap year with the last day of the month
+	timestamp = "day -1";
+	tm_ref.tm_year = 2016 - 1900; // leap year
+	tm_ref.tm_mon = 2 - 1;
+
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2016, 2, 29), boost::posix_time::time_duration(0, 0, 0));
+
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2016, 3, 1), boost::posix_time::time_duration(0, 0, 0));
+
+	// Run Tests
+	LegacyTimePeriod::ParseTimeSpec("day -1", &tm_beg, &tm_end, &tm_ref);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
 }
 
-BOOST_AUTO_TEST_CASE(advanced) {
-	tm beg, end, ref;
-	time_t ts_beg, ts_end, ts_beg_exp, ts_end_exp;
+BOOST_AUTO_TEST_CASE(advanced)
+{
+	tm tm_beg, tm_end, tm_ref;
+	String timestamp;
+	boost::posix_time::ptime begin;
+	boost::posix_time::ptime end;
+	boost::posix_time::ptime expectedBegin;
+	boost::posix_time::ptime expectedEnd;
 
-	//2019-05-06 where Icinga celebrates 10 years #monitoringlove
-	String timestamp = "22:00-06:00";
-	ref.tm_year = 2019 - 1900;
-	ref.tm_mon = 5 - 1;
-	ref.tm_mday = 6;
+	//-----------------------------------------------------
+	// 2019-05-06 where Icinga celebrates 10 years #monitoringlove
+	// 2019-05-06 22:00:00 - 2019-05-07 06:00:00
+	timestamp = "22:00-06:00";
+	tm_ref.tm_year = 2019 - 1900;
+	tm_ref.tm_mon = 5 - 1;
+	tm_ref.tm_mday = 6;
 
-	LegacyTimePeriod::ProcessTimeRangeRaw(timestamp, &ref, &beg, &end);
-	ts_beg = mktime(&beg);
-	ts_end = mktime(&end);
-	ts_beg_exp = 1557180000; // 2019-05-06 22:00:00
-	ts_end_exp = 1557208800; // 2019-05-07 06:00:00
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2019, 5, 6), boost::posix_time::time_duration(22, 0, 0));
 
-	BOOST_CHECK_EQUAL(ts_beg, ts_beg_exp);
-	BOOST_TEST_MESSAGE("Begin date: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_beg) << " expected " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_beg_exp));
-	BOOST_CHECK_EQUAL(ts_end, ts_end_exp);
-	BOOST_TEST_MESSAGE("End date: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_end) << " expected " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_end_exp));
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2019, 5, 7), boost::posix_time::time_duration(6, 0, 0));
 
+	// Run test
+	LegacyTimePeriod::ProcessTimeRangeRaw(timestamp, &tm_ref, &tm_beg, &tm_end);
 
-	//2019-05-06 Icinga is unleashed.
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	// 2019-05-06 Icinga is unleashed.
+	// 09:00:00 - 17:00:00
 	timestamp = "09:00-17:00";
-	ref.tm_year = 2009 - 1900;
-	ref.tm_mon = 5 - 1;
-	ref.tm_mday = 6;
+	tm_ref.tm_year = 2009 - 1900;
+	tm_ref.tm_mon = 5 - 1;
+	tm_ref.tm_mday = 6;
 
-	LegacyTimePeriod::ProcessTimeRangeRaw(timestamp, &ref, &beg, &end);
-	ts_beg = mktime(&beg);
-	ts_end = mktime(&end);
-	ts_beg_exp = 1241600400; // 2009-05-06 09:00:00
-	ts_end_exp = 1241629200; // 2009-05-06 17:00:00
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2009, 5, 6), boost::posix_time::time_duration(9, 0, 0));
 
-	BOOST_CHECK_EQUAL(ts_beg, ts_beg_exp);
-	BOOST_TEST_MESSAGE("Begin date: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_beg) << " expected " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_beg_exp));
-	BOOST_CHECK_EQUAL(ts_end, ts_end_exp);
-	BOOST_TEST_MESSAGE("End date: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_end) << " expected " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_end_exp));
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2009, 5, 6), boost::posix_time::time_duration(17, 0, 0));
 
-	//At our first Icinga Camp in SFO 2014 at GitHub HQ, we partied all night long with an overflow.
+	// Run test
+	LegacyTimePeriod::ProcessTimeRangeRaw(timestamp, &tm_ref, &tm_beg, &tm_end);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+
+	//-----------------------------------------------------
+	// At our first Icinga Camp in SFO 2014 at GitHub HQ, we partied all night long with an overflow.
+	// 2014-09-24 09:00:00 - 2014-09-25 06:00:00
 	timestamp = "09:00-30:00";
-	ref.tm_year = 2014 - 1900;
-	ref.tm_mon = 9 - 1;
-	ref.tm_mday = 24;
+	tm_ref.tm_year = 2014 - 1900;
+	tm_ref.tm_mon = 9 - 1;
+	tm_ref.tm_mday = 24;
 
-	LegacyTimePeriod::ProcessTimeRangeRaw(timestamp, &ref, &beg, &end);
-	ts_beg = mktime(&beg);
-	ts_end = mktime(&end);
-	ts_beg_exp = 1411549200; // 2014-09-24 09:00:00
-	ts_end_exp = 1411624800; // 2014-09-25 06:00:00
+	expectedBegin = boost::posix_time::ptime(boost::gregorian::date(2014, 9, 24), boost::posix_time::time_duration(9, 0, 0));
 
-	BOOST_CHECK_EQUAL(ts_beg, ts_beg_exp);
-	BOOST_TEST_MESSAGE("Begin date: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_beg) << " expected " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_beg_exp));
-	BOOST_CHECK_EQUAL(ts_end, ts_end_exp);
-	BOOST_TEST_MESSAGE("End date: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_end) << " expected " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", ts_end_exp));
+	expectedEnd = boost::posix_time::ptime(boost::gregorian::date(2014, 9, 25), boost::posix_time::time_duration(6, 0, 0));
 
- }
+	// Run test
+	LegacyTimePeriod::ProcessTimeRangeRaw(timestamp, &tm_ref, &tm_beg, &tm_end);
+
+	// Compare times
+	begin = boost::posix_time::ptime_from_tm(tm_beg);
+	end = boost::posix_time::ptime_from_tm(tm_end);
+
+	BOOST_CHECK_EQUAL(begin, expectedBegin);
+	BOOST_CHECK_EQUAL(end, expectedEnd);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tools/win32/test.ps1
+++ b/tools/win32/test.ps1
@@ -24,7 +24,7 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
 
 cd "$env:ICINGA2_BUILDPATH"
 
-ctest.exe -C "${env:CMAKE_BUILD_TYPE}" -T test -O $env:ICINGA2_BUILDPATH/Test.xml --output-on-failure
+ctest.exe -C "${env:CMAKE_BUILD_TYPE}" -T test -O $env:ICINGA2_BUILDPATH/Test.xml --output-on-failure --log_level=all
 if ($lastexitcode -ne 0) {
   cd ..
   exit $lastexitcode


### PR DESCRIPTION
The current implementation uses hardcoded local timestamps. While it
sounded reasonable to just revamp this with tm structs and mktime(),
the pure C approach really hurts us developers.

The underlaying code inside the TimePeriod class uses such as well,
and with changing the unit tests to use Boost.DateTime, several
issues have been unveiled.

The "day -X" specification would return tm.mday=0 in some cases,
mktime() used in the tests supported this. But did Icinga really
do the things specified then?

Instead of relying of "sort of defined" behaviour of C-ish interfaces,
we should use modern programming techniques going along.

Parsing the legacy timeperiod format isn't fun at all. Up until
now, we couldn't use the power of the Gregorian calendar
and other timestamp/date functionality in C++. With using
Boost.DateTime, this should really become better.

fixes #7257