### PR TITLE
Improve experience with 'Node Setup for Agents/Satellite'

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -35,6 +35,9 @@ different results for
 As of v2.12 our [API](12-icinga2-api.md) URL endpoint [`/v1/actions/acknowledge-problem`](12-icinga2-api.md#icinga2-api-actions-acknowledge-problem) refuses acknowledging an already acknowledged checkable by overwriting the acknowledgement.
 To replace an acknowledgement you have to remove the old one before adding the new one.
 
+The deprecated parameters `--cert` and `--key` for the `pki save-cert` CLI command
+have been removed from the command and documentation.
+
 ## Upgrading to v2.11 <a id="upgrading-to-2-11"></a>
 
 ### Bugfixes for 2.11 <a id="upgrading-to-2-11-bugfixes"></a>

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -809,6 +809,23 @@ bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::sh
 	return rc == 1;
 }
 
+bool IsCa(const std::shared_ptr<X509>& cacert)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	/* OpenSSL 1.1.x provides https://www.openssl.org/docs/man1.1.0/man3/X509_check_ca.html
+	 *
+	 * 0 if it is not CA certificate,
+	 * 1 if it is proper X509v3 CA certificate with basicConstraints extension CA:TRUE,
+	 * 3 if it is self-signed X509 v1 certificate
+	 * 4 if it is certificate with keyUsage extension with bit keyCertSign set, but without basicConstraints,
+	 * 5 if it has outdated Netscape Certificate Type extension telling that it is CA certificate.
+	 */
+	return (X509_check_ca(cacert.get()) == 1);
+#else /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+	BOOST_THROW_EXCEPTION(std::invalid_argument("Not supported on this platform, OpenSSL version too old."));
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+}
+
 std::string to_string(const errinfo_openssl_error& e)
 {
 	std::ostringstream tmp;

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -47,6 +47,7 @@ String SHA256(const String& s);
 String RandomString(int length);
 
 bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::shared_ptr<X509>& certificate);
+bool IsCa(const std::shared_ptr<X509>& cacert);
 
 class openssl_error : virtual public std::exception, virtual public boost::exception { };
 

--- a/lib/cli/pkisavecertcommand.cpp
+++ b/lib/cli/pkisavecertcommand.cpp
@@ -26,16 +26,14 @@ void PKISaveCertCommand::InitParameters(boost::program_options::options_descript
 	boost::program_options::options_description& hiddenDesc) const
 {
 	visibleDesc.add_options()
-		("key", po::value<std::string>(), "Key file path (input), obsolete")
-		("cert", po::value<std::string>(), "Certificate file path (input), obsolete")
 		("trustedcert", po::value<std::string>(), "Trusted certificate file path (output)")
-		("host", po::value<std::string>(), "Icinga 2 host")
+		("host", po::value<std::string>(), "Parent Icinga instance to fetch the public TLS certificate from")
 		("port", po::value<std::string>()->default_value("5665"), "Icinga 2 port");
 }
 
 std::vector<String> PKISaveCertCommand::GetArgumentSuggestions(const String& argument, const String& word) const
 {
-	if (argument == "key" || argument == "cert" || argument == "trustedcert")
+	if (argument == "trustedcert")
 		return GetBashCompletionSuggestions("file", word);
 	else if (argument == "host")
 		return GetBashCompletionSuggestions("hostname", word);
@@ -66,7 +64,7 @@ int PKISaveCertCommand::Run(const boost::program_options::variables_map& vm, con
 	String port = vm["port"].as<std::string>();
 
 	Log(LogInformation, "cli")
-		<< "Retrieving X.509 certificate for '" << host << ":" << port << "'.";
+		<< "Retrieving TLS certificate for '" << host << ":" << port << "'.";
 
 	std::shared_ptr<X509> cert = PkiUtility::FetchCert(host, port);
 


### PR DESCRIPTION
- 'node setup' now verifies the --trustedcert certificate being a client certificate, not the ca.crt CA certificate file
    - Add IsCa() function to allow generic certificate checks whether it is a CA certificate
    - Add check to 'node setup'
    - Improve parameter description
- Refine the documentation
    - Explain why 'pki save-cert' is needed to prevent MITM attacks
    - Add sample output for 'pki save-cert'
    - Remove obsolete parameters --cert/--key