### PR TITLE
Auto-rewrite associative DSL expression trees

### DIFF
--- a/lib/base/debuginfo.cpp
+++ b/lib/base/debuginfo.cpp
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "base/debuginfo.hpp"
-#include "base/convert.hpp"
-#include <fstream>
 
 using namespace icinga;
 
@@ -33,67 +31,4 @@ DebugInfo icinga::DebugInfoRange(const DebugInfo& start, const DebugInfo& end)
 	result.LastLine = end.LastLine;
 	result.LastColumn = end.LastColumn;
 	return result;
-}
-
-#define EXTRA_LINES 2
-
-void icinga::ShowCodeLocation(std::ostream& out, const DebugInfo& di, bool verbose)
-{
-	if (di.Path.IsEmpty())
-		return;
-
-	out << "Location: " << di;
-
-	std::ifstream ifs;
-	ifs.open(di.Path.CStr(), std::ifstream::in);
-
-	int lineno = 0;
-	char line[1024];
-
-	while (ifs.good() && lineno <= di.LastLine + EXTRA_LINES) {
-		if (lineno == 0)
-			out << "\n";
-
-		lineno++;
-
-		ifs.getline(line, sizeof(line));
-
-		for (int i = 0; line[i]; i++)
-			if (line[i] == '\t')
-				line[i] = ' ';
-
-		int extra_lines = verbose ? EXTRA_LINES : 0;
-
-		if (lineno < di.FirstLine - extra_lines || lineno > di.LastLine + extra_lines)
-			continue;
-
-		String pathInfo = di.Path + "(" + Convert::ToString(lineno) + "): ";
-		out << pathInfo;
-		out << line << "\n";
-
-		if (lineno >= di.FirstLine && lineno <= di.LastLine) {
-			int start, end;
-
-			start = 0;
-			end = strlen(line);
-
-			if (lineno == di.FirstLine)
-				start = di.FirstColumn - 1;
-
-			if (lineno == di.LastLine && di.LastColumn > 0) {
-				end = di.LastColumn;
-			}
-
-			if (start < 0) {
-				end -= start;
-				start = 0;
-			}
-
-			out << String(pathInfo.GetLength(), ' ');
-			out << String(start, ' ');
-			out << String(end - start, '^');
-
-			out << "\n";
-		}
-	}
 }

--- a/lib/base/debuginfo.hpp
+++ b/lib/base/debuginfo.hpp
@@ -4,8 +4,10 @@
 #ifndef DEBUGINFO_H
 #define DEBUGINFO_H
 
+#include "base/convert.hpp"
 #include "base/i2-base.hpp"
 #include "base/string.hpp"
+#include <fstream>
 
 namespace icinga
 {
@@ -30,7 +32,66 @@ std::ostream& operator<<(std::ostream& out, const DebugInfo& val);
 
 DebugInfo DebugInfoRange(const DebugInfo& start, const DebugInfo& end);
 
-void ShowCodeLocation(std::ostream& out, const DebugInfo& di, bool verbose = true);
+template<class T, unsigned long ExtraLines = 2>
+void ShowCodeLocation(T& out, const DebugInfo& di, bool verbose = true)
+{
+	if (di.Path.IsEmpty())
+		return;
+
+	out << "Location: " << di;
+
+	std::ifstream ifs;
+	ifs.open(di.Path.CStr(), std::ifstream::in);
+
+	int lineno = 0;
+	char line[1024];
+
+	while (ifs.good() && lineno <= di.LastLine + ExtraLines) {
+		if (lineno == 0)
+			out << "\n";
+
+		lineno++;
+
+		ifs.getline(line, sizeof(line));
+
+		for (int i = 0; line[i]; i++)
+			if (line[i] == '\t')
+				line[i] = ' ';
+
+		int extra_lines = verbose ? ExtraLines : 0;
+
+		if (lineno < di.FirstLine - extra_lines || lineno > di.LastLine + extra_lines)
+			continue;
+
+		String pathInfo = di.Path + "(" + Convert::ToString(lineno) + "): ";
+		out << pathInfo;
+		out << line << "\n";
+
+		if (lineno >= di.FirstLine && lineno <= di.LastLine) {
+			int start, end;
+
+			start = 0;
+			end = strlen(line);
+
+			if (lineno == di.FirstLine)
+				start = di.FirstColumn - 1;
+
+			if (lineno == di.LastLine && di.LastColumn > 0)
+				end = di.LastColumn;
+
+			if (start < 0) {
+				end -= start;
+				start = 0;
+			}
+
+			out << String(pathInfo.GetLength(), ' ');
+			out << String(start, ' ');
+			out << String(end - start, '^');
+
+			out << "\n";
+		}
+	}
+}
 
 }
 

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -17,11 +17,14 @@
 #include "base/defer.hpp"
 #include <boost/exception_ptr.hpp>
 #include <boost/exception/errinfo_nested_exception.hpp>
+#include <cmath>
 
 using namespace icinga;
 
 boost::signals2::signal<void (ScriptFrame&, ScriptError *ex, const DebugInfo&)> Expression::OnBreakpoint;
 boost::thread_specific_ptr<bool> l_InBreakpointHandler;
+
+const long double AssociativeExpression::m_Log2 = logl(2);
 
 Expression::~Expression()
 { }


### PR DESCRIPTION
... if depth > log2(leaves) * 2 to reduce recursion and thereby avoid stack overflows.

fixes #7827
refs #7826
closes #7825