### PR TITLE
Boost Coroutines: Increase the default stack size from 64 to 256KB

### DIFF
--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -107,7 +107,10 @@ public:
 		// Rationale: Low cost Windows agent only & https://github.com/Icinga/icinga2/issues/7431
 		return 8 * 1024 * 1024;
 #else /* _WIN32 */
-		return boost::coroutines::stack_allocator::traits_type::default_size(); // Default 64 KB
+		// Increase the stack size for Linux/Unix coroutines for many JSON objects on the stack.
+		// This may help mitigate possible stack overflows. https://github.com/Icinga/icinga2/issues/7532
+		return 256 * 1024;
+		//return boost::coroutines::stack_allocator::traits_type::default_size(); // Default 64 KB
 #endif /* _WIN32 */
 	}
 


### PR DESCRIPTION
With #6559 I have learned that the default stack size for coroutines may to low causing crashes on Windows in this regard. The default of 64KB may be too low, especially keeping in mind that for example nlohmann/json puts an overhead of 1 pointer for each JSON object. If many of them are used within a coroutine, e.g. an agent/satellite replaying the log, the theory says that 64KB may be too low.

Our application default would be 256KB the lowest, if the application is not started with `--no-stack-rlimit` (which is the default param used on Debian and RHEL). 

```
int Application::GetDefaultRLimitStack()
{
        return 256 * 1024;
}
```

Therefore I consider setting a Coroutine stack size of 256KB (maybe 512KB) a better default than the Boost ASIO default. This may increase the memory foot print of course, but prevent any stack corruption which likely happens here. 

References I had in my pocket:

- https://github.com/boostorg/beast/issues/1055
- https://stackoverflow.com/questions/41030285/boostproperty-treeread-xml-segfaults-in-an-asio-handler-spawned-using-boost

refs #7532