### PR TITLE
Fix timing point for Application::GetStartTime() (related to command endpoint grace period)

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -166,8 +166,6 @@ static int Main()
 		argv += 3;
 	}
 
-	Application::SetStartTime(Utility::GetTime());
-
 	/* Set thread title. */
 	Utility::SetThreadName("Main Thread", false);
 

--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -1162,6 +1162,11 @@ void Application::SetMainTime(double ts)
 	m_MainTime = ts;
 }
 
+double Application::GetUptime()
+{
+	return Utility::GetTime() - m_StartTime;
+}
+
 bool Application::GetScriptDebuggerEnabled()
 {
 	return m_ScriptDebuggerEnabled;

--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -51,7 +51,6 @@ static bool l_InExceptionHandler = false;
 int Application::m_ArgC;
 char **Application::m_ArgV;
 double Application::m_StartTime;
-double Application::m_MainTime;
 bool Application::m_ScriptDebuggerEnabled = false;
 double Application::m_LastReloadFailed;
 
@@ -965,7 +964,7 @@ int Application::Run()
 	}
 #endif /* _WIN32 */
 
-	SetMainTime(Utility::GetTime());
+	SetStartTime(Utility::GetTime());
 
 	return Main();
 }
@@ -1150,16 +1149,6 @@ double Application::GetStartTime()
 void Application::SetStartTime(double ts)
 {
 	m_StartTime = ts;
-}
-
-double Application::GetMainTime()
-{
-	return m_MainTime;
-}
-
-void Application::SetMainTime(double ts)
-{
-	m_MainTime = ts;
 }
 
 double Application::GetUptime()

--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -98,6 +98,8 @@ public:
 	static double GetMainTime();
 	static void SetMainTime(double ts);
 
+	static double GetUptime();
+
 	static bool GetScriptDebuggerEnabled();
 	static void SetScriptDebuggerEnabled(bool enabled);
 

--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -95,9 +95,6 @@ public:
 	static double GetStartTime();
 	static void SetStartTime(double ts);
 
-	static double GetMainTime();
-	static void SetMainTime(double ts);
-
 	static double GetUptime();
 
 	static bool GetScriptDebuggerEnabled();

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -581,6 +581,12 @@ void Checkable::ExecuteCheck()
 			 * using the proper check interval once we've received a check result.
 			 */
 			SetNextCheck(Utility::GetTime() + GetCheckCommand()->GetTimeout() + 30);
+
+		/*
+		 * Let the user know that there was a problem with the check if
+		 * 1) The endpoint is not syncing (replay log, etc.)
+		 * 2) Outside of the cold startup window (5min)
+		 */
 		} else if (!endpoint->GetSyncing() && Application::GetInstance()->GetStartTime() < Utility::GetTime() - 300) {
 			/* fail to perform check on unconnected endpoint */
 			cr->SetState(ServiceUnknown);

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -194,6 +194,7 @@ Timestamp Checkable::GetNextUpdate() const
 	auto cr (GetLastCheckResult());
 	double interval, latency;
 
+	// TODO: Document this behavior.
 	if (cr) {
 		interval = GetProblem() && GetStateType() == StateTypeSoft ? GetRetryInterval() : GetCheckInterval();
 		latency = cr->GetExecutionEnd() - cr->GetScheduleStart();
@@ -202,7 +203,7 @@ Timestamp Checkable::GetNextUpdate() const
 		latency = 0.0;
 	}
 
-	return (GetEnableActiveChecks() ? GetNextCheck() : (cr ? cr->GetExecutionEnd() : Application::GetMainTime()) + interval) + interval + 2 * latency;
+	return (GetEnableActiveChecks() ? GetNextCheck() : (cr ? cr->GetExecutionEnd() : Application::GetStartTime()) + interval) + interval + 2 * latency;
 }
 
 void Checkable::NotifyFixedDowntimeStart(const Downtime::Ptr& downtime)

--- a/lib/icinga/cib.cpp
+++ b/lib/icinga/cib.cpp
@@ -329,7 +329,7 @@ void CIB::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata) {
 	status->Set("num_services_handled", ss.services_handled);
 	status->Set("num_services_problem", ss.services_problem);
 
-	double uptime = Utility::GetTime() - Application::GetStartTime();
+	double uptime = Application::GetUptime();
 	status->Set("uptime", uptime);
 
 	HostStatistics hs = CalculateHostStats();

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -206,7 +206,7 @@ bool IcingaApplication::ResolveMacro(const String& macro, const CheckResult::Ptr
 		*result = Utility::FormatDateTime("%H:%M:%S %z", now);
 		return true;
 	} else if (macro == "uptime") {
-		*result = Utility::FormatDuration(Utility::GetTime() - Application::GetStartTime());
+		*result = Utility::FormatDuration(Application::GetUptime());
 		return true;
 	}
 

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -102,7 +102,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	perfdata->Add(new PerfdataValue("num_services_handled", ss.services_handled));
 	perfdata->Add(new PerfdataValue("num_services_problem", ss.services_problem));
 
-	double uptime = Utility::GetTime() - Application::GetStartTime();
+	double uptime = Application::GetUptime();
 	perfdata->Add(new PerfdataValue("uptime", uptime));
 
 	HostStatistics hs = CIB::CalculateHostStats();

--- a/lib/methods/randomchecktask.cpp
+++ b/lib/methods/randomchecktask.cpp
@@ -25,7 +25,7 @@ void RandomCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		return;
 
 	double now = Utility::GetTime();
-	double uptime = now - Application::GetStartTime();
+	double uptime = Application::GetUptime();
 
 	String output = "Hello from " + IcingaApplication::GetInstance()->GetNodeName()
 		+ ". Icinga 2 has been running for " + Utility::FormatDuration(uptime)

--- a/lib/remote/apilistener-authority.cpp
+++ b/lib/remote/apilistener-authority.cpp
@@ -40,10 +40,10 @@ void ApiListener::UpdateObjectAuthority()
 			endpoints.push_back(endpoint);
 		}
 
-		double mainTime = Application::GetMainTime();
+		double startTime = Application::GetStartTime();
 
 		/* 30 seconds cold startup, don't update any authority to give the secondary endpoint time to reconnect. */
-		if (num_total > 1 && endpoints.size() <= 1 && (mainTime == 0 || Utility::GetTime() - mainTime < 30))
+		if (num_total > 1 && endpoints.size() <= 1 && (startTime == 0 || Utility::GetTime() - startTime < 30))
 			return;
 
 		std::sort(endpoints.begin(), endpoints.end(),


### PR DESCRIPTION
- Treat the main start time as real application start time
- Align ObjectAuthority (main) with command endpoint checks (old start)
- Introduce Application::GetUptime() to avoid stats code duplication

fixes #7597