### PR TITLE
 Windows: Add ServiceAccount property to msi installer

### DIFF
--- a/icinga-installer/icinga2.wixpatch.cmake
+++ b/icinga-installer/icinga2.wixpatch.cmake
@@ -2,6 +2,7 @@
   <CPackWiXFragment Id="#PRODUCT">
     <Property Id="ALLUSERS">1</Property>
     <Property Id="MSIRESTARTMANAGERCONTROL">Disable</Property>
+	<Property Id="SERVICEACCOUNT" Hidden="yes" Value="NT AUTHORITY\NetworkService"/>
 
     <PropertyRef Id="WIX_IS_NETFRAMEWORK_46_OR_LATER_INSTALLED" />
     <Condition Message='This application requires .NET Framework 4.6 or higher. Please install the .NET Framework then run this installer again.'>
@@ -9,7 +10,7 @@
     </Condition>
 
     <CustomAction Id="XtraUpgradeNSIS" BinaryKey="icinga2_installer" ExeCommand="upgrade-nsis" Execute="deferred" Impersonate="no" />
-    <CustomAction Id="XtraInstall" FileKey="CM_FP_sbin.icinga2_installer.exe" ExeCommand="install" Execute="deferred" Impersonate="no" />
+    <CustomAction Id="XtraInstall" FileKey="CM_FP_sbin.icinga2_installer.exe" ExeCommand="install --scm-user &quot;[SERVICEACCOUNT]&quot;" Execute="deferred" Impersonate="no" />
     <CustomAction Id="XtraUninstall" FileKey="CM_FP_sbin.icinga2_installer.exe" ExeCommand="uninstall" Execute="deferred" Impersonate="no" />
 
     <Binary Id="icinga2_installer" SourceFile="$<TARGET_FILE:icinga-installer>" />


### PR DESCRIPTION
This PR adds the possibility to change the default icinga2 service user ("NT AUTHORITY\Network Service") via an msi transform. 
This PR changes two things:
- It adds an --scm-user parameter to the icinga-installer binary which then passes this parameter to the icinga2 binary.
- It adds an "SERVICEACCOUNT" property to the msi which than gets passed to the icinga-installer binary via the added --scm-user parameter.

So it is for example possible to create an MST which transforms the installation so that icinga2 runs as LocalSystem user which is useful when you want to check the state of Windows update.