### PR TITLE
Dev: Allow to delay main worker process in order to attach with LLDB

### DIFF
--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -566,6 +566,28 @@ ICINGA2\_RLIMIT\_FILES     |**Read-write.** Defines the resource limit for `RLIM
 ICINGA2\_RLIMIT\_PROCESSES |**Read-write.** Defines the resource limit for `RLIMIT_NPROC` that should be set at start-up. Value cannot be set lower than the default `16 * 1024`. 0 disables the setting. Set in Icinga 2 sysconfig.
 ICINGA2\_RLIMIT\_STACK     |**Read-write.** Defines the resource limit for `RLIMIT_STACK` that should be set at start-up. Value cannot be set lower than the default `256 * 1024`. 0 disables the setting. Set in Icinga 2 sysconfig.
 
+#### Debug Constants and Variables <a id="icinga-constants-debug"></a>
+
+These constants are only available in debug builds for developers and help with tracing messages and attaching to debuggers.
+
+Variable                   | Description
+---------------------------|-------------------
+Internal.DebugJsonRpc      | **Read-write.** Setting this to `1` prints the raw JSON-RPC message to STDOUT.
+Internal.DebugWorkerDelay  | **Read-write.** Delays the main worker process by X seconds after forked from the umbrella process. This helps with attaching LLDB which cannot follow child forks like GDB.
+
+Example:
+
+```
+$ icinga2 daemon -DInternal.DebugWorkerDelay=120
+Closed FD 6 which we inherited from our parent process.
+[2020-01-29 12:22:33 +0100] information/cli: Icinga application loader (version: v2.11.0-477-gfe8701d77; debug)
+[2020-01-29 12:22:33 +0100] information/RunWorker: DEBUG: Current PID: 85253. Sleeping for 120 seconds to allow lldb/gdb -p <PID> attachment.
+
+$ lldb -p 85253
+(lldb) b icinga::Checkable::ProcessCheckResult
+(lldb) c
+```
+
 
 ## Apply <a id="apply"></a>
 


### PR DESCRIPTION
Introduce `-DInternal.DebugWorkerDelay=120` and sleep inside `RunWorker()`.

Rationale: With 2.11 we've introduced a real umbrella process where the
main process is spawned as child fork. Running icinga2 in foreground on
a macOS shell with LLDB will now exit, and not follow the child process.

LLDB doesn't support `follow-fork-mode child` like GDB and therefore we
need to:

- Print the child process PID
- Sleep for X seconds to allow the developer to run `lldb -p <PID>`, set breakpoints, etc.

This commit also documents all available debug build enabled internal constants.

Example:

```
$ icinga2 daemon -DInternal.DebugWorkerDelay=120
Closed FD 6 which we inherited from our parent process.
[2020-01-29 12:22:33 +0100] information/cli: Icinga application loader (version: v2.11.0-477-gfe8701d77; debug)
[2020-01-29 12:22:33 +0100] information/RunWorker: DEBUG: Current PID: 85253. Sleeping for 120 seconds to allow lldb/gdb -p <PID> attachment.
```

```
$ lldb -p 85253
(lldb) process attach --pid 85253
Process 85253 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
    frame #0: 0x00007fff6edcdbba libsystem_kernel.dylib`__semwait_signal + 10
libsystem_kernel.dylib`__semwait_signal:
->  0x7fff6edcdbba <+10>: jae    0x7fff6edcdbc4            ; <+20>
    0x7fff6edcdbbc <+12>: movq   %rax, %rdi
    0x7fff6edcdbbf <+15>: jmp    0x7fff6edcc68d            ; cerror
    0x7fff6edcdbc4 <+20>: retq
Target 0: (icinga2) stopped.

Executable module set to "/usr/local/icinga/icinga2/lib/icinga2/sbin/icinga2".
Architecture set to: x86_64h-apple-macosx-.
(lldb) b eventqueue.cpp:259
Breakpoint 1: where = icinga2`icinga::EventsFilter::operator bool() + 16 at eventqueue.cpp:259:20, address = 0x000000010fe517b0
(lldb) c
Process 85253 resuming
Process 85253 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGUSR2
    frame #0: 0x00007fff6edcdbba libsystem_kernel.dylib`__semwait_signal + 10
libsystem_kernel.dylib`__semwait_signal:
->  0x7fff6edcdbba <+10>: jae    0x7fff6edcdbc4            ; <+20>
    0x7fff6edcdbbc <+12>: movq   %rax, %rdi
    0x7fff6edcdbbf <+15>: jmp    0x7fff6edcc68d            ; cerror
    0x7fff6edcdbc4 <+20>: retq
Target 0: (icinga2) stopped.
(lldb) c
Process 85253 resuming
Process 85253 stopped
* thread #5, stop reason = breakpoint 1.1
    frame #0: 0x000000010fe517b0 icinga2`icinga::EventsFilter::operator bool(this=0x0000700001d46470) at eventqueue.cpp:259:20
   256
   257 	EventsFilter::operator bool()
   258 	{
-> 259 		return !m_Inboxes.empty();
   260 	}
   261
   262 	void EventsFilter::Push(Dictionary::Ptr event)
Target 0: (icinga2) stopped.
(lldb) p m_Inboxes
(std::__1::map<boost::intrusive_ptr<icinga::Expression>, std::__1::set<boost::intrusive_ptr<icinga::EventsInbox>, std::__1::less<boost::intrusive_ptr<icinga::EventsInbox> >, std::__1::allocator<boost::intrusive_ptr<icinga::EventsInbox> > >, std::__1::less<boost::intrusive_ptr<icinga::Expression> >, std::__1::allocator<std::__1::pair<const boost::intrusive_ptr<icinga::Expression>, std::__1::set<boost::intrusive_ptr<icinga::EventsInbox>, std::__1::less<boost::intrusive_ptr<icinga::EventsInbox> >, std::__1::allocator<boost::intrusive_ptr<icinga::EventsInbox> > > > > >) $0 = size=0 {}
(lldb) n
Process 85253 stopped
* thread #5, stop reason = step over
    frame #0: 0x0000000110183158 icinga2`icinga::ApiEvents::StateChangeHandler(checkable=0x0000700001d47920, cr=0x0000700001d487d0, type=StateTypeHard, origin=0x0000700001d48428) at apievents.cpp:71:25
   68  		std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("StateChange");
   69  		auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::StateChange));
   70
-> 71  		if (queues.empty() && !inboxes)
   72  			return;
   73
   74  		Log(LogDebug, "ApiEvents", "Processing event type 'StateChange'.");
Target 0: (icinga2) stopped.
(lldb)
Process 85253 stopped
* thread #5, stop reason = step over
    frame #0: 0x0000000110183180 icinga2`icinga::ApiEvents::StateChangeHandler(checkable=0x0000700001d47920, cr=0x0000700001d487d0, type=StateTypeHard, origin=0x0000700001d48428) at apievents.cpp:72:3
   69  		auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::StateChange));
   70
   71  		if (queues.empty() && !inboxes)
-> 72  			return;
   73
   74  		Log(LogDebug, "ApiEvents", "Processing event type 'StateChange'.");
   75
Target 0: (icinga2) stopped.
```