### PR TITLE
Forbid dependency cycles

### DIFF
--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -36,6 +36,7 @@ public:
 
 	static void EvaluateApplyRules(const intrusive_ptr<Host>& host);
 	static void EvaluateApplyRules(const intrusive_ptr<Service>& service);
+	static void AssertNoCycles();
 
 	/* Note: Only use them for unit test mocks. Prefer OnConfigLoaded(). */
 	void SetParent(intrusive_ptr<Checkable> parent);
@@ -49,6 +50,8 @@ protected:
 private:
 	Checkable::Ptr m_Parent;
 	Checkable::Ptr m_Child;
+
+	static bool m_AssertNoCyclesForIndividualDeps;
 
 	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
 	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter = false);


### PR DESCRIPTION
... at config loading time.

```
$ icinga2 daemon -C -c just-dc1.conf
[2023-02-06 11:11:48 +0100] information/cli: Icinga application loader (version: v2.13.0-500-ga7ce8e1e5; debug)
[2023-02-06 11:11:48 +0100] information/cli: Loading configuration file(s).
[2023-02-06 11:11:48 +0100] information/ConfigItem: Committing config item(s).
[2023-02-06 11:11:48 +0100] information/ConfigItem: Instantiated 2 CheckCommands.
[2023-02-06 11:11:48 +0100] information/ConfigItem: Instantiated 1 Host.
[2023-02-06 11:11:48 +0100] information/ConfigItem: Instantiated 1 IcingaApplication.
[2023-02-06 11:11:48 +0100] information/ConfigItem: Instantiated 1 Dependency.
[2023-02-06 11:11:48 +0100] critical/config: Error: Dependency cycle:
Host 'h1'
-> Dependency 'h1!h1'
-> Host 'h1'
[2023-02-06 11:11:48 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

```
$ curl -ksSu root:123456 -H 'Accept: application/json' -X PUT -d '{"attrs":{"parent_host_name":"a","child_host_name":"b","vars":{"lolcat":"mew"}}}' https://127.0.0.1:5665/v1/objects/dependencies/'b!a';echo
{"results":[{"code":500,"errors":["Error: Dependency cycle:\nHost 'a'\n-> Dependency 'a!b'\n-> Host 'b'\n-> Dependency 'b!a'\n-> Host 'a'\n"],"status":"Object could not be created."}]}
```