### PR TITLE
RequestCertificateHandler(): don't disconnect nodes already integrated into the cluster

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -249,7 +249,13 @@ delayed_request:
 	Log(LogInformation, "JsonRpcConnection")
 		<< "Certificate request for CN '" << cn << "' is pending. Waiting for approval.";
 
-    client->Disconnect();
+	if (origin) {
+		auto client (origin->FromClient);
+
+		if (client && !client->GetEndpoint()) {
+			client->Disconnect();
+		}
+	}
 
 	return result;
 }


### PR DESCRIPTION
... not to cause a reconnect loop.