### PR TITLE
Start ApiListener#SyncClient() in the thread pool

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -708,12 +708,9 @@ void ApiListener::NewClientHandlerInternal(
 		if (endpoint) {
 			endpoint->AddClient(aclient);
 
-			IoEngine::SpawnCoroutine(IoEngine::Get().GetIoContext(), [this, aclient, endpoint](asio::yield_context yc) {
-				CpuBoundWork syncClient (yc);
-
+			Utility::QueueAsyncCallback([this, aclient, endpoint]() {
 				SyncClient(aclient, endpoint, true);
 			});
-
 		} else if (!AddAnonymousClient(aclient)) {
 			Log(LogNotice, "ApiListener")
 				<< "Ignoring anonymous JSON-RPC connection " << conninfo


### PR DESCRIPTION
... not hosting the coroutines not to block them.

Otherwise a large replay log would block messages sending
until the peer disconnects us.