### PR TITLE
Don't send Heartbeat messages when connection is unauthenticated

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -54,8 +54,11 @@ void JsonRpcConnection::Start()
 
 	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { HandleIncomingMessages(yc); });
 	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { WriteOutgoingMessages(yc); });
-	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { HandleAndWriteHeartbeats(yc); });
 	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { CheckLiveness(yc); });
+
+	// Only send heartbeat messages when the connection is unauthenticated.
+	if (m_Authenticated)
+        IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { HandleAndWriteHeartbeats(yc); });
 }
 
 void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)


### PR DESCRIPTION
Do not send Heartbeat messages when the connection is not authenticated.

# Context

When a new JSON-RPC connection is established we start to sent heartbeat messages, even if the connection is not authenticated (e.g. certificate not signed). If the connection stalls for some reason and the answer to the heartbeat message is not received in time we disconnect the client. 

https://github.com/Icinga/icinga2/blob/202e90b62654033b29c983ee5f2e40e3b7c516b8/lib/remote/jsonrpcconnection-heartbeat.cpp#L30-L35

# Problem

On unauthenticated connections we don't set the `m_Endpoint` variable, only when authenticated. In the log message from above we use `m_Endpoint` variable which will result in a crash. 

https://github.com/Icinga/icinga2/blob/202e90b62654033b29c983ee5f2e40e3b7c516b8/lib/remote/jsonrpcconnection.cpp#L45-L46

I think it is not necessary to send heartbeat messages on unauthenticated connections. But I may not see the full scope here. I'll leave this PR as draft and maybe @dnsmichi and @Al2Klimov can have a look? :-)

This may have an influence on #7569 and #7687. 