### PR TITLE
modified-attributes.conf: store attributes to modify in Internal.modified_attributes

### DIFF
--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -37,7 +37,9 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_StatsNS = new Namespace(true);
 	globalNS->Set("StatsFunctions", l_StatsNS, true);
 
-	globalNS->Set("Internal", new Namespace(), true);
+	Namespace::Ptr intNS = new Namespace();
+	intNS->Set("modified_attributes", new Dictionary(), true);
+	globalNS->Set("Internal", intNS, true);
 }, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -255,7 +255,7 @@ bool DaemonUtility::LoadConfigFiles(const std::vector<std::string>& configs,
 
 	WorkQueue upq(25000, Configuration::Concurrency);
 	upq.SetName("DaemonUtility::LoadConfigFiles");
-	bool result = ConfigItem::CommitItems(ascope.GetContext(), upq, newItems);
+	bool result = ConfigItem::CommitItems(ascope.GetContext(), upq, newItems, false, true);
 
 	if (!result) {
 		ConfigCompilerContext::GetInstance()->CancelObjectsFile();

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -595,10 +595,27 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	return true;
 }
 
-bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent)
+bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems,
+	bool silent, bool withModAttrs)
 {
 	if (!silent)
 		Log(LogInformation, "ConfigItem", "Committing config item(s).");
+
+	if (withModAttrs) {
+		/* restore modified attributes */
+		if (Utility::PathExists(Configuration::ModAttrPath)) {
+			std::unique_ptr<Expression> expression = ConfigCompiler::CompileFile(Configuration::ModAttrPath);
+
+			if (expression) {
+				try {
+					ScriptFrame frame(true);
+					expression->Evaluate(frame);
+				} catch (const std::exception& ex) {
+					Log(LogCritical, "config", DiagnosticInformation(ex));
+				}
+			}
+		}
+	}
 
 	if (!CommitNewItems(context, upq, newItems)) {
 		upq.ReportExceptions("config");

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -192,6 +192,20 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 		m_Scope->CopyTo(frame.Locals);
 	try {
 		m_Expression->Evaluate(frame, &debugHints);
+
+		Dictionary::Ptr allMods (Namespace::Ptr(ScriptGlobal::Get("Internal"))->Get("modified_attributes"));
+		Dictionary::Ptr typeMods (allMods->Get(type->GetName()));
+
+		if (typeMods) {
+			Function::Ptr objMods (typeMods->Get(m_Name));
+
+			if (objMods) {
+				objMods->Invoke({dobj});
+
+				ObjectLock oLock(typeMods);
+				typeMods->Remove(m_Name);
+			}
+		}
 	} catch (const std::exception& ex) {
 		if (m_IgnoreOnError) {
 			Log(LogNotice, "ConfigObject")

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -678,7 +678,9 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 {
 	if (withModAttrs) {
 		/* restore modified attributes */
-		if (Utility::PathExists(Configuration::ModAttrPath)) {
+		if (Utility::PathExists(Configuration::ModAttrPath) &&
+			!Dictionary::Ptr(Namespace::Ptr(ScriptGlobal::Get("Internal"))->Get("modified_attributes"))->GetLength()
+		) {
 			std::unique_ptr<Expression> expression = ConfigCompiler::CompileFile(Configuration::ModAttrPath);
 
 			if (expression) {

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -53,7 +53,8 @@ public:
 	static ConfigItem::Ptr GetByTypeAndName(const Type::Ptr& type,
 		const String& name);
 
-	static bool CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent = false);
+	static bool CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems,
+		bool silent = false, bool withModAttrs = false);
 	static bool ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated = false,
 		bool mainConfigActivation = false, bool withModAttrs = false, const Value& cookie = Empty);
 

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -136,15 +136,11 @@ static void PersistModAttrHelper(AtomicFile& fp, ConfigObject::Ptr& previousObje
 			ConfigWriter::EmitRaw(fp, "\n}\n\n");
 		}
 
-		ConfigWriter::EmitRaw(fp, "var obj = ");
-
-		Array::Ptr args1 = new Array({
-			object->GetReflectionType()->GetName(),
-			object->GetName()
-		});
-		ConfigWriter::EmitFunctionCall(fp, "get_object", args1);
-
-		ConfigWriter::EmitRaw(fp, "\nif (obj) {\n");
+		ConfigWriter::EmitRaw(fp, "Internal.modified_attributes[");
+		ConfigWriter::EmitValue(fp, 0, object->GetReflectionType()->GetName());
+		ConfigWriter::EmitRaw(fp, "][");
+		ConfigWriter::EmitValue(fp, 0, object->GetName());
+		ConfigWriter::EmitRaw(fp, "] = obj => {\n");
 	}
 
 	ConfigWriter::EmitRaw(fp, "\tobj.");


### PR DESCRIPTION
... to apply them at the right time.

Before they were applied all together after apply rules. So parent object attrs having an effect on whether, how and how many child objects are applied missed the modification before evaluating the apply rules.

Now they're applied just after committing individual objects and have the desired effect on child objects as per:

fixes #5235
fixes #8699

Before they were stored as sequence of all modifications for applying all at once, now in a 2D dict so commit can pick the individual object's mod atttrs function.