### PR TITLE
Remove parameter --commit from check_mysql_health command definition as it is not available

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2404,7 +2404,6 @@ mysql_health_warningx            | **Optional.** The extended warning thresholds
 mysql_health_criticalx           | **Optional.** The extended critical thresholds depending on the mode.
 mysql_health_mode                | **Required.** The mode uses predefined keywords for the different checks. For example "connection-time", "slave-lag" or "sql".
 mysql_health_method              | **Optional.** How the plugin should connect to the database (`dbi` for using DBD::Mysql (default), `mysql` for using the mysql-Tool).
-mysql_health_commit              | **Optional.** Turns on autocommit for the dbd::\* module.
 mysql_health_notemp              | **Optional.** Ignore temporary databases/tablespaces.
 mysql_health_nooffline           | **Optional.** Skip the offline databases.
 mysql_health_regexp              | **Optional.** Parameter name/name2/name3 will be interpreted as (perl) regular expression.

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -218,10 +218,6 @@ object CheckCommand "mysql_health" {
 			value = "$mysql_health_method$"
 			description = "how the plugin should connect to the database (dbi for using DBD::mysql (default), mysql for using the mysql-Tool)"
 		}
-		"--commit" = {
-			value = "$mysql_health_commit$"
-			description = "turns on autocommit for the dbd::* module"
-		}
 		"--notemp" = {
 			value = "$mysql_health_notemp$"
 			description = "Ignore temporary databases/tablespaces"


### PR DESCRIPTION
Parameter --commit is not available in the check_mysql_health plugin