### PR TITLE
Fix missing stats for current_concurrent_checks via REST API

### DIFF
--- a/lib/icinga/cib.cpp
+++ b/lib/icinga/cib.cpp
@@ -289,7 +289,9 @@ void CIB::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata) {
 	status->Set("active_service_checks_15min", GetActiveServiceChecksStatistics(60 * 15));
 	status->Set("passive_service_checks_15min", GetPassiveServiceChecksStatistics(60 * 15));
 
+	// Checker related stats
 	status->Set("remote_check_queue", ClusterEvents::GetCheckRequestQueueSize());
+	status->Set("current_concurrent_checks", Checkable::GetPendingChecks());
 
 	CheckableCheckStatistics scs = CalculateServiceCheckStats();
 


### PR DESCRIPTION
It was added inside the 'icinga' check task, but not for the REST API.
Thanks for asking, @Thomas-Gelf