### PR TITLE
Add summarized performance data to check_network

### DIFF
--- a/plugins/check_network.cpp
+++ b/plugins/check_network.cpp
@@ -193,6 +193,7 @@ static int printOutput(printInfoStruct& printInfo, const std::vector<nInterface>
 
 	std::wcout << " " << tIn + tOut << L"B/s | "
 		<< L"'network'=" << tIn + tOut << L"B;" << printInfo.warn.pString() << L";" << printInfo.crit.pString() << L";" << L"0; "
+		<< L"'network_in'=" << tIn << L"B 'network_out'=" << tOut << L"B "
 		<< tss.str() << '\n';
 
 	return state;


### PR DESCRIPTION
This adds two new performance data values to check_network, 'network_in'
and 'network_out'.

On systems with multiple network interfaces the 'network_in' value holds
the summarized input bytes and the 'network_out' value holds the
summarized output bytes.

On systems with multiple network interfaces this comes in handy when you create graphing dashboards and want to visualize the summarized inbound/outbound bytes.