### PR TITLE
Performing a reload might result in zombie processes

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -54,6 +54,7 @@ double Application::m_StartTime;
 double Application::m_MainTime;
 bool Application::m_ScriptDebuggerEnabled = false;
 double Application::m_LastReloadFailed;
+bool Application::m_ReloadTimeoutOccurred = false;
 
 /**
  * Constructor for the Application class.
@@ -1180,6 +1181,16 @@ double Application::GetLastReloadFailed()
 void Application::SetLastReloadFailed(double ts)
 {
 	m_LastReloadFailed = ts;
+}
+
+bool Application::GetReloadTimeoutOccurred()
+{
+	return m_ReloadTimeoutOccurred;
+}
+
+void Application::SetReloadTimeoutOccurred(bool occurred)
+{
+	m_ReloadTimeoutOccurred = occurred;
 }
 
 void Application::ValidateName(const Lazy<String>& lvalue, const ValidationUtils& utils)

--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -104,6 +104,9 @@ public:
 	static double GetLastReloadFailed();
 	static void SetLastReloadFailed(double ts);
 
+	static bool GetReloadTimeoutOccurred();
+	static void SetReloadTimeoutOccurred(bool occurred);
+
 	static void DisplayInfoMessage(std::ostream& os, bool skipVersion = false);
 
 protected:
@@ -139,6 +142,7 @@ private:
 	static double m_MainTime;
 	static bool m_ScriptDebuggerEnabled;
 	static double m_LastReloadFailed;
+	static bool m_ReloadTimeoutOccurred;
 
 #ifdef _WIN32
 	static BOOL WINAPI CtrlHandler(DWORD type);

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -746,6 +746,8 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 						<< "Waited for " << Utility::FormatDuration(Utility::GetTime() - start) << " on old process to exit.";
 				}
 
+				Application::SetReloadTimeoutOccurred(false);
+
 				// Old instance shut down, allow the new one to continue working beyond config validation
 				(void)kill(nextWorker, SIGUSR2);
 

--- a/lib/methods/pluginchecktask.cpp
+++ b/lib/methods/pluginchecktask.cpp
@@ -55,6 +55,10 @@ void PluginCheckTask::ProcessFinishedHandler(const Checkable::Ptr& checkable, co
 	Checkable::CurrentConcurrentChecks.fetch_sub(1);
 	Checkable::DecreasePendingChecks();
 
+	if (Application::GetReloadTimeoutOccurred()) {
+		return;
+	}
+
 	if (pr.ExitStatus > 3) {
 		Process::Arguments parguments = Process::PrepareCommand(commandLine);
 		Log(LogWarning, "PluginCheckTask")


### PR DESCRIPTION
## Describe the bug

If you perform a reload and the `ReloadTimeout`-parameter is reached, all check processes that have not exited until then will become zombie processes.

## To Reproduce

1. Create a check command that runs for a long time (`sleep 300` by example) and a host/service using it
2. Define a ReloadTimeout (in /etc/icinga2/constants.conf) with a value less than the runtime of the previously defined check command
3. Wait until you see the check is being performed (`ps aux | grep sleep`)
4. Perform an reload (`systemctl reload icinga2`)
5. The process will now be listed as `[sleep] <defunct>` (using `ps aux | grep sleep`)

## Expected behavior

If the reload timeout is reached, all remaining check processes should be killed. In previous versions, there was no umbrella process, so the remaining check processes got killed during the shutdown of the old icinga2 binary. In 2.11.0, all check processes belong to the umbrella process which survives a reload.

## Your Environment

* Version 2.11.0
* checked on RHEL6 (SystemV) and RHEL7 (systemd)

## Additional context

I wrote a patch that works around this problem. If the reload timeout approaches, checkercomponent will set a flag for this situation and running processes will be killed. checkercomponent will wait up to 10 seconds until there are no pending checks anymore. Check results of processes that got killed during this phase will not be processed to avoid false positives.