### PR TITLE
FireSuppressedNotifications(const Notification::Ptr&): don't send notifications while suppressed by checkable

### DIFF
--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -173,24 +173,7 @@ static void FireSuppressedNotifications(Checkable* checkable)
 				bool still_applies = checkable->NotificationReasonApplies(type);
 
 				if (still_applies) {
-					bool still_suppressed;
-
-					switch (type) {
-						case NotificationProblem:
-							/* Fall through. */
-						case NotificationRecovery:
-							still_suppressed = !checkable->IsReachable(DependencyNotification) || checkable->IsInDowntime() || checkable->IsAcknowledged();
-							break;
-						case NotificationFlappingStart:
-							/* Fall through. */
-						case NotificationFlappingEnd:
-							still_suppressed = checkable->IsInDowntime();
-							break;
-						default:
-							break;
-					}
-
-					if (!still_suppressed && !checkable->IsLikelyToBeCheckedSoon() && !wasLastParentRecoveryRecent.Get()) {
+					if (!checkable->NotificationReasonSuppressed(type) && !checkable->IsLikelyToBeCheckedSoon() && !wasLastParentRecoveryRecent.Get()) {
 						Checkable::OnNotificationsRequested(checkable, type, checkable->GetLastCheckResult(), "", "", nullptr);
 
 						subtract |= type;
@@ -254,6 +237,27 @@ bool Checkable::NotificationReasonApplies(NotificationType type)
 			return !IsFlapping();
 		default:
 			VERIFY(!"Checkable#NotificationReasonStillApplies(): given type not implemented");
+			return false;
+	}
+}
+
+/**
+ * Returns whether *this not allows sending a notification of type type right now.
+ *
+ * @param type The type of notification to send (or not to send).
+ *
+ * @return Whether not to send the notification.
+ */
+bool Checkable::NotificationReasonSuppressed(NotificationType type)
+{
+	switch (type) {
+		case NotificationProblem:
+		case NotificationRecovery:
+			return !IsReachable(DependencyNotification) || IsInDowntime() || IsAcknowledged();
+		case NotificationFlappingStart:
+		case NotificationFlappingEnd:
+			return IsInDowntime();
+		default:
 			return false;
 	}
 }

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -242,11 +242,11 @@ bool Checkable::NotificationReasonApplies(NotificationType type)
 }
 
 /**
- * Returns whether *this not allows sending a notification of type type right now.
+ * Checks if notifications of a given type should be suppressed for this Checkable at the moment.
  *
- * @param type The type of notification to send (or not to send).
+ * @param type The notification type for which to query the suppression status.
  *
- * @return Whether not to send the notification.
+ * @return true if no notification of this type should be sent.
  */
 bool Checkable::NotificationReasonSuppressed(NotificationType type)
 {

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -175,6 +175,7 @@ public:
 	void ValidateMaxCheckAttempts(const Lazy<int>& lvalue, const ValidationUtils& value) final;
 
 	bool NotificationReasonApplies(NotificationType type);
+	bool NotificationReasonSuppressed(NotificationType type);
 	bool IsLikelyToBeCheckedSoon();
 
 	static void IncreasePendingChecks();

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -91,7 +91,7 @@ void FireSuppressedNotifications(const Notification::Ptr& notification)
 
 		if ((!tp || tp->IsInside(Utility::GetTime())) && !checkable->IsLikelyToBeCheckedSoon()) {
 			for (auto type : {NotificationProblem, NotificationRecovery, NotificationFlappingStart, NotificationFlappingEnd}) {
-				if (!(suppressedTypes & type))
+				if (!(suppressedTypes & type) || checkable->NotificationReasonSuppressed(type))
 					continue;
 
 				auto notificationName (notification->GetName());


### PR DESCRIPTION
... e.g. if a notification enters its time period (not suppressed anymore), but its checkable has entered a downtime (suppressed).

fixes #8509