### PR TITLE
added packages-warning parameter to apt check command

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -209,6 +209,7 @@ apt_critical            | **Optional.** If the full package information of any o
 apt_timeout             | **Optional.** Seconds before plugin times out (default: 10).
 apt_only_critical       | **Optional.** Only warn about critical upgrades.
 apt_list                | **Optional.** List packages available for upgrade.
+apt_packages_warning    | **Optional.** Minimum number of packages available for upgrade to return WARNING status. Default is 1 package.
 
 
 ### breeze <a id="plugin-check-command-breeze"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1954,6 +1954,9 @@ object CheckCommand "apt" {
 			set_if = "$apt_list$"
 			description = "List packages available for upgrade."
 		}
+		"--packages-warning" = {
+    	set_if = "$apt_packages_warning"
+			description = "Minimum number of packages available for upgrade to return WARNING status. Default is 1 package."
 	}
 
 	timeout = 5m
@@ -3168,4 +3171,3 @@ object CheckCommand "uptime" {
 	vars.uptime_warning = "30m"
 	vars.uptime_critical = "15m"
 }
-


### PR DESCRIPTION
Parameter is available in check_apt command, however, was not present in checkcommand definition in ITL. Updated the checkcommand and the docs with the description as mentioned in the checkcommand itself (https://www.monitoring-plugins.org/doc/man/check_apt.html)