### PR TITLE
Log config object deletions to replay log

### DIFF
--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -423,7 +423,7 @@ void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const Mess
 		if (!target)
 			target = Zone::GetLocalZone();
 
-		RelayMessage(origin, target, message, false);
+		RelayMessage(origin, target, message, true);
 	}
 }
 


### PR DESCRIPTION
The initial config object sync for each new connection (in `ApiListener::SendRuntimeConfigObjects()`) only considers currently existing objects and has no way to pass the information that objects were deleted in the meantime.

This commit logs config object deletions to the replay log if required so that there is a chance that it will be propagated to nodes that were offline when the deletion happened.

Note that this can only be considered a workaround as the replay log might be pruned or could even be completely disabled. Also, there still seems to be a race-condition between the config sync and replay log of multiple new connections at the same time.

backport of #8455 for support/2.11