### PR TITLE
Revert "MacroProcessor::ResolveArguments(): skip null argument values"

### DIFF
--- a/lib/icinga/macroprocessor.cpp
+++ b/lib/icinga/macroprocessor.cpp
@@ -511,8 +511,6 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 				continue;
 			}
 
-			arg.SkipValue = arg.SkipValue || arg.AValue.GetType() == ValueEmpty;
-
 			args.emplace_back(std::move(arg));
 		}
 


### PR DESCRIPTION
This reverts commit e4bdcedbca069cb9d42c40ce6ce8054ed3ee1b58.