### PR TITLE
Terminate windows check processes with UNKNOWN state on timeout

### DIFF
--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -1024,7 +1024,7 @@ bool Process::DoEvents()
 
 			m_OutputStream << "<Timeout exceeded.>";
 #ifdef _WIN32
-			TerminateProcess(m_Process, 1);
+			TerminateProcess(m_Process, 3);
 #else /* _WIN32 */
 			int error = ProcessKill(-m_Process, SIGKILL);
 			if (error) {


### PR DESCRIPTION
On Windows this terminates checks that reached the timeout with the UNKNOWN
state instead the WARNING state.

Credit for the patch goes to @araujorm. Thanks!

# Test

Requires a basic master - agent (Windows) setup.

Create a simple batch script on Windows which will sleep for a long time e.g. 65 seconds. This will trigger the default check timeout of 60 seconds.

On the Windows agent in `C:\sleep.bat`
```
@echo off

echo %time%
timeout 65 > NUL
echo %time%
```

Now let Icinga 2 execute the script.

Zone: `global-templates`:
```
object CheckCommand "test" {
	command = [ "C:\\sleep.bat" ]
}
```
Zone `master`:
```
object Host "icinga2-win10" {
	check_command = "icmp"

	address = "192.168.122.55"
}

apply Service "sleep" {
	check_command = "test"

	check_interval = 1s
	retry_interval = 1s

	command_endpoint = host.name

	assign where host.name == "icinga2-win10"
}
```
Call the Icinga 2 API on the master to verify that the state is now 3 (UNKNOWN).

fixes #7787

