### PR TITLE
Fix crash when notifications are sent while the notification object is deleted

### DIFF
--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -431,7 +431,11 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			<< "Sending " << (reminder ? "reminder " : "") << "'" << NotificationTypeToString(type) << "' notification '"
 			<< notificationName << "' for user '" << userName << "'";
 
-		Utility::QueueAsyncCallback(std::bind(&Notification::ExecuteNotificationHelper, this, type, user, cr, force, author, text));
+		// Explicitly use Notification::Ptr to keep the reference counted while the callback is active
+		Notification::Ptr notification (this);
+		Utility::QueueAsyncCallback([notification, type, user, cr, force, author, text]() {
+			notification->ExecuteNotificationHelper(type, user, cr, force, author, text);
+		});
 
 		/* collect all notified users */
 		allNotifiedUsers.insert(user);


### PR DESCRIPTION
When sending notifications, an asynchronous callback is scheduled which captures the `this` pointer which is not reference-counted. This PR fixes this by using a reference-counted `Notification::Ptr` instead.

fixes #8587