### PR TITLE
Modified phpfpm-status CheckCommand to allow custom ssl parameters

### DIFF
--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -710,7 +710,20 @@ object CheckCommand "phpfpm_status" {
 			description = "timeout in seconds (Default: 15)"
 		}
 		"-S" = {
-			set_if = "$phpfpm_status_ssl$"
+			value = {{
+				var phpfpm_status_ssl = macro("$phpfpm_status_ssl$")
+
+				if (phpfpm_status_ssl == true) {
+					return ""
+				} else if (phpfpm_status_ssl.len() > 0) {
+					return phpfpm_status_ssl
+				}
+			}}
+			set_if = {{
+				var phpfpm_status_ssl = macro("$phpfpm_status_ssl$")
+
+				return phpfpm_status_ssl == true || (typeof(phpfpm_status_ssl) == String && phpfpm_status_ssl.len() > 0)
+			}}
 			description = "Wether we should use HTTPS instead of HTTP. Note that you can give some extra parameters to this settings. Default value is 'TLSv1' but you could use things like 'TLSv1_1' or 'TLSV1_2' (or even 'SSLv23:!SSLv2:!SSLv3' for old stuff)."
 		}
 		"-x" = {


### PR DESCRIPTION
We should be able to set custom ssl parameters to match the definition of the "-S / -ssl" parameter as documented