### PR TITLE
Cluster Config Sync: Ensure that empty production environment is populated with new sync

### DIFF
--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -667,7 +667,11 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 		<< "' vs. new (" << newChecksums->GetLength() << "): '"
 		<< JsonEncode(newChecksums) << "'.";
 
-	// Don't check for different length, this may be influenced from internal files
+	// If we didn't have any configuration, and now receive one, trigger a change.
+	if (oldChecksums->GetLength() == 0 && newChecksums->GetLength() > 0)
+		return true;
+
+	// At this stage, we are sure to have had old production config.
 	ObjectLock olock(oldChecksums);
 
 	for (const Dictionary::Pair& kv : oldChecksums) {

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -301,6 +301,8 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 	Utility::MkDirP(apiZonesStageDir, 0700);
 
 	// Analyse and process the update.
+	size_t count = 0;
+
 	ObjectLock olock(updateV1);
 
 	for (const Dictionary::Pair& kv : updateV1) {
@@ -484,6 +486,8 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 				}
 			}
 		}
+
+		count++;
 	}
 
 	/*
@@ -497,13 +501,13 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 	 */
 	if (configChange) {
 		Log(LogInformation, "ApiListener")
-			<< "Received configuration from endpoint '" << fromEndpointName
-			<< "' is different to production, triggering validation and reload.";
+			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
+			<< "' are different to production, triggering validation and reload.";
 		AsyncTryActivateZonesStage(relativePaths);
 	} else {
 		Log(LogInformation, "ApiListener")
-			<< "Received configuration from endpoint '" << fromEndpointName
-			<< "' is equal to production, not triggering reload.";
+			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
+			<< "' are equal to production, not triggering reload.";
 	}
 
 	return Empty;


### PR DESCRIPTION
This PR fixes the problem that old checksums = 0 would not be populated
with a new checksum update for production.

It also counts the applicable updates and logs them
at the end.

```
[2019-07-10 12:34:27 +0200] information/ApiListener: Received configuration updates (2) from endpoint 'master1' are equal to production, not triggering reload.
```

fixes #7296