### PR TITLE
Ido*sqlConnection#InternalDeactivateObject(): mark object inactive also in memory

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -833,6 +833,8 @@ void IdoMysqlConnection::InternalDeactivateObject(const DbObject::Ptr& dbobj)
 
 	/* Note that we're _NOT_ clearing the db refs via SetReference/SetConfigUpdate/SetStatusUpdate
 	 * because the object is still in the database. */
+
+	SetObjectActive(dbobj, false);
 }
 
 bool IdoMysqlConnection::FieldToEscapedString(const String& key, const Value& value, Value *result)

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -648,6 +648,8 @@ void IdoPgsqlConnection::InternalDeactivateObject(const DbObject::Ptr& dbobj)
 
 	/* Note that we're _NOT_ clearing the db refs via SetReference/SetConfigUpdate/SetStatusUpdate
 	 * because the object is still in the database. */
+
+	SetObjectActive(dbobj, false);
 }
 
 bool IdoPgsqlConnection::FieldToEscapedString(const String& key, const Value& value, Value *result)


### PR DESCRIPTION
Previously:
    1. You delete an object from a config file
    2. You reload Icinga
    3. Icinga fetches all objects and whether they're active from the IDO
    4. Icinga recognizes that the just deleted object doesn't exist anymore
    5. Icinga marks it as inactive in the IDO, but not in memory
    6. You re-create the just deleted object via API
    7. Icinga still thinks it's active and doesn't activate it - it's invisible

fixes #8584