### PR TITLE
Prepare Windows build scripts for builds with Visual Studio 2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,17 @@
 ---
 version: 2.11.0.dev.{build}
 
-os: Visual Studio 2017
+os: Visual Studio 2019
 platform: x64
 
 environment:
   BITS: 64
   CMAKE_BUILD_TYPE: Debug
-  CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+  CMAKE_GENERATOR: "Visual Studio 16 2019"
+  CMAKE_GENERATOR_PLATFORM: x64
   # https://www.appveyor.com/docs/windows-images-software/#boost
-  BOOST_ROOT: 'C:\Libraries\boost_1_67_0'
-  BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_67_0\lib64-msvc-14.1'
+  BOOST_ROOT: 'C:\Libraries\boost_1_71_0'
+  BOOST_LIBRARYDIR: 'C:\Libraries\boost_1_71_0\lib64-msvc-14.2'
   # https://www.appveyor.com/docs/windows-images-software/#tools
   OPENSSL_ROOT_DIR: 'C:\OpenSSL-v111-Win64'
   BISON_BINARY: 'C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_bison.exe'

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -17,16 +17,19 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
   $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
 }
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
-  $env:CMAKE_GENERATOR = 'Visual Studio 15 2017 Win64'
+  $env:CMAKE_GENERATOR = 'Visual Studio 16 2019'
+}
+if (-not (Test-Path env:CMAKE_GENERATOR_PLATFORM)) {
+  $env:CMAKE_GENERATOR_PLATFORM = 'x64'
 }
 if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
-  $env:OPENSSL_ROOT_DIR = 'c:\local\OpenSSL_1_1_1b-Win64'
+  $env:OPENSSL_ROOT_DIR = 'c:\local\OpenSSL_1_1_1h-Win64'
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = 'c:\local\boost_1_69_0-Win64'
+  $env:BOOST_ROOT = 'c:\local\boost_1_71_0-Win64'
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_69_0-Win64\lib64-msvc-14.1'
+  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_71_0-Win64\lib64-msvc-14.2'
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'
@@ -48,7 +51,7 @@ if (Test-Path CMakeCache.txt) {
 
 & cmake.exe "$sourcePath" `
   -DCMAKE_BUILD_TYPE="$env:CMAKE_BUILD_TYPE" `
-  -G "$env:CMAKE_GENERATOR" -DCPACK_GENERATOR=WIX `
+  -G "$env:CMAKE_GENERATOR" -A "$env:CMAKE_GENERATOR_PLATFORM" -DCPACK_GENERATOR=WIX `
   -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF `
   -DICINGA2_WITH_LIVESTATUS=OFF -DICINGA2_WITH_COMPAT=OFF `
   -DOPENSSL_ROOT_DIR="$env:OPENSSL_ROOT_DIR" `

--- a/tools/win32/load-vsenv.ps1
+++ b/tools/win32/load-vsenv.ps1
@@ -18,7 +18,7 @@ if (-not (Test-Path $BUILD)) {
 if (Test-Path env:VS_INSTALL_PATH) {
   $VSBASE = $env:VS_INSTALL_PATH
 } else {
-  $VSBASE = "C:\Program Files (x86)\Microsoft Visual Studio\2017"
+  $VSBASE = "C:\Program Files (x86)\Microsoft Visual Studio\2019"
 }
 
 if (Test-Path env:BITS) {


### PR DESCRIPTION
$env:CMAKE_GENERATOR_PLATFORM is only used in configure-dev.ps1 but now is also required in configure.ps1 to allow the build pipeline to be upgraded to Visual Studio 2019.

Note: Merge together with https://git.icinga.com/packaging/windows-icinga2/-/merge_requests/3