### PR TITLE
check_mysql: don't set -H if -s is given

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2694,6 +2694,7 @@ object CheckCommand "mysql" {
 
 	arguments = {
 		"-H" = {
+			set_if = {{ !macro("$mysql_socket$") }}
 			value = "$mysql_hostname$"
 			description = "Host name, IP Address, or unix socket (must be an absolute path)"
 		}


### PR DESCRIPTION
... as -H overrides -s.

fixes #8017