### PR TITLE
Windows setup wizard: Remove deprecated parameters for 'pki save-cert'

### DIFF
--- a/agent/windows-setup-agent/SetupWizard.cs
+++ b/agent/windows-setup-agent/SetupWizard.cs
@@ -162,7 +162,7 @@ namespace Icinga
 
 			_TrustedFile = Path.GetTempFileName();
 
-			processArguments = "pki save-cert --host \"" + host + "\" --port \"" + port + "\" --key \"" + pathPrefix + ".key\" --cert \"" + pathPrefix + ".crt\" --trustedcert \"" + _TrustedFile + "\"";
+			processArguments = "pki save-cert --host \"" + host + "\" --port \"" + port + "\" --trustedcert \"" + _TrustedFile + "\"";
 			if (!RunProcess(Program.Icinga2InstallDir + "\\sbin\\icinga2.exe",
 				processArguments,
 				out output)) {


### PR DESCRIPTION
Missing from #7835