### PR TITLE
icinga2 daemon: reset INT/TERM signal handler once triggered

### DIFF
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -410,6 +410,8 @@ static void WorkerSignalHandler(int num, siginfo_t *info, void*)
 			if (info->si_pid == 0 || info->si_pid == l_UmbrellaPid) {
 				// The umbrella process requested our termination
 				Application::RequestShutdown();
+				(void)signal(SIGINT, SIG_DFL);
+				(void)signal(SIGTERM, SIG_DFL);
 			}
 			break;
 		default:


### PR DESCRIPTION
... not to run it twice.