### PR TITLE
Improve error message for POST queries

### DIFF
--- a/lib/remote/modifyobjecthandler.cpp
+++ b/lib/remote/modifyobjecthandler.cpp
@@ -65,7 +65,8 @@ bool ModifyObjectHandler::HandleRequest(
 
 	if (attrsVal.GetReflectionType() != Dictionary::TypeInstance) {
 		HttpUtility::SendJsonError(response, params, 400,
-			"Invalid type for 'attrs' attribute specified. Dictionary type is required.");
+			"Invalid type for 'attrs' attribute specified. Dictionary type is required."
+			"Or is this a POST query and you missed adding a 'X-HTTP-Method-Override: GET' header?");
 		return true;
 	}
 


### PR DESCRIPTION
If the user does a POST query but forgets to add the
'X-HTTP-Method-Override: GET' HTP header, the error message was
misleading. This changes the error message to a more detailed message
which might give the user a better understanding what the problem
could be.

Fixes #7675.