### PR TITLE
TLS: Fetch the cipher list and log them for debugging (OpenSSL 1.1.x)

### DIFF
--- a/lib/base/array-script.cpp
+++ b/lib/base/array-script.cpp
@@ -107,22 +107,7 @@ static Value ArrayJoin(const Value& separator)
 	ScriptFrame *vframe = ScriptFrame::GetCurrentFrame();
 	Array::Ptr self = static_cast<Array::Ptr>(vframe->Self);
 	REQUIRE_NOT_NULL(self);
-
-	Value result;
-	bool first = true;
-
-	ObjectLock olock(self);
-	for (const Value& item : self) {
-		if (first) {
-			first = false;
-		} else {
-			result = result + separator;
-		}
-
-		result = result + item;
-	}
-
-	return result;
+	return self->Join(separator);
 }
 
 static Array::Ptr ArrayReverse()

--- a/lib/base/array.cpp
+++ b/lib/base/array.cpp
@@ -297,6 +297,26 @@ String Array::ToString() const
 	return msgbuf.str();
 }
 
+Value Array::Join(const Value& separator) const
+{
+	Value result;
+	bool first = true;
+
+	ObjectLock olock(this);
+
+	for (const Value& item : m_Data) {
+		if (first) {
+			first = false;
+		} else {
+			result = result + separator;
+		}
+
+		result = result + item;
+	}
+
+	return result;
+}
+
 Array::Ptr Array::Unique() const
 {
 	std::set<Value> result;

--- a/lib/base/array.hpp
+++ b/lib/base/array.hpp
@@ -94,6 +94,7 @@ public:
 	void Sort(bool overrideFrozen = false);
 
 	String ToString() const override;
+	Value Join(const Value& separator) const;
 
 	Array::Ptr Unique() const;
 	void Freeze();

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -176,6 +176,21 @@ void SetCipherListToSSLContext(const std::shared_ptr<boost::asio::ssl::context>&
 			<< boost::errinfo_api_function("SSL_CTX_set_cipher_list")
 			<< errinfo_openssl_error(ERR_peek_error()));
 	}
+
+	//With OpenSSL 1.1.0, there might not be any returned 0.
+	STACK_OF(SSL_CIPHER) *ciphers;
+	Array::Ptr cipherNames = new Array();
+
+	ciphers = SSL_CTX_get_ciphers(context->native_handle());
+	for (int i = 0; i < sk_SSL_CIPHER_num(ciphers); i++) {
+		const SSL_CIPHER *cipher = sk_SSL_CIPHER_value(ciphers, i);
+		String cipher_name = SSL_CIPHER_get_name(cipher);
+
+		cipherNames->Add(cipher_name);
+	}
+
+	Log(LogNotice, "TlsUtility")
+		<< "Available TLS cipher list: " << cipherNames->Join(" ");
 }
 
 /**

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -177,6 +177,7 @@ void SetCipherListToSSLContext(const std::shared_ptr<boost::asio::ssl::context>&
 			<< errinfo_openssl_error(ERR_peek_error()));
 	}
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	//With OpenSSL 1.1.0, there might not be any returned 0.
 	STACK_OF(SSL_CIPHER) *ciphers;
 	Array::Ptr cipherNames = new Array();
@@ -191,6 +192,7 @@ void SetCipherListToSSLContext(const std::shared_ptr<boost::asio::ssl::context>&
 
 	Log(LogNotice, "TlsUtility")
 		<< "Available TLS cipher list: " << cipherNames->Join(" ");
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 }
 
 /**


### PR DESCRIPTION
```
michi@Michaels-MacBook-Pro /usr/local/icinga/icinga2/etc/icinga2 $ icinga2 daemon -x notice | grep cipher
[2019-07-12 14:41:04 +0200] notice/TlsUtility: Available TLS cipher list: TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_SHA256 TLS_AES_128_GCM_SHA256 ECDHE-ECDSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 ECDHE-ECDSA-CHACHA20-POLY1305 ECDHE-RSA-CHACHA20-POLY1305 ECDHE-ECDSA-AES128-GCM-SHA256 ECDHE-RSA-AES128-GCM-SHA256 ECDHE-ECDSA-AES256-SHA384 ECDHE-RSA-AES256-SHA384 ECDHE-ECDSA-AES128-SHA256 ECDHE-RSA-AES128-SHA256
```

refs #7277