### PR TITLE
ProcessCheckResult(): Make sure hosts aren't locked during Service::GetSeverity()

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -358,9 +358,12 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		SetLastCheckResult(cr);
 
 		if (GetProblem() != wasProblem) {
-			for (auto& service : host->GetServices()) {
+			auto services = host->GetServices();
+			olock.Unlock();
+			for (auto& service : services) {
 				Service::OnHostProblemChanged(service, cr, origin);
 			}
+			olock.Lock();
 		}
 	}
 


### PR DESCRIPTION
This prevents a deadlock in Service::GetSeverity(). This happens when a host switches from problem to non problem state or the other way around, while one of the hosts services gets a state change at the same time. This results in two parallel state changes on that service, which triggers two parallel calls to Service::GetSeverity():

- Thread 1 
    - (1) ProcessCheckResult(host) 
    - (2) Lock(host) 
    - (3) OnHostProblemChange(service) 
    - (4) GetSeverity() 
    - (5) Lock(service) -> Can't lock, because already locked by 2.2
    - (6) Lock(host)
- Thread 2
    - (1) ProcessCheckResult(service) 
    - (2) Lock(service) 
    - (3) OnStateChange(service) 
    - (4) GetSeverity() 
    - (5) Lock(service) 
    - (6) Lock(host) -> Can't lock, because already locked by 1.2

The issue only happens with Icinga DB enabled, because we don't use GetSeverity() anywhere else.

fixes #8160 