### PR TITLE
Forget that attribute is modified if it's changed back to its original state via API

### DIFF
--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -174,8 +174,17 @@ void ConfigObject::ModifyAttribute(const String& attr, const Value& value, bool 
 							original_attributes->Set(key, Empty);
 					}
 				}
-			} else if (!original_attributes->Contains(attr))
-				original_attributes->Set(attr, oldValue);
+			} else {
+				Value originalAttribute;
+
+				if (original_attributes->Get(attr, &originalAttribute)) {
+					if (JsonEncode(value) == JsonEncode(originalAttribute)) {
+						original_attributes->Remove(attr);
+					}
+				} else {
+					original_attributes->Set(attr, oldValue);
+				}
+			}
 		}
 
 		dict->Set(key, value);
@@ -183,7 +192,14 @@ void ConfigObject::ModifyAttribute(const String& attr, const Value& value, bool 
 		newValue = value;
 
 		if (field.Attributes & FAConfig) {
-			if (!original_attributes->Contains(attr)) {
+			Value originalAttribute;
+
+			if (original_attributes->Get(attr, &originalAttribute)) {
+				if (JsonEncode(value) == JsonEncode(originalAttribute)) {
+					updated_original_attributes = true;
+					original_attributes->Remove(attr);
+				}
+			} else {
 				updated_original_attributes = true;
 				original_attributes->Set(attr, oldValue);
 			}


### PR DESCRIPTION
The title says it all.

fixes #7986

## Edit

E.g. if I change the Director-configured enable_active_checks=true via API to false and back to true, Icinga forgets the false instead of replacing it with true. I.e. mod. attrs. neutralise each other. Director config changes cause no such thing and IIRC we don't want that (#8739).