### PR TITLE
IcingaDB: start initial dump in callback instead of timer

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -117,6 +117,7 @@ void IcingaDB::ConfigStaticInitialize()
 
 void IcingaDB::UpdateAllConfigObjects()
 {
+	Log(LogInformation, "IcingaDB") << "Starting initial config/status dump";
 	double startTime = Utility::GetTime();
 
 	// Use a Workqueue to pack objects in parallel

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -35,8 +35,7 @@ public:
 	virtual void Stop(bool runtimeRemoved) override;
 
 private:
-	void ReconnectTimerHandler();
-	void TryToReconnect();
+	void OnConnectedHandler();
 
 	void PublishStatsTimerHandler();
 	void PublishStats();
@@ -134,7 +133,6 @@ private:
 	}
 
 	Timer::Ptr m_StatsTimer;
-	Timer::Ptr m_ReconnectTimer;
 	WorkQueue m_WorkQueue;
 
 	String m_PrefixConfigObject;

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -233,6 +233,10 @@ void RedisConnection::Connect(asio::yield_context& yc)
 
 			Log(LogInformation, "IcingaDB", "Connected to Redis server");
 
+			if (m_ConnectedCallback) {
+				m_ConnectedCallback(yc);
+			}
+
 			break;
 		} catch (const boost::coroutines::detail::forced_unwind&) {
 			throw;
@@ -499,4 +503,15 @@ void RedisConnection::WriteOne(RedisConnection::Query& query, asio::yield_contex
 	} else {
 		WriteOne(m_UnixConn, query, yc);
 	}
+}
+
+/**
+ * Specify a callback that is run each time a connection is successfully established
+ *
+ * The callback is executed from a Boost.Asio coroutine and should therefore not perform blocking operations.
+ *
+ * @param callback Callback to execute
+ */
+void RedisConnection::SetConnectedCallback(std::function<void(asio::yield_context& yc)> callback) {
+	m_ConnectedCallback = std::move(callback);
 }

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -82,6 +82,8 @@ namespace icinga
 		void SuppressQueryKind(QueryPriority kind);
 		void UnsuppressQueryKind(QueryPriority kind);
 
+		void SetConnectedCallback(std::function<void(boost::asio::yield_context& yc)> callback);
+
 	private:
 		/**
 		 * What to do with the responses to Redis queries.
@@ -179,6 +181,8 @@ namespace icinga
 
 		// Indicate that there's something to send/receive
 		AsioConditionVariable m_QueuedWrites, m_QueuedReads;
+
+		std::function<void(boost::asio::yield_context& yc)> m_ConnectedCallback;
 	};
 
 /**


### PR DESCRIPTION
Previously, the initial config dump was started in a timer executed every 15 seconds. During the first execution of the timer, the Redis connection is typically not established yet. Therefore, this delayed the initial sync by up to 15 seconds.

This commit instead triggers the sync from a callback that is executed after the connection is successfully established.

The timer is removed completely. On first glance, it looks like it would ensure that a lost connection is reestablished, but this is handled internally by RedisConnection. After the config has been dumped once, that timer wouldn't ever attempt a reconnect anyways.