### PR TITLE
Disallow fetching the ticket salt via REST API

### DIFF
--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -99,6 +99,9 @@ bool VariableQueryHandler::HandleRequest(
 	ArrayData results;
 
 	for (const Dictionary::Ptr& var : objs) {
+		if (var->Get("name") == "TicketSalt")
+			continue;
+
 		results.emplace_back(new Dictionary({
 			{ "name", var->Get("name") },
 			{ "type", var->Get("type") },


### PR DESCRIPTION
For security reasons, we should disable fetching this credential specific constant.