### PR TITLE
Add check_procs.exe --command filter option

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1643,11 +1643,12 @@ When using `procs_win_user` this plugins needs administrative privileges to acce
 
 Custom variables:
 
-Name             | Description
-:----------------|:------------
-procs\_win\_warn | **Optional**. The warning threshold.
-procs\_win\_crit | **Optional**. The critical threshold.
-procs\_win\_user | **Optional**. Count this users processes.
+Name                | Description
+:-------------------|:------------
+procs\_win\_warn    | **Optional**. The warning threshold.
+procs\_win\_crit    | **Optional**. The critical threshold.
+procs\_win\_command | **Optional**. Only scan for matches of COMMAND (without path).
+procs\_win\_user    | **Optional**. Count this users processes.
 
 
 ### service-windows <a id="windows-plugins-service-windows"></a>

--- a/itl/command-plugins-windows.conf
+++ b/itl/command-plugins-windows.conf
@@ -202,6 +202,10 @@ object CheckCommand "procs-windows" {
 			value = "$procs_win_crit$"
 			description = "Critical threshold"
 		}
+		"-C" = {
+			value = "$procs_win_command$"
+			description = "Only scan for matches of COMMAND (without path)"
+		}
 		"-u" = {
 			value = "$procs_win_user$"
 			description = "Count only procs of this user"

--- a/plugins/check_procs.cpp
+++ b/plugins/check_procs.cpp
@@ -259,7 +259,7 @@ static int countProcs(const std::wstring& user)
 			std::wcout << L"Received token, saving information" << '\n';
 
 		//write Info in pSIDTokenUser
-		if (!GetTokenInformation(hToken, TokenUser, pSIDTokenUser, dwReturnLength, NULL))
+		if (!GetTokenInformation(hToken, TokenUser, pSIDTokenUser, dwReturnLength, &dwReturnLength))
 			continue;
 
 		AcctName = NULL;


### PR DESCRIPTION
On Linux, we've got the `check_procs -C` command from [monitoring-plugins.org](https://www.monitoring-plugins.org/doc/man/check_procs.html) to filter for processes based on their command name. On Windows, such a feature was missing and is added with this PR.

If called with the new `-C`/`--command` filter, check_procs.exe will only count processes where the file part of the process image path exactly matches the given command name.

Example:
```
> check_procs.exe -C svchost.exe
PROCS OK 4 | procs=4;;;0;
```

Options `-C` and `-u` can be combined. Then a process must match both command name AND user to be counted.

Note:
- refactors the code a bit, e.g. changes the goto style cleanup to C++ RAII style resource management
- contains a separate small bugfix commit because [GetTokenInformation](https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation) was called wrong, which caused the `--user` feature to always fail (at least on my system)