### PR TITLE
Fix TLS context not being updated on signed certificate messages on agents

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -423,7 +423,7 @@ bool ApiListener::AddListener(const String& node, const String& service)
 	return true;
 }
 
-void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, Shared<boost::asio::ssl::context>::Ptr& sslContext)
+void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, const Shared<boost::asio::ssl::context>::Ptr& sslContext)
 {
 	namespace asio = boost::asio;
 

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -416,14 +416,14 @@ bool ApiListener::AddListener(const String& node, const String& service)
 	Log(LogInformation, "ApiListener")
 		<< "Started new listener on '[" << localEndpoint.address() << "]:" << localEndpoint.port() << "'";
 
-	IoEngine::SpawnCoroutine(io, [this, acceptor, sslContext](asio::yield_context yc) { ListenerCoroutineProc(yc, acceptor, sslContext); });
+	IoEngine::SpawnCoroutine(io, [this, acceptor](asio::yield_context yc) { ListenerCoroutineProc(yc, acceptor, m_SSLContext); });
 
 	UpdateStatusFile(localEndpoint);
 
 	return true;
 }
 
-void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, const Shared<boost::asio::ssl::context>::Ptr& sslContext)
+void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, Shared<boost::asio::ssl::context>::Ptr& sslContext)
 {
 	namespace asio = boost::asio;
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -153,7 +153,7 @@ private:
 
 	void NewClientHandler(boost::asio::yield_context yc, const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role);
 	void NewClientHandlerInternal(boost::asio::yield_context yc, const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role);
-	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, Shared<boost::asio::ssl::context>::Ptr& sslContext);
+	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, const Shared<boost::asio::ssl::context>::Ptr& sslContext);
 
 	WorkQueue m_RelayQueue;
 	WorkQueue m_SyncQueue{0, 4};

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -153,7 +153,7 @@ private:
 
 	void NewClientHandler(boost::asio::yield_context yc, const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role);
 	void NewClientHandlerInternal(boost::asio::yield_context yc, const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role);
-	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, const Shared<boost::asio::ssl::context>::Ptr& sslContext);
+	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server, Shared<boost::asio::ssl::context>::Ptr& sslContext);
 
 	WorkQueue m_RelayQueue;
 	WorkQueue m_SyncQueue{0, 4};


### PR DESCRIPTION
This uses the class member variable for the SSL context inside the lambda expression which is captured by `this`.

The problem occurs with the following setup:

Master:
* should connect to the agent

Agent
* removed `host` attribute for the master

1. Setup master

```
root@deb10i2m1:/# icinga2 node setup --master --disable-confd 

information/cli: Checking in existing certificates for common name 'deb10i2m1'...
information/cli: Certificates not yet generated. Running 'api setup' now.
information/cli: Generating new CA.
information/base: Writing private key to '/var/lib/icinga2/ca//ca.key'.
information/base: Writing X509 certificate to '/var/lib/icinga2/ca//ca.crt'.
information/cli: Generating new CSR in '/var/lib/icinga2/certs//deb10i2m1.csr'.
information/base: Writing private key to '/var/lib/icinga2/certs//deb10i2m1.key'.
information/base: Writing certificate signing request to '/var/lib/icinga2/certs//deb10i2m1.csr'.
information/cli: Signing CSR with CA and writing certificate to '/var/lib/icinga2/certs//deb10i2m1.crt'.
information/pki: Writing certificate to file '/var/lib/icinga2/certs//deb10i2m1.crt'.
information/cli: Copying CA certificate to '/var/lib/icinga2/certs//ca.crt'.
information/cli: Generating master configuration for Icinga 2.
information/cli: Adding new ApiUser 'root' in '/etc/icinga2/conf.d/api-users.conf'.
information/cli: Reading '/etc/icinga2/icinga2.conf'.
information/cli: Enabling the 'api' feature.
Enabling feature api. Make sure to restart Icinga 2 for these changes to take effect.
information/cli: Generating zone and object configuration.
information/cli: Dumping config items to file '/etc/icinga2/zones.conf'.
information/cli: Created backup file '/etc/icinga2/zones.conf.orig'.
information/cli: Updating the APIListener feature.
information/cli: Created backup file '/etc/icinga2/features-available/api.conf.orig'.
information/cli: Updating 'NodeName' constant in '/etc/icinga2/constants.conf'.
information/cli: Created backup file '/etc/icinga2/constants.conf.orig'.
information/cli: Updating 'ZoneName' constant in '/etc/icinga2/constants.conf'.
information/cli: Backup file '/etc/icinga2/constants.conf.orig' already exists. Skipping backup.
information/cli: Updating 'TicketSalt' constant in '/etc/icinga2/constants.conf'.
information/cli: Backup file '/etc/icinga2/constants.conf.orig' already exists. Skipping backup.
information/cli: Edit the api feature config file '/etc/icinga2/features-available/api.conf' and set a secure 'ticket_salt' attribute.
information/cli: Updating '"conf.d"' include in '/etc/icinga2/icinga2.conf'.
information/cli: Created backup file '/etc/icinga2/icinga2.conf.orig'.
information/cli: Disabled conf.d inclusion
information/cli: Updating '"conf.d/api-users.conf"' include in '/etc/icinga2/icinga2.conf'.
information/cli: Backup file '/etc/icinga2/icinga2.conf.orig' already exists. Skipping backup.
information/cli: Make sure to restart Icinga 2.
```

