### PR TITLE
Ensure that log replay files are properly renamed on Windows

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1193,7 +1193,13 @@ void ApiListener::RotateLogFile()
 	// If the log is being rotated more than once per second,
 	// don't overwrite the previous one, but silently deny rotation.
 	if (!Utility::PathExists(newpath)) {
-		(void) rename(oldpath.CStr(), newpath.CStr());
+		try {
+			Utility::RenameFile(oldpath, newpath);
+		} catch (const std::exception& ex) {
+			Log(LogCritical, "ApiListener")
+				<< "Cannot rotate replay log file from '" << oldpath << "' to '"
+				<< newpath << "': " << ex.what();
+		}
 	}
 }
 


### PR DESCRIPTION
rename() without _unlink() before doesn't work on Windows.
This commits also adds an error message which was swallowed
previously.