### PR TITLE
Update URLs of check_logstash plugin

### DIFF
--- a/doc/05-service-monitoring.md
+++ b/doc/05-service-monitoring.md
@@ -953,7 +953,7 @@ Instead, choose a plugin and configure its parameters and thresholds. The follow
 ### Log Monitoring <a id="service-monitoring-log"></a>
 
 * [check_logfiles](https://labs.consol.de/nagios/check_logfiles/)
-* [check_logstash](https://github.com/widhalmt/check_logstash)
+* [check_logstash](https://github.com/NETWAYS/check_logstash)
 * [check_graylog2_stream](https://github.com/Graylog2/check-graylog2-stream)
 
 ### Virtualization Monitoring <a id="service-monitoring-virtualization"></a>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2938,7 +2938,7 @@ This category includes all plugins for log management, for example [Logstash](ht
 
 #### logstash <a id="plugins-contrib-command-logstash"></a>
 
-The [logstash](https://github.com/widhalmt/check_logstash) plugin connects to
+The [logstash](https://github.com/NETWAYS/check_logstash) plugin connects to
 the Node API of Logstash. This plugin requires at least Logstash version 5.0.x.
 
 The Node API is not activated by default. You have to configure your Logstash


### PR DESCRIPTION
We moved `check_logstash` to NETways GitHub repsitories. This PR reflects that change in the documentation.