### PR TITLE
Docs: Mention that Raspbian 4+ / Debian Buster is required

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -19,7 +19,7 @@ Official repositories ([support matrix](https://icinga.com/support/details/)):
   ------------------------|---------------------------
   Debian                  | [Icinga Repository](https://packages.icinga.com/debian/)
   Ubuntu                  | [Icinga Repository](https://packages.icinga.com/ubuntu/)
-  Raspbian		  | [Icinga Repository](https://packages.icinga.com/raspbian/)
+  Raspbian		  | [Icinga Repository](https://packages.icinga.com/raspbian/). Note that **Raspbian 4+ `icinga-buster` is required.**
   RHEL/CentOS             | [Icinga Repository](https://packages.icinga.com/epel/)
   openSUSE                | [Icinga Repository](https://packages.icinga.com/openSUSE/)
   SLES                    | [Icinga Repository](https://packages.icinga.com/SUSE/)
@@ -83,7 +83,7 @@ wget -O - https://packages.icinga.com/icinga.key | apt-key add -
 apt-get update
 ```
 
-Raspbian:
+Raspbian 4+ / `icinga-buster`:
 
 ```
 apt-get update

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -18,6 +18,10 @@ EOL distributions where no packages are available with this release:
 * Ubuntu 14 LTS
 * RHEL/CentOS 6 x86
 
+Raspbian Packages for Debian Buster (Raspbian 4) are available.
+Please note that Stretch is not supported suffering from compiler
+regressions. Upgrade to Raspbian 4+ is highly recommended.
+
 #### Added: Boost 1.66+
 
 The rewrite of our core network stack for cluster and REST API


### PR DESCRIPTION
Stretch is still crashing sometimes, so we'll skip our support
on that. @nbuchwitz