### PR TITLE
IcingaDB: Expose last_check column for checkable objects

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1896,6 +1896,7 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	else
 		attrs->Set("check_timeout", TimestampToMilliseconds(checkable->GetCheckTimeout()));
 
+	attrs->Set("last_check", TimestampToMilliseconds(checkable->GetLastCheck()));
 	attrs->Set("last_update", TimestampToMilliseconds(Utility::GetTime()));
 	attrs->Set("last_state_change", TimestampToMilliseconds(checkable->GetLastStateChange()));
 	attrs->Set("next_check", TimestampToMilliseconds(checkable->GetNextCheck()));


### PR DESCRIPTION
fixes #7784