### PR TITLE
Cluster config sync: Fix new files not being moved

### DIFF
--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -687,12 +687,12 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			 */
 			if (Utility::Match("/.*", path)) {
 				Log(LogDebug, "ApiListener")
-						<< "Ignoring internal file '" << path << "'";
+						<< "Ignoring old internal file '" << path << "'.";
 				continue;
 			}
 
 			Log(LogDebug, "ApiListener")
-					<< "Checking " << path << " for old checksum: " << oldChecksum;
+					<< "Checking " << path << " for old checksum: " << oldChecksum << ".";
 
 			// Check if key exists first for more verbose logging.
 			// TODO: Don't do this later on.
@@ -728,15 +728,14 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			 */
 			if (Utility::Match("/.*", path)) {
 				Log(LogDebug, "ApiListener")
-						<< "Ignoring internal file '" << path << "'";
+						<< "Ignoring new internal file '" << path << "'.";
 				continue;
 			}
 
 			Log(LogDebug, "ApiListener")
-				<< "Checking " << path << " for new checksum: " << newChecksum;
+				<< "Checking " << path << " for new checksum: " << newChecksum << ".";
 
 			// Here we only need to check if the checksum exists, checksums in both sets have already been compared
-			// TODO: Don't do this later on.
 			if (!oldChecksums->Contains(path)) {
 				Log(LogDebug, "ApiListener")
 					<< "File '" << path << "' was added by remote.";

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -667,7 +667,6 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 		<< "' vs. new (" << newChecksums->GetLength() << "): '"
 		<< JsonEncode(newChecksums) << "'.";
 
-
 	/* Since internal files are synced here too, we can not depend on length.
 	 * So we need to go through both checksum sets to cover the cases"everything is new" and "everything was deleted".
 	 */
@@ -677,36 +676,36 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			String path = kv.first;
 			String oldChecksum = kv.second;
 
-			// TODO: Figure out if config changes only apply to '.conf'. Leaving this open for other config files.
-			//if (!Utility::Match("*.conf", path))
-			//	continue;
-
 			/* Ignore internal files, especially .timestamp and .checksums.
 			 *
 			 * If we don't, this results in "always change" restart loops.
 			 */
 			if (Utility::Match("/.*", path)) {
 				Log(LogDebug, "ApiListener")
-						<< "Ignoring old internal file '" << path << "'.";
+					<< "Ignoring old internal file '" << path << "'.";
+
 				continue;
 			}
 
 			Log(LogDebug, "ApiListener")
-					<< "Checking " << path << " for old checksum: " << oldChecksum << ".";
+				<< "Checking " << path << " for old checksum: " << oldChecksum << ".";
 
 			// Check if key exists first for more verbose logging.
-			// TODO: Don't do this later on.
+			// Note: Don't do this later on.
 			if (!newChecksums->Contains(path)) {
 				Log(LogDebug, "ApiListener")
-						<< "File '" << path << "' was deleted by remote.";
+					<< "File '" << path << "' was deleted by remote.";
+
 				return true;
 			}
 
 			String newChecksum = newChecksums->Get(path);
+
 			if (newChecksum != kv.second) {
 				Log(LogDebug, "ApiListener")
-						<< "Path '" << path << "' doesn't match old checksum '"
-						<< oldChecksum << "' with new checksum '" << newChecksum << "'.";
+					<< "Path '" << path << "' doesn't match old checksum '"
+					<< oldChecksum << "' with new checksum '" << newChecksum << "'.";
+
 				return true;
 			}
 		}
@@ -718,27 +717,25 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			String path = kv.first;
 			String newChecksum = kv.second;
 
-			// TODO: Figure out if config changes only apply to '.conf'. Leaving this open for other config files.
-			//if (!Utility::Match("*.conf", path))
-			//	continue;
-
 			/* Ignore internal files, especially .timestamp and .checksums.
 			 *
 			 * If we don't, this results in "always change" restart loops.
 			 */
 			if (Utility::Match("/.*", path)) {
 				Log(LogDebug, "ApiListener")
-						<< "Ignoring new internal file '" << path << "'.";
+					<< "Ignoring new internal file '" << path << "'.";
+
 				continue;
 			}
 
 			Log(LogDebug, "ApiListener")
 				<< "Checking " << path << " for new checksum: " << newChecksum << ".";
 
-			// Here we only need to check if the checksum exists, checksums in both sets have already been compared
+			// Check if the checksum exists, checksums in both sets have already been compared
 			if (!oldChecksums->Contains(path)) {
 				Log(LogDebug, "ApiListener")
 					<< "File '" << path << "' was added by remote.";
+
 				return true;
 			}
 		}

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -301,6 +301,8 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 	Utility::MkDirP(apiZonesStageDir, 0700);
 
 	// Analyse and process the update.
+	size_t count = 0;
+
 	ObjectLock olock(updateV1);
 
 	for (const Dictionary::Pair& kv : updateV1) {
@@ -480,6 +482,8 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 				}
 			}
 		}
+
+		count++;
 	}
 
 	/*
@@ -493,13 +497,13 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 	 */
 	if (configChange) {
 		Log(LogInformation, "ApiListener")
-			<< "Received configuration from endpoint '" << fromEndpointName
-			<< "' is different to production, triggering validation and reload.";
+			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
+			<< "' are different to production, triggering validation and reload.";
 		AsyncTryActivateZonesStage(relativePaths);
 	} else {
 		Log(LogInformation, "ApiListener")
-			<< "Received configuration from endpoint '" << fromEndpointName
-			<< "' is equal to production, not triggering reload.";
+			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
+			<< "' are equal to production, not triggering reload.";
 	}
 
 	return Empty;


### PR DESCRIPTION
This changes the algorithm for computing staging/production changes.

First we go over the old checksums and if one is missing or has changed we know we have to update. After this we traverse the new checksums to find out if one is new. This also adds a few possibly unnecessary Debug log messages.

Full test protocol will follow, so far I have tested this only for the case of no old config.

fixes #7296