### PR TITLE
Fix open connections when agent waits for CA approval

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -243,6 +243,8 @@ delayed_request:
 	Log(LogInformation, "JsonRpcConnection")
 		<< "Certificate request for CN '" << cn << "' is pending. Waiting for approval.";
 
+    client->Disconnect();
+
 	return result;
 }
 


### PR DESCRIPTION
This closes the agent connection when the certificate sign requests
waits for CA approval.

For testing this use the setup from https://github.com/Icinga/icinga2/issues/7680#issuecomment-561340075. 

Monitor the open files with:

```
(for pid in $(pidof icinga2); do lsof -p $pid; done) | wc -l
```

The amount should be constant.

Before:

```
[2019-12-03 20:10:13 +0000] information/ApiListener: Reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:13 +0000] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2a1': code 18: self signed certificate
[2019-12-03 20:10:13 +0000] information/ApiListener: New client connection for identity 'deb10i2a1' to [172.17.0.3]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:10:13 +0000] information/ApiListener: Finished reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:13 +0000] information/JsonRpcConnection: Received certificate request for CN 'deb10i2a1' not signed by our CA.
[2019-12-03 20:10:13 +0000] information/JsonRpcConnection: Certificate request for CN 'deb10i2a1' is pending. Waiting for approval.
[2019-12-03 20:10:23 +0000] information/ApiListener: Reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:23 +0000] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2a1': code 18: self signed certificate
[2019-12-03 20:10:23 +0000] information/ApiListener: New client connection for identity 'deb10i2a1' to [172.17.0.3]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:10:23 +0000] information/ApiListener: Finished reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:23 +0000] information/JsonRpcConnection: Received certificate request for CN 'deb10i2a1' not signed by our CA.
[2019-12-03 20:10:23 +0000] information/JsonRpcConnection: Certificate request for CN 'deb10i2a1' is pending. Waiting for approval.
[2019-12-03 20:10:33 +0000] information/ApiListener: Reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:33 +0000] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2a1': code 18: self signed certificate
[2019-12-03 20:10:33 +0000] information/ApiListener: New client connection for identity 'deb10i2a1' to [172.17.0.3]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:10:33 +0000] information/ApiListener: Finished reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:33 +0000] information/JsonRpcConnection: Received certificate request for CN 'deb10i2a1' not signed by our CA.
[2019-12-03 20:10:33 +0000] information/JsonRpcConnection: Certificate request for CN 'deb10i2a1' is pending. Waiting for approval.
[2019-12-03 20:10:43 +0000] information/ApiListener: Reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:43 +0000] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2a1': code 18: self signed certificate
[2019-12-03 20:10:43 +0000] information/ApiListener: New client connection for identity 'deb10i2a1' to [172.17.0.3]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:10:43 +0000] information/ApiListener: Finished reconnecting to endpoint 'deb10i2a1' via host '172.17.0.3' and port '5665'
[2019-12-03 20:10:43 +0000] information/JsonRpcConnection: Received certificate request for CN 'deb10i2a1' not signed by our CA.
[2019-12-03 20:10:43 +0000] information/JsonRpcConnection: Certificate request for CN 'deb10i2a1' is pending. Waiting for approval.

```

After:

```
[2019-12-03 20:54:46 +0100] information/ApiListener: Reconnecting to endpoint 'deb10i2c1' via host '172.17.0.2' and port '5665'
[2019-12-03 20:54:46 +0100] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2c1': code 18: self signed certificate
[2019-12-03 20:54:46 +0100] information/ApiListener: New client connection for identity 'deb10i2c1' to [172.17.0.2]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:54:46 +0100] information/ApiListener: Finished reconnecting to endpoint 'deb10i2c1' via host '172.17.0.2' and port '5665'
[2019-12-03 20:54:46 +0100] information/JsonRpcConnection: Received certificate request for CN 'deb10i2c1' not signed by our CA.
[2019-12-03 20:54:46 +0100] information/JsonRpcConnection: Certificate request for CN 'deb10i2c1' is pending. Waiting for approval.
[2019-12-03 20:54:46 +0100] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2c1'
[2019-12-03 20:54:46 +0100] information/ConfigObject: Dumping program state to file '/usr/local/icinga2/var/lib/icinga2/icinga2.state'
[2019-12-03 20:54:56 +0100] information/ApiListener: New client connection for identity 'deb10i2c1' from [172.17.0.2]:53020 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:54:56 +0100] information/JsonRpcConnection: Received certificate request for CN 'deb10i2c1' not signed by our CA.
[2019-12-03 20:54:56 +0100] information/JsonRpcConnection: Certificate request for CN 'deb10i2c1' is pending. Waiting for approval.
[2019-12-03 20:54:56 +0100] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2c1'
[2019-12-03 20:54:56 +0100] information/ApiListener: Reconnecting to endpoint 'deb10i2c1' via host '172.17.0.2' and port '5665'
[2019-12-03 20:54:56 +0100] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2c1': code 18: self signed certificate
[2019-12-03 20:54:56 +0100] information/ApiListener: New client connection for identity 'deb10i2c1' to [172.17.0.2]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:54:56 +0100] information/ApiListener: Finished reconnecting to endpoint 'deb10i2c1' via host '172.17.0.2' and port '5665'
[2019-12-03 20:54:56 +0100] information/JsonRpcConnection: Received certificate request for CN 'deb10i2c1' not signed by our CA.
[2019-12-03 20:54:56 +0100] information/JsonRpcConnection: Certificate request for CN 'deb10i2c1' is pending. Waiting for approval.
[2019-12-03 20:54:56 +0100] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2c1'
[2019-12-03 20:55:06 +0100] information/ApiListener: New client connection for identity 'deb10i2c1' from [172.17.0.2]:53026 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:55:06 +0100] information/JsonRpcConnection: Received certificate request for CN 'deb10i2c1' not signed by our CA.
[2019-12-03 20:55:06 +0100] information/JsonRpcConnection: Certificate request for CN 'deb10i2c1' is pending. Waiting for approval.
[2019-12-03 20:55:06 +0100] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2c1'
[2019-12-03 20:55:06 +0100] information/ApiListener: Reconnecting to endpoint 'deb10i2c1' via host '172.17.0.2' and port '5665'
[2019-12-03 20:55:06 +0100] warning/ApiListener: Certificate validation failed for endpoint 'deb10i2c1': code 18: self signed certificate
[2019-12-03 20:55:06 +0100] information/ApiListener: New client connection for identity 'deb10i2c1' to [172.17.0.2]:5665 (certificate validation failed: code 18: self signed certificate)
[2019-12-03 20:55:06 +0100] information/ApiListener: Finished reconnecting to endpoint 'deb10i2c1' via host '172.17.0.2' and port '5665'
[2019-12-03 20:55:06 +0100] information/JsonRpcConnection: Received certificate request for CN 'deb10i2c1' not signed by our CA.
[2019-12-03 20:55:06 +0100] information/JsonRpcConnection: Certificate request for CN 'deb10i2c1' is pending. Waiting for approval.
[2019-12-03 20:55:06 +0100] warning/JsonRpcConnection: API client disconnected for identity 'deb10i2c1'


```

fixes #7680