### PR TITLE
Improve new IDO logging

### DIFF
--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -259,7 +259,7 @@ void DbConnection::LogStatsHandler()
 
 	auto output = round(m_OutputQueries.CalculateRate(now, 10));
 
-	if (pending < output * 2 && !timeoutReached) {
+	if (pending < output * 5 && !timeoutReached) {
 		return;
 	}
 

--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -262,23 +262,9 @@ void DbConnection::LogStatsHandler()
 
 	auto input = round(m_InputQueries.CalculateRate(now, 10));
 
-	String timeInfo = "";
-
-	// If we run into our logging timeout, we don't want to display our calculations
-	// because it should already be basically empty for over 5 minutes.
-	if (!timeoutReached) {
-		timeInfo = " empty in ";
-		auto rate = output - input;
-
-		if (rate <= 0)
-			timeInfo += "infinite time, your task handler isn't able to keep up";
-		else
-			timeInfo += Utility::FormatDuration(pending / rate);
-	}
-
 	Log(LogInformation, GetReflectionType()->GetName())
 		<< "Pending queries: " << pending << " (Input: " << input
-		<< "/s; Output: " << output << "/s)" << timeInfo;
+		<< "/s; Output: " << output << "/s)";
 
 	/* Reschedule next log entry in 5 minutes. */
 	if (timeoutReached) {

--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -245,6 +245,9 @@ void DbConnection::CleanUpHandler()
 
 void DbConnection::LogStatsHandler()
 {
+	if (!GetConnected())
+		return;
+
 	auto pending = m_PendingQueries.load();
 
 	auto now = Utility::GetTime();

--- a/lib/db_ido/dbconnection.hpp
+++ b/lib/db_ido/dbconnection.hpp
@@ -106,6 +106,8 @@ private:
 	Timer::Ptr m_CleanUpTimer;
 	Timer::Ptr m_LogStatsTimer;
 
+	double m_LogStatsTimeout;
+
 	void CleanUpHandler();
 	void LogStatsHandler();
 


### PR DESCRIPTION
This PR improves the new IDO logging in the following ways:
- Do not log, if the queue is less then 5 seconds away from being empty (was 2 seconds before - this caused endless logging with stats like those: Pending queries: 9 (Input: 3/s; Output: 2/s))
- Do not log, if not connected/active
- Remove ETA (Was never even close to being accurate)
- Add a timeout to log every 5 minutes not matter what