### PR TITLE
CLI: Add OpenSSL version to 'Build' section in --version

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -14,6 +14,7 @@
 #include "base/convert.hpp"
 #include "base/scriptglobal.hpp"
 #include "base/process.hpp"
+#include "base/tlsutility.hpp"
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/exception/errinfo_api_function.hpp>
 #include <boost/exception/errinfo_errno.hpp>
@@ -551,7 +552,8 @@ void Application::DisplayInfoMessage(std::ostream& os, bool skipVersion)
 
 	os << "\nBuild information:\n"
 		<< "  Compiler: " << systemNS->Get("BuildCompilerName") << " " << systemNS->Get("BuildCompilerVersion") << "\n"
-		<< "  Build host: " << systemNS->Get("BuildHostName") << "\n";
+		<< "  Build host: " << systemNS->Get("BuildHostName") << "\n"
+		<< "  OpenSSL version: " << GetOpenSSLVersion() << "\n";
 
 	os << "\nApplication information:\n"
 		<< "\nGeneral paths:\n"

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -8,6 +8,8 @@
 #include "base/application.hpp"
 #include "base/exception.hpp"
 #include <boost/asio/ssl/context.hpp>
+#include <openssl/opensslv.h>
+#include <openssl/crypto.h>
 #include <fstream>
 
 namespace icinga
@@ -16,6 +18,15 @@ namespace icinga
 static bool l_SSLInitialized = false;
 static boost::mutex *l_Mutexes;
 static boost::mutex l_RandomMutex;
+
+String GetOpenSSLVersion()
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	return OpenSSL_version(OPENSSL_VERSION);
+#else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+	return SSLeay_version(SSLEAY_VERSION);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+}
 
 #ifdef CRYPTO_LOCK
 static void OpenSSLLockingCallback(int mode, int type, const char *, int)

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -23,6 +23,8 @@ namespace icinga
 
 void InitializeOpenSSL();
 
+String GetOpenSSLVersion();
+
 Shared<boost::asio::ssl::context>::Ptr MakeAsioSslContext(const String& pubkey = String(), const String& privkey = String(), const String& cakey = String());
 void AddCRLToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& context, const String& crlPath);
 void SetCipherListToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& context, const String& cipherList);


### PR DESCRIPTION
This helps to see against which OpenSSL version Icinga was built.
Inspired by #5572