### PR TITLE
Remove all codes related to the heartbeat timeout

### DIFF
--- a/lib/remote/jsonrpcconnection-heartbeat.cpp
+++ b/lib/remote/jsonrpcconnection-heartbeat.cpp
@@ -15,6 +15,12 @@ using namespace icinga;
 
 REGISTER_APIFUNCTION(Heartbeat, event, &JsonRpcConnection::HeartbeatAPIHandler);
 
+/**
+ * We still send a heartbeat without timeout here
+ * to keep the m_Seen variable up to date. This is to keep the
+ * cluster connection alive when there isn't much going on.
+ */
+
 void JsonRpcConnection::HandleAndWriteHeartbeats(boost::asio::yield_context yc)
 {
 	boost::system::error_code ec;
@@ -26,44 +32,17 @@ void JsonRpcConnection::HandleAndWriteHeartbeats(boost::asio::yield_context yc)
 		if (m_ShuttingDown) {
 			break;
 		}
-
-		if (m_NextHeartbeat != 0 && m_NextHeartbeat < Utility::GetTime()) {
-			{
-				Log logMsg (LogWarning, "JsonRpcConnection");
-
-				if (m_Endpoint) {
-					logMsg << "Client for endpoint '" << m_Endpoint->GetName() << "'";
-				} else {
-					logMsg << "Anonymous client";
-				}
-
-				logMsg << " has requested heartbeat message but hasn't responded in time. Closing connection.";
-			}
-
-			Disconnect();
-			break;
-		}
-
-		if (m_Endpoint) {
-			SendMessageInternal(new Dictionary({
-				{ "jsonrpc", "2.0" },
-				{ "method", "event::Heartbeat" },
-				{ "params", new Dictionary({
-					{ "timeout", 120 }
-				}) }
-			}));
-		}
+		
+		SendMessageInternal(new Dictionary({
+			{ "jsonrpc", "2.0" },
+			{ "method", "event::Heartbeat" },
+			{ "params", new Dictionary() }
+		}));
 	}
 }
 
 Value JsonRpcConnection::HeartbeatAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
-	Value vtimeout = params->Get("timeout");
-
-	if (!vtimeout.IsEmpty()) {
-		origin->FromClient->m_NextHeartbeat = Utility::GetTime() + vtimeout;
-	}
-
 	return Empty;
 }
 


### PR DESCRIPTION
until now, if the timeout is exceeded, the connection is immediately terminated.
But since we do not want to disconnect even if the timeout is exceeded, it is
better to send the messages without timeout and have deleted everything that
related to the heartbeat timeout. We also have another mechanism in
JRPC::CheckLiveness that does the disconnect.