### PR TITLE
Add check_smart.pl plugin as smart-advanced command

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2799,6 +2799,30 @@ smart_attributes_config_path    | **Required.** Path to the smart attributes con
 smart_attributes_device         | **Required.** Device name (e.g. /dev/sda) to monitor.
 
 
+#### smart-advanced <a id="plugin-contrib-command-smart-advanced"></a>
+
+The [check_smart](https://www.claudiokuenzler.com/monitoring-plugins/check_smart.php) plugin uses the `smartctl` command from the `smartmontools` package to monitor SMART values of physical drives. Hard, solid state and NVMe drives are supported. Both Direct drive access or drive behind a storage controller (such as RAID) are supported.
+
+Either smart_device (-d) or smart_global (-g) is required. smart_interface (-i) is always required.
+
+Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
+
+Name                   | Description
+-----------------------|-----------------------------------------------------------------------
+smart_device           | **Required.** Path to physical block device to be SMART monitored, e.g. /dev/sda.
+smart_interface        | **Required.** Drive's interface type, must be one of: auto, ata, scsi, nvme, 3ware,N, areca,N, hpt,L/M/N, cciss,N, megaraid,N.
+smart_global           | **(Required.)** A glob expression of physical devices to be monitored, eg -g "/dev/sd[a-z]".
+smart_raw_list         | **Optional.** List (comma separated, without spaces!) of SMART attributes to check for their raw values.
+smart_exclude_list     | **Optional.** List of (comma separated) SMART attributes which should be excluded (=ignored) from checks, but still appear in perfdata.
+smart_exclude_all_list | **Optional.** List of (comma separated) SMART attributes which should be excluded (=ignored) **completely** from checks and perfdata.
+smart_bad              | **Optional.** Threshold value (integer) when to warn for N bad entries (ATA: Current Pending Sector, SCSI: Grown defect list). Note: Deprecated for ATA drives, use `smart_warn` instead. Continue to use this for SCSI drives.
+smart_warn             | **Optional.** Comma separated list of thresholds for ATA drives (e.g. `'Reallocated_Sector_Ct=10,Current_Pending_Sector=62'`).
+smart_selftest         | **Optional.** If set to true, additionally check SMART's selftest log for errors.
+smart_quiet            | **Optional.** If set to true, only show failing drive(s) when faults are detected (only affects output when used with `smart_global`).
+
+Either smart_device (-d) or smart_global (-g) is required. smart_interface (-i) is always required.
+
+
 ### IcingaCLI <a id="plugin-contrib-icingacli"></a>
 
 This category includes all plugins using the icingacli provided by Icinga Web 2.

--- a/itl/plugins-contrib.d/smart-advanced.conf
+++ b/itl/plugins-contrib.d/smart-advanced.conf
@@ -1,0 +1,53 @@
+/* 
+ * Icinga2 CheckCommand definition for the SMART Advanced (check_smart.pl) Monitoring Plugin
+ */
+
+object CheckCommand "smart-advanced" {
+	command = [ PluginContribDir + "/check_smart.pl" ]
+
+	arguments = {
+		"-d" = {
+			value = "$smart_device$"
+			description = "A physical block device to be SMART monitored, eg /dev/sda."
+		}
+		"-g" = {
+			value = "$smart_global$"
+			description = "A glob expression of physical devices to be monitored, eg -g '/dev/sd[a-z]'."
+		}
+		"-i" = {
+			value = "$smart_interface$"
+			description = "Drive's interface type, must be one of: auto, ata, scsi, nvme, 3ware,N, areca,N, hpt,L/M/N, cciss,N, megaraid,N."
+		}
+		"-r" = {
+			value = "$smart_raw_list$"
+			description = "List (comma separated, without spaces!) of SMART attributes to check for their raw values."
+		}
+		"-e" = {
+			value = "$smart_exclude_list$"
+			description = "List of (comma separated) SMART attributes which should be excluded (=ignored) from checks, but still appear in perfdata."
+		}
+		"-E" = {
+			value = "$smart_exclude_all_list$"
+			description = "List of (comma separated) SMART attributes which should be excluded (=ignored) completely from checks and perfdata."
+		}
+		"-b" = {
+			value = "$smart_bad$"
+			description = "Threshold value (integer) when to warn for N bad entries (ATA: Current Pending Sector, SCSI: Grown defect list). Note: Deprecated for ATA drives, use `smart_warn` instead. Continue to use this for SCSI drives."
+		}
+		"-w" = {
+			value = "$smart_warn$"
+			description = "Comma separated list of thresholds for ATA drives (e.g. `'Reallocated_Sector_Ct=10,Current_Pending_Sector=62'`)."
+		}
+		"-s" = {
+			set_if = "$smart_selftest$"
+			description = "If set to true, additionally check SMART's selftest log for errors."
+		}
+		"-q" = {
+			set_if = "$smart_quiet$"
+			description = "If set to true, only show failing drive(s) when faults are detected (only affects output when used with `smart_global`)."
+		}
+	}
+
+	vars.smart_selftest = false
+	vars.smart_quiet = false
+}


### PR DESCRIPTION
This PR adds the check_smart.pl monitoring plugin under the `smart-advanced` check command (`smart` is already used by the check_ide_smart plugin). 