### PR TITLE
API: Don't accept object updates for unknown global zone

### DIFF
--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -72,6 +72,16 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 		return Empty;
 	}
 
+	String objZone = params->Get("zone");
+
+	if (!Zone::GetByName(objZone)) {
+		Log(LogNotice, "ApiListener")
+			<< "Discarding 'config update object' message"
+			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
+			<< " for object '" << objName << "' of type '" << objType << "'. Objects zone '" << objZone << "' isn't known locally.";
+		return Empty;
+	}
+
 	/* ignore messages if the endpoint does not accept config */
 	if (!listener->GetAcceptConfig()) {
 		Log(LogWarning, "ApiListener")
@@ -315,6 +325,7 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 	params->Set("name", object->GetName());
 	params->Set("type", object->GetReflectionType()->GetName());
 	params->Set("version", object->GetVersion());
+	params->Set("zone", object->GetZoneName());
 
 	if (object->GetPackage() == "_api") {
 		String file;


### PR DESCRIPTION
This PR fixes an ugly log message when a cluster endpoint gets a runtime object update for a locally unknown global zone.

### To reproduce:
#### Setup:
- 1 Master
- 1 Agent

#### Steps:
1. Disable zone `global-templates` on the agent
2. Create an object in zone `global-templates` via the API:
```
curl -s -k -u root:icinga -H 'Accept: application/json' -X PUT -k "https://localhost:5665/v1/objects/hostgroups/testhostgroup" -d '{ "attrs": { "display_name": "Test", "zone": "global-templates" } }'
```
3. Watch for message in agents logs:
```bash
# Without fix
[2020-11-06 15:30:42 +0000] critical/config: Error: Validation failed for object 'testhostgroup' of type 'HostGroup'; Attribute 'zone': Object 'global-templates' of type 'Zone' does not exist.
Location: in /var/lib/icinga2/api/packages/_api/ac6c8d7d-c63d-455f-8862-ed91ed9ef505/conf.d/hostgroups/testhostgroup.conf: 4:2-4:26
/var/lib/icinga2/api/packages/_api/ac6c8d7d-c63d-455f-8862-ed91ed9ef505/conf.d/hostgroups/testhostgroup.conf(2):  display_name = "Test"
/var/lib/icinga2/api/packages/_api/ac6c8d7d-c63d-455f-8862-ed91ed9ef505/conf.d/hostgroups/testhostgroup.conf(3):  version = 1604674450.538329
/var/lib/icinga2/api/packages/_api/ac6c8d7d-c63d-455f-8862-ed91ed9ef505/conf.d/hostgroups/testhostgroup.conf(4):  zone = "global-templates"
                                                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
/var/lib/icinga2/api/packages/_api/ac6c8d7d-c63d-455f-8862-ed91ed9ef505/conf.d/hostgroups/testhostgroup.conf(5): }
/var/lib/icinga2/api/packages/_api/ac6c8d7d-c63d-455f-8862-ed91ed9ef505/conf.d/hostgroups/testhostgroup.conf(6):

# With fix
[2020-11-06 15:34:28 +0000] notice/ApiListener: Discarding 'config update object' message from 'noh-mb.local' (endpoint: 'noh-mb.local', zone: 'noh-mb.local') for object 'testhostgroup' of type 'HostGroup'. Objects zone global-templates isn't known locally.
```

ref/NC/693847