### PR TITLE
Catch exceptions in the thread running HandleConfigUpdate

### DIFF
--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -312,7 +312,16 @@ Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const D
 		return Empty;
 	}
 
-	std::thread([origin, params, listener]() { listener->HandleConfigUpdate(origin, params); }).detach();
+	std::thread([origin, params, listener]() {
+		try {
+			listener->HandleConfigUpdate(origin, params);
+		} catch (const std::exception& ex) {
+			auto msg ("Exception during config sync: " + DiagnosticInformation(ex));
+
+			Log(LogCritical, "ApiListener") << msg;
+			listener->UpdateLastFailedZonesStageValidation(msg);
+		}
+	}).detach();
 	return Empty;
 }
 


### PR DESCRIPTION
With dc3062a9b06fed69cdbb1508ace6eb2f77f87553, exceptions in this code
path were no longer caught properly. This commit restores exception
handling for this function.

Backport of #8318.