### PR TITLE
OpenTsdbWriter - Custom Tag Support

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1703,8 +1703,9 @@ Configuration Attributes:
   host            	    | String                | **Optional.** OpenTSDB host address. Defaults to `127.0.0.1`.
   port            	    | Number                | **Optional.** OpenTSDB port. Defaults to `4242`.
   enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `false`.
-  host_template             | Dictionary                | **Optional.** Specify additional tags to be included with host metrics. This requires a sub-dictionary named `tags`. More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags). Defaults to an `empty Dictionary`.
-  service_template          | Dictionary                | **Optional.** Specify additional tags to be included with service metrics. This requires a sub-dictionary named `tags`. More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags). Defaults to an `empty Dictionary`.
+  enable_generic_metrics    | Boolean               | **Optional.** Re-use metric names to store different perfdata values for a particular check. Use tags to distinguish perfdata instead of metric name. Defaults to `false`.
+  host_template             | Dictionary                | **Optional.** Specify additional tags to be included with host metrics. This requires a sub-dictionary named `tags`. Also specify a naming prefix by setting `metric`. More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags) and [OpenTSDB Metric Prefix](14-features.md#opentsdb-metric-prefix). More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags). Defaults to an `empty Dictionary`.
+  service_template          | Dictionary                | **Optional.** Specify additional tags to be included with service metrics. This requires a sub-dictionary named `tags`. Also specify a naming prefix by setting `metric`. More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags) and [OpenTSDB Metric Prefix](14-features.md#opentsdb-metric-prefix). Defaults to an `empty Dictionary`.
 
 
 ### PerfdataWriter <a id="objecttype-perfdatawriter"></a>

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1703,6 +1703,8 @@ Configuration Attributes:
   host            	    | String                | **Optional.** OpenTSDB host address. Defaults to `127.0.0.1`.
   port            	    | Number                | **Optional.** OpenTSDB port. Defaults to `4242`.
   enable\_ha                | Boolean               | **Optional.** Enable the high availability functionality. Only valid in a [cluster setup](06-distributed-monitoring.md#distributed-monitoring-high-availability-features). Defaults to `false`.
+  host_template             | Dictionary                | **Optional.** Specify additional tags to be included with host metrics. This requires a sub-dictionary named `tags`. More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags). Defaults to an `empty Dictionary`.
+  service_template          | Dictionary                | **Optional.** Specify additional tags to be included with service metrics. This requires a sub-dictionary named `tags`. More information can be found in [OpenTSDB custom tags](14-features.md#opentsdb-custom-tags). Defaults to an `empty Dictionary`.
 
 
 ### PerfdataWriter <a id="objecttype-perfdatawriter"></a>

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -652,6 +652,96 @@ with the following tags
 > You might want to set the tsd.core.auto_create_metrics setting to `true`
 > in your opentsdb.conf configuration file.
 
+#### Custom Tags <a id="opentsdb-custom-tags"></a>
+
+In addition to the default tags listed above, it is possible to send
+your own custom tags with your data to OpenTSDB.
+
+Note that custom tags are sent **in addition** to the default hostname,
+type and service name tags. If you do not include this section in the
+config file, no custom tags will be included.
+
+Custom tags can be custom attributes or built in attributes.
+
+Consider a host object:
+
+```
+object Host "my-server1" {
+  address = "10.0.0.1"
+  check_command = "hostalive"
+  vars.location = "Australia"
+}
+```
+
+and a service object:
+
+```
+object Service "ping" {
+  host_name = "localhost"
+  check_command = "my-ping"
+
+  vars.ping_packets = 10
+}
+```
+
+It is possible to send `vars.location` and `vars.ping_packets` along
+with performance data. Additionally, any other attribute can be sent
+as a tag, such as `check_command`.
+
+You can make use of the `host_template` and `service_template` blocks
+in the `opentsdb.conf` configuration file.
+
+An example OpenTSDB configuration file which makes use of custom tags:
+
+```
+object OpenTsdbWriter "opentsdb" {
+  host = "127.0.0.1"
+  port = 4242
+  host_template = {
+    tags = {
+      location = "$host.vars.location$"
+      checkcommand = "$host.check_command$"
+    }
+  }
+  service_template = {
+    tags = {
+      location = "$host.vars.location$"
+      pingpackets = "$service.vars.ping_packets$"
+      checkcommand = "$service.check_command$"
+    }
+  }
+}
+```
+
+Depending on what keyword the macro begins with, will determine what
+attributes are available in the macro context. The below table explains
+what attributes are available with links to each object type.
+
+  start of macro | description
+  ---------------|------------------------------------------
+  \$host...$     | Attributes available on a [Host object](09-object-types.md#objecttype-host)
+  \$service...$  | Attributes available on a [Service object](09-object-types.md#objecttype-service)
+  \$icinga...$   | Attributes available on the [IcingaApplication object](09-object-types.md#icingaapplication)
+
+> **Note**
+>
+> Ensure you do not name your custom attributes with a dot in the name.
+> Dots located inside a macro tell the interpreter to expand a
+> dictionary.
+> 
+> Do not do this in your object configuration:
+> 
+> `vars["my.attribute"]`
+> 
+> as you will be unable to reference `my.attribute` because it is not a
+> dictionary.
+> 
+> Instead, use underscores or another character:
+> 
+> `vars.my_attribute` or `vars["my_attribute"]`
+
+
+
 #### OpenTSDB in Cluster HA Zones <a id="opentsdb-writer-cluster-ha"></a>
 
 The OpenTSDB feature supports [high availability](06-distributed-monitoring.md#distributed-monitoring-high-availability-features)

--- a/etc/icinga2/features-available/opentsdb.conf
+++ b/etc/icinga2/features-available/opentsdb.conf
@@ -6,17 +6,20 @@
 object OpenTsdbWriter "opentsdb" {
   //host = "127.0.0.1"
   //port = 4242
+  //enable_generic_metrics = false
 
   // Custom Tagging, refer to Icinga object type documentation for
   // OpenTsdbWriter
   //host_template = {
+  //  metric = "icinga.host"
   //  tags = {
-  //    checkcommand = "$host.check_command$"
+  //    zone = "$host.zone$"
   //  }
   //}
   //service_template = {
+  //  metric = "icinga.service.$service.check_command$"
   //  tags = {
-  //    checkcommand = "$service.check_command$"
+  //    zone = "$service.zone$"
   //  }
   //}
 }

--- a/etc/icinga2/features-available/opentsdb.conf
+++ b/etc/icinga2/features-available/opentsdb.conf
@@ -6,4 +6,17 @@
 object OpenTsdbWriter "opentsdb" {
   //host = "127.0.0.1"
   //port = 4242
+
+  // Custom Tagging, refer to Icinga object type documentation for
+  // OpenTsdbWriter
+  //host_template = {
+  //  tags = {
+  //    checkcommand = "$host.check_command$"
+  //  }
+  //}
+  //service_template = {
+  //  tags = {
+  //    checkcommand = "$service.check_command$"
+  //  }
+  //}
 }

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -194,7 +194,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 				continue;
 			}
 			
-			String tagname = pair.first;
+			String tagname = Convert::ToString(pair.first);
 			tags[tagname] = EscapeTag(value);
 			
 		}

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -176,7 +176,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 	String metric;
 	std::map<String, String> tags;
 
-	// Resolve macros in configuration template
+	// Resolve macros in configuration template and build custom tag list
 	if (config_tmpl_tags) {
 		
 		ObjectLock olock(config_tmpl_tags);
@@ -188,7 +188,8 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 			
 			if (!missing_macro.IsEmpty()) {
 				Log(LogDebug, "OpenTsdbWriter")
-					<< "Macro in config template does not exist:'" << missing_macro << "'.";
+					<< "Unable to resolve macro:'" << missing_macro 
+					<< "' for this host or service.";
 				
 				continue;
 			}

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -155,6 +155,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 	Host::Ptr host;
 	Dictionary::Ptr config_tmpl;
 	Dictionary::Ptr config_tmpl_tags;
+	String config_tmpl_metric;
 
 	if (service) {
 		host = service->GetHost();
@@ -168,13 +169,14 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 	// Get the tags nested dictionary in the service/host template in the config
 	if (config_tmpl) {
 		config_tmpl_tags = config_tmpl->Get("tags");
+		config_tmpl_metric = config_tmpl->Get("metric");
 	}
 
 	String metric;
 	std::map<String, String> tags;
 
 	// Resolve macros in configuration template and build custom tag list
-	if (config_tmpl_tags) {
+	if (config_tmpl_tags || !config_tmpl_metric.IsEmpty()) {
 
 		// Configure config template macro resolver
 		MacroProcessor::ResolverList resolvers;
@@ -183,24 +185,46 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 		resolvers.emplace_back("host", host);
 		resolvers.emplace_back("icinga", IcingaApplication::GetInstance());
 		
-		ObjectLock olock(config_tmpl_tags);
+		// Resolve macros for the service and host template config line
+		if (config_tmpl_tags) {
+			ObjectLock olock(config_tmpl_tags);
+			
+			for (const Dictionary::Pair& pair : config_tmpl_tags) {
+				
+				String missing_macro;
+				Value value = MacroProcessor::ResolveMacros(pair.second, resolvers, cr, &missing_macro);
+				
+				if (!missing_macro.IsEmpty()) {
+					Log(LogDebug, "OpenTsdbWriter")
+						<< "Unable to resolve macro:'" << missing_macro 
+						<< "' for this host or service.";
+					
+					continue;
+				}
+				
+				String tagname = Convert::ToString(pair.first);
+				tags[tagname] = EscapeTag(value);
+				
+			}
+		}
 		
-		for (const Dictionary::Pair& pair : config_tmpl_tags) {
+		// Resolve macros for the metric config line
+		if (!config_tmpl_metric.IsEmpty()) {
 			
 			String missing_macro;
-			Value value = MacroProcessor::ResolveMacros(pair.second, resolvers, cr, &missing_macro);
+			Value value = MacroProcessor::ResolveMacros(config_tmpl_metric, resolvers, cr, &missing_macro);
 			
 			if (!missing_macro.IsEmpty()) {
 				Log(LogDebug, "OpenTsdbWriter")
 					<< "Unable to resolve macro:'" << missing_macro 
 					<< "' for this host or service.";
 				
-				continue;
 			}
+			else {
 			
-			String tagname = Convert::ToString(pair.first);
-			tags[tagname] = EscapeTag(value);
+				config_tmpl_metric = Convert::ToString(value);
 			
+			}
 		}
 	}
 
@@ -210,13 +234,23 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 	double ts = cr->GetExecutionEnd();
 
 	if (service) {
-		String serviceName = service->GetShortName();
-		String escaped_serviceName = EscapeMetric(serviceName);
-		metric = "icinga.service." + escaped_serviceName;
 
+		if (!config_tmpl_metric.IsEmpty()) {
+			metric = config_tmpl_metric;
+		} else {
+			String serviceName = service->GetShortName();
+			String escaped_serviceName = EscapeMetric(serviceName);
+			metric = "icinga.service." + escaped_serviceName;
+		}
+		
 		SendMetric(checkable, metric + ".state", tags, service->GetState(), ts);
+
 	} else {
-		metric = "icinga.host";
+		if (!config_tmpl_metric.IsEmpty()) {
+			metric = config_tmpl_metric;
+		} else {
+			metric = "icinga.host";
+		}
 		SendMetric(checkable, metric + ".state", tags, host->GetState(), ts);
 	}
 
@@ -280,20 +314,32 @@ void OpenTsdbWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 				continue;
 			}
 		}
+		
+		String metric_name;
+		std::map<String, String> tags_new = tags;
 
-		String escaped_key = EscapeMetric(pdv->GetLabel());
-		boost::algorithm::replace_all(escaped_key, "::", ".");
+		// Do not break original functionality where perfdata labels form
+		// part of the metric name
+		if (!GetEnableGenericMetrics()) {
+			String escaped_key = EscapeMetric(pdv->GetLabel());
+			boost::algorithm::replace_all(escaped_key, "::", ".");
+			metric_name = metric + "." + escaped_key;
+		} else {
+			String escaped_key = EscapeTag(pdv->GetLabel());
+			metric_name = metric;
+			tags_new["label"] = escaped_key;
+		}
 
-		SendMetric(checkable, metric + "." + escaped_key, tags, pdv->GetValue(), ts);
+		SendMetric(checkable, metric_name, tags_new, pdv->GetValue(), ts);
 
 		if (pdv->GetCrit())
-			SendMetric(checkable, metric + "." + escaped_key + "_crit", tags, pdv->GetCrit(), ts);
+			SendMetric(checkable, metric_name + "_crit", tags_new, pdv->GetCrit(), ts);
 		if (pdv->GetWarn())
-			SendMetric(checkable, metric + "." + escaped_key + "_warn", tags, pdv->GetWarn(), ts);
+			SendMetric(checkable, metric_name + "_warn", tags_new, pdv->GetWarn(), ts);
 		if (pdv->GetMin())
-			SendMetric(checkable, metric + "." + escaped_key + "_min", tags, pdv->GetMin(), ts);
+			SendMetric(checkable, metric_name + "_min", tags_new, pdv->GetMin(), ts);
 		if (pdv->GetMax())
-			SendMetric(checkable, metric + "." + escaped_key + "_max", tags, pdv->GetMax(), ts);
+			SendMetric(checkable, metric_name + "_max", tags_new, pdv->GetMax(), ts);
 	}
 }
 
@@ -360,6 +406,7 @@ String OpenTsdbWriter::EscapeTag(const String& str)
 
 	boost::replace_all(result, " ", "_");
 	boost::replace_all(result, "\\", "_");
+	boost::replace_all(result, ":", "_");
 
 	return result;
 }
@@ -427,6 +474,10 @@ void OpenTsdbWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lvalue, c
 {
 	ObjectImpl<OpenTsdbWriter>::ValidateHostTemplate(lvalue, utils);
 
+	String metric = lvalue()->Get("metric");
+	if (!MacroProcessor::ValidateMacroString(metric))
+		BOOST_THROW_EXCEPTION(ValidationError(this, { "host_template", "metric" }, "Closing $ not found in macro format string '" + metric + "'."));
+
 	Dictionary::Ptr tags = lvalue()->Get("tags");
 	if (tags) {
 		ObjectLock olock(tags);
@@ -447,6 +498,10 @@ void OpenTsdbWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lvalue, c
 void OpenTsdbWriter::ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils)
 {
 	ObjectImpl<OpenTsdbWriter>::ValidateServiceTemplate(lvalue, utils);
+
+	String metric = lvalue()->Get("metric");
+	if (!MacroProcessor::ValidateMacroString(metric))
+		BOOST_THROW_EXCEPTION(ValidationError(this, { "service_template", "metric" }, "Closing $ not found in macro format string '" + metric + "'."));
 
 	Dictionary::Ptr tags = lvalue()->Get("tags");
 	if (tags) {

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -379,6 +379,13 @@ String OpenTsdbWriter::EscapeMetric(const String& str)
 	return result;
 }
 
+/**
+* Validates the host_template configuration block in the configuration
+* file and checks for syntax errors.
+*
+* @param lvalue The host_template dictionary
+* @param utils Validation helper utilities
+*/
 void OpenTsdbWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils)
 {
 	ObjectImpl<OpenTsdbWriter>::ValidateHostTemplate(lvalue, utils);
@@ -393,6 +400,13 @@ void OpenTsdbWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lvalue, c
 	}
 }
 
+/**
+* Validates the service_template configuration block in the 
+* configuration file and checks for syntax errors.
+*
+* @param lvalue The service_template dictionary
+* @param utils Validation helper utilities
+*/
 void OpenTsdbWriter::ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils)
 {
 	ObjectImpl<OpenTsdbWriter>::ValidateServiceTemplate(lvalue, utils);

--- a/lib/perfdata/opentsdbwriter.hpp
+++ b/lib/perfdata/opentsdbwriter.hpp
@@ -26,6 +26,9 @@ public:
 
 	static void StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata);
 
+	void ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils) override;
+	void ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils) override;
+
 protected:
 	void OnConfigLoaded() override;
 	void Resume() override;

