### PR TITLE
Docs: Syncing binaries with the config sync are not supported

### DIFF
--- a/doc/06-distributed-monitoring.md
+++ b/doc/06-distributed-monitoring.md
@@ -1179,6 +1179,17 @@ Disadvantages:
 * Additional zone and endpoint configuration needed.
 * Replay log is replicated on reconnect after connection loss. This might increase the data transfer and create an overload on the connection.
 
+> **Note**
+>
+> This mode only supports **configuration text files** for Icinga. Do not abuse
+> this for syncing binaries, this is not supported and may harm your production
+> environment. The config sync uses checksums to detect changes, binaries may
+> trigger reload loops.
+>
+> This is a fair warning. If you want to deploy plugin binaries, create
+> packages for dependency management and use infrastructure lifecycle tools
+> such as Foreman, Puppet, Ansible, etc.
+
 To make sure that all involved nodes accept configuration and/or
 commands, you need to configure the `Zone` and `Endpoint` hierarchy
 on all nodes.

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -168,6 +168,16 @@ prior to installing new clients/agents.
 
 Technical details are available in the [technical concepts](19-technical-concepts.md#technical-concepts-cluster-config-sync) chapter.
 
+Since the config sync change detection now uses checksums, this may fail
+with anything else than syncing configuration text files. Syncing binary
+files were never supported, but rumors say that some users do so.
+
+Such binaries wrapped into JSON-RPC cluster messages may always cause changes
+and trigger reload loops. In order to prevent such harm in production,
+use infrastructure tools such as Foreman, Puppet, Ansible, etc. to install
+plugins on the masters, satellites and agents.
+
+
 #### HA-aware Features <a id="upgrading-to-2-11-cluster-ha-aware-features"></a>
 
 v2.11 introduces additional HA functionality similar to the DB IDO feature.


### PR DESCRIPTION
Adding a detection will slow down the config sync for anyone else.
Given that the loops with checksum changes only affect a few users,
the docs update is enough this time.

fixes #7382