### PR TITLE
Improve check_dns command when used with monitoring-plugins 2.3

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -393,7 +393,8 @@ Name                 | Description
 dns_lookup           | **Optional.** The hostname or IP to query the DNS for. Defaults to "$host_name$".
 dns_server           | **Optional.** The DNS server to query. Defaults to the server configured in the OS.
 dns_query_type       | **Optional.** The DNS record query type where TYPE =(A, AAAA, SRV, TXT, MX, ANY). The default query type is 'A' (IPv4 host entry). **Only supported by the Nagios plugins version of check\_dns, not by the monitoring plugins one.**
-dns_expected_answers | **Optional.** The answer(s) to look for. A hostname must end with a dot. Multiple answers must be defined as array.
+dns_expected_answers | **Optional.** The answer(s) to look for. A hostname must end with a dot. Format depends on the monitoring-plugins version: In version 2.2 and before, a single string with the values alphabetically ordered and joined by commas. In version 2.3 and later, multiple answers must be defined as array.
+dns_all_expected     | **Optional.** Denotes whether to require all values passed in `dns_expected_answers` to pass, or at least one. Only supported in newer versions of monitoring-plugins (2.3 and later), and is needed in such versions to replicate behaviour of previous versions of the plugins.
 dns_authoritative    | **Optional.** Expect the server to send an authoritative answer.
 dns_accept_cname     | **Optional.** Accept cname responses as a valid result to a query.
 dns_wtime            | **Optional.** Return warning if elapsed time exceeds value.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2013,7 +2013,11 @@ object CheckCommand "dns" {
 		}
 		"-a" = {
 			value = "$dns_expected_answers$"
-			description = "Optional ip address or host you expect the DNS server to return. Host must end with a dot (.). This option can be repeated multiple times (Returns OK if any value match). If multiple addresses are returned at once, you have to match the whole string of addresses separated with commas (sorted alphabetically)."
+			description = "Optional ip address or host you expect the DNS server to return. Host must end with a dot (.). This option can be repeated multiple times (Returns OK if any value match). If multiple addresses are returned at once: for version 2.2 and earlier of the monitoring-plugins, you have to match the whole string of addresses separated with commas (sorted alphabetically). For version 2.3 and later, you need to pass a list of strings, one for each address you want to match."
+		}
+		"-L" = {
+			set_if = "$dns_all_expected$"
+			description = "Return critical if the list of expected addresses does not match all addresses returned. Only supported in newer versions of monitoring-plugins (2.3 and later), and is needed in such versions to replicate behaviour of previous versions of the plugins. When not passed, one address is enough for success, instead of all."
 		}
 		"-A" = {
 			set_if = "$dns_authoritative$"


### PR DESCRIPTION
Version 2.3 of monitoring plugins did two things:

- change how multiple addresses are expected; no longer a single
  argument, with comma separated values, but repeated "-a" argument;
  sadly this is incompatible change, and configs need to be changed
  manually; this is commit
  monitoring-plugins/monitoring-plugins@a03068743f;
- add a "-L" argument that requires all passed addresses to be
  matched, which allows for stronger validation (all vs. at least
  one); this is commit
  monitoring-plugins/monitoring-plugins@fd9a7d2e00;

Both of these were committed a long while ago (2018), but were only
released very recently, in the 2.3 release (December 2020).

I've tried to make the descriptions as good as I could, but not sure
they're very readable, feedback welcome.

Signed-off-by: Iustin Pop <iustin@k1024.org>