### PR TITLE
Feature/execute shutdown command

### DIFF
--- a/lib/icinga/CMakeLists.txt
+++ b/lib/icinga/CMakeLists.txt
@@ -61,6 +61,7 @@ set(icinga_SOURCES
   timeperiod.cpp timeperiod.hpp timeperiod-ti.hpp
   user.cpp user.hpp user-ti.hpp
   usergroup.cpp usergroup.hpp usergroup-ti.hpp
+  commandutils.cpp commandutils.hpp
 )
 
 if(ICINGA2_UNITY_BUILD)

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -53,7 +53,7 @@ Dictionary::Ptr ApiActions::ShutdownHost(const ConfigObject::Ptr& object,
     }
 
     Checkable::Ptr custom_checkable;
-    custom_checkable = host->GetServiceByShortName("neteye-shutdown-manager-enabled");
+    custom_checkable = host->GetServiceByShortName("shutdown-service");
     if (! custom_checkable){
         return ApiActions::CreateResult(404, "Checkable service not found.");
     }

--- a/lib/icinga/apiactions.hpp
+++ b/lib/icinga/apiactions.hpp
@@ -29,6 +29,7 @@ public:
 	static Dictionary::Ptr ShutdownProcess(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
 	static Dictionary::Ptr RestartProcess(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
 	static Dictionary::Ptr GenerateTicket(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
+	static Dictionary::Ptr ShutdownHost(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
 
 private:
 	static Dictionary::Ptr CreateResult(int code, const String& status, const Dictionary::Ptr& additional = nullptr);

--- a/lib/icinga/clusterevents.hpp
+++ b/lib/icinga/clusterevents.hpp
@@ -46,6 +46,7 @@ public:
 	static Value AcknowledgementClearedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
 	static Value ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
+	static Value ExecuteCommandWithMacrosAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
 	static Dictionary::Ptr MakeCheckResultMessage(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 

--- a/lib/icinga/commandutils.cpp
+++ b/lib/icinga/commandutils.cpp
@@ -1,0 +1,73 @@
+#include "icinga/commandutils.hpp"
+#include "icinga/host.hpp"
+#include "icinga/checkcommand.hpp"
+#include "remote/apilistener.hpp"
+#include "remote/httputility.hpp"
+
+using namespace icinga;
+
+
+void CommandUtils::ExecuteCommandLocally(const Checkable::Ptr& checkable, const CheckCommand::Ptr& command, const Dictionary::Ptr& params)
+{
+
+    Dictionary::Ptr macros;
+    if (!params->Contains("macros"))
+        macros = new Dictionary();
+    else
+        macros = params->Get("macros");
+
+    Array::Ptr command_line_tmp = command->GetCommandLine();
+    Value shutdown_command_value = params->Get("shutdown_command");
+    Array::Ptr full_command;
+    if (shutdown_command_value.IsObjectType<Array>()){
+        full_command = shutdown_command_value;
+    } else{
+        Log(LogNotice, "CommandUtils")
+                << "Shutdown command must be of type Array.";
+        return;
+    }
+
+    if(full_command->GetLength() == 0){
+        Log(LogNotice, "CommandUtils")
+                << "Shutdown command must not be empty.";
+        return;
+    }
+    CheckResult::Ptr cr = new CheckResult();
+    command->SetCommandLine(full_command);
+    command->Execute(checkable, cr, macros, true);
+    command->SetCommandLine(command_line_tmp);
+}
+
+
+void CommandUtils::SendCommandMessageToEndpoints(const Endpoint::Ptr& endpoint, const ApiListener::Ptr& listener, const Dictionary::Ptr& message)
+{
+
+    Zone::Ptr local_zone = Zone::GetLocalZone();
+    Endpoint::Ptr local_endpoint = Endpoint::GetLocalEndpoint();
+
+    std::set<Endpoint::Ptr> target_endpoints;
+    for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
+        if (zone->GetParent() == local_zone) {
+            std::set<Endpoint::Ptr> endpoints = zone->GetEndpoints();
+            target_endpoints.insert(endpoints.begin(), endpoints.end());
+        }
+    }
+
+    for (const Endpoint::Ptr& e : target_endpoints) {
+        if (e == local_endpoint || ! e->GetConnected())
+            continue;
+        if (e == endpoint) {
+            Log(LogNotice, "CommandUtils") << "Sending message to target endpoint '" << e->GetName() << "'.";
+            listener->SyncSendMessage(e, message);
+            return;
+        }
+    }
+
+    for (const Endpoint::Ptr& e : target_endpoints) {
+        if (e == local_endpoint || ! e->GetConnected())
+            continue;
+        Log(LogNotice, "CommandUtils") << "Broadcasting message to connected endpoint '" << e->GetName() << "'.";
+        listener->SyncSendMessage(e, message);
+    }
+
+}

--- a/lib/icinga/commandutils.hpp
+++ b/lib/icinga/commandutils.hpp
@@ -1,0 +1,23 @@
+#ifndef COMMANDUTILS_H
+#define COMMANDUTILS_H
+
+#include "remote/apilistener.hpp"
+#include "icinga/checkcommand.hpp"
+#include "icinga/host.hpp"
+
+namespace icinga
+{
+
+    class CommandUtils
+    {
+    public:
+        static void ExecuteCommandLocally(const Checkable::Ptr& checkable, const CheckCommand::Ptr& command, const Dictionary::Ptr& params);
+        static void SendCommandMessageToEndpoints(const Endpoint::Ptr& endpoint, const ApiListener::Ptr& listener, const Dictionary::Ptr& message);
+
+    private:
+        CommandUtils();
+    };
+
+}
+
+#endif /* COMMANDUTILS_H */


### PR DESCRIPTION
This feature adds the shutdown-host endpoint to the API.

This endpoint allows submitting shutdown commands to Icinga2 nodes in a distributed monitoring environment. 
Commands are distributed via cluster messages.