### PR TITLE
Introduce ConfigObject#authority_group

### DIFF
--- a/lib/base/configobject.ti
+++ b/lib/base/configobject.ti
@@ -72,6 +72,7 @@ abstract class ConfigObject : ConfigObjectBase < ConfigType
 		get;
 	};
 	[get_protected, no_user_modify] bool active;
+	[config] String authority_group;
 	[get_protected, no_user_modify] bool paused {
 		default {{{ return true; }}}
 	};

--- a/lib/remote/apilistener-authority.cpp
+++ b/lib/remote/apilistener-authority.cpp
@@ -65,10 +65,17 @@ void ApiListener::UpdateObjectAuthority()
 
 			bool authority;
 
-			if (!my_zone)
+			if (!my_zone) {
 				authority = true;
-			else
-				authority = endpoints[Utility::SDBM(object->GetName()) % endpoints.size()] == my_endpoint;
+			} else {
+				auto authorityGroup (object->GetAuthorityGroup());
+
+				if (authorityGroup.IsEmpty()) {
+					authorityGroup = object->GetName();
+				}
+
+				authority = endpoints[Utility::SDBM(authorityGroup) % endpoints.size()] == my_endpoint;
+			}
 
 #ifdef I2_DEBUG
 // 			//Enable on demand, causes heavy logging on each run.


### PR DESCRIPTION
... for letting the same instance handle multiple config objects.

fixes #6856