### PR TITLE
Fix null pointer dereferences when deleting objects while scheduling downtimes

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -381,10 +381,9 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 		}
 	}
 
-	String downtimeName = Downtime::AddDowntime(checkable, author, comment, startTime, endTime,
+	Downtime::Ptr downtime = Downtime::AddDowntime(checkable, author, comment, startTime, endTime,
 		fixed, triggerName, duration);
-
-	Downtime::Ptr downtime = Downtime::GetByName(downtimeName);
+	String downtimeName = downtime->GetName();
 
 	Dictionary::Ptr additional = new Dictionary({
 		{ "name", downtimeName },
@@ -404,10 +403,9 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 			Log(LogNotice, "ApiActions")
 				<< "Creating downtime for service " << hostService->GetName() << " on host " << host->GetName();
 
-			String serviceDowntimeName = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
+			Downtime::Ptr serviceDowntime = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
 				fixed, triggerName, duration);
-
-			Downtime::Ptr serviceDowntime = Downtime::GetByName(serviceDowntimeName);
+			String serviceDowntimeName = serviceDowntime->GetName();
 
 			serviceDowntimes.push_back(new Dictionary({
 				{ "name", serviceDowntimeName },
@@ -435,13 +433,12 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 			Log(LogNotice, "ApiActions")
 				<< "Scheduling downtime for child object " << child->GetName();
 
-			String childDowntimeName = Downtime::AddDowntime(child, author, comment, startTime, endTime,
+			Downtime::Ptr childDowntime = Downtime::AddDowntime(child, author, comment, startTime, endTime,
 				fixed, triggerName, duration);
+			String childDowntimeName = childDowntime->GetName();
 
 			Log(LogNotice, "ApiActions")
 				<< "Add child downtime '" << childDowntimeName << "'.";
-
-			Downtime::Ptr childDowntime = Downtime::GetByName(childDowntimeName);
 
 			Dictionary::Ptr childAdditional = new Dictionary({
 				{ "name", childDowntimeName },
@@ -460,10 +457,9 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 					Log(LogNotice, "ApiActions")
 						<< "Creating downtime for service " << hostService->GetName() << " on child host " << host->GetName();
 
-					String serviceDowntimeName = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
+					Downtime::Ptr serviceDowntime = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
 						fixed, triggerName, duration);
-
-					Downtime::Ptr serviceDowntime = Downtime::GetByName(serviceDowntimeName);
+					String serviceDowntimeName = serviceDowntime->GetName();
 
 					childServiceDowntimes.push_back(new Dictionary({
 						{ "name", serviceDowntimeName },

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -206,7 +206,7 @@ int Downtime::GetNextDowntimeID()
 	return l_NextDowntimeID;
 }
 
-String Downtime::AddDowntime(const Checkable::Ptr& checkable, const String& author,
+Downtime::Ptr Downtime::AddDowntime(const Checkable::Ptr& checkable, const String& author,
 	const String& comment, double startTime, double endTime, bool fixed,
 	const String& triggeredBy, double duration,
 	const String& scheduledDowntime, const String& scheduledBy,
@@ -302,7 +302,7 @@ String Downtime::AddDowntime(const Checkable::Ptr& checkable, const String& auth
 		<< "' and '" << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S", endTime) << "', author: '"
 		<< author << "', " << (fixed ? "fixed" : "flexible with " + Convert::ToString(duration) + "s duration");
 
-	return fullName;
+	return downtime;
 }
 
 void Downtime::RemoveDowntime(const String& id, bool cancelled, bool expired, const MessageOrigin::Ptr& origin)

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -75,12 +75,10 @@ void Downtime::OnAllConfigLoaded()
 {
 	ObjectImpl<Downtime>::OnAllConfigLoaded();
 
-	Host::Ptr host = Host::GetByName(GetHostName());
-
 	if (GetServiceName().IsEmpty())
-		m_Checkable = host;
+		m_Checkable = Host::GetByName(GetHostName());
 	else
-		m_Checkable = host->GetServiceByShortName(GetServiceName());
+		m_Checkable = Service::GetByNamePair(GetHostName(), GetServiceName());
 
 	if (!m_Checkable)
 		BOOST_THROW_EXCEPTION(ScriptError("Downtime '" + GetName() + "' references a host/service which doesn't exist.", GetDebugInfo()));

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -45,7 +45,7 @@ public:
 
 	static int GetNextDowntimeID();
 
-	static String AddDowntime(const intrusive_ptr<Checkable>& checkable, const String& author,
+	static Ptr AddDowntime(const intrusive_ptr<Checkable>& checkable, const String& author,
 		const String& comment, double startTime, double endTime, bool fixed,
 		const String& triggeredBy, double duration, const String& scheduledDowntime = String(),
 		const String& scheduledBy = String(), const String& id = String(),

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -1049,7 +1049,7 @@ void ExternalCommandProcessor::ScheduleAndPropagateTriggeredHostDowntime(double,
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Creating downtime for host " << host->GetName();
 
-	String parentDowntime = Downtime::AddDowntime(host, arguments[6], arguments[7],
+	Downtime::Ptr parentDowntime = Downtime::AddDowntime(host, arguments[6], arguments[7],
 		Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
 		Convert::ToBool(is_fixed), triggeredBy, Convert::ToDouble(arguments[5]));
 
@@ -1065,7 +1065,7 @@ void ExternalCommandProcessor::ScheduleAndPropagateTriggeredHostDowntime(double,
 
 		(void) Downtime::AddDowntime(child, arguments[6], arguments[7],
 			Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
-			Convert::ToBool(is_fixed), parentDowntime, Convert::ToDouble(arguments[5]));
+			Convert::ToBool(is_fixed), parentDowntime->GetName(), Convert::ToDouble(arguments[5]));
 	}
 }
 

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -253,11 +253,10 @@ void ScheduledDowntime::CreateNextDowntime()
 			return;
 	}
 
-	String downtimeName = Downtime::AddDowntime(GetCheckable(), GetAuthor(), GetComment(),
+	Downtime::Ptr downtime = Downtime::AddDowntime(GetCheckable(), GetAuthor(), GetComment(),
 		segment.first, segment.second,
 		GetFixed(), String(), GetDuration(), GetName(), GetName());
-
-	Downtime::Ptr downtime = Downtime::GetByName(downtimeName);
+	String downtimeName = downtime->GetName();
 
 	int childOptions = Downtime::ChildOptionsFromValue(GetChildOptions());
 	if (childOptions > 0) {
@@ -275,11 +274,11 @@ void ScheduledDowntime::CreateNextDowntime()
 			Log(LogNotice, "ScheduledDowntime")
 				<< "Scheduling downtime for child object " << child->GetName();
 
-			String childDowntimeName = Downtime::AddDowntime(child, GetAuthor(), GetComment(),
+			Downtime::Ptr childDowntime = Downtime::AddDowntime(child, GetAuthor(), GetComment(),
 				segment.first, segment.second, GetFixed(), triggerName, GetDuration(), GetName(), GetName());
 
 			Log(LogNotice, "ScheduledDowntime")
-				<< "Add child downtime '" << childDowntimeName << "'.";
+				<< "Add child downtime '" << childDowntime->GetName() << "'.";
 		}
 	}
 }


### PR DESCRIPTION
This pull requests fixes multiple null pointer dereferences that can occur if config objects are deleted while downtimes are scheduled. One affects scheduling service downtimes on hosts which are deleted in parallel, the others affect downtimes already being deleted while they are still in the progress of being deleted. Please see the individual commit messages for details.

fixes #8583