### PR TITLE
Share "Last reload attempt failed" time across Icinga process tree on *nix

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -62,7 +62,12 @@ int Application::m_ArgC;
 char **Application::m_ArgV;
 double Application::m_StartTime;
 bool Application::m_ScriptDebuggerEnabled = false;
-double Application::m_LastReloadFailed;
+
+#ifdef _WIN32
+double Application::m_LastReloadFailed = 0;
+#else /* _WIN32 */
+SharedMemory<Application::AtomicTs> Application::m_LastReloadFailed (0);
+#endif /* _WIN32 */
 
 #ifdef _WIN32
 static LPTOP_LEVEL_EXCEPTION_FILTER l_DefaultUnhandledExceptionFilter = nullptr;
@@ -1208,12 +1213,20 @@ void Application::SetScriptDebuggerEnabled(bool enabled)
 
 double Application::GetLastReloadFailed()
 {
+#ifdef _WIN32
 	return m_LastReloadFailed;
+#else /* _WIN32 */
+	return m_LastReloadFailed.Get().load();
+#endif /* _WIN32 */
 }
 
 void Application::SetLastReloadFailed(double ts)
 {
+#ifdef _WIN32
 	m_LastReloadFailed = ts;
+#else /* _WIN32 */
+	m_LastReloadFailed.Get().store(ts);
+#endif /* _WIN32 */
 }
 
 void Application::ValidateName(const Lazy<String>& lvalue, const ValidationUtils& utils)

--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -4,9 +4,11 @@
 #define APPLICATION_H
 
 #include "base/i2-base.hpp"
+#include "base/atomic.hpp"
 #include "base/application-ti.hpp"
 #include "base/logger.hpp"
 #include "base/configuration.hpp"
+#include "base/shared-memory.hpp"
 #include <iosfwd>
 
 namespace icinga
@@ -137,7 +139,13 @@ private:
 	static double m_StartTime;
 	static double m_MainTime;
 	static bool m_ScriptDebuggerEnabled;
+#ifdef _WIN32
 	static double m_LastReloadFailed;
+#else /* _WIN32 */
+	typedef Atomic<double> AtomicTs;
+	static_assert(AtomicTs::is_always_lock_free);
+	static SharedMemory<AtomicTs> m_LastReloadFailed;
+#endif /* _WIN32 */
 
 #ifdef _WIN32
 	static BOOL WINAPI CtrlHandler(DWORD type);

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -813,6 +813,7 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 					break;
 				case -2:
 					Log(LogCritical, "Application", "Found error in config: reloading aborted");
+					Application::SetLastReloadFailed(Utility::GetTime());
 					break;
 				default:
 					Log(LogInformation, "Application")
@@ -820,6 +821,7 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 
 					NotifyStatus("Shutting down old instance...");
 
+					Application::SetLastReloadFailed(0);
 					(void)kill(currentWorker, SIGTERM);
 
 					{


### PR DESCRIPTION
... as only the umbrella process knows that time,
but the icinga check running in the main process also needs to know it.

fixes #8428

## TODO

* [x] #9754