### PR TITLE
Main(): don't call Process::InitializeSpawnHelper()

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -639,8 +639,6 @@ static int Main()
 				}
 			}
 		}
-
-		Process::InitializeSpawnHelper();
 #endif /* _WIN32 */
 
 		std::vector<std::string> args;


### PR DESCRIPTION
... to avoid zombie processes after reload.

fixes #7614