### PR TITLE
Clear ApiListener#last_failed_zones_stage_validation on config::Update if config not changed

### DIFF
--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -534,6 +534,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 		Log(LogInformation, "ApiListener")
 			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
 			<< "' do not qualify for production, not triggering reload.";
+		listener->ClearLastFailedZonesStageValidation();
 	}
 }
 


### PR DESCRIPTION
fixes #7642