### PR TITLE
*DbObject#CalculateConfigHash(): sort groups to be hashed

### DIFF
--- a/lib/db_ido/hostdbobject.cpp
+++ b/lib/db_ido/hostdbobject.cpp
@@ -356,8 +356,12 @@ String HostDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) co
 
 	Array::Ptr groups = host->GetGroups();
 
-	if (groups)
+	if (groups) {
+		groups = groups->ShallowClone();
+		ObjectLock oLock (groups);
+		std::sort(groups->Begin(), groups->End());
 		hashData += DbObject::HashValue(groups);
+	}
 
 	ArrayData parents;
 

--- a/lib/db_ido/servicedbobject.cpp
+++ b/lib/db_ido/servicedbobject.cpp
@@ -308,8 +308,12 @@ String ServiceDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields)
 
 	Array::Ptr groups = service->GetGroups();
 
-	if (groups)
+	if (groups) {
+		groups = groups->ShallowClone();
+		ObjectLock oLock (groups);
+		std::sort(groups->Begin(), groups->End());
 		hashData += DbObject::HashValue(groups);
+	}
 
 	ArrayData dependencies;
 

--- a/lib/db_ido/userdbobject.cpp
+++ b/lib/db_ido/userdbobject.cpp
@@ -150,8 +150,12 @@ String UserDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) co
 
 	Array::Ptr groups = user->GetGroups();
 
-	if (groups)
+	if (groups) {
+		groups = groups->ShallowClone();
+		ObjectLock oLock (groups);
+		std::sort(groups->Begin(), groups->End());
 		hashData += DbObject::HashValue(groups);
+	}
 
 	return SHA256(hashData);
 }


### PR DESCRIPTION
... to ensure consistent hashes across config reloads.

This will likely cause a heavy update once for all objects in >1 group,
but it will ensure that this happens the last time.