### PR TITLE
Revert: Fix duplicate entry error

### DIFF
--- a/lib/db_ido/dbobject.cpp
+++ b/lib/db_ido/dbobject.cpp
@@ -234,9 +234,8 @@ void DbObject::SendVarsConfigUpdateHeavy()
 
 			DbQuery query3;
 			query3.Table = "customvariables";
-			query3.Type = DbQueryInsert | DbQueryUpdate;
+			query3.Type = DbQueryInsert;
 			query3.Category = DbCatConfig;
-
 			query3.Fields = new Dictionary({
 				{ "varname", kv.first },
 				{ "varvalue", value },
@@ -245,13 +244,6 @@ void DbObject::SendVarsConfigUpdateHeavy()
 				{ "object_id", obj },
 				{ "instance_id", 0 } /* DbConnection class fills in real ID */
 			});
-
-			query3.WhereCriteria = new Dictionary({
-				{ "object_id", obj },
-				{ "config_type", 1 },
-				{ "varname", kv.first }
-			});
-
 			queries.emplace_back(std::move(query3));
 		}
 	}


### PR DESCRIPTION
This reverts #8241

The initial PR should fix config like this:
```
vars.test = "herp"
vars["test "] = "derp"
``` 

But instead of fixing it, it just hides the error. The problem here is the trailing space in ["test "]. MySQL ignores trailing spaces when comparing unique keys, which leads to duplicate key errors.

Also this PR slows down config dumps, because we always update & insert instead of just inserting.

We should find another solution for the trailing spaces problem.