### PR TITLE
Add support for check_snmp_brocade

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2798,6 +2798,42 @@ Name                            | Description
 smart_attributes_config_path    | **Required.** Path to the smart attributes config file (e.g. check_smartdb.json).
 smart_attributes_device         | **Required.** Device name (e.g. /dev/sda) to monitor.
 
+### Hardware <a id="plugin-contrib-hardware-switch"></a>
+
+This category includes all plugin check commands for various network hardware checks.
+
+#### fiberchannel-brocade <a id="plugin-contrib-command-fiberchannel-brocade"></a>
+
+The [check_snmp_brocade](https://exchange.nagios.org/directory/Plugins/Hardware/Network-Gear/Brocade/check_snmp_brocade--2D-monitor-Brocade-fibre-channel-switches/details) plugin
+monitors the hardware health of Brocade Fiber Channel Switches via SNMP.
+
+The plugin runs remote SNMP queries.
+
+Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
+
+Name                                  | Description
+--------------------------------------|-----------------------------------------------------------------------
+fiberchannel_brocade_hostname         | **Required.** Hostname or IP-address of the server (SNMP mode only)"
+fiberchannel_brocade_community        | **Optional.** SNMP community of the switch (SNMP v1/2 only)"
+fiberchannel_brocade_snmpversion      | **Optional.** The SNMP protocol to use (default: 2c, other possibilities: 1,3)"
+fiberchannel_brocade_seclevel         | **Optional.** The SNMP security level to use (default: noAuthNoPriv, othet possibilities: authNoPriv,authPriv)"
+fiberchannel_brocade_port             | **Optional.** The SNMP port to use (default: 161)"
+fiberchannel_brocade_context          | **Optional.** SNMPv3 context name"
+fiberchannel_brocade_fc_port          | **Optional.** Port number as shown in the output of `switchshow`. Can't combine with --systeminfo parameter"
+fiberchannel_brocade_systeminfo       | **Optional.** Get global data like boot date, overall status, reachability"
+fiberchannel_brocade_sensor           | **Optional.** Additional to --systeminfo. Status of powersupply, fans and temp sensors"
+fiberchannel_brocade_global           | **Optional.** Global data like boot date, overall status"
+fiberchannel_brocade_perfdata         | **Optional.** Print performance data of the selected FC port specified via -P parameter"
+fiberchannel_brocade_secname          | **Optional.** The SNMPv3 securityName for the USM security model"
+fiberchannel_brocade_authpassword     | **Optional.** The authentication password for SNMPv3"
+fiberchannel_brocade_authprotocol     | **Optional.** The authentication protocol for SNMPv3 (md5|sha)"
+fiberchannel_brocade_privpassword     | **Optional.** The password for SNMPv3 authPriv security level"
+fiberchannel_brocade_privprotocol     | **Optional.** The private protocol for SNMPv3 (des|aes)"
+fiberchannel_brocade_sfptemp          | **Optional.** Checks the temperature of all SFPs"
+fiberchannel_brocade_sfptemp_warning  | **Optional.** This is the warning offset the critical temperature as delivered by the system. Default is 10 Celsius. Must be used with --sfptemp parameter"
+fiberchannel_brocade_sfptemp_critical | **Optional.** Maximum temperature for SFPs. If not set it will be taken from your switch"
+fiberchannel_brocade_allports         | **Optional.** Default is only to show ports which are too hot. With this flag all ports will be shown. Must be used with --sfptemp"
+fiberchannel_brocade_multiline        | **Optional.** Multiline output in overview. This mean technically that a multiline output uses a HTML <br> for the GUI instead of be aware that your messing connections (email, SMS...) must use a filter to file out the <br>. A sed oneliner will do the job."
 
 ### IcingaCLI <a id="plugin-contrib-icingacli"></a>
 

--- a/itl/plugins-contrib.d/CMakeLists.txt
+++ b/itl/plugins-contrib.d/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+
 
 install(
-  FILES big-data.conf databases.conf hardware.conf icingacli.conf ipmi.conf logmanagement.conf metrics.conf network-components.conf network-services.conf operating-system.conf raid-controller.conf smart-attributes.conf storage.conf virtualization.conf vmware.conf web.conf
+  FILES big-data.conf databases.conf hardware.conf hardware-switch.conf icingacli.conf ipmi.conf logmanagement.conf metrics.conf network-components.conf network-services.conf operating-system.conf raid-controller.conf smart-attributes.conf storage.conf virtualization.conf vmware.conf web.conf
   DESTINATION ${ICINGA2_INCLUDEDIR}/plugins-contrib.d
 )

--- a/itl/plugins-contrib.d/hardware-switch.conf
+++ b/itl/plugins-contrib.d/hardware-switch.conf
@@ -1,0 +1,95 @@
+
+object CheckCommand "fiberchannel-brocade" {
+	import "ipv4-or-ipv6"
+	command = [ PluginContribDir + "/check_snmp_brocade" ]
+	arguments = {
+		"--hostname" = {
+			value = "$fiberchannel_brocade_hostname$"
+			description = "Hostname or IP-address of the server (SNMP mode only)"
+			required = true
+		}
+		"--community" = {
+			value = "$fiberchannel_brocade_community$"
+			description = "SNMP community of the switch (SNMP v1/2 only)"
+		}
+		"--snmpversion" = {
+			value = "$fiberchannel_brocade_snmpversion$"
+			description = "The SNMP protocol to use (default: 2c, other possibilities: 1,3)"
+		}
+		"--seclevel" = {
+			value = "$fiberchannel_brocade_seclevel$"
+			description = "The SNMP security level to use (default: noAuthNoPriv, othet possibilities: authNoPriv,authPriv)"
+		}
+		"--port" = {
+			value = "$fiberchannel_brocade_port$"
+			description = "The SNMP port to use (default: 161)"
+		}
+		"--context" = {
+			value = "$fiberchannel_brocade_context$"
+			description = "SNMPv3 context name"
+		}
+		# It seems --fc-port parameter is not working using its short form
+		"-P" = {
+			value = "$fiberchannel_brocade_fc_port$"
+			description = "Port number as shown in the output of `switchshow`. Can't combine with --systeminfo parameter"
+		}
+		"--systeminfo" = {
+			set_if = "$fiberchannel_brocade_systeminfo$"
+			description = "Get global data like boot date, overall status, reachability"
+		}
+		"--sensor" = {
+			set_if = "$fiberchannel_brocade_sensor$"
+			description = "Additional to --systeminfo. Status of powersupply, fans and temp sensors"
+		}
+		"--global" = {
+			set_if = "$fiberchannel_brocade_global$"
+			description = "Global data like boot date, overall status"
+		}
+		"--performancedata" = {
+			value = "$fiberchannel_brocade_perfdata$"
+			description = "Print performance data of the selected FC port specified via -P parameter"
+		}
+		"--secname" = {
+			value = "$fiberchannel_brocade_secname$"
+			description = "The SNMPv3 securityName for the USM security model"
+		}
+		"--authpassword" = {
+			value = "$fiberchannel_brocade_authpassword$"
+			description = "The authentication password for SNMPv3"
+		}
+		"--authproto" = {
+			value = "$fiberchannel_brocade_authprotocol$"
+			description = "The authentication protocol for SNMPv3 (md5|sha)"
+		}
+		"--privpasswd" = {
+			value = "$fiberchannel_brocade_privpassword$"
+			description = "The password for SNMPv3 authPriv security level"
+		}
+		"--privproto" = {
+			value = "$fiberchannel_brocade_privprotocol$"
+			description = "The private protocol for SNMPv3 (des|aes)"
+		}
+		"--sfptemp" = {
+			set_if = "$fiberchannel_brocade_sfptemp$"
+			description = "Checks the temperature of all SFPs"
+		}
+		"--sfptemp_warn" = {
+			value = "$fiberchannel_brocade_sfptemp_warning$"
+			description = "This is the warning offset the critical temperature as delivered by the system. Default is 10 Celsius. Must be used with --sfptemp parameter"
+		}
+		"--maxsfptemp" = {
+			value = "$fiberchannel_brocade_sfptemp_critical$"
+			description = "Maximum temperature for SFPs. If not set it will be taken from your switch"
+		}
+		"--allports" = {
+			set_if = "$fiberchannel_brocade_allports$"
+			description = "Default is only to show ports which are too hot. With this flag all ports will be shown. Must be used with --sfptemp"
+		}
+		"--multiline" = {
+			set_if = "$fiberchannel_brocade_multiline$"
+			description = "Multiline output in overview. This mean technically that a multiline output uses a HTML <br> for the GUI instead of be aware that your messing connections (email, SMS...) must use a filter to file out the <br>. A sed oneliner will do the job."
+		}
+	}
+	vars.fiberchannel_brocade_hostname = "$check_address$"
+	vars.fiberchannel_brocade_community = "public"
+}


### PR DESCRIPTION
Add support for check_snmp_brocade - monitor Brocade fibre channel switches check plugin

https://exchange.nagios.org/directory/Plugins/Hardware/Network-Gear/Brocade/check_snmp_brocade--2D-monitor-Brocade-fibre-channel-switches/details