### PR TITLE
Allow to apply Notifications based on HostGroups

### DIFF
--- a/lib/icinga/comment.ti
+++ b/lib/icinga/comment.ti
@@ -33,7 +33,9 @@ public:
 class Comment : ConfigObject < CommentNameComposer
 {
 	load_after Host;
+	load_after HostGroup;
 	load_after Service;
+	load_after ServiceGroup;
 
 	[config, no_user_modify, protected, required, navigation(host)] name(Host) host_name {
 		navigate {{{

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -24,7 +24,9 @@ class Dependency : CustomVarObject < DependencyNameComposer
 	activation_priority -10;
 
 	load_after Host;
+	load_after HostGroup;
 	load_after Service;
+	load_after ServiceGroup;
 
 	[config, no_user_modify, required, navigation(child_host)] name(Host) child_host_name {
 		navigate {{{

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -24,7 +24,9 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	activation_priority -10;
 
 	load_after Host;
+	load_after HostGroup;
 	load_after Service;
+	load_after ServiceGroup;
 
 	[config, no_user_modify, required, navigation(host)] name(Host) host_name {
 		navigate {{{

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -30,8 +30,6 @@ void Host::OnAllConfigLoaded()
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Host '" + GetName() + "' cannot be put into global zone '" + zone->GetName() + "'."));
 	}
 
-	HostGroup::EvaluateObjectRules(this);
-
 	Array::Ptr groups = GetGroups();
 
 	if (groups) {
@@ -50,6 +48,9 @@ void Host::OnAllConfigLoaded()
 
 void Host::CreateChildObjects(const Type::Ptr& childType)
 {
+	if (childType == HostGroup::TypeInstance)
+		HostGroup::EvaluateObjectRules(this);
+
 	if (childType == ScheduledDowntime::TypeInstance)
 		ScheduledDowntime::EvaluateApplyRules(this);
 

--- a/lib/icinga/hostgroup.ti
+++ b/lib/icinga/hostgroup.ti
@@ -10,6 +10,8 @@ namespace icinga
 
 class HostGroup : CustomVarObject
 {
+	load_after Host;
+
 	[config] String display_name {
 		get {{{
 			String displayName = m_DisplayName.load();

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -22,7 +22,9 @@ public:
 class Notification : CustomVarObject < NotificationNameComposer
 {
 	load_after Host;
+	load_after HostGroup;
 	load_after Service;
+	load_after ServiceGroup;
 	load_after User;
 	load_after UserGroup;
 

--- a/lib/icinga/scheduleddowntime.ti
+++ b/lib/icinga/scheduleddowntime.ti
@@ -25,7 +25,9 @@ class ScheduledDowntime : CustomVarObject < ScheduledDowntimeNameComposer
 	activation_priority 20;
 
 	load_after Host;
+	load_after HostGroup;
 	load_after Service;
+	load_after ServiceGroup;
 
 	[config, protected, no_user_modify, required, navigation(host)] name(Host) host_name {
 		navigate {{{

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -57,8 +57,6 @@ void Service::OnAllConfigLoaded()
 	if (m_Host)
 		m_Host->AddService(this);
 
-	ServiceGroup::EvaluateObjectRules(this);
-
 	Array::Ptr groups = GetGroups();
 
 	if (groups) {
@@ -77,6 +75,9 @@ void Service::OnAllConfigLoaded()
 
 void Service::CreateChildObjects(const Type::Ptr& childType)
 {
+	if (childType == ServiceGroup::TypeInstance)
+		ServiceGroup::EvaluateObjectRules(this);
+
 	if (childType == ScheduledDowntime::TypeInstance)
 		ScheduledDowntime::EvaluateApplyRules(this);
 

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -26,6 +26,7 @@ class Service : Checkable < ServiceNameComposer
 	load_after ApiListener;
 	load_after Endpoint;
 	load_after Host;
+	load_after HostGroup;
 	load_after Zone;
 
 	[config, no_user_modify, required, signal_with_old_value] array(name(ServiceGroup)) groups {

--- a/lib/icinga/servicegroup.ti
+++ b/lib/icinga/servicegroup.ti
@@ -10,6 +10,8 @@ namespace icinga
 
 class ServiceGroup : CustomVarObject
 {
+	load_after Service;
+
 	[config] String display_name {
 		get {{{
 			String displayName = m_DisplayName.load();


### PR DESCRIPTION
fixes #8116

## Edit

Define an order in which to load Notifications after HostGroups, so Notification applies can use the HostGroups info.

## Edit II

Maybe it already accidentally(!) just works for most(!) users and they don't need this PR. But IMAO if we wanna support this, we shall define the load order so Icinga always(!) has HostGroups while applying Notifications.