### PR TITLE
Fix minimum version parsing in the 'icinga' check

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -20,6 +20,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include <boost/regex.hpp>
 #include <ios>
 #include <fstream>
 #include <iostream>
@@ -1170,6 +1171,26 @@ unsigned long Utility::SDBM(const String& str, size_t len)
 	}
 
 	return hash;
+}
+
+String Utility::ParseVersion(const String& v)
+{
+	/*
+	 * 2.11.0-0.rc1.1
+	 * v2.10.5
+	 * r2.10.3
+	 * v2.11.0-rc1-58-g7c1f716da
+	 */
+	boost::regex pattern("^[vr]?(2\\.\\d+\\.\\d+).*$");
+	boost::smatch result;
+
+	if (boost::regex_search(v.GetData(), result, pattern)) {
+		String res(result[1].first, result[1].second);
+		return res;
+	}
+
+	// Couldn't not extract anything, return unparsed version
+	return v;
 }
 
 int Utility::CompareVersion(const String& v1, const String& v2)

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -100,6 +100,7 @@ public:
 
 	static unsigned long SDBM(const String& str, size_t len = String::NPos);
 
+	static String ParseVersion(const String& v);
 	static int CompareVersion(const String& v1, const String& v2);
 
 	static int Random();

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -172,11 +172,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		}
 	}
 
-	/* Extract the version number of the running Icinga2 instance.
-	 * We assume that appVersion will allways be something like 'v2.10.1-8-gaebe6da' and we want to extract '2.10.1'.
-	 */
-	int endOfVersionNumber = appVersion.FindFirstOf("-") - 1;
-	String parsedAppVersion = appVersion.SubStr(1, endOfVersionNumber);
+	String parsedAppVersion = Utility::ParseVersion(appVersion);
 
 	/* Return an error if the version is less than specified (optional). */
 	if (missingIcingaMinVersion.IsEmpty() && !icingaMinVersion.IsEmpty() && Utility::CompareVersion(icingaMinVersion, parsedAppVersion) < 0) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,7 @@ add_boost_test(base
     base_type/byname
     base_type/instantiate
     base_utility/parse_version
+    base_utility/compare_version
     base_utility/comparepasswords_works
     base_utility/comparepasswords_issafe
     base_utility/validateutf8

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ add_boost_test(base
     base_type/assign
     base_type/byname
     base_type/instantiate
+    base_utility/parse_version
     base_utility/comparepasswords_works
     base_utility/comparepasswords_issafe
     base_utility/validateutf8

--- a/test/base-utility.cpp
+++ b/test/base-utility.cpp
@@ -8,6 +8,16 @@ using namespace icinga;
 
 BOOST_AUTO_TEST_SUITE(base_utility)
 
+BOOST_AUTO_TEST_CASE(parse_version)
+{
+	BOOST_CHECK(Utility::ParseVersion("2.11.0-0.rc1.1") == "2.11.0");
+	BOOST_CHECK(Utility::ParseVersion("v2.10.5") == "2.10.5");
+	BOOST_CHECK(Utility::ParseVersion("r2.11.1") == "2.11.1");
+	BOOST_CHECK(Utility::ParseVersion("v2.11.0-rc1-58-g7c1f716da") == "2.11.0");
+
+	BOOST_CHECK(Utility::ParseVersion("v2.11butactually3.0") == "v2.11butactually3.0");
+}
+
 BOOST_AUTO_TEST_CASE(comparepasswords_works)
 {
 	BOOST_CHECK(Utility::ComparePasswords("", ""));

--- a/test/base-utility.cpp
+++ b/test/base-utility.cpp
@@ -18,6 +18,13 @@ BOOST_AUTO_TEST_CASE(parse_version)
 	BOOST_CHECK(Utility::ParseVersion("v2.11butactually3.0") == "v2.11butactually3.0");
 }
 
+BOOST_AUTO_TEST_CASE(compare_version)
+{
+	BOOST_CHECK(Utility::CompareVersion("2.10.5", Utility::ParseVersion("v2.10.4")) < 0);
+	BOOST_CHECK(Utility::CompareVersion("2.11.0", Utility::ParseVersion("2.11.0-0")) == 0);
+	BOOST_CHECK(Utility::CompareVersion("2.10.5", Utility::ParseVersion("2.11.0-0.rc1.1")) > 0);
+}
+
 BOOST_AUTO_TEST_CASE(comparepasswords_works)
 {
 	BOOST_CHECK(Utility::ComparePasswords("", ""));


### PR DESCRIPTION
- Utility::ParseVersion with regex extraction, and unit tests
- Unit tests for Utility::CompareVersion
- Use Utility::ParseVersion in icingachecktask

fixes #7415