### PR TITLE
Flapping: Allow to ignore states in flapping detection

### DIFF
--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -468,6 +468,8 @@ when a [host](09-object-types.md#objecttype-host) or [service](09-object-types.m
 The default thresholds are 30% for high and 25% for low. If the computed flapping value exceeds the high threshold a
 host or service is considered flapping until it drops below the low flapping threshold.
 
+The attribute `flapping_ignore_states` allows to ignore state changes to specified states during the flapping calculation.
+
 `FlappingStart` and `FlappingEnd` notifications will be sent out accordingly, if configured. See the chapter on
 [notifications](alert-notifications) for details
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -359,6 +359,7 @@ Configuration Attributes:
   event\_command            | Object name           | **Optional.** The name of an event command that should be executed every time the host's state changes or the host is in a `SOFT` state.
   flapping\_threshold\_high | Number                | **Optional.** Flapping upper bound in percent for a host to be considered flapping. Default `30.0`
   flapping\_threshold\_low  | Number                | **Optional.** Flapping lower bound in percent for a host to be considered  not flapping. Default `25.0`
+  flapping\_ignore\_states  | Array                 | **Optional.** A list of states that should be ignored during flapping calculation. By default no state is ignored.
   volatile                  | Boolean               | **Optional.** Treat all state changes as HARD changes. See [here](08-advanced-topics.md#volatile-services-hosts) for details. Defaults to `false`.
   zone                      | Object name           | **Optional.** The zone this object is a member of. Please read the [distributed monitoring](06-distributed-monitoring.md#distributed-monitoring) chapter for details.
   command\_endpoint         | Object name           | **Optional.** The endpoint where commands are executed on.
@@ -721,6 +722,7 @@ Configuration Attributes:
   enable\_flapping          | Boolean               | **Optional.** Whether flap detection is enabled. Defaults to `false`.
   flapping\_threshold\_high | Number                | **Optional.** Flapping upper bound in percent for a service to be considered flapping. `30.0`
   flapping\_threshold\_low  | Number                | **Optional.** Flapping lower bound in percent for a service to be considered  not flapping. `25.0`
+  flapping\_ignore\_states  | Array                 | **Optional.** A list of states that should be ignored during flapping calculation. By default no state is ignored.
   enable\_perfdata          | Boolean               | **Optional.** Whether performance data processing is enabled. Defaults to `true`.
   event\_command            | Object name           | **Optional.** The name of an event command that should be executed every time the service's state changes or the service is in a `SOFT` state.
   volatile                  | Boolean               | **Optional.** Treat all state changes as HARD changes. See [here](08-advanced-topics.md#volatile-services-hosts) for details. Defaults to `false`.

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -369,7 +369,7 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 
 	bool was_flapping = IsFlapping();
 
-	UpdateFlappingStatus(old_state != cr->GetState());
+	UpdateFlappingStatus(cr->GetState());
 
 	bool is_flapping = IsFlapping();
 

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -15,6 +15,15 @@ using namespace icinga;
 REGISTER_TYPE_WITH_PROTOTYPE(Checkable, Checkable::GetPrototype());
 INITIALIZE_ONCE(&Checkable::StaticInitialize);
 
+const std::map<String, int> Checkable::m_FlappingStateFilterMap ({
+	{"OK", FlappingStateFilterOk},
+	{"Warning", FlappingStateFilterWarning},
+	{"Critical", FlappingStateFilterCritical},
+	{"Unknown", FlappingStateFilterUnknown},
+	{"Up", FlappingStateFilterOk},
+	{"Down", FlappingStateFilterCritical},
+});
+
 boost::signals2::signal<void (const Checkable::Ptr&, const String&, const String&, AcknowledgementType, bool, bool, double, double, const MessageOrigin::Ptr&)> Checkable::OnAcknowledgementSet;
 boost::signals2::signal<void (const Checkable::Ptr&, const String&, double, const MessageOrigin::Ptr&)> Checkable::OnAcknowledgementCleared;
 boost::signals2::signal<void (const Checkable::Ptr&, double)> Checkable::OnFlappingChange;
@@ -34,6 +43,13 @@ void Checkable::StaticInitialize()
 Checkable::Checkable()
 {
 	SetSchedulingOffset(Utility::Random());
+}
+
+void Checkable::OnConfigLoaded()
+{
+	ObjectImpl<Checkable>::OnConfigLoaded();
+
+	SetFlappingIgnoreStatesFilter(FilterArrayToInt(GetFlappingIgnoreStates(), m_FlappingStateFilterMap, ~0));
 }
 
 void Checkable::OnAllConfigLoaded()

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -39,6 +39,17 @@ enum CheckableType
 	CheckableService
 };
 
+/**
+ * @ingroup icinga
+ */
+enum FlappingStateFilter
+{
+	FlappingStateFilterOk = 1,
+	FlappingStateFilterWarning = 2,
+	FlappingStateFilterCritical = 4,
+	FlappingStateFilterUnknown = 8,
+};
+
 class CheckCommand;
 class EventCommand;
 class Dependency;
@@ -183,6 +194,7 @@ public:
 
 protected:
 	void Start(bool runtimeCreated) override;
+	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
 
 private:
@@ -222,7 +234,10 @@ private:
 	void GetAllChildrenInternal(std::set<Checkable::Ptr>& children, int level = 0) const;
 
 	/* Flapping */
-	void UpdateFlappingStatus(bool stateChange);
+	static const std::map<String, int> m_FlappingStateFilterMap;
+
+	void UpdateFlappingStatus(ServiceState newState);
+	static int ServiceStateToFlappingFilter(ServiceState state);
 };
 
 }

--- a/lib/icinga/checkable.ti
+++ b/lib/icinga/checkable.ti
@@ -73,6 +73,9 @@ abstract class Checkable : CustomVarObject
 		default {{{ return true; }}}
 	};
 
