### PR TITLE
PluginUtility::ParseCheckOutput(): if it doesn't look like perfdata, it's not perfdata

### DIFF
--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -109,7 +109,7 @@ std::pair<String, String> PluginUtility::ParseCheckOutput(const String& output)
 		if (!text.IsEmpty())
 			text += "\n";
 
-		if (delim != String::NPos) {
+		if (delim != String::NPos && line.FindFirstOf("=", delim) != String::NPos) {
 			text += line.SubStr(0, delim);
 
 			if (!perfdata.IsEmpty())


### PR DESCRIPTION
fixes #8006