### PR TITLE
IDO: Make sure to insert program status

### DIFF
--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -150,7 +150,7 @@ void DbConnection::UpdateProgramStatus()
 	DbQuery query1;
 	query1.Table = "programstatus";
 	query1.IdColumn = "programstatus_id";
-	query1.Type = DbQueryInsert | DbQueryUpdate;
+	query1.Type = DbQueryInsert | DbQueryDelete;
 	query1.Category = DbCatProgramStatus;
 
 	query1.Fields = new Dictionary({
@@ -177,7 +177,7 @@ void DbConnection::UpdateProgramStatus()
 		{ "instance_id", 0 }  /* DbConnection class fills in real ID */
 	});
 
-	query1.Priority = PriorityHigh;
+	query1.Priority = PriorityImmediate;
 	queries.emplace_back(std::move(query1));
 
 	DbQuery query2;
@@ -484,7 +484,7 @@ void DbConnection::UpdateAllObjects()
 			continue;
 
 		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
-			UpdateObject(object);
+			m_QueryQueue.Enqueue([this, object](){ UpdateObject(object); }, PriorityHigh);
 		}
 	}
 }

--- a/lib/db_ido/dbconnection.hpp
+++ b/lib/db_ido/dbconnection.hpp
@@ -95,6 +95,8 @@ protected:
 	void IncreasePendingQueries(int count);
 	void DecreasePendingQueries(int count);
 
+	WorkQueue m_QueryQueue{10000000, 1, LogNotice};
+
 private:
 	bool m_IDCacheValid{false};
 	std::map<std::pair<DbType::Ptr, DbReference>, String> m_ConfigHashes;

--- a/lib/db_ido_mysql/idomysqlconnection.hpp
+++ b/lib/db_ido_mysql/idomysqlconnection.hpp
@@ -54,8 +54,6 @@ protected:
 private:
 	DbReference m_InstanceID;
 
-	WorkQueue m_QueryQueue{10000000, 1, LogNotice};
-
 	Library m_Library;
 	std::unique_ptr<MysqlInterface, MysqlInterfaceDeleter> m_Mysql;
 

--- a/lib/db_ido_pgsql/idopgsqlconnection.hpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.hpp
@@ -48,8 +48,6 @@ protected:
 private:
 	DbReference m_InstanceID;
 
-	WorkQueue m_QueryQueue{1000000, 1, LogNotice};
-
 	Library m_Library;
 	std::unique_ptr<PgsqlInterface, PgsqlInterfaceDeleter> m_Pgsql;
 


### PR DESCRIPTION
This PR makes sure, that the IDO always inserts the program status and resolves an issue with both masters (HA setup) writing at the same time, because the program status wasn't inserted.