### PR TITLE
Remove upq from ConfigItem::ActivateItems

### DIFF
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -275,11 +275,8 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 			return EXIT_FAILURE;
 		}
 
-		WorkQueue upq(25000, Configuration::Concurrency);
-		upq.SetName("DaemonCommand::Run");
-
 		// activate config only after daemonization: it starts threads and that is not compatible with fork()
-		if (!ConfigItem::ActivateItems(upq, newItems, false, false, true)) {
+		if (!ConfigItem::ActivateItems(newItems, false, false, true)) {
 			Log(LogCritical, "cli", "Error activating configuration.");
 			return EXIT_FAILURE;
 		}

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -624,7 +624,7 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 	return true;
 }
 
-bool ConfigItem::ActivateItems(WorkQueue& upq, const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated,
+bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated,
 	bool silent, bool withModAttrs, const Value& cookie)
 {
 	static boost::mutex mtx;
@@ -697,13 +697,6 @@ bool ConfigItem::ActivateItems(WorkQueue& upq, const std::vector<ConfigItem::Ptr
 		}
 	}
 
-	upq.Join();
-
-	if (upq.HasExceptions()) {
-		upq.ReportExceptions("ConfigItem");
-		return false;
-	}
-
 #ifdef I2_DEBUG
 	for (const ConfigItem::Ptr& item : newItems) {
 		ConfigObject::Ptr object = item->m_Object;
@@ -738,7 +731,7 @@ bool ConfigItem::RunWithActivationContext(const Function::Ptr& function)
 	if (!CommitItems(scope.GetContext(), upq, newItems, true))
 		return false;
 
-	if (!ActivateItems(upq, newItems, false, true))
+	if (!ActivateItems(newItems, false, true))
 		return false;
 
 	return true;

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -53,7 +53,7 @@ public:
 		const String& name);
 
 	static bool CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent = false);
-	static bool ActivateItems(WorkQueue& upq, const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated = false,
+	static bool ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated = false,
 		bool silent = false, bool withModAttrs = false, const Value& cookie = Empty);
 
 	static bool RunWithActivationContext(const Function::Ptr& function);

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -217,7 +217,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		 * uq, items, runtimeCreated, silent, withModAttrs, cookie
 		 * IMPORTANT: Forward the cookie aka origin in order to prevent sync loops in the same zone!
 		 */
-		if (!ConfigItem::ActivateItems(upq, newItems, true, true, false, cookie)) {
+		if (!ConfigItem::ActivateItems(newItems, true, true, false, cookie)) {
 			if (errors) {
 				Log(LogNotice, "ConfigObjectUtility")
 					<< "Failed to activate config object '" << fullName << "'. Aborting and removing config path '" << path << "'.";


### PR DESCRIPTION
Since commit d9010c7b9faaec137f3e195b370edbb406c37d76, ActivateItems no longer uses the WorkQueue upq to perform tasks but instead performs these locally. One instance of `upq.Join()`/`upq.HasExceptions()` remained in the function, but I believe this was just missed when removing the `upq.Enqueue()` call just before.

This commit removes the corresponding parameter and updates all call sites accordingly.