### PR TITLE
WIP: Tests: Checkresults should use non-paused objects

### DIFF
--- a/test/icinga-checkresult.cpp
+++ b/test/icinga-checkresult.cpp
@@ -49,6 +49,7 @@ BOOST_AUTO_TEST_CASE(host_1attempt)
 	host->SetActive(true);
 	host->SetMaxCheckAttempts(1);
 	host->Activate();
+	host->SetPaused(false); // Simulate a non-cluster setup
 	host->SetAuthority(true);
 	host->SetStateRaw(ServiceOK);
 	host->SetStateType(StateTypeHard);
@@ -98,6 +99,7 @@ BOOST_AUTO_TEST_CASE(host_2attempts)
 	host->SetActive(true);
 	host->SetMaxCheckAttempts(2);
 	host->Activate();
+	host->SetPaused(false); // Simulate a non-cluster setup
 	host->SetAuthority(true);
 	host->SetStateRaw(ServiceOK);
 	host->SetStateType(StateTypeHard);
@@ -154,6 +156,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	host->SetActive(true);
 	host->SetMaxCheckAttempts(3);
 	host->Activate();
+	host->SetPaused(false); // Simulate a non-cluster setup
 	host->SetAuthority(true);
 	host->SetStateRaw(ServiceOK);
 	host->SetStateType(StateTypeHard);
@@ -217,6 +220,7 @@ BOOST_AUTO_TEST_CASE(service_1attempt)
 	service->SetActive(true);
 	service->SetMaxCheckAttempts(1);
 	service->Activate();
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetAuthority(true);
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);
@@ -266,6 +270,7 @@ BOOST_AUTO_TEST_CASE(service_2attempts)
 	service->SetActive(true);
 	service->SetMaxCheckAttempts(2);
 	service->Activate();
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetAuthority(true);
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);
@@ -322,6 +327,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	service->SetActive(true);
 	service->SetMaxCheckAttempts(3);
 	service->Activate();
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetAuthority(true);
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);
@@ -389,6 +395,7 @@ BOOST_AUTO_TEST_CASE(host_flapping_notification)
 	Host::Ptr host = new Host();
 	host->SetActive(true);
 	host->Activate();
+	host->SetPaused(false); // Simulate a non-cluster setup
 	host->SetAuthority(true);
 	host->SetStateRaw(ServiceOK);
 	host->SetStateType(StateTypeHard);
@@ -443,6 +450,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_notification)
 	Service::Ptr service = new Service();
 	service->SetActive(true);
 	service->Activate();
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetAuthority(true);
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);
@@ -497,6 +505,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_problem_notifications)
 
 	Service::Ptr service = new Service();
 	service->Activate();
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetAuthority(true);
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);
@@ -596,6 +605,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_into_bad)
 	Service::Ptr service = new Service();
 	service->Activate();
 	service->SetAuthority(true);
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);
 	service->SetEnableFlapping(true);
@@ -673,6 +683,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_over_bad_into_ok)
 
 	Service::Ptr service = new Service();
 	service->Activate();
+	service->SetPaused(false); // Simulate a non-cluster setup
 	service->SetAuthority(true);
 	service->SetStateRaw(ServiceOK);
 	service->SetStateType(StateTypeHard);


### PR DESCRIPTION
https://build.icinga.com/job/icinga2-snapshot/job/rpm-centos-6-1binary/arch=x86_64/349/console

```
        Start  73: base-icinga_checkresult/host_1attempt
 73/105 Test  #73: base-icinga_checkresult/host_1attempt ...................................***Exception: Other  0.02 sec
Running 1 test case...
Before first check result (ok, hard)
First check result (unknown)
Notification triggered: PROBLEM
Second check result (ok)
Notification triggered: RECOVERY
Third check result (critical)
Notification triggered: PROBLEM
Fourth check result (ok)
Notification triggered: RECOVERY

*** No errors detected
terminate called without an active exception

        Start  74: base-icinga_checkresult/host_2attempts
 74/105 Test  #74: base-icinga_checkresult/host_2attempts ..................................***Exception: Other  0.09 sec
Running 1 test case...
Before first check result (ok, hard)
First check result (unknown)
Second check result (critical)
Notification triggered: PROBLEM
Third check result (ok)
Notification triggered: RECOVERY
Fourth check result (critical)
Fifth check result (ok)

*** No errors detected
terminate called without an active exception

        Start  75: base-icinga_checkresult/host_3attempts
 75/105 Test  #75: base-icinga_checkresult/host_3attempts ..................................***Exception: Other  0.07 sec
Running 1 test case...
Before first check result (ok, hard)
First check result (unknown)
Second check result (critical)
Third check result (critical)
Notification triggered: PROBLEM
Fourth check result (ok)
Notification triggered: RECOVERY
Fifth check result (critical)
Sixth check result (ok)

*** No errors detected
terminate called without an active exception

        Start  76: base-icinga_checkresult/service_1attempt
 76/105 Test  #76: base-icinga_checkresult/service_1attempt ................................***Exception: Other  0.06 sec
Running 1 test case...
Before first check result (ok, hard)
First check result (unknown)
Notification triggered: PROBLEM
Second check result (ok)
Notification triggered: RECOVERY
Third check result (critical)
Notification triggered: PROBLEM
Fourth check result (ok)
Notification triggered: RECOVERY

*** No errors detected
terminate called without an active exception

        Start  77: base-icinga_checkresult/service_2attempts
 77/105 Test  #77: base-icinga_checkresult/service_2attempts ...............................***Exception: Other  0.06 sec
Running 1 test case...
Before first check result (ok, hard)
First check result (unknown)
Second check result (critical)
Notification triggered: PROBLEM
Third check result (ok)
Notification triggered: RECOVERY
Fourth check result (critical)
Fifth check result (ok)

*** No errors detected
terminate called without an active exception

        Start  78: base-icinga_checkresult/service_3attempts
 78/105 Test  #78: base-icinga_checkresult/service_3attempts ...............................***Exception: Other  0.27 sec
Running 1 test case...
Before first check result (ok, hard)
First check result (unknown)
Second check result (critical)
Third check result (critical)
Notification triggered: PROBLEM
Fourth check result (ok)
Notification triggered: RECOVERY
Fifth check result (critical)
Sixth check result (ok)

*** No errors detected
terminate called without an active exception


100/105 Test #100: livestatus-livestatus/hosts .............................................***Exception: Other  0.06 sec
Running 1 test case...

*** No errors detected
terminate called without an active exception

        Start 101: livestatus-livestatus/services
101/105 Test #101: livestatus-livestatus/services ..........................................***Exception: Other  0.10 sec
Running 1 test case...

*** No errors detected
terminate called without an active exception
```