### PR TITLE
WIP: Add process-check-results API action

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -31,6 +31,7 @@ REGISTER_APIACTION(remove_downtime, "Service;Host;Downtime", &ApiActions::Remove
 REGISTER_APIACTION(shutdown_process, "", &ApiActions::ShutdownProcess);
 REGISTER_APIACTION(restart_process, "", &ApiActions::RestartProcess);
 REGISTER_APIACTION(generate_ticket, "", &ApiActions::GenerateTicket);
+REGISTER_APIACTION(process_check_results, "", &ApiActions::ProcessCheckResults);
 
 Dictionary::Ptr ApiActions::CreateResult(int code, const String& status,
 	const Dictionary::Ptr& additional)
@@ -117,6 +118,13 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 
 	return ApiActions::CreateResult(200, "Successfully processed check result for object '" + checkable->GetName() + "'.");
 }
+//TODO Func by SD Start
+Dictionary::Ptr ApiActions::ProcessCheckResults(const ConfigObject::Ptr& object,
+                                               const Dictionary::Ptr& params)
+{
+    return ApiActions::CreateResult(200, "Successfully processed check result for object (new Func last return ).");
+}
+//TODO Func by SD End
 
 Dictionary::Ptr ApiActions::RescheduleCheck(const ConfigObject::Ptr& object,
 	const Dictionary::Ptr& params)

--- a/lib/icinga/apiactions.hpp
+++ b/lib/icinga/apiactions.hpp
@@ -29,7 +29,7 @@ public:
 	static Dictionary::Ptr ShutdownProcess(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
 	static Dictionary::Ptr RestartProcess(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
 	static Dictionary::Ptr GenerateTicket(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
-
+    static Dictionary::Ptr ProcessCheckResults(const ConfigObject::Ptr& object, const Dictionary::Ptr& params);
 private:
 	static Dictionary::Ptr CreateResult(int code, const String& status, const Dictionary::Ptr& additional = nullptr);
 };


### PR DESCRIPTION
This PR implements a new API action called `process-check-results`. The existing action `process-check-result` cannot be extended due to the filter/type requirement.

Schema:

- Hosts: `host1`
- Services: `host1!svc1` 

fixes #3553

TODO: 
- [ ] Error handling
- [ ] Docs
- [ ] Tests with service objects

## Tests

```
curl -k -s -u root:PasswordHere -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/process-check-results' \
-d '{
        "check_results":
        [
            {
                "name": "host1",
                "exit_status": 1,
                "plugin_output": "Test1",
                "check_command" : "dummy",
                "execute_start":1,
                "execute_end":5,
                "check_source":"Sukhwinders-MacBook-Pro.local",
                "ttl":300,
                "performance_data":"rta=0.065000ms;100.000000;200.000000;0.000000 pl=0%;5;15;0"
            },
            {
                "name": "host2",
                 "exit_status":0,
                  "plugin_output": "Test2"
            }
        ]
    }'
```