### PR TITLE
Introduce Command#arguments[].separator

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -140,6 +140,7 @@ All available argument value entries are shown below:
   order                     | Number                | Set if multiple arguments require a defined argument order. The syntax is `..., -3, -2, -1, <un-ordered keys>, 1, 2, 3, ...`. [More details](03-monitoring-basics.md#command-arguments-order).
   repeat\_key               | Boolean               | If the argument value is an array, repeat the argument key, or not. Defaults to true (repeat). [More details](03-monitoring-basics.md#command-arguments-repeat-key).
   key 	                    | String                | Optional argument key overriding the key identifier. [More details](03-monitoring-basics.md#command-arguments-key).
+  separator                 | String                | Key-value separator. If given, e.g. `=`, appears between key and value like `--key=value` instead of the regular `--key` `value`.
 
 `value` and `description` are commonly used, the other entries allow
 to build more advanced CheckCommand objects and arguments.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1925,10 +1925,12 @@ object CheckCommand "apt" {
 		}
 		"--upgrade" = {
 			value = "$apt_upgrade$"
+			separator = "="
 			description = "[Default] Perform an upgrade. If an optional OPTS argument is provided, apt-get will be run with these command line options instead of the default."
 		}
 		"--dist-upgrade" = {
 			value = "$apt_dist_upgrade$"
+			separator = "="
 			description = "Perform a dist-upgrade instead of normal upgrade. Like with -U OPTS can be provided to override the default options."
 		}
 		"--include" = {

--- a/lib/icinga/command.ti
+++ b/lib/icinga/command.ti
@@ -41,6 +41,7 @@ validator Command {
 			String set_if;
 			Function set_if;
 			Number order;
+			String separator;
 		};
 	};
 

--- a/lib/icinga/macroprocessor.cpp
+++ b/lib/icinga/macroprocessor.cpp
@@ -376,13 +376,17 @@ void MacroProcessor::ValidateCustomVars(const ConfigObject::Ptr& object, const D
 }
 
 void MacroProcessor::AddArgumentHelper(const Array::Ptr& args, const String& key, const String& value,
-	bool add_key, bool add_value)
+	bool add_key, bool add_value, const Value& separator)
 {
-	if (add_key)
-		args->Add(key);
+	if (add_key && separator.GetType() != ValueEmpty && add_value) {
+		args->Add(key + separator + value);
+	} else {
+		if (add_key)
+			args->Add(key);
 
-	if (add_value)
-		args->Add(value);
+		if (add_value)
+			args->Add(value);
+	}
 }
 
 Value MacroProcessor::EscapeMacroShellArg(const Value& value)
@@ -412,6 +416,7 @@ struct CommandArgument
 	bool RepeatKey{true};
 	bool SkipValue{false};
 	String Key;
+	Value Separator;
 	Value AValue;
 
 	bool operator<(const CommandArgument& rhs) const
@@ -459,6 +464,7 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 				if (argdict->Contains("repeat_key"))
 					arg.RepeatKey = argdict->Get("repeat_key");
 				arg.Order = argdict->Get("order");
+				arg.Separator = argdict->Get("separator");
 
 				Value set_if = argdict->Get("set_if");
 
@@ -539,10 +545,10 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 					} else
 						add_key = !arg.SkipKey && arg.RepeatKey;
 
-					AddArgumentHelper(command_arr, arg.Key, value, add_key, !arg.SkipValue);
+					AddArgumentHelper(command_arr, arg.Key, value, add_key, !arg.SkipValue, arg.Separator);
 				}
 			} else
-				AddArgumentHelper(command_arr, arg.Key, arg.AValue, !arg.SkipKey, !arg.SkipValue);
+				AddArgumentHelper(command_arr, arg.Key, arg.AValue, !arg.SkipKey, !arg.SkipValue, arg.Separator);
 		}
 	}
 

--- a/lib/icinga/macroprocessor.hpp
+++ b/lib/icinga/macroprocessor.hpp
@@ -51,7 +51,7 @@ private:
 		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros, int recursionLevel);
 
 	static void AddArgumentHelper(const Array::Ptr& args, const String& key, const String& value,
-		bool add_key, bool add_value);
+		bool add_key, bool add_value, const Value& separator);
 	static Value EscapeMacroShellArg(const Value& value);
 
 };

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -990,7 +990,7 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 					values = new Dictionary({{"value", kv.second}});
 				}
 
-				for (const char *attr : {"value", "set_if"}) {
+				for (const char *attr : {"value", "set_if", "separator"}) {
 					Value value;
 
 					// Stringify if set.


### PR DESCRIPTION
... for letting check commands produce argv like --key=value, not just --key value.

fixes #6277