### PR TITLE
ApiListener#max_anonymous_clients: default to amount of endpoints x 2

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -330,6 +330,10 @@ void ApiListener::Start(bool runtimeCreated)
 	m_ApiPackageIntegrityTimer->Start();
 
 	OnMasterChanged(true);
+
+	if (GetMaxAnonymousClients() < 0) {
+		SetMaxAnonymousClients(ConfigType::GetObjectsByType<Endpoint>().size() * 2u, true);
+	}
 }
 
 void ApiListener::RenewOwnCert()


### PR DESCRIPTION
... not to open too many FDs in misconfigured setups.