### PR TITLE
Added new option ignore-sct for ssl_cert to ITL

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5608,7 +5608,7 @@ ssl_cert_disable_ssl_versions | **Optional.** Disable specific SSL versions out 
 ssl_cert_cipher               | **Optional.** Cipher selection: force {ecdsa,rsa} authentication.
 ssl_cert_ignore_expiration    | **Optional.** Ignore expiration date.
 ssl_cert_ignore_ocsp          | **Optional.** Do not check revocation with OCSP.
-ssl_cert_ignore_stc           | **Optional.** Do not check for signed certificate timestamps.
+ssl_cert_ignore_sct           | **Optional.** Do not check for signed certificate timestamps.
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5608,6 +5608,7 @@ ssl_cert_disable_ssl_versions | **Optional.** Disable specific SSL versions out 
 ssl_cert_cipher               | **Optional.** Cipher selection: force {ecdsa,rsa} authentication.
 ssl_cert_ignore_expiration    | **Optional.** Ignore expiration date.
 ssl_cert_ignore_ocsp          | **Optional.** Do not check revocation with OCSP.
+ssl_cert_ignore_stc           | **Optional.** Do not check for signed certificate timestamps.
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -554,6 +554,10 @@ object CheckCommand "ssl_cert" {
 			set_if = "$ssl_cert_ignore_ocsp$"
 			description = "Do not check revocation with OCSP"
 		}
+		"--ignore-stc" = {
+			set_if = "$ssl_cert_ignore_stc$"
+			description = "Do not check for signed certificate timestamps"
+		}
 
 	}
 

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -554,8 +554,8 @@ object CheckCommand "ssl_cert" {
 			set_if = "$ssl_cert_ignore_ocsp$"
 			description = "Do not check revocation with OCSP"
 		}
-		"--ignore-stc" = {
-			set_if = "$ssl_cert_ignore_stc$"
+		"--ignore-sct" = {
+			set_if = "$ssl_cert_ignore_sct$"
 			description = "Do not check for signed certificate timestamps"
 		}
 


### PR DESCRIPTION
Added option to ignore `signed certificate timestamps` check. This check has been implemented in `check_ssl_cert` recently and is enabled by default.