### PR TITLE
Drop passive check results for unreachable hosts/services

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -200,7 +200,7 @@ Configuration Attributes:
   parent\_service\_name     | Object name           | **Optional.** The parent service. If omitted, this dependency object is treated as host dependency.
   child\_host\_name         | Object name           | **Required.** The child host.
   child\_service\_name      | Object name           | **Optional.** The child service. If omitted, this dependency object is treated as host dependency.
-  disable\_checks           | Boolean               | **Optional.** Whether to disable checks when this dependency fails. Defaults to false.
+  disable\_checks           | Boolean               | **Optional.** Whether to disable checks (i.e., don't schedule active checks and drop passive results) when this dependency fails. Defaults to false.
   disable\_notifications    | Boolean               | **Optional.** Whether to disable notifications when this dependency fails. Defaults to true.
   ignore\_soft\_states      | Boolean               | **Optional.** Whether to ignore soft states for the reachability calculation. Defaults to true.
   period                    | Object name           | **Optional.** Time period object during which this dependency is enabled.

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -1,6 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 #include "icinga/apiactions.hpp"
+#include "icinga/checkable.hpp"
 #include "icinga/service.hpp"
 #include "icinga/servicegroup.hpp"
 #include "icinga/hostgroup.hpp"
@@ -57,6 +58,9 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 
 	if (!checkable->GetEnablePassiveChecks())
 		return ApiActions::CreateResult(403, "Passive checks are disabled for object '" + checkable->GetName() + "'.");
+
+	if (!checkable->IsReachable(DependencyCheckExecution))
+		return ApiActions::CreateResult(200, "Ignoring passive check result for unreachable object '" + checkable->GetName() + "'.");
 
 	Host::Ptr host;
 	Service::Ptr service;

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -1,6 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 #include "icinga/externalcommandprocessor.hpp"
+#include "icinga/checkable.hpp"
 #include "icinga/host.hpp"
 #include "icinga/service.hpp"
 #include "icinga/user.hpp"
@@ -283,6 +284,12 @@ void ExternalCommandProcessor::ProcessHostCheckResult(double time, const std::ve
 	if (!host->GetEnablePassiveChecks())
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Got passive check result for host '" + arguments[0] + "' which has passive checks disabled."));
 
+	if (!host->IsReachable(DependencyCheckExecution)) {
+		Log(LogNotice, "ExternalCommandProcessor")
+			<< "Ignoring passive check result for unreachable host '" << arguments[0] << "'";
+		return;
+	}
+
 	int exitStatus = Convert::ToDouble(arguments[1]);
 	CheckResult::Ptr result = new CheckResult();
 	std::pair<String, String> co = PluginUtility::ParseCheckOutput(arguments[2]);
@@ -323,6 +330,12 @@ void ExternalCommandProcessor::ProcessServiceCheckResult(double time, const std:
 
 	if (!service->GetEnablePassiveChecks())
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Got passive check result for service '" + arguments[1] + "' which has passive checks disabled."));
+
+	if (!service->IsReachable(DependencyCheckExecution)) {
+		Log(LogNotice, "ExternalCommandProcessor")
+			<< "Ignoring passive check result for unreachable service '" << arguments[1] << "'";
+		return;
+	}
 
 	int exitStatus = Convert::ToDouble(arguments[2]);
 	CheckResult::Ptr result = new CheckResult();


### PR DESCRIPTION
I make heavy use of passive check results fed into Icinga by long-running deamons: an snmptrapd plugin deals with SNMP traps possibly announcing table changes (with zero forks), a collectd plugin continuously checks metrics against thresholds including building averages and utilizing hysteresis (again with zero forks).

I also make heavy use of dependencies; in fact, I would argue a monitoring setup without carefully crafted dependencies reducing notifications to those of the root cause seriously degrades it's usefulness.

Now, while dependencies can be made to stop active checks being scheduled upon un-reachability, passive check results are still both issued and processed; the long-running deamons have no notion of reachability (until I teach collectd to gather it by querying IDO or such – but that's another issue).

This inevitably makes the child service go into HARD state during un-reachability because the daemon keeps issuing non-OK results. Then, when the problem resolves, timing may be such that the parent recovers first (host going up) while the child is still dysfunctional (SNMP agent not yet fully up). Meanwhile, the daemon will continue to deliver non-OK states to Icinga, causing superflous notifications.

The remedy is, of course, to silently discard passive check results while active checks are not being scheduled.