### PR TITLE
GET /v1/objects/*: handle "attrs":[] as expected

### DIFF
--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -31,7 +31,7 @@ Dictionary::Ptr ObjectQueryHandler::SerializeObjectAttrs(const Object::Ptr& obje
 		}
 	}
 
-	if (!isJoin && (!attrs || attrs->GetLength() == 0))
+	if (!isJoin && !attrs)
 		allAttrs = true;
 
 	if (allAttrs) {


### PR DESCRIPTION
... i.e. yield no attrs and not all.

fixes #8167