### PR TITLE
Add parameters needed for PKI usage.

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -880,6 +880,12 @@ nrpe_arguments	| **Optional.** Arguments that should be passed to the command. M
 nrpe_ipv4       | **Optional.** Use IPv4 connection. Defaults to false.
 nrpe_ipv6       | **Optional.** Use IPv6 connection. Defaults to false.
 nrpe_version_2	| **Optional.** Use this if you want to connect using NRPE v2 protocol. Defaults to false.
+nrpe_ca		| **Optional.** The CA file to use for PKI. Defaults to none.
+nrpe_cert	| **Optional.** The client cert file to use for PKI. Defaults to none.
+nrpe_key	| **Optional.** The client key file to use for PKI. Defaults to none.
+nrpe_ssl_version	| **Optional.** The SSL/TLS version to use. Defaults to TLSv1+.
+nrpe_cipher_list	| **Optional.** The list of SSL ciphers to use. Default depends on check_nrpe version.
+nrpe_dh_opt	| **Optional.** Anonymous Diffie Hellman use: 0 = deny, 1 = allow, 2 = force. Default depends on check_nrpe version.
 
 
 ### nscp <a id="plugin-check-command-nscp"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2316,6 +2316,30 @@ object CheckCommand "nrpe" {
 			set_if = "$nrpe_version_2$"
 			description = "Use this if you want to connect to NRPE v2"
 		}
+		"-A" = {
+			value = "$nrpe_ca$"
+			description = "The CA file to use for PKI"
+		}
+		"-C" = {
+			value = "$nrpe_cert$"
+			description = "The cert file to use for PKI"
+		}
+		"-K" = {
+			value = "$nrpe_key$"
+			description = "The key file to use for PKI"
+		}
+		"-S" = {
+			value = "$nrpe_ssl_version$"
+			description = "The SSL/TLS version to use"
+		}
+		"-L" = {
+			value = "$nrpe_cipher_list$"
+			description = "The list of SSL ciphers to use"
+		}
+		"-d" = {
+			value = "$nrpe_dh_opt$"
+			description = "Anonymous Diffie Hellman use: 0 = deny, 1 = allow, 2 = force"
+		}
 	}
 
 	vars.nrpe_address = "$check_address$"


### PR DESCRIPTION
fixes #6552

To use PKI with nrpe, a CA must be specified and anonymous DH must be disabled.
If client certificates are enforced by nrped, additionally a private cert and key
must be specified. This patch adds all these parameters as well TLS configuration
options to limit the TLS version and crypto parameters:

nrpe_ca          - The CA file to use for PKI. Defaults to none.
nrpe_cert        - The client cert file to use for PKI. Defaults to none.
nrpe_key         - The client key file to use for PKI. Defaults to none.
nrpe_ssl_version - The SSL/TLS version to use. Defaults to TLSv1+.
nrpe_cipher_list - The list of SSL ciphers to use. Default depends on check_nrpe version.
nrpe_dh_opt      - Anonymous Diffie Hellman use: 0 = deny, 1 = allow, 2 = force.
                   Default depends on check_nrpe version.