### PR TITLE
Set log_duration=0 for Host/Service Command Endpoints

### DIFF
--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -56,6 +56,12 @@ void Checkable::OnAllConfigLoaded()
 			BOOST_THROW_EXCEPTION(ValidationError(this, { "command_endpoint" },
 				"Checkable with command endpoint requires a zone. Please check the troubleshooting documentation."));
 		}
+
+		/* If this is a command_endpoint, forcefully disable the 'log_duration' setting. */
+		if (endpoint->GetLogDuration() > 0) {
+			ObjectLock olock(endpoint);
+			endpoint->SetLogDuration(0);
+		}
 	}
 }
 


### PR DESCRIPTION
This happens in memory after the configuration has been
loaded, and as such, before any connection attempt or sync.

This needs a special explanation in the docs.

If the value already is 0, no objectlock/set is fired. This
avoids extra round trips for e.g. Director generated agent
endpoint objects.