### PR TITLE
ApiListener#ReplayLog(): consider replay log messages too old only based on Endpoint#local_log_position

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1412,8 +1412,6 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 					break;
 				}
 
-				peer_ts = pmessage->Get("timestamp");
-
 				if (file.first > logpos_ts + 10) {
 					logpos_ts = file.first;
 


### PR DESCRIPTION
... not to loose any perfdata for graphers during replay.

fixes #8125