### PR TITLE
Internal methods must update the 'command' key in the check result

### DIFF
--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -6,6 +6,7 @@
 #include "icinga/cib.hpp"
 #include "icinga/service.hpp"
 #include "icinga/icingaapplication.hpp"
+#include "icinga/checkcommand.hpp"
 #include "base/application.hpp"
 #include "base/objectlock.hpp"
 #include "base/convert.hpp"
@@ -26,6 +27,9 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 
 	if (resolvedMacros && !useResolvedMacros)
 		return;
+
+	CheckCommand::Ptr command = checkable->GetCheckCommand();
+	cr->SetCommand(command->GetName());
 
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 

--- a/lib/methods/clusterzonechecktask.cpp
+++ b/lib/methods/clusterzonechecktask.cpp
@@ -29,8 +29,8 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 		return;
 	}
 
-	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
-	Value raw_command = commandObj->GetCommandLine();
+	CheckCommand::Ptr command = checkable->GetCheckCommand();
+	Value raw_command = command->GetCommandLine();
 
 	Host::Ptr host;
 	Service::Ptr service;
@@ -40,7 +40,7 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 	if (service)
 		resolvers.emplace_back("service", service);
 	resolvers.emplace_back("host", host);
-	resolvers.emplace_back("command", commandObj);
+	resolvers.emplace_back("command", command);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
 	String zoneName = MacroProcessor::ResolveMacros("$cluster_zone$", resolvers, checkable->GetLastCheckResult(),
@@ -57,6 +57,8 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 
 	if (resolvedMacros && !useResolvedMacros)
 		return;
+
+	cr->SetCommand(command->GetName());
 
 	if (zoneName.IsEmpty()) {
 		cr->SetOutput("Macro 'cluster_zone' must be set.");

--- a/lib/methods/dummychecktask.cpp
+++ b/lib/methods/dummychecktask.cpp
@@ -22,7 +22,7 @@ void DummyCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResu
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
 
-	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
+	CheckCommand::Ptr command = checkable->GetCheckCommand();
 
 	Host::Ptr host;
 	Service::Ptr service;
@@ -32,7 +32,7 @@ void DummyCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResu
 	if (service)
 		resolvers.emplace_back("service", service);
 	resolvers.emplace_back("host", host);
-	resolvers.emplace_back("command", commandObj);
+	resolvers.emplace_back("command", command);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
 	int dummyState = MacroProcessor::ResolveMacros("$dummy_state$", resolvers, checkable->GetLastCheckResult(),
@@ -55,6 +55,7 @@ void DummyCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResu
 	cr->SetExitStatus(dummyState);
 	cr->SetExecutionStart(now);
 	cr->SetExecutionEnd(now);
+	cr->SetCommand(command->GetName());
 
 	checkable->ProcessCheckResult(cr);
 }

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -26,7 +26,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
 
-	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
+	CheckCommand::Ptr command = checkable->GetCheckCommand();
 
 	Host::Ptr host;
 	Service::Ptr service;
@@ -36,7 +36,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	if (service)
 		resolvers.emplace_back("service", service);
 	resolvers.emplace_back("host", host);
-	resolvers.emplace_back("command", commandObj);
+	resolvers.emplace_back("command", command);
 	resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 
 	String missingIcingaMinVersion;
@@ -185,6 +185,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	}
 
 	cr->SetOutput(output);
+	cr->SetCommand(command->GetName());
 
 	checkable->ProcessCheckResult(cr);
 }

--- a/lib/methods/randomchecktask.cpp
+++ b/lib/methods/randomchecktask.cpp
@@ -5,6 +5,7 @@
 #endif /* _WIN32 */
 #include "methods/randomchecktask.hpp"
 #include "icinga/icingaapplication.hpp"
+#include "icinga/checkcommand.hpp"
 #include "base/utility.hpp"
 #include "base/perfdatavalue.hpp"
 #include "base/function.hpp"
@@ -43,6 +44,9 @@ void RandomCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	}));
 
 	cr->SetState(static_cast<ServiceState>(Utility::Random() % 4));
+
+	CheckCommand::Ptr command = checkable->GetCheckCommand();
+	cr->SetCommand(command->GetName());
 
 	checkable->ProcessCheckResult(cr);
 }

--- a/lib/methods/sleepchecktask.cpp
+++ b/lib/methods/sleepchecktask.cpp
@@ -47,5 +47,8 @@ void SleepCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResu
     cr->SetExecutionStart(now);
     cr->SetExecutionEnd(now);
 
+    CheckCommand::Ptr command = checkable->GetCheckCommand();
+    cr->SetCommand(command->GetName());
+
     checkable->ProcessCheckResult(cr);
 }


### PR DESCRIPTION
Currently this is `null` which isn't really correct.

As otherwise, it is tremendously hard to figure out which check
command was involved, if you're not looking at the `.check_command`
checkable object.