### PR TITLE
Docs: In some places, Timeperiod is used instead of TimePeriod

### DIFF
--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -261,7 +261,7 @@ If you want to specify a notification period across midnight,
 you can define it the following way:
 
 ```
-object Timeperiod "across-midnight" {
+object TimePeriod "across-midnight" {
   display_name = "Nightly Notification"
   ranges = {
     "saturday" = "22:00-24:00"
@@ -275,7 +275,7 @@ the first day as start with an overlapping range into
 the next day:
 
 ```
-object Timeperiod "do-not-disturb" {
+object TimePeriod "do-not-disturb" {
   display_name = "Weekend DND"
   ranges = {
     "saturday" = "22:00-06:00"
@@ -290,7 +290,7 @@ days, weeks or months. This can be useful when taking components offline
 for a distinct period of time.
 
 ```
-object Timeperiod "standby" {
+object TimePeriod "standby" {
   display_name = "Standby"
   ranges = {
     "2016-09-30 - 2016-10-30" = "00:00-24:00"

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -62,7 +62,7 @@ By default this template is automatically imported into all [EventCommand](09-ob
 
 ### legacy-timeperiod <a id="itl-legacy-timeperiod"></a>
 
-Timeperiod template for [Timeperiod objects](09-object-types.md#objecttype-timeperiod).
+Timeperiod template for [TimePeriod objects](09-object-types.md#objecttype-timeperiod).
 
 The `legacy-timeperiod` timeperiod does not support any vars.
 


### PR DESCRIPTION
Some code examples in the documentation use object `Timeperiod` instead of `TimePeriod`, resulting in the following error when the Icinga 2 service is loaded with this configuration:
`critical/config: Error: Error while evaluating expression: Tried to access undefined script variable 'Timeperiod'`

This pull request replaces Timeperiod with TimePeriod in those code examples.