### PR TITLE
Revert "icinga2 daemon: reap remaining child processes after reload"

### DIFF
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -790,17 +790,6 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 						<< "Waited for " << Utility::FormatDuration(Utility::GetTime() - start) << " on old process to exit.";
 				}
 
-				for (int info;;) {
-					auto pid (waitpid(-1, &info, WNOHANG));
-
-					if (pid < 1) {
-						break;
-					}
-
-					Log(LogNotice, "cli")
-						<< "Reaped child process " << pid << ".";
-				}
-
 				// Old instance shut down, allow the new one to continue working beyond config validation
 				(void)kill(nextWorker, SIGUSR2);
 


### PR DESCRIPTION
This reverts commit 91265a5b0e134006893576a465c4c84906f1eb82 which isn't needed anymore as Icinga 2 isn't PID 1 anymore.