### PR TITLE
Fixed haproxy naming issue

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2900,17 +2900,17 @@ Custom attributes passed as [command parameters](03-monitoring-basics.md#command
 
 Name                                | Description
 ------------------------------------|-----------------------------------------------------------------------------------------------------
-graphite_url                        | **Required.** Target url.
-graphite_metric                     | **Required.** Metric path string.
-graphite_shortname                  | **Optional.** Metric short name (used for performance data).
-graphite_duration                   | **Optional.** Length, in minute of data to parse (default: 5).
-graphite_function                   | **Optional.** Function applied to metrics for thresholds (default: average).
-graphite_warning                    | **Required.** Warning threshold.
+graphite_url                        | **Required.** Target url.
+graphite_metric                     | **Required.** Metric path string.
+graphite_shortname                  | **Optional.** Metric short name (used for performance data).
+graphite_duration                   | **Optional.** Length, in minute of data to parse (default: 5).
+graphite_function                   | **Optional.** Function applied to metrics for thresholds (default: average).
+graphite_warning                    | **Required.** Warning threshold.
 graphite_critical                   | **Required.** Critical threshold.
 graphite_units                      | **Optional.** Adds a text tag to the metric count in the plugin output. Useful to identify the metric units. Doesn't affect data queries.
 graphite_message                    | **Optional.** Text message to output (default: "metric count:").
 graphite_zero_on_error              | **Optional.** Return 0 on a graphite 500 error.
-graphite_link_graph                 | **Optional.** Add a link in the plugin output, showing a 24h graph for this metric in graphite.
+graphite_link_graph                 | **Optional.** Add a link in the plugin output, showing a 24h graph for this metric in graphite.
 
 ### Network Components <a id="plugin-contrib-network-components"></a>
 
@@ -5591,7 +5591,7 @@ uptime                  | How long the cache has been running (in seconds)
 ratio                   | The cache hit ratio expressed as a percentage of hits to hits + misses.  Default thresholds are 95 and 90.
 usage                   | Cache file usage as a percentage of the total cache space.
 
-#### haproxy <a id="plugin-contrib-command-haproxy"></a>
+#### haproxy_status <a id="plugin-contrib-command-haproxy"></a>
 
 The [check_haproxy](https://salsa.debian.org/nagios-team/pkg-nagios-plugins-contrib/blob/master/check_haproxy/check_haproxy) plugin,
 also available in the [monitoring-plugins-contrib](https://packages.debian.org/nagios-plugins-contrib) on debian,
@@ -5611,16 +5611,16 @@ Custom attributes passed as [command parameters](03-monitoring-basics.md#command
 
 Name                    | Description
 ------------------------|----------------------------------------------------------------------------------
-haproxy_username        | **Optional.** Username for HTTP Auth
-haproxy_password        | **Optional.** Password for HTTP Auth
-haproxy_url             | **Required.** URL of the HAProxy csv statistics page.
-haproxy_timeout         | **Optional.** Seconds before plugin times out (default: 10)
-haproxy_warning         | **Optional.** Warning request time threshold (in seconds)
-haproxy_critical        | **Optional.** Critical request time threshold (in seconds)
+haproxy\_status\_username        | **Optional.** Username for HTTP Auth
+haproxy\_status\_password        | **Optional.** Password for HTTP Auth
+haproxy\_status\_url             | **Required.** URL of the HAProxy csv statistics page.
+haproxy\_status\_timeout         | **Optional.** Seconds before plugin times out (default: 10)
+haproxy\_status\_warning         | **Optional.** Warning request time threshold (in seconds)
+haproxy\_status\_critical        | **Optional.** Critical request time threshold (in seconds)
 
-#### haproxy_status <a id="plugin-contrib-command-haproxy_status"></a>
+#### haproxy <a id="plugin-contrib-command-haproxy_status"></a>
 
-The [check_haproxy_status](https://github.com/jonathanio/monitoring-nagios-haproxy) plugin,
+The [check_haproxy](https://github.com/jonathanio/monitoring-nagios-haproxy) plugin,
 uses the `haproxy` statistics socket to monitor [haproxy](http://www.haproxy.org/) frontends/backends.
 
 This plugin need read/write access to the statistics socket with an operator level. You can configure it in the global section of haproxy to allow icinga user to use it:
@@ -5632,15 +5632,15 @@ Custom attributes passed as [command parameters](03-monitoring-basics.md#command
 
 Name                        | Description
 ----------------------------|----------------------------------------------------------------------------------
-haproxy\_status\_default    | **Optional.** Set/Override the defaults which will be applied to all checks (unless specifically set by --overrides).
-haproxy\_status\_frontends  | **Optional.** Enable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached).
-haproxy\_status\_nofrontends| **Optional.** Disable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached).
-haproxy\_status\_backends   | **Optional.** Enable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached).
-haproxy\_status\_nobackends | **Optional.** Disable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached).
-haproxy\_status\_servers    | **Optional.** Enable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues).
-haproxy\_status\_noservers  | **Optional.** Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues).
-haproxy\_status\_overrides  | **Optional.** Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above.
-haproxy\_status\_socket     | **Required.** Path to the socket check_haproxy should connect to
+haproxy\_default    | **Optional.** Set/Override the defaults which will be applied to all checks (unless specifically set by --overrides).
+haproxy\_frontends  | **Optional.** Enable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached).
+haproxy\_nofrontends| **Optional.** Disable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached).
+haproxy\_backends   | **Optional.** Enable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached).
+haproxy\_nobackends | **Optional.** Disable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached).
+haproxy\_servers    | **Optional.** Enable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues).
+haproxy\_noservers  | **Optional.** Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues).
+haproxy\_overrides  | **Optional.** Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above.
+haproxy\_socket     | **Required.** Path to the socket check_haproxy should connect to
 
 #### phpfpm_status <a id="plugin-contrib-command-phpfpm_status"></a>
 

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -591,28 +591,28 @@ object CheckCommand "haproxy_status" {
 
 	arguments = {
 		"--username" = {
-			value = "$haproxy_username$"
+			value = "$haproxy_status_username$"
 			description = "Username for HTTP Auth"
 		}
 		"--password" = {
-			value = "$haproxy_password$"
+			value = "$haproxy_status_password$"
 			description = "Password for HTTP Auth"
 		}
 		"--url" = {
-			value = "$haproxy_url$"
+			value = "$haproxy_status_url$"
 			description = "URL of the HAProxy csv statistics page"
 			required = true
 		}
 		"--timeout" = {
-			value = "$haproxy_timeout$"
+			value = "$haproxy_status_timeout$"
 			description = "Seconds before plugin times out (default: 10)"
 		}
 		"-w" = {
-			value = "$haproxy_warning$"
+			value = "$haproxy_status_warning$"
 			description = "Warning request time threshold (in seconds)"
 		}
 		"-c" = {
-			value = "$haproxy_critical$"
+			value = "$haproxy_status_critical$"
 			description = "Critical request time threshold (in seconds)"
 		}
 	}
@@ -624,39 +624,39 @@ object CheckCommand "haproxy" {
 
 	arguments = {
 		"--defaults" = {
-			value = "$haproxy_status_default$"
+			value = "$haproxy_default$"
 			description = "Set/Override the defaults which will be applied to all checks (unless specifically set by --overrides)."
 		}
 		"--frontends" = {
-			set_if = "$haproxy_status_frontends$"
+			set_if = "$haproxy_frontends$"
 			description = "Enable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached)."
 		}
 		"--nofrontends" = {
-			set_if = "$haproxy_status_nofrontends$"
+			set_if = "$haproxy_nofrontends$"
 			description = "Disable checks for the frontends in HAProxy (that they're marked as OPEN and the session limits haven't been reached)."
 		}
 		"--backends" = {
-			set_if = "$haproxy_status_backends$"
+			set_if = "$haproxy_backends$"
 			description = "Enable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached)."
 		}
 		"--nobackends" = {
-			set_if = "$haproxy_status_nobackends$"
+			set_if = "$haproxy_nobackends$"
 			description = "Disable checks for the backends in HAProxy (that they have the required quorum of servers, and that the session limits haven't been reached)."
 		}
 		"--servers" = {
-			set_if = "$haproxy_status_servers$"
+			set_if = "$haproxy_servers$"
 			description = "Enable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
 		}
 		"--noservers" = {
-			set_if = "$haproxy_status_noservers$"
+			set_if = "$haproxy_noservers$"
 			description = "Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
 		}
 		"--overrides" = {
-			value = "$haproxy_status_overrides$"
+			value = "$haproxy_overrides$"
 			description = "Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above."
 		}
 		"--socket" = {
-			value = "$haproxy_status_socket$"
+			value = "$haproxy_socket$"
 			description = "Path to the socket check_haproxy should connect to"
 			required = true
 		}

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -585,7 +585,7 @@ object CheckCommand "varnish" {
 	}
 }
 
-object CheckCommand "haproxy" {
+object CheckCommand "haproxy_status" {
 	import "plugin-check-command"
 	command = [ PluginDir + "/check_haproxy" ]
 
@@ -618,9 +618,9 @@ object CheckCommand "haproxy" {
 	}
 }
 
-object CheckCommand "haproxy_status" {
+object CheckCommand "haproxy" {
 	import "plugin-check-command"
-	command = [ PluginDir + "/check_haproxy_status" ]
+	command = [ PluginDir + "/check_haproxy" ]
 
 	arguments = {
 		"--defaults" = {


### PR DESCRIPTION
CheckCommand haproxy is using status_page and CheckCommand haproxy_status is using socket so I'd like to propose these changes to fix the naming issue and also the command path.