### PR TITLE
fix boost library order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ else()
   set(LOGROTATE_CREATE "\n\tcreate 644 ${ICINGA2_USER} ${ICINGA2_GROUP}")
 endif()
 
-find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS context coroutine date_time filesystem thread system program_options regex REQUIRED)
+find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS coroutine context date_time filesystem thread system program_options regex REQUIRED)
 
 # Boost.Coroutine2 (the successor of Boost.Coroutine)
 # (1) doesn't even exist in old Boost versions and


### PR DESCRIPTION
When statically compiling icinga2 with a local boost the order of the boost libraries matters.
Correcting the order fixes the following linker issue:

```
make[5]: Entering directory `.../icinga2/icinga2-2.11.3/build'
[ 98%] Linking CXX executable ../Bin/RELEASE/icinga2
.../boost_1_72_0/lib/libboost_coroutine.a(coroutine_context.o): In function `boost::coroutines::detail::coroutine_context::coroutine_context(void (*)(boost::context::detail::transfer_t), boost::coroutines::detail::preallocated const&)':
coroutine_context.cpp:(.text+0x59): undefined reference to `make_fcontext'
.../boost_1_72_0/lib/libboost_coroutine.a(coroutine_context.o): In function `boost::coroutines::detail::coroutine_context::jump(boost::coroutines::detail::coroutine_context&, void*)':
coroutine_context.cpp:(.text+0xe8): undefined reference to `jump_fcontext'
collect2: error: ld returned 1 exit status
make[5]: *** [Bin/RELEASE/icinga2] Error 1
```

Signed-off-by: Sven Nierlein <sven@nierlein.de>