### PR TITLE
WIP: Lower the default log_duration to 1h, reducing log replay problems in default envs

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -259,17 +259,17 @@ name you specified. This means you can define more than one object with the same
 Endpoint objects are used to specify connection information for remote
 Icinga 2 instances. More details can be found in the [distributed monitoring chapter](06-distributed-monitoring.md#distributed-monitoring).
 
-Example:
+Example for a satellite:
 
 ```
-object Endpoint "icinga2-agent1.localdomain" {
-  host = "192.168.56.111"
+object Endpoint "icinga2-satellite1.localdomain" {
+  host = "192.168.56.105"
   port = 5665
-  log_duration = 1d
+  log_duration = 1h
 }
 ```
 
-Example (disable replay log):
+Example for an agent (disable the replay log):
 
 ```
 object Endpoint "icinga2-agent1.localdomain" {
@@ -285,7 +285,7 @@ Configuration Attributes:
   --------------------------|-----------------------|----------------------------------
   host                      | String                | **Optional.** The hostname/IP address of the remote Icinga 2 instance.
   port                      | Number                | **Optional.** The service name/port of the remote Icinga 2 instance. Defaults to `5665`.
-  log\_duration             | Duration              | **Optional.** Duration for keeping replay logs on connection loss. Defaults to `1d` (86400 seconds). Attribute is specified in seconds. If log_duration is set to 0, replaying logs is disabled. You could also specify the value in human readable format like `10m` for 10 minutes or `1h` for one hour.
+  log\_duration             | Duration              | **Optional.** Duration for keeping replay logs on connection loss. Defaults to `1h` (3600 seconds). Attribute is specified in seconds. If log_duration is set to 0, storing and replaying logs is disabled. You could also specify the value in human readable format like `10m` for 10 minutes or `1h` for one hour.
 
 Endpoint objects cannot currently be created with the API.
 

--- a/lib/remote/endpoint.ti
+++ b/lib/remote/endpoint.ti
@@ -16,7 +16,7 @@ class Endpoint : ConfigObject
 		default {{{ return "5665"; }}}
 	};
 	[config] double log_duration {
-		default {{{ return 86400; }}}
+		default {{{ return 3600; }}}
 	};
 
 	[state] Timestamp local_log_position;


### PR DESCRIPTION
@lippserd

This sources from my analysis of defaults used in environments.
Not many people know that the docs point to `log_duration=0` for agent setups,
our CLI commands lack the possibility to do so (no dedicated separation between agent/satellite).

Also, satellite/master downtimes are expected to be <1h. If users need to keep
longer downtimes, they are able to configure the endpoint objects in zones.conf
on their own.

The majority of setups never touches this default setting, and as such, I'd propose
to lower the default which

- reduces storage size on disk, less events
- faster replay with less events for endpoints

We should still add a mechanism to the CLI commands to set this to `0` for agents
by default.