### PR TITLE
Explicitly write the 1.x legacy attribute 'interval_length' for Livestatus

### DIFF
--- a/lib/livestatus/hoststable.cpp
+++ b/lib/livestatus/hoststable.cpp
@@ -771,7 +771,7 @@ Value HostsTable::CheckIntervalAccessor(const Value& row)
 	if (!host)
 		return Empty;
 
-	return host->GetCheckInterval() / 60.0;
+	return host->GetCheckInterval() / LIVESTATUS_INTERVAL_LENGTH;
 }
 
 Value HostsTable::RetryIntervalAccessor(const Value& row)
@@ -781,7 +781,7 @@ Value HostsTable::RetryIntervalAccessor(const Value& row)
 	if (!host)
 		return Empty;
 
-	return host->GetRetryInterval() / 60.0;
+	return host->GetRetryInterval() / LIVESTATUS_INTERVAL_LENGTH;
 }
 
 Value HostsTable::NotificationIntervalAccessor(const Value& row)

--- a/lib/livestatus/servicestable.cpp
+++ b/lib/livestatus/servicestable.cpp
@@ -792,7 +792,7 @@ Value ServicesTable::CheckIntervalAccessor(const Value& row)
 	if (!service)
 		return Empty;
 
-	return service->GetCheckInterval() / 60.0;
+	return service->GetCheckInterval() / LIVESTATUS_INTERVAL_LENGTH;
 }
 
 Value ServicesTable::RetryIntervalAccessor(const Value& row)
@@ -802,7 +802,7 @@ Value ServicesTable::RetryIntervalAccessor(const Value& row)
 	if (!service)
 		return Empty;
 
-	return service->GetRetryInterval() / 60.0;
+	return service->GetRetryInterval() / LIVESTATUS_INTERVAL_LENGTH;
 }
 
 Value ServicesTable::NotificationIntervalAccessor(const Value& row)

--- a/lib/livestatus/statustable.cpp
+++ b/lib/livestatus/statustable.cpp
@@ -67,7 +67,7 @@ void StatusTable::AddColumns(Table *table, const String& prefix,
 	table->AddColumn(prefix + "program_start", Column(&StatusTable::ProgramStartAccessor, objectAccessor));
 	table->AddColumn(prefix + "last_command_check", Column(&Table::ZeroAccessor, objectAccessor));
 	table->AddColumn(prefix + "last_log_rotation", Column(&Table::ZeroAccessor, objectAccessor));
-	table->AddColumn(prefix + "interval_length", Column(&Table::ZeroAccessor, objectAccessor));
+	table->AddColumn(prefix + "interval_length", Column(&StatusTable::IntervalLengthAccessor, objectAccessor));
 	table->AddColumn(prefix + "num_hosts", Column(&StatusTable::NumHostsAccessor, objectAccessor));
 	table->AddColumn(prefix + "num_services", Column(&StatusTable::NumServicesAccessor, objectAccessor));
 	table->AddColumn(prefix + "program_version", Column(&StatusTable::ProgramVersionAccessor, objectAccessor));
@@ -185,6 +185,11 @@ Value StatusTable::ProcessPerformanceDataAccessor(const Value&)
 Value StatusTable::ProgramStartAccessor(const Value&)
 {
 	return static_cast<long>(Application::GetStartTime());
+}
+
+Value StatusTable::IntervalLengthAccessor(const Value&)
+{
+	return LIVESTATUS_INTERVAL_LENGTH;
 }
 
 Value StatusTable::NumHostsAccessor(const Value&)

--- a/lib/livestatus/statustable.hpp
+++ b/lib/livestatus/statustable.hpp
@@ -45,6 +45,7 @@ protected:
 	static Value EnableFlapDetectionAccessor(const Value& row);
 	static Value ProcessPerformanceDataAccessor(const Value& row);
 	static Value ProgramStartAccessor(const Value& row);
+	static Value IntervalLengthAccessor(const Value& row);
 	static Value NumHostsAccessor(const Value& row);
 	static Value NumServicesAccessor(const Value& row);
 	static Value ProgramVersionAccessor(const Value& row);

--- a/lib/livestatus/table.hpp
+++ b/lib/livestatus/table.hpp
@@ -12,6 +12,9 @@
 namespace icinga
 {
 
+// Well, don't ask.
+#define LIVESTATUS_INTERVAL_LENGTH 60.0
+
 struct LivestatusRowValue {
 	Value Row;
 	LivestatusGroupByType GroupByType;


### PR DESCRIPTION
fixes #7402