### PR TITLE
Don't set Notification#no_more_notifications on custom notifications

### DIFF
--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -389,7 +389,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		if (type == NotificationProblem && GetInterval() <= 0)
 			SetNoMoreNotifications(true);
-		else
+		else if (type != NotificationCustom)
 			SetNoMoreNotifications(false);
 
 		if (type == NotificationProblem && GetInterval() > 0)


### PR DESCRIPTION
... as it has nothing to do with reminder notifications.

fixes #6333

## Edit

Imagine you get a problem notification. The above if branch does SetNoMoreNotifications(true), so that (the only) GetNoMoreNotifications() in NotificationComponent prevent reminders if none configured.

Now, if you send a custom notification, w/o my change the else branch does SetNoMoreNotifications(false), so that the NotificationComponent **sends** a reminder next time despite none configured.