### PR TITLE
MacroProcessor::ResolveArguments(): skip null argument values

### DIFF
--- a/lib/icinga/macroprocessor.cpp
+++ b/lib/icinga/macroprocessor.cpp
@@ -511,6 +511,8 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 				continue;
 			}
 
+			arg.SkipValue = arg.SkipValue || arg.AValue.GetType() == ValueEmpty;
+
 			args.emplace_back(std::move(arg));
 		}
 


### PR DESCRIPTION
fixes #7558