+	[config] array(String) flapping_ignore_states;
+	[no_user_view, no_user_modify] int flapping_ignore_states_filter_real (FlappingIgnoreStatesFilter);
+
 	[config, deprecated] double flapping_threshold;
 
 	[config] double flapping_threshold_low {
@@ -163,6 +166,9 @@ abstract class Checkable : CustomVarObject
 	};
 	[state] Timestamp flapping_last_change;
 
+	[state, enum, no_user_view, no_user_modify] ServiceState flapping_last_state {
+		default {{{ return ServiceUnknown; }}}
+	};
 	[state, no_user_view, no_user_modify] int flapping_buffer;
 	[state, no_user_view, no_user_modify] int flapping_index;
 	[state, protected] bool flapping;


### PR DESCRIPTION
This PR adds the `flapping_ignore_states` attribute to the `Checkable`object. It allows to define states that should be ignored during flapping detection. 

## Tests

### Setup

#### Config
```
object Host "flapper" {
    check_command = "dummy"
    check_interval = 1s
    retry_interval = 1s
    enable_flapping = true

    vars.seq = [ 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
    vars.idx = 0

    var that = this
    vars.dummy_state = function() use(that) {
        var ret = that.vars.seq[that.vars.idx % len(that.vars.seq)]
        that.vars.idx += 1
        return ret
    }
}
```

#### API calls

```
while true; do
        CURL=$(curl -k -s -u root:icinga -H 'Accept: application/json' -X GET 'https://localhost:5665/v1/objects/hosts/flapper' | jq '.results[].attrs.flapping')
        echo $(date): $CURL
        sleep 5;
done
```

### Cases

#### No filter + Critical/OK sequence:
Filter: `none`
Sequence: `vars.seq = [ 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]`

```
Mon Jan 18 12:50:15 CET 2021: false
Mon Jan 18 12:50:20 CET 2021: false
Mon Jan 18 12:50:25 CET 2021: false
Mon Jan 18 12:50:30 CET 2021: true
Mon Jan 18 12:50:35 CET 2021: true
Mon Jan 18 12:50:41 CET 2021: true
Mon Jan 18 12:50:46 CET 2021: true
Mon Jan 18 12:50:51 CET 2021: true
Mon Jan 18 12:50:56 CET 2021: false
Mon Jan 18 12:51:01 CET 2021: false
Mon Jan 18 12:51:06 CET 2021: false
Mon Jan 18 12:51:11 CET 2021: true
Mon Jan 18 12:51:16 CET 2021: true
Mon Jan 18 12:51:21 CET 2021: true
Mon Jan 18 12:51:26 CET 2021: true
Mon Jan 18 12:51:31 CET 2021: true
```

#### No filter + Critical/Warning sequence:
Filter: `none`
Sequence: `vars.seq = [ 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 ]`

```
Mon Jan 18 12:55:34 CET 2021: true
Mon Jan 18 12:55:39 CET 2021: true
Mon Jan 18 12:55:44 CET 2021: true
Mon Jan 18 12:55:49 CET 2021: true
Mon Jan 18 12:55:55 CET 2021: true
Mon Jan 18 12:56:00 CET 2021: true
Mon Jan 18 12:56:05 CET 2021: true
Mon Jan 18 12:56:10 CET 2021: true
```

#### Critical filter + Critical/OK sequence:
Filter: `flapping_ignore_states = ["Critical"]`
Sequence: `vars.seq = [ 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]`

```
Mon Jan 18 13:27:25 CET 2021: false
Mon Jan 18 13:27:30 CET 2021: false
Mon Jan 18 13:27:36 CET 2021: false
Mon Jan 18 13:27:41 CET 2021: false
Mon Jan 18 13:27:46 CET 2021: false
Mon Jan 18 13:27:51 CET 2021: false
Mon Jan 18 13:27:56 CET 2021: false
Mon Jan 18 13:28:01 CET 2021: false
```

#### Critical filter + Critical/Warning sequence:
Filter: `flapping_ignore_states = ["Critical"]`
Sequence: `vars.seq = [ 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 ]`

```
Mon Jan 18 13:48:03 CET 2021: false
Mon Jan 18 13:48:08 CET 2021: false
Mon Jan 18 13:48:13 CET 2021: true
Mon Jan 18 13:48:18 CET 2021: true
Mon Jan 18 13:48:23 CET 2021: true
Mon Jan 18 13:48:28 CET 2021: true
Mon Jan 18 13:48:33 CET 2021: true
Mon Jan 18 13:48:38 CET 2021: true
Mon Jan 18 13:48:43 CET 2021: false
Mon Jan 18 13:48:48 CET 2021: false
Mon Jan 18 13:48:53 CET 2021: true
Mon Jan 18 13:48:58 CET 2021: true
Mon Jan 18 13:49:03 CET 2021: true
Mon Jan 18 13:49:08 CET 2021: true
Mon Jan 18 13:49:13 CET 2021: true
Mon Jan 18 13:49:18 CET 2021: true
```

#### Critical/Warning filter + Critical/Warning sequence:
Filter: `flapping_ignore_states = ["Critical", "Warning"]`
Sequence: `vars.seq = [ 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1 ]`
```
Mon Jan 18 13:54:56 CET 2021: false
Mon Jan 18 13:55:01 CET 2021: false
Mon Jan 18 13:55:06 CET 2021: false
Mon Jan 18 13:55:11 CET 2021: false
Mon Jan 18 13:55:16 CET 2021: false
Mon Jan 18 13:55:21 CET 2021: false
Mon Jan 18 13:55:26 CET 2021: false
Mon Jan 18 13:55:32 CET 2021: false
```

fixes #8307 