### PR TITLE
ConfigObjectUtility#CreateObject(): check config objects for duplicates

### DIFF
--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -152,11 +152,13 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 {
 	CreateStorage();
 
-	ConfigItem::Ptr item = ConfigItem::GetByTypeAndName(type, fullName);
+	{
+		auto configType (dynamic_cast<ConfigType*>(type.get()));
 
-	if (item) {
-		errors->Add("Object '" + fullName + "' already exists.");
-		return false;
+		if (configType && configType->GetObject(fullName)) {
+			errors->Add("Object '" + fullName + "' already exists.");
+			return false;
+		}
 	}
 
 	String path;


### PR DESCRIPTION
... not to delete already existing objects during a trial of re-creation.

fixes #7726
fixes #7094