### PR TITLE
Remove rhel-8-server-optional-rpms, as it is not/no longer available for RHEL 8

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -170,7 +170,6 @@ RHEL 8:
 ```
 ARCH=$( /bin/arch )
 
-subscription-manager repos --enable rhel-8-server-optional-rpms
 subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 
 dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm


### PR DESCRIPTION
As our Ansible deployments kept failing when trying to add the `rhel-8-server-optional-rpms` we came to know that it is not/no longer available for RHEL 8.

> BaseOS and AppStream contain all software packages, which were available in extras and optional repositories before.

Source: https://access.redhat.com/discussions/4171061#comment-1531531