### PR TITLE
Close FDs based on /proc/self/fd

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -906,24 +906,13 @@ int main(int argc, char **argv)
 #ifndef _WIN32
 	String keepFDs = Utility::GetFromEnvironment("ICINGA2_KEEP_FDS");
 	if (keepFDs.IsEmpty()) {
-		rlimit rl;
-		if (getrlimit(RLIMIT_NOFILE, &rl) >= 0) {
-			rlim_t maxfds = rl.rlim_max;
-
-			if (maxfds == RLIM_INFINITY)
-				maxfds = 65536;
-
-			for (rlim_t i = 3; i < maxfds; i++) {
-				int rc = close(i);
-
 #ifdef I2_DEBUG
-				if (rc >= 0)
-					std::cerr << "Closed FD " << i << " which we inherited from our parent process." << std::endl;
+		Utility::CloseAllFDs({0, 1, 2}, [](int fd) {
+			std::cerr << "Closed FD " << fd << " which we inherited from our parent process." << std::endl;
+		});
 #else /* I2_DEBUG */
-				(void)rc;
+		Utility::CloseAllFDs({0, 1, 2});
 #endif /* I2_DEBUG */
-			}
-		}
 	}
 #endif /* _WIN32 */
 

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -240,17 +240,7 @@ static void ProcessHandler()
 	sigfillset(&mask);
 	sigprocmask(SIG_SETMASK, &mask, nullptr);
 
-	rlimit rl;
-	if (getrlimit(RLIMIT_NOFILE, &rl) >= 0) {
-		rlim_t maxfds = rl.rlim_max;
-
-		if (maxfds == RLIM_INFINITY)
-			maxfds = 65536;
-
-		for (rlim_t i = 3; i < maxfds; i++)
-			if (i != static_cast<rlim_t>(l_ProcessControlFD))
-				(void)close(i);
-	}
+	Utility::CloseAllFDs({0, 1, 2, l_ProcessControlFD});
 
 	for (;;) {
 		size_t length;

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -8,6 +8,7 @@
 #include "base/array.hpp"
 #include "base/threadpool.hpp"
 #include <boost/thread/tss.hpp>
+#include <functional>
 #include <typeinfo>
 #include <vector>
 
@@ -80,6 +81,8 @@ public:
 #ifndef _WIN32
 	static void SetNonBlocking(int fd, bool nb = true);
 	static void SetCloExec(int fd, bool cloexec = true);
+
+	static void CloseAllFDs(const std::vector<int>& except, std::function<void(int)> onClose = nullptr);
 #endif /* _WIN32 */
 
 	static void SetNonBlockingSocket(SOCKET s, bool nb = true);


### PR DESCRIPTION
... not to waste time with close(2)ing RLIMIT_NOFILE-3 non-existing FDs.

Newer kernel = higher RLIMIT_NOFILE = more time wasted

fixes #8437