2. Add agent to masters `zone.conf`

```
root@deb10i2m1:/# vim /etc/icinga2/zones.conf

/*
 * Generated by Icinga 2 node setup commands
 * on 2019-11-25 21:29:20 +0000
 */

object Endpoint "deb10i2m1" {
}

object Zone "master" {
	endpoints = [ "deb10i2m1" ]
}

object Zone "global-templates" {
	global = true
}

object Zone "director-global" {
	global = true
}

object Endpoint "deb10i2c1" {
	host = "172.17.0.3"
}

object Zone "deb10i2c1" {
	parent = "master"
	endpoints = [ "deb10i2c1" ]
}
```

And (re)start the master.

3. Setup agent using the wizard

```
root@deb10i2c1:/# icinga2 node wizard   
    
Welcome to the Icinga 2 Setup Wizard!

We will guide you through all required configuration details.

Please specify if this is an agent/satellite setup ('n' installs a master setup) [Y/n]:  

Starting the Agent/Satellite setup routine...

Please specify the common name (CN) [deb10i2c1]: 

Please specify the parent endpoint(s) (master or satellite) where this node should connect to:
Master/Satellite Common Name (CN from your master/satellite node): deb10i2m1

Do you want to establish a connection to the parent node from this node? [Y/n]: 
Please specify the master/satellite connection information:
Master/Satellite endpoint host (IP address or FQDN): 172.17.0.2
Master/Satellite endpoint port [5665]: 

Add more master/satellite endpoints? [y/N]: 
Parent certificate information:

 Subject:     CN = deb10i2m1
 Issuer:      CN = Icinga CA
 Valid From:  Nov 25 21:29:20 2019 GMT
 Valid Until: Nov 21 21:29:20 2034 GMT
 Fingerprint: DF 76 B5 03 88 D0 EE 38 D1 4E 55 A2 0F B3 3D E9 97 65 78 BF 

Is this information correct? [y/N]: y

Please specify the request ticket generated on your Icinga 2 master (optional).
 (Hint: # icinga2 pki ticket --cn 'deb10i2c1'): 

No ticket was specified. Please approve the certificate signing request manually
on the master (see 'icinga2 ca list' and 'icinga2 ca sign --help' for details).
Please specify the API bind host/port (optional):
Bind Host []: 
Bind Port []: 

Accept config from parent node? [y/N]: y
Accept commands from parent node? [y/N]: y

Reconfiguring Icinga...
Disabling feature notification. Make sure to restart Icinga 2 for these changes to take effect.
Enabling feature api. Make sure to restart Icinga 2 for these changes to take effect.

Local zone name [deb10i2c1]: 
Parent zone name [master]: 

Default global zones: global-templates director-global
Do you want to specify additional global zones? [y/N]: 

Do you want to disable the inclusion of the conf.d directory [Y/n]: 
Disabling the inclusion of the conf.d directory...

Done.

Now restart your Icinga 2 daemon to finish the installation!

```

