### PR TITLE
IcingaDB: Fix enumeral mismatch compiler warnings

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1237,7 +1237,7 @@ void IcingaDB::SendStatusUpdate(const ConfigObject::Ptr& object, const CheckResu
 	if (!cr) {
 		hard_state = 99;
 	} else {
-		hard_state = service ? service->GetLastHardState() : host->GetLastHardState();
+		hard_state = service ? Convert::ToLong(service->GetLastHardState()) : Convert::ToLong(host->GetLastHardState());
 	}
 
 	std::vector<String> xAdd ({
@@ -1246,7 +1246,7 @@ void IcingaDB::SendStatusUpdate(const ConfigObject::Ptr& object, const CheckResu
 		"environment_id", SHA1(GetEnvironment()),
 		"host_id", GetObjectIdentifier(host),
 		"state_type", Convert::ToString(type),
-		"soft_state", Convert::ToString(cr ? service ? cr->GetState() : Host::CalculateState(cr->GetState()) : 99),
+		"soft_state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetState()) : Convert::ToLong(Host::CalculateState(cr->GetState())) : 99),
 		"hard_state", Convert::ToString(hard_state),
 		"attempt", Convert::ToString(checkable->GetCheckAttempt()),
 		"previous_soft_state", Convert::ToString(GetPreviousState(checkable, service, StateTypeSoft)),
@@ -1322,7 +1322,7 @@ void IcingaDB::SendSentNotification(
 		"notification_id", GetObjectIdentifier(notification),
 		"host_id", GetObjectIdentifier(host),
 		"type", Convert::ToString(type),
-		"state", Convert::ToString(service ? cr->GetState() : Host::CalculateState(cr->GetState())),
+		"state", Convert::ToString(service ? Convert::ToLong(cr->GetState()) : Convert::ToLong(Host::CalculateState(cr->GetState()))),
 		"previous_hard_state", Convert::ToString(GetPreviousState(checkable, service, StateTypeHard)),
 		"author", Utility::ValidateUTF8(author),
 		"text", Utility::ValidateUTF8(finalText),


### PR DESCRIPTION
This fixes 3 enumeral mismatch compiler warnings when building the
IcingaDB target.

```
/home/michael/Development/Icinga/icinga2/lib/icingadb/icingadb-objects.cpp: In member function ‘void icinga::IcingaDB::SendStatusUpdate(const Ptr&, const Ptr&, icinga::StateType)’:
/home/michael/Development/Icinga/icinga2/lib/icingadb/icingadb-objects.cpp:1225:24: warning: enumeral mismatch in conditional expression: ‘icinga::ServiceState’ vs ‘icinga::HostState’ [-Wenum-compare]
   hard_state = service ? service->GetLastHardState() : host->GetLastHardState();
                ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/michael/Development/Icinga/icinga2/lib/icingadb/icingadb-objects.cpp:1234:48: warning: enumeral mismatch in conditional expression: ‘icinga::ServiceState’ vs ‘icinga::HostState’ [-Wenum-compare]
   "soft_state", Convert::ToString(cr ? service ? cr->GetState() : Host::CalculateState(cr->GetState()) : 99),
                                        ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/michael/Development/Icinga/icinga2/lib/icingadb/icingadb-objects.cpp: In member function ‘void icinga::IcingaDB::SendSentNotification(const Ptr&, const Ptr&, const std::set<boost::intrusive_ptr<icinga::User> >&, icinga::NotificationType, const Ptr&, const icinga::String&, const icinga::String&)’:
/home/michael/Development/Icinga/icinga2/lib/icingadb/icingadb-objects.cpp:1310:38: warning: enumeral mismatch in conditional expression: ‘icinga::ServiceState’ vs ‘icinga::HostState’ [-Wenum-compare]
   "state", Convert::ToString(service ? cr->GetState() : Host::CalculateState(cr->GetState())),
                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The occur on Debian 10 with GCC `gcc (Debian 8.3.0-6) 8.3.0`