### PR TITLE
Node setup: auto-store ticket salt

### DIFF
--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -376,4 +376,13 @@ void NodeUtility::UpdateConstant(const String& name, const String& value)
 
 	ifp.close();
 	ofp.Commit();
+
+	std::ofstream vars;
+	vars.exceptions(vars.eofbit | vars.failbit | vars.badbit);
+	vars.open(Configuration::VarsPath.CStr(), vars.out | vars.binary | vars.ate);
+
+	NetString::WriteStringToStream(vars, JsonEncode(new Dictionary({
+		{ "name", name },
+		{ "value", value }
+	})));
 }


### PR DESCRIPTION
... not to have to run daemon -C after node wizard before pki ticket.

pki ticket requires TicketSalt. It reads it from a file daemon -C writes. I.e. I have to run daemon -C after node wizard before I can run pki ticket. This change lets pki ticket write TicketSalt by itself.

fixes #8072
closes #8070