### PR TITLE
Fix ‘fs::copy_option’ has not been declared with boost 1.74.0

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -725,7 +725,11 @@ void Utility::CopyFile(const String& source, const String& target)
 {
 	namespace fs = boost::filesystem;
 
+#if BOOST_VERSION >= 107400
+	fs::copy_file(fs::path(source.Begin(), source.End()), fs::path(target.Begin(), target.End()), fs::copy_options::overwrite_existing);
+#else /* BOOST_VERSION */
 	fs::copy_file(fs::path(source.Begin(), source.End()), fs::path(target.Begin(), target.End()), fs::copy_option::overwrite_if_exists);
+#endif /* BOOST_VERSION */
 }
 
 /*


### PR DESCRIPTION
It was deprecated in https://github.com/boostorg/filesystem/commit/f199152b7df036ff1606c85e4ea1b28edfeda6cc

This isn't enough to fix the build with boost 1.74.0 though.