### PR TITLE
Introduce Utility::MkTime()

### DIFF
--- a/lib/base/datetime.cpp
+++ b/lib/base/datetime.cpp
@@ -35,7 +35,7 @@ DateTime::DateTime(const std::vector<Value>& args)
 
 		tms.tm_isdst = -1;
 
-		m_Value = mktime(&tms);
+		m_Value = Utility::MkTime(&tms);
 	} else if (args.size() == 1)
 		m_Value = args[0];
 	else

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -1410,6 +1410,12 @@ tm Utility::LocalTime(time_t ts)
 #endif /* _MSC_VER */
 }
 
+time_t Utility::MkTime(tm *timeptr)
+{
+	timeptr->tm_isdst = -1;
+	return mktime(timeptr);
+}
+
 bool Utility::PathExists(const String& path)
 {
 	namespace fs = boost::filesystem;

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -112,6 +112,7 @@ public:
 	static String GetFQDN();
 
 	static tm LocalTime(time_t ts);
+	static time_t MkTime(tm *timeptr);
 
 	static bool PathExists(const String& path);
 	static time_t GetFileCreationTime(const String& path);

--- a/lib/compat/compatlogger.cpp
+++ b/lib/compat/compatlogger.cpp
@@ -576,7 +576,7 @@ void CompatLogger::ScheduleNextRotation()
 		tmthen.tm_hour = 0;
 	}
 
-	time_t ts = mktime(&tmthen);
+	time_t ts = Utility::MkTime(&tmthen);
 
 	Log(LogNotice, "CompatLogger")
 		<< "Rescheduling rotation timer for compat log '"

--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -16,9 +16,9 @@ REGISTER_FUNCTION_NONCONST(Internal, LegacyTimePeriod, &LegacyTimePeriod::Script
 bool LegacyTimePeriod::IsInTimeRange(tm *begin, tm *end, int stride, tm *reference)
 {
 	time_t tsbegin, tsend, tsref;
-	tsbegin = mktime(begin);
-	tsend = mktime(end);
-	tsref = mktime(reference);
+	tsbegin = Utility::MkTime(begin);
+	tsend = Utility::MkTime(end);
+	tsref = Utility::MkTime(reference);
 
 	if (tsref < tsbegin || tsref > tsend)
 		return false;
@@ -50,7 +50,7 @@ void LegacyTimePeriod::FindNthWeekday(int wday, int n, tm *reference)
 	reference->tm_mday = 1;
 
 	for (;;) {
-		mktime(reference);
+		Utility::MkTime(reference);
 
 		if (reference->tm_wday == wday) {
 			seen++;
@@ -331,8 +331,8 @@ bool LegacyTimePeriod::IsInDayDefinition(const String& daydef, tm *reference)
 	ParseTimeRange(daydef, &begin, &end, &stride, reference);
 
 	Log(LogDebug, "LegacyTimePeriod")
-		<< "ParseTimeRange: '" << daydef << "' => " << mktime(&begin)
-		<< " -> " << mktime(&end) << ", stride: " << stride;
+		<< "ParseTimeRange: '" << daydef << "' => " << Utility::MkTime(&begin)
+		<< " -> " << Utility::MkTime(&end) << ", stride: " << stride;
 
 	return IsInTimeRange(&begin, &end, stride, reference);
 }
@@ -381,8 +381,8 @@ Dictionary::Ptr LegacyTimePeriod::ProcessTimeRange(const String& timestamp, tm *
 	ProcessTimeRangeRaw(timestamp, reference, &begin, &end);
 
 	return new Dictionary({
-		{ "begin", (long)mktime(&begin) },
-		{ "end", (long)mktime(&end) }
+		{ "begin", (long)Utility::MkTime(&begin) },
+		{ "end", (long)Utility::MkTime(&end) }
 	});
 }
 
@@ -406,13 +406,13 @@ Dictionary::Ptr LegacyTimePeriod::FindRunningSegment(const String& daydef, const
 	time_t tsend, tsiter, tsref;
 	int stride;
 
-	tsref = mktime(reference);
+	tsref = Utility::MkTime(reference);
 
 	ParseTimeRange(daydef, &begin, &end, &stride, reference);
 
 	iter = begin;
 
-	tsend = mktime(&end);
+	tsend = Utility::MkTime(&end);
 
 	do {
 		if (IsInTimeRange(&begin, &end, stride, &iter)) {
@@ -444,7 +444,7 @@ Dictionary::Ptr LegacyTimePeriod::FindRunningSegment(const String& daydef, const
 		iter.tm_hour = 0;
 		iter.tm_min = 0;
 		iter.tm_sec = 0;
-		tsiter = mktime(&iter);
+		tsiter = Utility::MkTime(&iter);
 	} while (tsiter < tsend);
 
 	return nullptr;
@@ -464,13 +464,13 @@ Dictionary::Ptr LegacyTimePeriod::FindNextSegment(const String& daydef, const St
 			ref.tm_mday++;
 		}
 
-		tsref = mktime(&ref);
+		tsref = Utility::MkTime(&ref);
 
 		ParseTimeRange(daydef, &begin, &end, &stride, &ref);
 
 		iter = begin;
 
-		tsend = mktime(&end);
+		tsend = Utility::MkTime(&end);
 
 		do {
 			if (IsInTimeRange(&begin, &end, stride, &iter)) {
@@ -501,7 +501,7 @@ Dictionary::Ptr LegacyTimePeriod::FindNextSegment(const String& daydef, const St
 			iter.tm_hour = 0;
 			iter.tm_min = 0;
 			iter.tm_sec = 0;
-			tsiter = mktime(&iter);
+			tsiter = Utility::MkTime(&iter);
 		} while (tsiter < tsend);
 	}
 


### PR DESCRIPTION
... which resets its param's #tm_isdst which otherwise disturbs mktime(3) return values if the parameter is on a DST border.

fixes #7066