### PR TITLE
Fix 'check_timeout' not being forwarded to agent command endpoints

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1742,13 +1742,14 @@ params    | Dictionary
 
 ##### Params
 
-Key           | Type          | Description
---------------|---------------|------------------
-host          | String        | Host name.
-service       | String        | Service name.
-command\_type | String        | `check_command` or `event_command`.
-command       | String        | CheckCommand or EventCommand name.
-macros        | Dictionary    | Command arguments as key/value pairs for remote execution.
+Key            | Type          | Description
+---------------|---------------|------------------
+host           | String        | Host name.
+service        | String        | Service name.
+command\_type  | String        | `check_command` or `event_command`.
+command        | String        | CheckCommand or EventCommand name.
+check\_timeout | Number        | Check timeout of the checkable object, if specified as `check_timeout` attribute.
+macros         | Dictionary    | Command arguments as key/value pairs for remote execution.
 
 
 ##### Functions

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -569,6 +569,13 @@ void Checkable::ExecuteCheck()
 			if (service)
 				params->Set("service", service->GetShortName());
 
+			/*
+			 * If the host/service object specifies the 'check_timeout' attribute,
+			 * forward this to the remote endpoint to limit the command execution time.
+			 */
+			if (!GetCheckTimeout().IsEmpty())
+				params->Set("check_timeout", GetCheckTimeout());
+
 			params->Set("macros", macros);
 
 			ApiListener::Ptr listener = ApiListener::GetInstance();

--- a/lib/icinga/clusterevents-check.cpp
+++ b/lib/icinga/clusterevents-check.cpp
@@ -124,6 +124,14 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 	attrs->Set("__name", params->Get("host"));
 	attrs->Set("type", "Host");
 
+	/*
+	 * Override the check timeout if the parent caller provided the value. Compatible with older versions not
+	 * passing this inside the cluster message.
+	 * This happens with host/service command_endpoint agents and the 'check_timeout' attribute being specified.
+	 */
+	if (params->Contains("check_timeout"))
+		attrs->Set("check_timeout", params->Get("check_timeout"));
+
 	Deserialize(host, attrs, false, FAConfig);
 
 	if (params->Contains("service"))


### PR DESCRIPTION
fixes #6992