### PR TITLE
Support Boost 1.74 when setting HTTP headers

### DIFF
--- a/lib/base/string.cpp
+++ b/lib/base/string.cpp
@@ -127,6 +127,18 @@ String::operator const std::string&() const
 	return m_Data;
 }
 
+/**
+ * Conversion function to boost::string_view.
+ *
+ * This allows using String as the value for HTTP headers in boost::beast::http::basic_fields::set.
+ *
+ * @return A boost::string_view representing this string.
+ */
+String::operator boost::string_view() const
+{
+	return boost::string_view(m_Data);
+}
+
 const char *String::CStr() const
 {
 	return m_Data.c_str();

--- a/lib/base/string.hpp
+++ b/lib/base/string.hpp
@@ -6,6 +6,7 @@
 #include "base/i2-base.hpp"
 #include "base/object.hpp"
 #include <boost/range/iterator.hpp>
+#include <boost/utility/string_view.hpp>
 #include <string>
 #include <iosfwd>
 
@@ -71,6 +72,7 @@ public:
 	bool operator<(const String& rhs) const;
 
 	operator const std::string&() const;
+	operator boost::string_view() const;
 
 	const char *CStr() const;
 

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -494,7 +494,7 @@ void ElasticsearchWriter::SendRequest(const String& body)
 		request.set(http::field::authorization, "Basic " + Base64::Encode(username + ":" + password));
 
 	request.body() = body;
-	request.set(http::field::content_length, request.body().size());
+	request.content_length(request.body().size());
 
 	/* Don't log the request body to debug log, this is already done above. */
 	Log(LogDebug, "ElasticsearchWriter")

--- a/lib/perfdata/influxdbwriter.cpp
+++ b/lib/perfdata/influxdbwriter.cpp
@@ -517,7 +517,7 @@ void InfluxdbWriter::Flush()
 	}
 
 	request.body() = body;
-	request.set(http::field::content_length, request.body().size());
+	request.content_length(request.body().size());
 
 	try {
 		if (stream.first) {

--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -84,7 +84,7 @@ bool ConfigFilesHandler::HandleRequest(
 		response.result(http::status::ok);
 		response.set(http::field::content_type, "application/octet-stream");
 		response.body() = content;
-		response.set(http::field::content_length, response.body().size());
+		response.content_length(response.body().size());
 	} catch (const std::exception& ex) {
 		HttpUtility::SendJsonError(response, params, 500, "Could not read file.",
 			DiagnosticInformation(ex));

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -186,7 +186,7 @@ bool EnsureValidHeaders(
 		} else {
 			response.set(http::field::content_type, "text/html");
 			response.body() = String("<h1>Bad Request</h1><p><pre>") + errorMsg + "</pre></p>";
-			response.set(http::field::content_length, response.body().size());
+			response.content_length(response.body().size());
 		}
 
 		response.set(http::field::connection, "close");
@@ -259,7 +259,7 @@ bool HandleAccessControl(
 					response.set(http::field::access_control_allow_methods, "GET, POST, PUT, DELETE");
 					response.set(http::field::access_control_allow_headers, "Authorization, Content-Type, X-HTTP-Method-Override");
 					response.body() = "Preflight OK";
-					response.set(http::field::content_length, response.body().size());
+					response.content_length(response.body().size());
 					response.set(http::field::connection, "close");
 
 					boost::system::error_code ec;
@@ -290,7 +290,7 @@ bool EnsureAcceptHeader(
 		response.result(http::status::bad_request);
 		response.set(http::field::content_type, "text/html");
 		response.body() = "<h1>Accept header is missing or not set to 'application/json'.</h1>";
-		response.set(http::field::content_length, response.body().size());
+		response.content_length(response.body().size());
 		response.set(http::field::connection, "close");
 
 		boost::system::error_code ec;
@@ -331,7 +331,7 @@ bool EnsureAuthenticatedUser(
 		} else {
 			response.set(http::field::content_type, "text/html");
 			response.body() = "<h1>Unauthorized. Please check your user credentials.</h1>";
-			response.set(http::field::content_length, response.body().size());
+			response.content_length(response.body().size());
 		}
 
 		boost::system::error_code ec;
@@ -423,7 +423,7 @@ bool EnsureValidBody(
 		} else {
 			response.set(http::field::content_type, "text/html");
 			response.body() = String("<h1>Bad Request</h1><p><pre>") + ec.message() + "</pre></p>";
-			response.set(http::field::content_length, response.body().size());
+			response.content_length(response.body().size());
 		}
 
 		response.set(http::field::connection, "close");

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -58,7 +58,7 @@ void HttpUtility::SendJsonBody(boost::beast::http::response<boost::beast::http::
 
 	response.set(http::field::content_type, "application/json");
 	response.body() = JsonEncode(val, params && GetLastParameter(params, "pretty"));
-	response.set(http::field::content_length, response.body().size());
+	response.content_length(response.body().size());
 }
 
 void HttpUtility::SendJsonError(boost::beast::http::response<boost::beast::http::string_body>& response,

--- a/lib/remote/infohandler.cpp
+++ b/lib/remote/infohandler.cpp
@@ -92,7 +92,7 @@ bool InfoHandler::HandleRequest(
 
 		body += R"(<p>More information about API requests is available in the <a href="https://icinga.com/docs/icinga2/latest/" target="_blank">documentation</a>.</p></html>)";
 		response.body() = body;
-		response.set(http::field::content_length, response.body().size());
+		response.content_length(response.body().size());
 	}
 
 	return true;


### PR DESCRIPTION
Alternative fix to the one proposed in #8190 for an [incompatible change in Boost.Beast 1.74](https://www.boost.org/doc/libs/1_74_0/libs/beast/doc/html/beast/release_notes.html):
> `#1956` Deprecate string_param (API Change) Actions Required string_param, which was previously the argument type when setting field values has been replaced by string_view. Because of this, it is no longer possible to set message field values directly as integrals. Users are requied to convert numeric arguments to a string type prior to calling fields::set et. al. Beast provides the non-allocating to_static_string() function for this purpose. To set Content-Length field manually, call message::content_length.

This PR changes two things:
* Use `message::content_length(...)` instead of `message::set(field::content_length, ...)` as suggested in the changelog
* Add a conversion function from `icinga::String` to `boost::string_view` so that is can also be used as the value just like `std::string`

fixes #8185
closes #8190