### PR TITLE
Catch exception when trusted cert is not readable during node setup on agent/satellite

### DIFF
--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -373,7 +373,15 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 			return 1;
 		}
 
-		trustedParentCert = GetX509Certificate(vm["trustedcert"].as<std::string>());
+		String trustedCert = vm["trustedcert"].as<std::string>();
+
+		try{
+			trustedParentCert = GetX509Certificate(trustedCert)
+		} catch (const std::exception&) {
+			Log(LogCritical, "cli")
+				<< "Can't read trusted cert at '" << trustedCert << "'.";
+			return 1;
+		}
 
 		Log(LogInformation, "cli")
 			<< "Verifying trusted certificate file '" << vm["trustedcert"].as<std::string>() << "'.";

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -376,7 +376,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 		String trustedCert = vm["trustedcert"].as<std::string>();
 
 		try{
-			trustedParentCert = GetX509Certificate(trustedCert)
+			trustedParentCert = GetX509Certificate(trustedCert);
 		} catch (const std::exception&) {
 			Log(LogCritical, "cli")
 				<< "Can't read trusted cert at '" << trustedCert << "'.";


### PR DESCRIPTION
This catches an exception when the trusted cert is not readable during
node setup.

# Test

```
icinga2 node setup \
--cn metis \
--endpoint deb10i2m1 \
--zone metis \
--parent_zone master \
--parent_host 172.17.0.2 \
--trustedcert /var/lib/icinga2/certs/trusted-parent.crt \
--accept-commands --accept-config \
--disable-confd
```

To trigger the exception ensure that `/var/lib/icinga2/certs/trusted-parent.crt` is not readable e.g. just delete it.

## Before

![Bildschirmfoto von 2020-02-13 19-37-08_shadow](https://user-images.githubusercontent.com/18580278/74468788-b7df8d00-4e9b-11ea-90ba-cde67b6cec59.png)


## After

![Bildschirmfoto von 2020-02-13 19-39-10_shadow](https://user-images.githubusercontent.com/18580278/74468793-bada7d80-4e9b-11ea-84d7-6dff10efbcf8.png)
