### PR TITLE
ConfigObject#RestoreObjects(): don't fail if the state file is corrupted

### DIFF
--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -551,7 +551,15 @@ void ConfigObject::RestoreObjects(const String& filename, int attributeTypes)
 	String message;
 	StreamReadContext src;
 	for (;;) {
-		StreamReadStatus srs = NetString::ReadStringFromStream(sfp, &message, src);
+		StreamReadStatus srs;
+
+		try {
+			srs = NetString::ReadStringFromStream(sfp, &message, src);
+		} catch (const std::exception& ex) {
+			Log(LogWarning, "ConfigObject")
+				<< "Failed to restore the complete state file: " << DiagnosticInformation(ex);
+			break;
+		}
 
 		if (srs == StatusEof)
 			break;


### PR DESCRIPTION
... not to crash Icinga 2 at startup just because of e.g. a truncated state file.

Instead just continue with the objects that could be restored (if any) and hope for the best.

fixes #8528