### PR TITLE
API /v1/config/stages 'activate' parameter

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1848,8 +1848,12 @@ in the Director's deployment log.
 Send a `POST` request to the URL endpoint `/v1/config/stages` and add the name of an existing
 configuration package to the URL path (e.g. `example-cmdb`).
 The request body must contain the `files` attribute with the value being
-a dictionary of file targets and their content. You can also specify an optional `reload` attribute
-that will tell icinga2 to reload after stage config validation. By default this is set to `true`.
+a dictionary of file targets and their content.
+
+Optional attributes include `reload` (defaults to `true`) and `activate` (defaults to `true`).
+The `reload` attribute will tell icinga2 to reload after stage config validation.
+The `activate` attribute will tell icinga2 to activate the stage if it validates.
+If `activate` is set to `false`, `reload` must also be `false`.
 
 The file path requires one of these two directories inside its path:
 
@@ -1898,6 +1902,10 @@ Icinga 2 automatically restarts the daemon in order to activate the new config s
 can be disabled by setting `reload` to `false` in the request.
 If the validation for the new config stage failed, the old stage
 and its configuration objects will remain active.
+
+Activation may be inhibited even for stages that validate correctly by setting
+`activate` to `false`. This may be useful for validating the contents of a stage
+without making it active, for example in a CI (continuous integration) system.
 
 > **Note**
 >

--- a/lib/remote/configpackageutility.hpp
+++ b/lib/remote/configpackageutility.hpp
@@ -37,7 +37,7 @@ public:
 	static void SetActiveStage(const String& packageName, const String& stageName);
 	static void SetActiveStageToFile(const String& packageName, const String& stageName);
 	static void ActivateStage(const String& packageName, const String& stageName);
-	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool reload);
+	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool activate, bool reload);
 
 	static std::vector<std::pair<String, bool> > GetFiles(const String& packageName, const String& stageName);
 
@@ -54,7 +54,7 @@ private:
 	static void WritePackageConfig(const String& packageName);
 	static void WriteStageConfig(const String& packageName, const String& stageName);
 
-	static void TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName, bool reload);
+	static void TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName, bool activate, bool reload);
 };
 
 }


### PR DESCRIPTION
We keep our Icinga configuration primarily in Git and deploy it using a CI pipeline by making calls to the configuration management API functionality. Some of our configuration, however, is maintained outside the Git repository (using the `icinga/icinga2` Puppet module) and is required for the configuration in Git to validate. Thus we cannot easily validate the contents of the Git repository without actually pushing it into Icinga, however we do not want to make configuration live until it hits the right branch.

This pull request introduces a new `activate` parameter for the `/v1/config/stages` POST handler. The default value is `true` which results in no change for users. When set to `false` the stage is never activated, even if it passes validation. This allows us to collect the validation results and `startup.log` in our CI pipeline and delete the stage again, without any possibility of the production configuration changing.