### PR TITLE
Remove Utility::GetEnv from header

### DIFF
--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -52,8 +52,6 @@ public:
 	static String DirName(const String& path);
 	static String BaseName(const String& path);
 
-	static String GetEnv(const String& key);
-
 	static void NullDeleter(void *);
 
 	static double GetTime();


### PR DESCRIPTION
It is never used and not even implemented anywhere, probably a leftover.