### PR TITLE
Add extended checks options to snmp-interface command template

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2069,7 +2069,7 @@ snmp_interface_kbits        | **Optional.** Make the warning and critical levels
 snmp_interface_megabytes    | **Optional.** Make the warning and critical levels in Mbps or MBps. **Depends** on snmp_interface_kbits set to true. Defaults to true.
 snmp_interface_64bit        | **Optional.** Use 64 bits counters instead of the standard counters when checking bandwidth & performance data for interface >= 1Gbps. Defaults to false.
 snmp_interface_errors       | **Optional.** Add error & discard to Perfparse output. Defaults to true.
-snmp_interface_extended_checks | **Optional.** Also check the error and discard input/output. Defaults to false.
+snmp_interface_extended_checks | **Optional.** Also check the error and discard input/output. When enabled format of `snmp_warn` and `snmp_crit` changes to <In bytes>,<Out bytes>,<In error>,<Out error>,<In disc>,<Out disc>. More options available in the [snmp interface](http://nagios.manubulon.com/snmp_int.html) documentation. Defaults to false.
 snmp_interface_noregexp     | **Optional.** Do not use regexp to match interface name in description OID. Defaults to false.
 snmp_interface_delta        | **Optional.** Delta time of perfcheck. Defaults to "300" (5 min).
 snmp_interface_warncrit_percent | **Optional.** Make the warning and critical levels in % of reported interface speed. If set, **snmp_interface_megabytes** needs to be set to false. Defaults to false.

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2069,6 +2069,7 @@ snmp_interface_kbits        | **Optional.** Make the warning and critical levels
 snmp_interface_megabytes    | **Optional.** Make the warning and critical levels in Mbps or MBps. **Depends** on snmp_interface_kbits set to true. Defaults to true.
 snmp_interface_64bit        | **Optional.** Use 64 bits counters instead of the standard counters when checking bandwidth & performance data for interface >= 1Gbps. Defaults to false.
 snmp_interface_errors       | **Optional.** Add error & discard to Perfparse output. Defaults to true.
+snmp_interface_extended_checks | **Optional.** Also check the error and discard input/output. Defaults to false.
 snmp_interface_noregexp     | **Optional.** Do not use regexp to match interface name in description OID. Defaults to false.
 snmp_interface_delta        | **Optional.** Delta time of perfcheck. Defaults to "300" (5 min).
 snmp_interface_warncrit_percent | **Optional.** Make the warning and critical levels in % of reported interface speed. If set, **snmp_interface_megabytes** needs to be set to false. Defaults to false.

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -271,6 +271,10 @@ object CheckCommand "snmp-interface" {
 			set_if = "$snmp_interface_errors$"
 			description = "Add error & discard to Perfparse output"
 		}
+		"-q" = {
+			set_if = "$snmp_interface_extended_checks$"
+			description = "Also check the error and discard input/output"
+		}
 		"-i" = {
 			set_if = "$snmp_interface_inverse$"
 			description = "Make critical when up"
@@ -311,6 +315,7 @@ object CheckCommand "snmp-interface" {
 	vars.snmp_interface_megabytes = true
 	vars.snmp_interface_64bit = false
 	vars.snmp_interface_errors = true
+	vars.snmp_interface_extended_checks = false
 	vars.snmp_interface_noregexp = false
 	vars.snmp_interface_delta = 300
 	vars.snmp_interface_warncrit_percent = false

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -273,7 +273,7 @@ object CheckCommand "snmp-interface" {
 		}
 		"-q" = {
 			set_if = "$snmp_interface_extended_checks$"
-			description = "Also check the error and discard input/output"
+			description = "Also check the error and discard input/output. When enabled format of snmp_warn and snmp_crit changes to <In bytes>,<Out bytes>,<In error>,<Out error>,<In disc>,<Out disc>"
 		}
 		"-i" = {
 			set_if = "$snmp_interface_inverse$"


### PR DESCRIPTION
Enables admin to configure new `snmp_interface_extended_checks` option. Setting this to `true` adds  `-q` switch to the command using [check_snmp_int.pl](http://nagios.manubulon.com/snmp_int.html) script. In this mode script should also check for interface errors and packet discards.

This changes required format of `snmp_warn` and `snmp_crit` from `"<In warn>,<Out warn>"` to `"<In bytes>,<Out bytes>,<In error>,<Out error>,<In disc>,<Out disc>"`. Should we document this? If so where?