### PR TITLE
Remove incorrect assertion in ConfigItem::ActivateItems

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -697,17 +697,6 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 		}
 	}
 
-#ifdef I2_DEBUG
-	for (const ConfigItem::Ptr& item : newItems) {
-		ConfigObject::Ptr object = item->m_Object;
-
-		if (!object)
-			continue;
-
-		ASSERT(object && object->IsActive());
-	}
-#endif /* I2_DEBUG */
-
 	if (!silent)
 		Log(LogInformation, "ConfigItem", "Activated all objects.");
 


### PR DESCRIPTION
There is an assertion that after activating items, all these items are active, which sounds reasonable at first. However, with concurrent API queries, some of these could already be deleted and therefore be deactivated again.

Possible alternatives:
* Adding locking just to allow for this assertion sounds unreasonable to me.
* Adding some "object was active at some point" flag: could be done instead, but I'd only spend time on this if we agree that we want this.