### PR TITLE
Fix perfdata parser not recognize scientific notation

### DIFF
--- a/lib/base/perfdatavalue.cpp
+++ b/lib/base/perfdatavalue.cpp
@@ -45,7 +45,7 @@ PerfdataValue::Ptr PerfdataValue::Parse(const String& perfdata)
 
 	String valueStr = perfdata.SubStr(eqp + 1, spq - eqp - 1);
 
-	size_t pos = valueStr.FindFirstNotOf("+-0123456789.e");
+	size_t pos = valueStr.FindFirstNotOf("+-0123456789.eE");
 
 	double value = Convert::ToDouble(valueStr.SubStr(0, pos));
 
@@ -160,7 +160,7 @@ String PerfdataValue::Format() const
 
 Value PerfdataValue::ParseWarnCritMinMaxToken(const std::vector<String>& tokens, std::vector<String>::size_type index, const String& description)
 {
-	if (tokens.size() > index && tokens[index] != "U" && tokens[index] != "" && tokens[index].FindFirstNotOf("+-0123456789.e") == String::NPos)
+	if (tokens.size() > index && tokens[index] != "U" && tokens[index] != "" && tokens[index].FindFirstNotOf("+-0123456789.eE") == String::NPos)
 		return Convert::ToDouble(tokens[index]);
 	else {
 		if (tokens.size() > index && tokens[index] != "")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -143,6 +143,7 @@ add_boost_test(base
     icinga_perfdata/ignore_invalid_warn_crit_min_max
     icinga_perfdata/invalid
     icinga_perfdata/multi
+    icinga_perfdata/scientificnotation
     remote_url/id_and_path
     remote_url/parameters
     remote_url/get_and_set

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -123,4 +123,53 @@ BOOST_AUTO_TEST_CASE(multi)
 	BOOST_CHECK(pd->Get(1) == "test::b=4");
 }
 
+BOOST_AUTO_TEST_CASE(scientificnotation)
+{
+	PerfdataValue::Ptr pdv = PerfdataValue::Parse("test=1.1e+1");
+	BOOST_CHECK(pdv->GetLabel() == "test");
+	BOOST_CHECK(pdv->GetValue() == 11);
+
+	String str = pdv->Format();
+	BOOST_CHECK(str == "test=11");
+
+	pdv = PerfdataValue::Parse("test=1.1e1");
+	BOOST_CHECK(pdv->GetLabel() == "test");
+	BOOST_CHECK(pdv->GetValue() == 11);
+
+	str = pdv->Format();
+	BOOST_CHECK(str == "test=11");
+
+	pdv = PerfdataValue::Parse("test=1.1e-1");
+	BOOST_CHECK(pdv->GetLabel() == "test");
+	BOOST_CHECK(pdv->GetValue() == 0.11);
+
+	str = pdv->Format();
+	BOOST_CHECK(str == "test=0.110000");
+
+	pdv = PerfdataValue::Parse("test=1.1E1");
+	BOOST_CHECK(pdv->GetLabel() == "test");
+	BOOST_CHECK(pdv->GetValue() == 11);
+
+	str = pdv->Format();
+	BOOST_CHECK(str == "test=11");
+
+	pdv = PerfdataValue::Parse("test=1.1E-1");
+	BOOST_CHECK(pdv->GetLabel() == "test");
+	BOOST_CHECK(pdv->GetValue() == 0.11);
+
+	str = pdv->Format();
+	BOOST_CHECK(str == "test=0.110000");
+
+	pdv = PerfdataValue::Parse("test=1.1E-1;1.2e+1;1.3E-1;1.4e-2;1.5E2");
+	BOOST_CHECK(pdv->GetLabel() == "test");
+	BOOST_CHECK(pdv->GetValue() == 0.11);
+	BOOST_CHECK(pdv->GetWarn() == 12);
+	BOOST_CHECK(pdv->GetCrit() == 0.13);
+	BOOST_CHECK(pdv->GetMin() == 0.014);
+	BOOST_CHECK(pdv->GetMax() == 150);
+
+	str = pdv->Format();
+	BOOST_CHECK(str == "test=0.110000;12;0.130000;0.014000;150");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The scientific notation is basically allowed in our performance data
parser. In an edge case where scientific notation is delivered with
an big E letter our parser does not recognize it and drops it as
false performance data.

This wrong interpretation as false performance data affects all parts of
the performance data, the value itself, the warning value, the critical
value, the minimum value and the maximum value.

Since all parts of the performance data are extracted from the valueStr,
it is sufficient to transform it to the lower case.

Example: 
```
[2020-11-19 17:12:36 +0100] warning/InfluxdbWriter: Ignoring invalid perfdata for checkable 'xxx!JMX:Events/1m' and command 'by_ssh' with value: OneMinuteRate=5.863856523964383E-6
```
I could verify the issue locally with the following test script:

```
#!/usr/bin/env bash

echo "OK - Test output | 'OneMinuteRate'=4.1E-1;5.4E-3;10E-5;0;100"
```

https://community.icinga.com/t/influxdbwriter-invalid-perfdata-on-low-values/6109
