### PR TITLE
docs: Update MySQL package names for Debian

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -625,7 +625,7 @@ exporting all configuration and status information into a database.
 Debian/Ubuntu:
 
 ```
-apt-get install mysql-server mysql-client
+apt-get install mariadb-server mariadb-client
 
 mysql_secure_installation
 ```


### PR DESCRIPTION
Debian switched to MariaDB in stretch and removed the mysql-server and mysql-client packages in buster. The new mariadb packages are available starting in Debian jessie.

Note that Ubuntu still ships both MySQL and MariaDB, so this will change what will be installed there. If that's not desired, there must be split cases for Debian and Ubuntu. MariaDB is available from 16.04 on.