### PR TITLE
IDO: Do not log, if paused

### DIFF
--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -245,7 +245,7 @@ void DbConnection::CleanUpHandler()
 
 void DbConnection::LogStatsHandler()
 {
-	if (!GetConnected())
+	if (!GetConnected() || IsPaused())
 		return;
 
 	auto pending = m_PendingQueries.load();

--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -475,7 +475,7 @@ void IdoMysqlConnection::FinishConnect(double startTime)
 {
 	AssertOnWorkQueue();
 
-	if (!GetConnected())
+	if (!GetConnected() || IsPaused())
 		return;
 
 	FinishAsyncQueries();


### PR DESCRIPTION
We should not log, if paused. This also applies to shutdowns/reloads.