### PR TITLE
docs: better instructions for installing wixtoolset on Windows

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -1961,9 +1961,11 @@ CMake uses CPack and NSIS to create the setup executable including all binaries 
 in addition to setup dialogues and configuration. Therefore we’ll need to install [NSIS](http://nsis.sourceforge.net/Download)
 first.
 
-We also need to install the Windows Installer XML (WIX) toolset.
+We also need to install the Windows Installer XML (WIX) toolset. This has .NET 3.5 as a dependency which might need a
+reboot of the system which is not handled properly by Chocolatey. Therefore install it first and reboot when asked.
 
 ```
+Enable-WindowsOptionalFeature -FeatureName "NetFx3" -Online
 choco install -y wixtoolset
 ```
 


### PR DESCRIPTION
If you try to follow the existing instructions, you might be greeted by a long and useless error message when installing this which boils down to the fact that the DotNet3.5 Chocolatey package actually requires a reboot but does not properly ask for it. Enable-WindowsOptionalFeature basically does the same as the Chocolatey package would do, but nicely asks for a reboot after which the Chocolatey package can be installed (which basically is a noop then) properly.

fixes #8395