### PR TITLE
Add file age check for Windows command definition

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1739,6 +1739,8 @@ critical         | **Required**. The critical threshold of file age in seconds.
 
 All variables are required and all variables are positional. The variable order is: file warning critical.
 
+The check_file_age.cmd and the check_file_age.cmd.ps1 files are available for [download](https://github.com/KAMI911/icinga2-basic/tree/master/plugins).
+
 ## Plugin Check Commands for NSClient++ <a id="nscp-plugin-check-commands"></a>
 
 There are two methods available for querying NSClient++:

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1725,6 +1725,19 @@ Name             | Description
 users\_win\_warn | **Optional**. The warning threshold.
 users\_win\_crit | **Optional**. The critical threshold.
 
+### file-age-windows <a id="windows-plugins-file-age-windows"></a>
+
+Check command object for `check_file_age.cmd` command file and `check_file_age.cmd.ps1` plugin.
+
+Custom variables:
+
+Name             | Description
+:----------------|:------------
+file             | **Required**. File name and location
+warning          | **Required**. The warning threshold of file age in seconds.
+critical         | **Required**. The critical threshold of file age in seconds.
+
+All variables are required and all variables are positional. The variable order is: file warning critical.
 
 ## Plugin Check Commands for NSClient++ <a id="nscp-plugin-check-commands"></a>
 

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1731,11 +1731,11 @@ Check command object for `check_file_age.cmd` command file and `check_file_age.c
 
 Custom variables:
 
-Name             | Description
-:----------------|:------------
-file             | **Required**. File name and location
-warning          | **Required**. The warning threshold of file age in seconds.
-critical         | **Required**. The critical threshold of file age in seconds.
+Name                  | Description
+:---------------------|:------------
+file_age_win_file     | **Required**. File name and location
+file_age_win_warning  | **Required**. The warning threshold of file age in seconds.
+file_age_win_critical | **Required**. The critical threshold of file age in seconds.
 
 All variables are required and all variables are positional. The variable order is: file warning critical.
 

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -317,3 +317,38 @@ object CheckCommand "users-windows" {
 		}
 	}
 }
+
+/*
+ * Icinga2 CheckCommand definition for a file age check for Windows
+
+   check_file_age.cmd and check_file_age.cmd.ps1 files are available from here:
+     https://github.com/KAMI911/icinga2-basic/tree/master/plugins
+*/
+
+object CheckCommand "file-age-windows" {
+        command = [ PluginDir + "/check_file_age.cmd" ]
+
+        arguments = {
+                "file" = {
+                        skip_key = true
+                        order = 0
+                        value = "$file_age_file$"
+                        description = "File name and location"
+                        required = true
+                }
+                "warning" = {
+                        skip_key = true
+                        order = 1
+                        value = "$file_age_warning$"
+                        description = "Warning threshold of file age in seconds"
+                        required = true
+                }
+                "critical" = {
+                        skip_key = true
+                        order = 2
+                        value = "$file_age_critical$"
+                        description = "Critical threshold of file age in seconds"
+                        required = true
+                }
+        }
+}

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -318,13 +318,6 @@ object CheckCommand "users-windows" {
 	}
 }
 
-/*
- * Icinga2 CheckCommand definition for a file age check for Windows
-
-   check_file_age.cmd and check_file_age.cmd.ps1 files are available from here:
-     https://github.com/KAMI911/icinga2-basic/tree/master/plugins
-*/
-
 object CheckCommand "file-age-windows" {
         command = [ PluginDir + "/check_file_age.cmd" ]
 

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -317,31 +317,3 @@ object CheckCommand "users-windows" {
 		}
 	}
 }
-
-object CheckCommand "file-age-windows" {
-        command = [ PluginDir + "/check_file_age.cmd" ]
-
-        arguments = {
-                "file" = {
-                        skip_key = true
-                        order = 0
-                        value = "$file_age_file$"
-                        description = "File name and location"
-                        required = true
-                }
-                "warning" = {
-                        skip_key = true
-                        order = 1
-                        value = "$file_age_warning$"
-                        description = "Warning threshold of file age in seconds"
-                        required = true
-                }
-                "critical" = {
-                        skip_key = true
-                        order = 2
-                        value = "$file_age_critical$"
-                        description = "Critical threshold of file age in seconds"
-                        required = true
-                }
-        }
-}

--- a/itl/plugins-contrib.d/windows.conf
+++ b/itl/plugins-contrib.d/windows.conf
@@ -1,0 +1,28 @@
+
+object CheckCommand "file-age-windows" {
+        command = [ PluginDir + "/check_file_age.cmd" ]
+
+        arguments = {
+                "file" = {
+                        skip_key = true
+                        order = 0
+                        value = "$file_age_win_file$"
+                        description = "File name and location"
+                        required = true
+                }
+                "warning" = {
+                        skip_key = true
+                        order = 1
+                        value = "$file_age_win_warning$"
+                        description = "Warning threshold of file age in seconds"
+                        required = true
+                }
+                "critical" = {
+                        skip_key = true
+                        order = 2
+                        value = "$file_age_win_critical$"
+                        description = "Critical threshold of file age in seconds"
+                        required = true
+                }
+        }
+}


### PR DESCRIPTION
Add file age check plugin to Icinga 2 ITL. This is only for Windows and utilize a PowerShell script.