### PR TITLE
CLI: Add `pki verify` command for better TLS certificate troubleshooting

### DIFF
--- a/doc/11-cli-commands.md
+++ b/doc/11-cli-commands.md
@@ -38,6 +38,7 @@ Supported commands:
   * pki save-cert (saves another Icinga 2 instance's certificate)
   * pki sign-csr (signs a CSR)
   * pki ticket (generates a ticket)
+  * pki verify (verify TLS certificates: CN, signed by CA, is CA; Print certificate)
   * variable get (gets a variable)
   * variable list (lists all variables)
 
@@ -570,7 +571,7 @@ You will need them in the [distributed monitoring chapter](06-distributed-monito
 
 ```
 # icinga2 pki --help
-icinga2 - The Icinga 2 network monitoring daemon (version: v2.11.0)
+icinga2 - The Icinga 2 network monitoring daemon (version: v2.12.0)
 
 Usage:
   icinga2 <command> [<arguments>]
@@ -582,6 +583,7 @@ Supported commands:
   * pki save-cert (saves another Icinga 2 instance's certificate)
   * pki sign-csr (signs a CSR)
   * pki ticket (generates a ticket)
+  * pki verify (verify TLS certificates: CN, signed by CA, is CA; Print certificate)
 
 Global options:
   -h [ --help ]             show this help message

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -10,6 +10,9 @@ follow the instructions for v2.7 too.
 
 ## Upgrading to v2.12 <a id="upgrading-to-2-12"></a>
 
+* CLI
+    * New `pki verify` CLI command for better [TLS certificate troubleshooting](15-troubleshooting.md#troubleshooting-certificate-verification)
+
 ### Behavior changes <a id="upgrading-to-2-12-behavior-changes"></a>
 
 The behavior of multi parent [dependencies](03-monitoring-basics.md#dependencies) was fixed to e.g. render hosts unreachable when both router uplinks are down.

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -872,7 +872,13 @@ Array::Ptr GetSubjectAltNames(const std::shared_ptr<X509>& cert)
 		GENERAL_NAME* gen = sk_GENERAL_NAME_value(subjectAltNames, i);
 		if (gen->type == GEN_URI || gen->type == GEN_DNS || gen->type == GEN_EMAIL) {
 			ASN1_IA5STRING *asn1_str = gen->d.uniformResourceIdentifier;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 			String san = Convert::ToString(ASN1_STRING_data(asn1_str));
+#else /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+			String san = Convert::ToString(ASN1_STRING_get0_data(asn1_str));
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+
 			sans->Add(san);
 		}
 	}

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -6,12 +6,15 @@
 #include "base/i2-base.hpp"
 #include "base/object.hpp"
 #include "base/shared.hpp"
+#include "base/array.hpp"
 #include "base/string.hpp"
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/comp.h>
 #include <openssl/sha.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
@@ -48,6 +51,9 @@ String RandomString(int length);
 
 bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::shared_ptr<X509>& certificate);
 bool IsCa(const std::shared_ptr<X509>& cacert);
+int GetCertificateVersion(const std::shared_ptr<X509>& cert);
+String GetSignatureAlgorithm(const std::shared_ptr<X509>& cert);
+Array::Ptr GetSubjectAltNames(const std::shared_ptr<X509>& cert);
 
 class openssl_error : virtual public std::exception, virtual public boost::exception { };
 

--- a/lib/cli/CMakeLists.txt
+++ b/lib/cli/CMakeLists.txt
@@ -29,6 +29,7 @@ set(cli_SOURCES
   pkisavecertcommand.cpp pkisavecertcommand.hpp
   pkisigncsrcommand.cpp pkisigncsrcommand.hpp
   pkiticketcommand.cpp pkiticketcommand.hpp
+  pkiverifycommand.cpp pkiverifycommand.hpp
   variablegetcommand.cpp variablegetcommand.hpp
   variablelistcommand.cpp variablelistcommand.hpp
   variableutility.cpp variableutility.hpp

--- a/lib/cli/CMakeLists.txt
+++ b/lib/cli/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 add_library(cli OBJECT ${cli_SOURCES})
 
-add_dependencies(cli base config remote)
+add_dependencies(cli base config icinga remote)
 
 set_target_properties (
   cli PROPERTIES

--- a/lib/cli/pkiverifycommand.cpp
+++ b/lib/cli/pkiverifycommand.cpp
@@ -1,7 +1,7 @@
 /* Icinga 2 | (c) 2020 Icinga GmbH | GPLv2+ */
 
 #include "cli/pkiverifycommand.hpp"
-#include "icinga/checkresult.hpp"
+#include "icinga/service.hpp"
 #include "remote/pkiutility.hpp"
 #include "base/tlsutility.hpp"
 #include "base/logger.hpp"

--- a/lib/cli/pkiverifycommand.cpp
+++ b/lib/cli/pkiverifycommand.cpp
@@ -1,0 +1,161 @@
+/* Icinga 2 | (c) 2020 Icinga GmbH | GPLv2+ */
+
+#include "cli/pkiverifycommand.hpp"
+#include "icinga/checkresult.hpp"
+#include "remote/pkiutility.hpp"
+#include "base/tlsutility.hpp"
+#include "base/logger.hpp"
+#include <iostream>
+
+using namespace icinga;
+namespace po = boost::program_options;
+
+REGISTER_CLICOMMAND("pki/verify", PKIVerifyCommand);
+
+String PKIVerifyCommand::GetDescription() const
+{
+	return "Verify TLS certificates: CN, signed by CA, is CA; Print certificate";
+}
+
+String PKIVerifyCommand::GetShortDescription() const
+{
+	return "verify TLS certificates: CN, signed by CA, is CA; Print certificate";
+}
+
+void PKIVerifyCommand::InitParameters(boost::program_options::options_description& visibleDesc,
+	boost::program_options::options_description& hiddenDesc) const
+{
+	visibleDesc.add_options()
+		("cn", po::value<std::string>(), "Common Name (optional). Use with '--cert' to check the CN in the certificate.")
+		("cert", po::value<std::string>(), "Certificate file path (optional). Standalone: print certificate. With '--cacert': Verify against CA.")
+		("cacert", po::value<std::string>(), "CA certificate file path (optional). If passed standalone, verifies whether this is a CA certificate");
+}
+
+std::vector<String> PKIVerifyCommand::GetArgumentSuggestions(const String& argument, const String& word) const
+{
+	if (argument == "cert" || argument == "cacert")
+		return GetBashCompletionSuggestions("file", word);
+	else
+		return CLICommand::GetArgumentSuggestions(argument, word);
+}
+
+/**
+ * The entry point for the "pki verify" CLI command.
+ *
+ * @returns An exit status.
+ */
+int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const
+{
+	String cn, certFile, caCertFile;
+
+	if (vm.count("cn"))
+		cn = vm["cn"].as<std::string>();
+
+	if (vm.count("cert"))
+		certFile = vm["cert"].as<std::string>();
+
+	if (vm.count("cacert"))
+		caCertFile = vm["cacert"].as<std::string>();
+
+	/* Verify CN in certificate. */
+	if (!cn.IsEmpty() && !certFile.IsEmpty()) {
+		std::shared_ptr<X509> cert = GetX509Certificate(certFile);
+
+		Log(LogInformation, "cli")
+			<< "Verifying common name (CN) '" << cn << " in certificate '" << certFile << "'.";
+
+		std::cout << PkiUtility::GetCertificateInformation(cert) << "\n";
+
+		String certCN = GetCertificateCN(cert);
+
+		if (cn == certCN) {
+			Log(LogInformation, "cli")
+				<< "OK: CN '" << cn << "' matches certificate CN '" << certCN << "'.";
+
+			return ServiceOK;
+		} else {
+			Log(LogCritical, "cli")
+				<< "CRITICAL: CN '" << cn << "' does NOT match certificate CN '" << certCN << "'.";
+
+			return ServiceCritical;
+		}
+	}
+
+	/* Verify certificate. */
+	if (!certFile.IsEmpty() && !caCertFile.IsEmpty()) {
+		std::shared_ptr<X509> cert = GetX509Certificate(certFile);
+		std::shared_ptr<X509> cacert = GetX509Certificate(caCertFile);
+
+		Log(LogInformation, "cli")
+			<< "Verifying certificate '" << certFile << "'";
+
+		std::cout << PkiUtility::GetCertificateInformation(cert) << "\n";
+
+		Log(LogInformation, "cli")
+			<< " with CA certificate '" << caCertFile << "'.";
+
+		std::cout << PkiUtility::GetCertificateInformation(cacert) << "\n";
+
+		String certCN = GetCertificateCN(cert);
+
+		bool signedByCA;
+
+		try {
+			signedByCA = VerifyCertificate(cacert, cert);
+		} catch (const std::exception& ex) {
+			Log(LogCritical, "cli")
+				<< "CRITICAL: Certificate with CN '" << certCN << "' is NOT signed by CA: " << DiagnosticInformation(ex, false);
+
+			return ServiceCritical;
+		}
+
+		if (signedByCA) {
+			Log(LogInformation, "cli")
+				<< "OK: Certificate with CN '" << certCN << "' is signed by CA.";
+
+			return ServiceOK;
+		} else {
+			Log(LogCritical, "cli")
+				<< "CRITICAL: Certificate with CN '" << certCN << "' is NOT signed by CA.";
+
+			return ServiceCritical;
+		}
+	}
+
+
+	/* Standalone CA checks. */
+	if (certFile.IsEmpty() && !caCertFile.IsEmpty()) {
+		std::shared_ptr<X509> cacert = GetX509Certificate(caCertFile);
+
+		Log(LogInformation, "cli")
+			<< "Checking whether certificate '" << caCertFile << "' is a valid CA certificate.";
+
+		std::cout << PkiUtility::GetCertificateInformation(cacert) << "\n";
+
+		if (IsCa(cacert)) {
+			Log(LogInformation, "cli")
+				<< "OK: CA certificate file '" << caCertFile << "' was verified successfully.\n";
+
+			return ServiceOK;
+		} else {
+			Log(LogCritical, "cli")
+				<< "CRITICAL: The file '" << caCertFile << "' does not seem to be a CA certificate file.\n";
+
+			return ServiceCritical;
+		}
+	}
+
+	/* Print certificate */
+	if (!certFile.IsEmpty()) {
+		std::shared_ptr<X509> cert = GetX509Certificate(certFile);
+
+		Log(LogInformation, "cli")
+			<< "Printing certificate '" << certFile << "'";
+
+		std::cout << PkiUtility::GetCertificateInformation(cert) << "\n";
+
+		return ServiceOK;
+	}
+
+	return ServiceOK;
+}

--- a/lib/cli/pkiverifycommand.hpp
+++ b/lib/cli/pkiverifycommand.hpp
@@ -1,0 +1,32 @@
+/* Icinga 2 | (c) 2020 Icinga GmbH | GPLv2+ */
+
+#ifndef PKIVERIFYCOMMAND_H
+#define PKIVERIFYCOMMAND_H
+
+#include "cli/clicommand.hpp"
+
+namespace icinga
+{
+
+/**
+ * The "pki verify" command.
+ *
+ * @ingroup cli
+ */
+class PKIVerifyCommand final : public CLICommand
+{
+public:
+	DECLARE_PTR_TYPEDEFS(PKIVerifyCommand);
+
+	String GetDescription() const override;
+	String GetShortDescription() const override;
+	void InitParameters(boost::program_options::options_description& visibleDesc,
+		boost::program_options::options_description& hiddenDesc) const override;
+	std::vector<String> GetArgumentSuggestions(const String& argument, const String& word) const override;
+	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
+
+};
+
+}
+
+#endif /* PKIVERIFYCOMMAND_H */

--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -57,9 +57,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 	try {
 		signedByCA = VerifyCertificate(cacert, cert);
-	} catch (const std::exception& ex) {
-
-	}
+	} catch (const std::exception&) { } /* Swallow the exception on purpose, cacert will never be a non-CA certificate. */
 
 	Log(LogInformation, "JsonRpcConnection")
 		<< "Received certificate request for CN '" << cn << "'"

--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -53,7 +53,13 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 	String cn = GetCertificateCN(cert);
 
-	bool signedByCA = VerifyCertificate(cacert, cert);
+	bool signedByCA;
+
+	try {
+		signedByCA = VerifyCertificate(cacert, cert);
+	} catch (const std::exception& ex) {
+
+	}
 
 	Log(LogInformation, "JsonRpcConnection")
 		<< "Received certificate request for CN '" << cn << "'"
@@ -199,7 +205,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 	 * this ensures that the CA we have in /var/lib/icinga2/ca matches the one
 	 * we're using for cluster connections (there's no point in sending a client
 	 * a certificate it wouldn't be able to use to connect to us anyway) */
-	if (!VerifyCertificate(cacert, newcert)) {
+	if (!signedByCA) {
 		Log(LogWarning, "JsonRpcConnection")
 			<< "The CA in '" << listener->GetDefaultCaPath() << "' does not match the CA which Icinga uses "
 			<< "for its own cluster connections. This is most likely a configuration problem.";


### PR DESCRIPTION
This originates from testing the "is CA" functionality in #7835 and provides
a built-in replacement for the OpenSSL binary for printing and verifying Icinga
TLS certificates.

The CLI command also provides enhanced certificate information printing
with version, serial, signature algorithm and subject alt names (SANs).
The same applies to other functionality using this function (save-cert, etc.).

Supported modes:

- Print the TLS certificate
- Print and verify the CA certificate (checks whether this is a CA certificate)
- Verify the TLS certificate if it is signed by the provided CA certificate
- Verify the TLS certificate's common name (CN) matches against the given CN string

Bonus points:

- The exit codes follow the plugin API, so this can be used for automated checks
- On Windows, no-one ever installs the OpenSSL binary to do verification tests.
With providing this from the icinga2.exe binary, troubleshooting becomes even more easy.