### PR TITLE
Fixed name issue with haproxy

### DIFF
--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -585,7 +585,7 @@ object CheckCommand "varnish" {
 	}
 }
 
-object CheckCommand "haproxy" {
+object CheckCommand "haproxy_status" {
 	import "plugin-check-command"
 	command = [ PluginDir + "/check_haproxy" ]
 
@@ -618,9 +618,9 @@ object CheckCommand "haproxy" {
 	}
 }
 
-object CheckCommand "haproxy_status" {
+object CheckCommand "haproxy" {
 	import "plugin-check-command"
-	command = [ PluginDir + "/check_haproxy_status" ]
+	command = [ PluginDir + "/check_haproxy" ]
 
 	arguments = {
 		"--defaults" = {


### PR DESCRIPTION
Currently the haproxy command is using the in build status page and haproxy_status command is using the socket.

So I'd like to propose the change of both like haproxy command now is getting haproxy_status since it is using status page and haproxy_status command now to haproxy since it is using the real socket for it.

Also I fixed the command paths since they have been wrong as well...