### PR TITLE
Fix notification scripts to stay compatible with Dash 

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -103,7 +103,6 @@ done
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] Host $HOSTDISPLAYNAME is $HOSTSTATE!"
-ENCODED_SUBJECT="=?utf-8?B?$(base64 --wrap=0 <<< "$SUBJECT")?="
 
 ## Build the notification message
 NOTIFICATION_MESSAGE=`cat << EOF
@@ -158,15 +157,13 @@ if [ -n "$MAILFROM" ] ; then
 
   ## Debian/Ubuntu use mailutils which requires `-a` to append the header
   if [ -f /etc/debian_version ]; then
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE"  | tr -d '\015' \
-    | $MAILBIN -a "From: $MAILFROM" -s "$ENCODED_SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
   ## Other distributions (RHEL/SUSE/etc.) prefer mailx which sets a sender address with `-r`
   else
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-    | $MAILBIN -r "$MAILFROM" -s "$ENCODED_SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -r "$MAILFROM" -s "$SUBJECT" $USEREMAIL
   fi
 
 else
-  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$ENCODED_SUBJECT" $USEREMAIL
+  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" \
+  | $MAILBIN -s "$SUBJECT" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -94,32 +94,12 @@ shift $((OPTIND - 1))
 
 ## Keep formatting in sync with mail-service-notification.sh
 for P in LONGDATETIME HOSTNAME HOSTDISPLAYNAME HOSTOUTPUT HOSTSTATE USEREMAIL NOTIFICATIONTYPE ; do
-  eval "PAR=\$${P}"
+	eval "PAR=\$${P}"
 
-  if [ ! "$PAR" ] ; then
-    Error "Required parameter '$P' is missing."
-  fi
+	if [ ! "$PAR" ] ; then
+		Error "Required parameter '$P' is missing."
+	fi
 done
-
-## Add line-breaks to very long host-outputs to avoid
-## mail servers rejecting the message because of hitting
-## a max. message line limit (RFC821 max. 1000b per line)
-##
-## but move on, if the strings seems to take care of its
-## own formating (containing \n or \r)
-if [ ! -z "${HOSTOUTPUT}" ] \
-   && [ "${#HOSTOUTPUT}" -ge 900 ] \
-   && ! [[ "${HOSTOUTPUT}" =~ ($'\n'|$'\r') ]]; then
-  TMP_OUTPUT=''
-  STR_CNT=0
-  STR_STEPS=600
-  while [ $STR_CNT -lt ${#HOSTOUTPUT} ]; do
-    TMP_OUTPUT+="${HOSTOUTPUT:$STR_CNT:$STR_STEPS}\\n"
-    ((STR_CNT+=STR_STEPS)) || true
-  done
-  HOSTOUTPUT="${TMP_OUTPUT}"
-  unset TMP_OUTPUT STR_CNT
-fi
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] Host $HOSTDISPLAYNAME is $HOSTSTATE!"

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -107,7 +107,6 @@ done
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE!"
-ENCODED_SUBJECT="=?utf-8?B?$(base64 --wrap=0 <<< "$SUBJECT")?="
 
 ## Build the notification message
 NOTIFICATION_MESSAGE=`cat << EOF
@@ -163,15 +162,13 @@ if [ -n "$MAILFROM" ] ; then
 
   ## Debian/Ubuntu use mailutils which requires `-a` to append the header
   if [ -f /etc/debian_version ]; then
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-    | $MAILBIN -a "From: $MAILFROM" -s "$ENCODED_SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
   ## Other distributions (RHEL/SUSE/etc.) prefer mailx which sets a sender address with `-r`
   else
-    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-    | $MAILBIN -r "$MAILFROM" -s "$ENCODED_SUBJECT" $USEREMAIL
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | $MAILBIN -r "$MAILFROM" -s "$SUBJECT" $USEREMAIL
   fi
 
 else
-  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$ENCODED_SUBJECT" $USEREMAIL
+  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" \
+  | $MAILBIN -s "$SUBJECT" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -98,32 +98,12 @@ shift $((OPTIND - 1))
 
 ## Keep formatting in sync with mail-host-notification.sh
 for P in LONGDATETIME HOSTNAME HOSTDISPLAYNAME SERVICENAME SERVICEDISPLAYNAME SERVICEOUTPUT SERVICESTATE USEREMAIL NOTIFICATIONTYPE ; do
-  eval "PAR=\$${P}"
+        eval "PAR=\$${P}"
 
-  if [ ! "$PAR" ] ; then
-    Error "Required parameter '$P' is missing."
-  fi
+        if [ ! "$PAR" ] ; then
+                Error "Required parameter '$P' is missing."
+        fi
 done
-
-## Add line-breaks to very long service-outputs to avoid
-## mail servers rejecting the message because of hitting
-## a max. message line limit (RFC821 max. 1000b per line)
-##
-## but move on, if the strings seems to take care of its
-## own formating (containing \n or \r)
-if [ ! -z "${SERVICEOUTPUT}" ] \
-   && [ "${#SERVICEOUTPUT}" -ge 900 ] \
-   && ! [[ "${SERVICEOUTPUT}" =~ ($'\n'|$'\r') ]]; then
-   TMP_OUTPUT=''
-   STR_CNT=0
-   STR_STEPS=600
-   while [ $STR_CNT -lt ${#SERVICEOUTPUT} ]; do
-      TMP_OUTPUT+="${SERVICEOUTPUT:$STR_CNT:$STR_STEPS}\\n"
-      ((STR_CNT+=STR_STEPS)) || true
-   done
-   SERVICEOUTPUT="${TMP_OUTPUT}"
-   unset TMP_OUTPUT STR_CNT
-fi
 
 ## Build the message's subject
 SUBJECT="[$NOTIFICATIONTYPE] $SERVICEDISPLAYNAME on $HOSTDISPLAYNAME is $SERVICESTATE!"


### PR DESCRIPTION
This reverts the changes #6369 and #6822. Unfortunately they are not compatible with Dash on Debian/Ubuntu. For example `[[` and `<<<` are not available in Dash. 

fixes #7648