### PR TITLE
IcingaDB: wait for queries to be executed in inital sync

### DIFF
--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -79,6 +79,8 @@ namespace icinga
 		Reply GetResultOfQuery(Query query, QueryPriority priority);
 		Replies GetResultsOfQueries(Queries queries, QueryPriority priority);
 
+		void EnqueueCallback(const std::function<void(boost::asio::yield_context&)>& callback, QueryPriority priority);
+
 		void SuppressQueryKind(QueryPriority kind);
 		void UnsuppressQueryKind(QueryPriority kind);
 
@@ -117,6 +119,7 @@ namespace icinga
 			Shared<Queries>::Ptr FireAndForgetQueries;
 			Shared<std::pair<Query, std::promise<Reply>>>::Ptr GetResultOfQuery;
 			Shared<std::pair<Queries, std::promise<Replies>>>::Ptr GetResultsOfQueries;
+			std::function<void(boost::asio::yield_context&)> Callback;
 		};
 
 		typedef boost::asio::ip::tcp Tcp;


### PR DESCRIPTION
This delays the log message stating that the initial dump is done until all queries are actually done and now logs a meaningful duration. In addition, this delays the return of the function and therefore when state variables are updated by the caller.