### PR TITLE
Allow downtimes starting in the past added by Downtime#AddDowntime() to be triggered

### DIFF
--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -72,6 +72,9 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	[config] String authoritative_zone;
 
 	[no_user_view, no_user_modify] String removed_by;
+	[no_user_view, no_user_modify] bool can_be_triggered {
+		default {{{ return false; }}}
+	};
 };
 
 }


### PR DESCRIPTION
... not to loose downtime start notifications.

fixes #7896