### PR TITLE
Delay start of IcingaDB until most config objects are activated

### DIFF
--- a/lib/icingadb/icingadb.ti
+++ b/lib/icingadb/icingadb.ti
@@ -9,6 +9,8 @@ namespace icinga
 
 class IcingaDB : ConfigObject
 {
+	activation_priority 100;
+
 	[config] String host {
 		default {{{ return "127.0.0.1"; }}}
 	};


### PR DESCRIPTION
This commit sets the activation priority if IcingaDB objects to 100 (the same value as IDO uses) so that it get's activated after most regular config objects (hosts, services, ...).

Before (note how Icinga 2 continues to active objects for over a minute after IcingaDB is started and thinks the initial dump is done):

    [2021-01-19 08:33:19 +0000] information/IcingaDB: 'icingadb' started.
    [2021-01-19 08:34:02 +0000] information/IcingaDB: Initial config/status dump finished in 28.247 seconds.
    [2021-01-19 08:35:49 +0000] information/ConfigItem: Activated all objects.

After (now activation of objects is done right after IcingaDB is started, as it's one of the last objects to be activated):

    [2021-01-19 08:39:01 +0000] information/IcingaDB: 'icingadb' started.
    [2021-01-19 08:39:02 +0000] information/ConfigItem: Activated all objects.
    [2021-01-19 08:39:38 +0000] information/IcingaDB: Initial config/status dump finished in 21.6606 seconds.