--- a/lib/perfdata/opentsdbwriter.hpp
+++ b/lib/perfdata/opentsdbwriter.hpp
@@ -39,6 +39,9 @@ private:
 
 	Timer::Ptr m_ReconnectTimer;
 
+	Dictionary::Ptr m_ServiceConfigTemplate;
+	Dictionary::Ptr m_HostConfigTemplate;
+
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void SendMetric(const Checkable::Ptr& checkable, const String& metric,
 		const std::map<String, String>& tags, double value, double ts);
@@ -48,6 +51,9 @@ private:
 	static String EscapeMetric(const String& str);
 
 	void ReconnectTimerHandler();
+
+	void ReadConfigTemplate(const Dictionary::Ptr& stemplate, 
+		const Dictionary::Ptr& htemplate);
 };
 
 }

--- a/lib/perfdata/opentsdbwriter.ti
+++ b/lib/perfdata/opentsdbwriter.ti
@@ -27,6 +27,9 @@ class OpenTsdbWriter : ConfigObject
 	[config] Dictionary::Ptr service_template {
 		default {{{ return new Dictionary(); }}}
 	};
+	[config] bool enable_generic_metrics {
+		default {{{ return false; }}}
+	};
 
 	[no_user_modify] bool connected;
 	[no_user_modify] bool should_connect {
@@ -36,11 +39,13 @@ class OpenTsdbWriter : ConfigObject
 
 validator OpenTsdbWriter {
 	Dictionary host_template {
+		String metric;
 		Dictionary "tags" {
 			String "*";
 		};
 	};
 	Dictionary service_template {
+		String metric;
 		Dictionary "tags" {
 			String "*";
 		};

--- a/lib/perfdata/opentsdbwriter.ti
+++ b/lib/perfdata/opentsdbwriter.ti
@@ -20,10 +20,30 @@ class OpenTsdbWriter : ConfigObject
 	[config] bool enable_ha {
 		default {{{ return false; }}}
 	};
+	[config] Dictionary::Ptr host_template {
+		default {{{ return new Dictionary(); }}}
+	
+	};
+	[config] Dictionary::Ptr service_template {
+		default {{{ return new Dictionary(); }}}
+	};
 
 	[no_user_modify] bool connected;
 	[no_user_modify] bool should_connect {
 		default {{{ return true; }}}
+	};
+};
+
+validator OpenTsdbWriter {
+	Dictionary host_template {
+		Dictionary "tags" {
+			String "*";
+		};
+	};
+	Dictionary service_template {
+		Dictionary "tags" {
+			String "*";
+		};
 	};
 };
 


### PR DESCRIPTION
Currently the OpenTsdbWriter does not allow any configuration of the tags that are sent with perfdata, it is currently hard-coded to send the hostname, object type and service name as tags.

This PR adds support to define tags to send to OpenTSDB within the config file. These tags are sent in addition to the default ones.

This functionality is almost identical to how InfluxDbWriter allows setting custom tags, which can be user defined custom attributes (vars dictionary). Most of the implementation has been adapted from InfluxDbWriter.

For existing users who are using the OpenTsdbWriter, no functionality is changed unless the config file contains the new (optional) blocks. I didn't want to change too much of the core functionality as it might break upgrades for some users.

This is my first PR; I am happy to work with you on whatever needs to be done.