### PR TITLE
Use IoEngine::Spawn wrapper in RedisConnection class

### DIFF
--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -39,14 +39,14 @@ void RedisConnection::Start()
 	if (!m_Started.exchange(true)) {
 		Ptr keepAlive (this);
 
-		asio::spawn(m_Strand, [this, keepAlive](asio::yield_context yc) { ReadLoop(yc); });
-		asio::spawn(m_Strand, [this, keepAlive](asio::yield_context yc) { WriteLoop(yc); });
+		IoEngine::SpawnCoroutine(m_Strand, [this, keepAlive](asio::yield_context yc) { ReadLoop(yc); });
+		IoEngine::SpawnCoroutine(m_Strand, [this, keepAlive](asio::yield_context yc) { WriteLoop(yc); });
 	}
 
 	if (!m_Connecting.exchange(true)) {
 		Ptr keepAlive (this);
 
-		asio::spawn(m_Strand, [this, keepAlive](asio::yield_context yc) { Connect(yc); });
+		IoEngine::SpawnCoroutine(m_Strand, [this, keepAlive](asio::yield_context yc) { Connect(yc); });
 	}
 }
 

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -10,7 +10,6 @@
 #include "base/shared.hpp"
 #include "base/string.hpp"
 #include "base/value.hpp"
-#include <boost/asio/spawn.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/buffered_stream.hpp>
 #include <boost/asio/io_context.hpp>
@@ -304,7 +303,7 @@ RedisConnection::Reply RedisConnection::ReadOne(StreamPtr& stream, boost::asio::
 			if (!m_Connecting.exchange(true)) {
 				Ptr keepAlive (this);
 
-				asio::spawn(m_Strand, [this, keepAlive](asio::yield_context yc) { Connect(yc); });
+				IoEngine::SpawnCoroutine(m_Strand, [this, keepAlive](asio::yield_context yc) { Connect(yc); });
 			}
 		}
 
@@ -342,7 +341,7 @@ void RedisConnection::WriteOne(StreamPtr& stream, RedisConnection::Query& query,
 			if (!m_Connecting.exchange(true)) {
 				Ptr keepAlive (this);
 
-				asio::spawn(m_Strand, [this, keepAlive](asio::yield_context yc) { Connect(yc); });
+				IoEngine::SpawnCoroutine(m_Strand, [this, keepAlive](asio::yield_context yc) { Connect(yc); });
 			}
 		}
 


### PR DESCRIPTION
This avoids multiple locations for `asio::spawn` calls.