### PR TITLE
Fix name of 'timeperiods' livestatus table in doc

### DIFF
--- a/doc/24-appendix.md
+++ b/doc/24-appendix.md
@@ -611,7 +611,7 @@ Not supported: `neb_callbacks`, `neb_callbacks_rate`, `requests`, `requests_rate
   host_                 | join      | Prefix for attributes from implicit join with hosts table.
 
 
-#### Livestatus Timeperiod Table Attributes <a id="schema-livestatus-timeperiod-table-attributes"></a>
+#### Livestatus Timeperiods Table Attributes <a id="schema-livestatus-timeperiods-table-attributes"></a>
 
   Key                   | Type      | Note
   ----------------------|-----------|-------------------------


### PR DESCRIPTION
In the documentation the livestatus table is mentioned as `timeperiod` but the name is `timeperiods`. 

``` 
# echo -e 'GET timeperiod\nColumns: name alias\nResponseHeader: fixed16\n\n' | netcat myicinga2 6558
404          34
Table 'timeperiod' does not exist.
```

Using the correct table name:

```
# echo -e 'GET timeperiods\nColumns: name alias\nResponseHeader: fixed16\n\n' | netcat myicinga2 6558
200         384
never;Icinga 2 never TimePeriod
shortbusinesshours;Short Businesshours Mo-Fr 09-17
psshours;psshours
businesshours;Extended Businesshours Mo-Fr 06-19
exclude-0200-0759-daily;Exclude Daily 02:00 am - 07:59 am
24x7;24x7 TimePeriod
exclude-0100-0459-daily;Exclude Daily 01:00 am - 04:59 am
sla-service-standard;SLA Service Time Standard Mo-Fr 0800-1800
sla-service-high;sla-service-high
```