### PR TITLE
Added a variable for noregexp and declared it false, by default

### DIFF
--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -206,6 +206,10 @@ object CheckCommand "snmp-storage" {
 			value = "$snmp_storage_type$"
 			description = "Storage type: Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk"
 		}
+		"-r" = {
+			set_if = "$snmp_noregexp$"
+			description = "Do not use regexp to match storage name in description OID"
+		}
 	}
 
 	vars.snmp_storage_name = "^/$$"
@@ -213,6 +217,7 @@ object CheckCommand "snmp-storage" {
 	vars.snmp_crit = 90
 	vars.snmp_perf = true
 	vars.snmp_exclude = false
+	vars.snmp_noregexp = false
 }
 
 


### PR DESCRIPTION
I have some endpoints where I monitor only the "/" partition, and do not care about the other partitions. By including snmp_noregexp, to the snmp-storage command, I am able to accomplish this.

This PR has the snmp_noregexp set to false by default. If a user does not want to use regex to match the storage name, then they will need to set the value to "true" in their Icinga2 template.