### PR TITLE
Fix spelling errors.

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1713,7 +1713,7 @@ Message updates will be dropped when:
 
 The receiver constructs a virtual host object and looks for the local CheckCommand object.
 
-Returns UNKNWON as check result to the sender
+Returns UNKNOWN as check result to the sender
 
 * when the CheckCommand object does not exist.
 * when there was an exception triggered from check execution, e.g. the plugin binary could not be executed or similar.

--- a/plugins/check_nscp_api.cpp
+++ b/plugins/check_nscp_api.cpp
@@ -146,7 +146,7 @@ static int FormatOutput(const Dictionary::Ptr& result)
 		{ "OK", 0 },
 		{ "WARNING", 1},
 		{ "CRITICAL", 2},
-		{ "UNKNWON", 3}
+		{ "UNKNOWN", 3}
 	};
 
 	String state = static_cast<String>(payload->Get("result")).ToUpper();


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the 2.11.0-rc1 Debian package build:

 * UNKNWON -> UNKNOWN