### PR TITLE
HttpServerConnection: send Access-Control-Allow-Origin header

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -253,6 +253,7 @@ bool HandleAccessControl(
 				allowOriginHeader.Done();
 
 				response.set(http::field::access_control_allow_credentials, "true");
+				response.set(http::field::access_control_allow_origin, String(headerAllowOrigin->Join(", ")));
 
 				if (request.method() == http::verb::options && !request[http::field::access_control_request_method].empty()) {
 					response.result(http::status::ok);


### PR DESCRIPTION
... if ApiListener#access_control_allow_origin given.

fixes #7967