### PR TITLE
Metrics: Expose problem/handled counts for hosts/services

### DIFF
--- a/lib/icinga/cib.cpp
+++ b/lib/icinga/cib.cpp
@@ -187,8 +187,6 @@ ServiceStatistics CIB::CalculateServiceStats()
 	for (const Service::Ptr& service : ConfigType::GetObjectsByType<Service>()) {
 		ObjectLock olock(service);
 
-		CheckResult::Ptr cr = service->GetLastCheckResult();
-
 		if (service->GetState() == ServiceOK)
 			ss.services_ok++;
 		if (service->GetState() == ServiceWarning)
@@ -198,8 +196,11 @@ ServiceStatistics CIB::CalculateServiceStats()
 		if (service->GetState() == ServiceUnknown)
 			ss.services_unknown++;
 
+		CheckResult::Ptr cr = service->GetLastCheckResult();
+
 		if (!cr)
 			ss.services_pending++;
+
 		if (!service->IsReachable())
 			ss.services_unreachable++;
 
@@ -209,6 +210,11 @@ ServiceStatistics CIB::CalculateServiceStats()
 			ss.services_in_downtime++;
 		if (service->IsAcknowledged())
 			ss.services_acknowledged++;
+
+		if (service->GetHandled())
+			ss.services_handled++;
+		if (service->GetProblem())
+			ss.services_problem++;
 	}
 
 	return ss;
@@ -238,6 +244,11 @@ HostStatistics CIB::CalculateHostStats()
 			hs.hosts_in_downtime++;
 		if (host->IsAcknowledged())
 			hs.hosts_acknowledged++;
+
+		if (host->GetHandled())
+			hs.hosts_handled++;
+		if (host->GetProblem())
+			hs.hosts_problem++;
 	}
 
 	return hs;
@@ -315,6 +326,8 @@ void CIB::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata) {
 	status->Set("num_services_flapping", ss.services_flapping);
 	status->Set("num_services_in_downtime", ss.services_in_downtime);
 	status->Set("num_services_acknowledged", ss.services_acknowledged);
+	status->Set("num_services_handled", ss.services_handled);
+	status->Set("num_services_problem", ss.services_problem);
 
 	double uptime = Utility::GetTime() - Application::GetStartTime();
 	status->Set("uptime", uptime);
@@ -328,4 +341,6 @@ void CIB::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata) {
 	status->Set("num_hosts_flapping", hs.hosts_flapping);
 	status->Set("num_hosts_in_downtime", hs.hosts_in_downtime);
 	status->Set("num_hosts_acknowledged", hs.hosts_acknowledged);
+	status->Set("num_hosts_handled", hs.hosts_handled);
+	status->Set("num_hosts_problem", hs.hosts_problem);
 }

--- a/lib/icinga/cib.hpp
+++ b/lib/icinga/cib.hpp
@@ -30,6 +30,8 @@ struct ServiceStatistics {
 	double services_flapping;
 	double services_in_downtime;
 	double services_acknowledged;
+	double services_handled;
+	double services_problem;
 };
 
 struct HostStatistics {
@@ -40,6 +42,8 @@ struct HostStatistics {
 	double hosts_flapping;
 	double hosts_in_downtime;
 	double hosts_acknowledged;
+	double hosts_handled;
+	double hosts_problem;
 };
 
 /**

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -247,6 +247,12 @@ bool IcingaApplication::ResolveMacro(const String& macro, const CheckResult::Ptr
 		} else if (macro == "num_services_acknowledged") {
 			*result = ss.services_acknowledged;
 			return true;
+		} else if (macro == "num_services_handled") {
+			*result = ss.services_handled;
+			return true;
+		} else if (macro == "num_services_problem") {
+			*result = ss.services_problem;
+			return true;
 		}
 	}
 	else if (macro.Contains("num_hosts")) {
@@ -272,6 +278,12 @@ bool IcingaApplication::ResolveMacro(const String& macro, const CheckResult::Ptr
 			return true;
 		} else if (macro == "num_hosts_acknowledged") {
 			*result = hs.hosts_acknowledged;
+			return true;
+		} else if (macro == "num_hosts_handled") {
+			*result = hs.hosts_handled;
+			return true;
+		} else if (macro == "num_hosts_problem") {
+			*result = hs.hosts_problem;
 			return true;
 		}
 	}

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -99,6 +99,8 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	perfdata->Add(new PerfdataValue("num_services_flapping", ss.services_flapping));
 	perfdata->Add(new PerfdataValue("num_services_in_downtime", ss.services_in_downtime));
 	perfdata->Add(new PerfdataValue("num_services_acknowledged", ss.services_acknowledged));
+	perfdata->Add(new PerfdataValue("num_services_handled", ss.services_handled));
+	perfdata->Add(new PerfdataValue("num_services_problem", ss.services_problem));
 
 	double uptime = Utility::GetTime() - Application::GetStartTime();
 	perfdata->Add(new PerfdataValue("uptime", uptime));
@@ -112,6 +114,8 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	perfdata->Add(new PerfdataValue("num_hosts_flapping", hs.hosts_flapping));
 	perfdata->Add(new PerfdataValue("num_hosts_in_downtime", hs.hosts_in_downtime));
 	perfdata->Add(new PerfdataValue("num_hosts_acknowledged", hs.hosts_acknowledged));
+	perfdata->Add(new PerfdataValue("num_hosts_handled", hs.hosts_handled));
+	perfdata->Add(new PerfdataValue("num_hosts_problem", hs.hosts_problem));
 
 	std::vector<Endpoint::Ptr> endpoints = ConfigType::GetObjectsByType<Endpoint>();
 


### PR DESCRIPTION
With the addition of problem/handled as checkable runtime
attributes in #7096 we should also expose them via CIB
into

- icinga check
- /v1/status/CIB
- IcingaApplication runtime macros

This originates from a request by @phil-or at the recent
Icinga meetup in Linz.

<img width="639" alt="Screen Shot 2019-08-29 at 17 01 37" src="https://user-images.githubusercontent.com/382049/63954319-35951500-ca83-11e9-9b9a-4b8d001f1101.png">
