### PR TITLE
Fix CA verification regression

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -53,7 +53,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 	String cn = GetCertificateCN(cert);
 
-	bool signedByCA;
+	bool signedByCA = false;
 
 	try {
 		signedByCA = VerifyCertificate(cacert, cert);


### PR DESCRIPTION
Uninitialized bool values may evaluate to true while it should be false.

refs #7843
fixes #7945 