### PR TITLE
Update 09-object-types.md

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1473,7 +1473,7 @@ Cleanup Items:
 > **Supported units**
 >
 > Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
-> Check the [language reference](17-language-reference.md#numeric-literals-).
+> Check the [language reference](17-language-reference.md#duration-literals).
 
 Data Categories:
 
@@ -1572,7 +1572,7 @@ Cleanup Items:
 > **Supported units**
 >
 > Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
-> Check the [language reference](17-language-reference.md#numeric-literals-).
+> Check the [language reference](17-language-reference.md#duration-literals).
 
 Data Categories:
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -690,8 +690,7 @@ object Service "uptime" {
 
   check_command = "snmp"
 
-  vars.snmp_comm
-  y = "public"
+  vars.snmp_community = "public"
   vars.snmp_oid = "DISMAN-EVENT-MIB::sysUpTimeInstance"
 
   check_interval = 60s

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1473,7 +1473,7 @@ Cleanup Items:
 > **Supported units**
 >
 > Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
-> Check the [language reference](17-language-reference.md#numeric-literals-)
+> Check the [language reference](17-language-reference.md#numeric-literals-).
 
 Data Categories:
 
@@ -1572,8 +1572,7 @@ Cleanup Items:
 > **Supported units**
 >
 > Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
-> Check the [language reference](17-language-reference.md#numeric-literals-)
-
+> Check the [language reference](17-language-reference.md#numeric-literals-).
 
 Data Categories:
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1470,6 +1470,11 @@ Cleanup Items:
   servicechecks\_age              | Duration              | **Optional.** Max age for servicechecks table rows (start\_time). Defaults to 0 (never).
   systemcommands\_age             | Duration              | **Optional.** Max age for systemcommands table rows (start\_time). Defaults to 0 (never).
 
+> **Supported units**
+>
+> Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
+> Check the [language-reference](17-language-reference.md#numeric-literals-)
+
 Data Categories:
 
   Name                 | Description            | Required by
@@ -1563,6 +1568,12 @@ Cleanup Items:
   statehistory\_age               | Duration              | **Optional.** Max age for statehistory table rows (state\_time). Defaults to 0 (never).
   servicechecks\_age              | Duration              | **Optional.** Max age for servicechecks table rows (start\_time). Defaults to 0 (never).
   systemcommands\_age             | Duration              | **Optional.** Max age for systemcommands table rows (start\_time). Defaults to 0 (never).
+
+> **Supported units**
+>
+> Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
+> Check the [language-reference](17-language-reference.md#numeric-literals-)
+
 
 Data Categories:
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1473,7 +1473,7 @@ Cleanup Items:
 > **Supported units**
 >
 > Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
-> Check the [language-reference](17-language-reference.md#numeric-literals-)
+> Check the [language reference](17-language-reference.md#numeric-literals-)
 
 Data Categories:
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -690,7 +690,8 @@ object Service "uptime" {
 
   check_command = "snmp"
 
-  vars.snmp_community = "public"
+  vars.snmp_comm
+  y = "public"
   vars.snmp_oid = "DISMAN-EVENT-MIB::sysUpTimeInstance"
 
   check_interval = 60s
@@ -1572,7 +1573,7 @@ Cleanup Items:
 > **Supported units**
 >
 > Supported suffixes include ms (milliseconds), s (seconds), m (minutes), h (hours) and d (days).
-> Check the [language-reference](17-language-reference.md#numeric-literals-)
+> Check the [language reference](17-language-reference.md#numeric-literals-)
 
 
 Data Categories:


### PR DESCRIPTION
Because in this document it is not clear which units are allowed for DB Cleanup, I asked in the Community for it: https://community.icinga.com/t/db-ido-cleanup-possible-units/3854/2. We came to the conclusion that it would help if there is a notice which units are possible/allowed for this. For better finding I wrote  also a link to the language reference.