### PR TITLE
Fix and improve logging for runtime object sync

### DIFF
--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -240,8 +240,17 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		if (type->GetName() != "Comment" && type->GetName() != "Downtime")
 			ApiListener::UpdateObjectAuthority();
 
-		Log(LogInformation, "ConfigObjectUtility")
-			<< "Created and activated object '" << fullName << "' of type '" << type->GetName() << "'.";
+		// At this stage we should have a config object already. If not, it was ignored before.
+		auto *ctype = dynamic_cast<ConfigType *>(type.get());
+		ConfigObject::Ptr obj = ctype->GetObject(fullName);
+
+		if (obj) {
+			Log(LogInformation, "ConfigObjectUtility")
+				<< "Created and activated object '" << fullName << "' of type '" << type->GetName() << "'.";
+		} else {
+			Log(LogNotice, "ConfigObjectUtility")
+				<< "Object '" << fullName << "' was not created but ignored due to errors.";
+		}
 
 	} catch (const std::exception& ex) {
 		Utility::Remove(path);

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -277,7 +277,7 @@ void JsonRpcConnection::MessageHandler(const String& jsonString)
 	String method = vmethod;
 
 	Log(LogNotice, "JsonRpcConnection")
-		<< "Received '" << method << "' message from '" << m_Identity << "'";
+		<< "Received '" << method << "' message from identity '" << m_Identity << "'.";
 
 	Dictionary::Ptr resultMessage = new Dictionary();
 


### PR DESCRIPTION
config::UpdateObject would create a new object, but this may
have been silently ignored with 'ignore_on_error' - downtimes, etc.
Since we cannot simply fetch the error from inside the config compiler,
we'd just check whether there's a config object created at this stage.
This happens synchronously, and once there is, log something.

The previous code always logged the creation, even if the downtime
was ignored, e.g. when the first master sent one for local host objects.

This commit also adds more details: identity, endpoint, zone to extract
the MessageOrigin details into log messages for better troubleshooting
and debugging.

refs #7198