### PR TITLE
Catch exception when trusted cert is not readable during node setup on agent/satellite

### DIFF
--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -373,7 +373,15 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 			return 1;
 		}
 
-		trustedParentCert = GetX509Certificate(vm["trustedcert"].as<std::string>());
+		String trustedCert = vm["trustedcert"].as<std::string>();
+
+		try{
+			trustedParentCert = GetX509Certificate(trustedCert)
+		} catch (const std::exception&) {
+			Log(LogCritical, "cli")
+				<< "Can't read trusted cert at '" << trustedCert << "'.";
+			return 1;
+		}
 
 		Log(LogInformation, "cli")
 			<< "Verifying trusted certificate file '" << vm["trustedcert"].as<std::string>() << "'.";

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -376,7 +376,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm,
 		String trustedCert = vm["trustedcert"].as<std::string>();
 
 		try{
-			trustedParentCert = GetX509Certificate(trustedCert)
+			trustedParentCert = GetX509Certificate(trustedCert);
 		} catch (const std::exception&) {
 			Log(LogCritical, "cli")
 				<< "Can't read trusted cert at '" << trustedCert << "'.";


### PR DESCRIPTION
Backport of #7838