4. Remove `host` attribute from agents `zones.conf` file

```
root@deb10i2c1:/# vim /etc/icinga2/zones.conf

/*
 * Generated by Icinga 2 node setup commands
 * on 2019-11-25 21:34:44 +0000
 */

object Endpoint "deb10i2m1" {
}

object Zone "master" {
	endpoints = [ "deb10i2m1" ]
}

object Endpoint "deb10i2c1" {
}

object Zone "deb10i2c1" {
	endpoints = [ "deb10i2c1" ]
	parent = "master"
}

object Zone "global-templates" {
	global = true
}

object Zone "director-global" {
	global = true
}
``` 

5. Now restart the agent to apply the configuration changes

6. Sign the CSR on the master

```
root@deb10i2m1:/# icinga2 ca sign 791301d98c0316a8d99e37c96e1e9d75de554d52a0305ba741bf811ddccae56d
information/cli: Signed certificate for 'CN = deb10i2c1'.
```
7. Watch the agents log

```
[2019-11-25 21:39:14 +0000] information/ApiListener: New client connection for identity 'deb10i2m1' from [172.17.0.2]:36322
[2019-11-25 21:39:14 +0000] information/ApiListener: Requesting new certificate for this Icinga instance from endpoint 'deb10i2m1'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Sending config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Finished sending config file updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Finished syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Finished sending runtime config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Finished sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:14 +0000] information/ApiListener: Finished syncing endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:14 +0000] information/JsonRpcConnection: Received certificate update message for CN 'deb10i2c1'
[2019-11-25 21:39:14 +0000] information/JsonRpcConnection: Updating CA certificate in '/var/lib/icinga2/certs//ca.crt'.
[2019-11-25 21:39:14 +0000] information/JsonRpcConnection: Updating client certificate for CN 'deb10i2c1' in '/var/lib/icinga2/certs//deb10i2c1.crt'.
[2019-11-25 21:39:14 +0000] information/JsonRpcConnection: Updating the client certificate for CN 'deb10i2c1' at runtime and reconnecting the endpoints.
[2019-11-25 21:39:14 +0000] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2m1'
[2019-11-25 21:39:14 +0000] warning/ApiListener: Removing API client for endpoint 'deb10i2m1'. 0 API clients left.
[2019-11-25 21:39:24 +0000] information/ApiListener: New client connection for identity 'deb10i2m1' from [172.17.0.2]:36326
[2019-11-25 21:39:24 +0000] information/ApiListener: Requesting new certificate for this Icinga instance from endpoint 'deb10i2m1'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Sending config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Finished sending config file updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Finished syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Finished sending runtime config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Finished sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:24 +0000] information/ApiListener: Finished syncing endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:24 +0000] information/JsonRpcConnection: Received certificate update message for CN 'deb10i2c1'
[2019-11-25 21:39:24 +0000] information/JsonRpcConnection: Updating CA certificate in '/var/lib/icinga2/certs//ca.crt'.
[2019-11-25 21:39:24 +0000] information/JsonRpcConnection: Updating client certificate for CN 'deb10i2c1' in '/var/lib/icinga2/certs//deb10i2c1.crt'.
[2019-11-25 21:39:24 +0000] information/JsonRpcConnection: Updating the client certificate for CN 'deb10i2c1' at runtime and reconnecting the endpoints.
[2019-11-25 21:39:24 +0000] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2m1'
[2019-11-25 21:39:24 +0000] warning/ApiListener: Removing API client for endpoint 'deb10i2m1'. 0 API clients left.
[2019-11-25 21:39:34 +0000] information/ApiListener: New client connection for identity 'deb10i2m1' from [172.17.0.2]:36330
[2019-11-25 21:39:34 +0000] information/ApiListener: Requesting new certificate for this Icinga instance from endpoint 'deb10i2m1'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Sending config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Finished sending config file updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Finished syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Finished sending runtime config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Finished sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:34 +0000] information/ApiListener: Finished syncing endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:34 +0000] information/JsonRpcConnection: Received certificate update message for CN 'deb10i2c1'
[2019-11-25 21:39:34 +0000] information/JsonRpcConnection: Updating CA certificate in '/var/lib/icinga2/certs//ca.crt'.
[2019-11-25 21:39:34 +0000] information/JsonRpcConnection: Updating client certificate for CN 'deb10i2c1' in '/var/lib/icinga2/certs//deb10i2c1.crt'.
[2019-11-25 21:39:34 +0000] information/JsonRpcConnection: Updating the client certificate for CN 'deb10i2c1' at runtime and reconnecting the endpoints.
[2019-11-25 21:39:34 +0000] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2m1'
[2019-11-25 21:39:34 +0000] warning/ApiListener: Removing API client for endpoint 'deb10i2m1'. 0 API clients left.
[2019-11-25 21:39:44 +0000] information/ApiListener: New client connection for identity 'deb10i2m1' from [172.17.0.2]:36332
[2019-11-25 21:39:44 +0000] information/ApiListener: Requesting new certificate for this Icinga instance from endpoint 'deb10i2m1'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Sending config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Finished sending config file updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Finished syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Finished sending runtime config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Finished sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:44 +0000] information/ApiListener: Finished syncing endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:44 +0000] information/JsonRpcConnection: Received certificate update message for CN 'deb10i2c1'
[2019-11-25 21:39:44 +0000] information/JsonRpcConnection: Updating CA certificate in '/var/lib/icinga2/certs//ca.crt'.
[2019-11-25 21:39:44 +0000] information/JsonRpcConnection: Updating client certificate for CN 'deb10i2c1' in '/var/lib/icinga2/certs//deb10i2c1.crt'.
[2019-11-25 21:39:44 +0000] information/JsonRpcConnection: Updating the client certificate for CN 'deb10i2c1' at runtime and reconnecting the endpoints.
[2019-11-25 21:39:44 +0000] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2m1'
[2019-11-25 21:39:44 +0000] warning/ApiListener: Removing API client for endpoint 'deb10i2m1'. 0 API clients left.
[2019-11-25 21:39:54 +0000] information/ApiListener: New client connection for identity 'deb10i2m1' from [172.17.0.2]:36334
[2019-11-25 21:39:54 +0000] information/ApiListener: Requesting new certificate for this Icinga instance from endpoint 'deb10i2m1'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Sending config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Finished sending config file updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Finished syncing runtime objects to endpoint 'deb10i2m1'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Finished sending runtime config updates for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Finished sending replay log for endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:54 +0000] information/ApiListener: Finished syncing endpoint 'deb10i2m1' in zone 'master'.
[2019-11-25 21:39:54 +0000] information/JsonRpcConnection: Received certificate update message for CN 'deb10i2c1'
[2019-11-25 21:39:54 +0000] information/JsonRpcConnection: Updating CA certificate in '/var/lib/icinga2/certs//ca.crt'.
[2019-11-25 21:39:54 +0000] information/JsonRpcConnection: Updating client certificate for CN 'deb10i2c1' in '/var/lib/icinga2/certs//deb10i2c1.crt'.
[2019-11-25 21:39:54 +0000] information/JsonRpcConnection: Updating the client certificate for CN 'deb10i2c1' at runtime and reconnecting the endpoints.
[2019-11-25 21:39:54 +0000] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2m1'
[2019-11-25 21:39:54 +0000] warning/ApiListener: Removing API client for endpoint 'deb10i2m1'. 0 API clients left.
```

Notice that the agents always updates the certificate. The agent is in a loop. A restart of the agent ends the loop and the master can successfully connect and performs no further certificate updates.

While the agent was stuck in the loop I connected to the agent with `openssl s_client`. The used certificate was not updated, the issuer of the certificate was the agent and not the Icinga CA. After the agent restarts the correct certificate was used (issuer: Icinga CA). 

fixes #7650