### PR TITLE
Improve handling of exceptions thrown by RunWorker

### DIFF
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -688,7 +688,11 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 	}
 
 #ifdef _WIN32
-	return RunWorker(configs);
+	try {
+		return RunWorker(configs);
+	} catch (...) {
+		return EXIT_FAILURE;
+	}
 #else /* _WIN32 */
 	l_UmbrellaPid = getpid();
 	Application::SetUmbrellaProcess(l_UmbrellaPid);

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -526,6 +526,9 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 				}
 
 				_exit(RunWorker(configs, closeConsoleLog, stderrFile));
+			} catch (const std::exception& ex) {
+				Log(LogCritical, "cli") << "Exception in main process: " << DiagnosticInformation(ex);
+				_exit(EXIT_FAILURE);
 			} catch (...) {
 				_exit(EXIT_FAILURE);
 			}
@@ -690,6 +693,9 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 #ifdef _WIN32
 	try {
 		return RunWorker(configs);
+	} catch (const std::exception& ex) {
+		Log(LogCritical, "cli")	<< "Exception in main process: " << DiagnosticInformation(ex);
+		return EXIT_FAILURE;
 	} catch (...) {
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
This PR improves two aspects of exception handling for `RunWorker`:
* On Windows, previously exceptions weren't caught at all.
* On other platforms, there was only a `catch (...)`, this adds a handler for `std::exception` printing a log message.

refs #8480 (probably not a "fixes" but should give more useful information there)