### PR TITLE
Fix update execution message discarded. refs #8616

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -681,9 +681,15 @@ Dictionary::Ptr ApiActions::ExecuteCommand(const ConfigObject::Ptr& object, cons
 	if (!endpointPtr)
 		return ApiActions::CreateResult(404, "Can't find a valid endpoint for '" + resolved_endpoint + "'.");
 
-    /* Check if the endpoint zone can access the checkable */
+	/* Return an error when
+	 * the endpoint is different from the command endpoint of the checkable
+	 * and the endpoint zone can't access the checkable.
+	 * The endpoints are checked to allow for the case where command_endpoint is specified in the checkable
+	 * but checkable is not actually present in the agent.
+	 */
     Zone::Ptr endpointZone = endpointPtr->GetZone();
-    if (!endpointZone->CanAccessObject(checkable)) {
+    Endpoint::Ptr commandEndpoint = checkable->GetCommandEndpoint();
+    if (endpointPtr != commandEndpoint && !endpointZone->CanAccessObject(checkable)) {
         return ApiActions::CreateResult(
             409,
             "Zone '" + endpointZone->GetName() + "' cannot access checkable '" + checkable->GetName() + "'."

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -681,6 +681,15 @@ Dictionary::Ptr ApiActions::ExecuteCommand(const ConfigObject::Ptr& object, cons
 	if (!endpointPtr)
 		return ApiActions::CreateResult(404, "Can't find a valid endpoint for '" + resolved_endpoint + "'.");
 
+    /* Check if the endpoint zone can access the checkable */
+    Zone::Ptr endpointZone = endpointPtr->GetZone();
+    if (!endpointZone->CanAccessObject(checkable)) {
+        return ApiActions::CreateResult(
+            409,
+            "Zone '" + endpointZone->GetName() + "' cannot access checkable '" + checkable->GetName() + "'."
+        );
+    }
+
 	/* Get command */
 	String command;
 
@@ -806,6 +815,7 @@ Dictionary::Ptr ApiActions::ExecuteCommand(const ConfigObject::Ptr& object, cons
 	Dictionary::Ptr pending_execution = new Dictionary();
 	pending_execution->Set("pending", true);
 	pending_execution->Set("deadline", deadline);
+	pending_execution->Set("endpoint", resolved_endpoint);
 	Dictionary::Ptr executions = checkable->GetExecutions();
 
 	if (!executions)

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -761,8 +761,17 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 		}
 	}
 
+	String executionUuid = params->Get("source");
+
 	if (params->Contains("endpoint")) {
 		Endpoint::Ptr execEndpoint = Endpoint::GetByName(params->Get("endpoint"));
+
+		if (!execEndpoint) {
+			Log(LogWarning, "ClusterEvents")
+				<< "Discarding 'execute command' message " << executionUuid
+				<< ": Endpoint " << params->Get("endpoint") << " does not exist";
+			return Empty;
+		}
 
 		if (execEndpoint != Endpoint::GetLocalEndpoint()) {
 			Zone::Ptr endpointZone = execEndpoint->GetZone();
@@ -782,7 +791,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 						if (!(childEndpoint->GetCapabilities() & (uint_fast64_t)ApiCapabilities::ExecuteArbitraryCommand)) {
 							double now = Utility::GetTime();
 							Dictionary::Ptr executedParams = new Dictionary();
-							executedParams->Set("execution", params->Get("source"));
+							executedParams->Set("execution", executionUuid);
 							executedParams->Set("host", params->Get("host"));
 
 							if (params->Contains("service"))
@@ -802,6 +811,58 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 							listener->RelayMessage(nullptr, nullptr, executedMessage, true);
 							return Empty;
 						}
+					}
+
+					Checkable::Ptr checkable;
+					Host::Ptr host = Host::GetByName(params->Get("host"));
+					if (!host) {
+						Log(LogWarning, "ClusterEvents")
+                            << "Discarding 'execute command' message " << executionUuid
+							<< ": host " << params->Get("host") << " does not exist";
+						return Empty;
+					}
+
+					if (params->Contains("service"))
+						checkable = host->GetServiceByShortName(params->Get("service"));
+					else
+						checkable = host;
+
+					if (!checkable) {
+						String checkableName = host->GetName();
+						if (params->Contains("service"))
+							checkableName += "!" + params->Get("service");
+
+						Log(LogWarning, "ClusterEvents")
+                            << "Discarding 'execute command' message " << executionUuid
+							<< ": " << checkableName << " does not exist";
+						return Empty;
+					}
+
+					/* Check if the child zone can access the checkable, and if it's the same endpoint zone  */
+					if (!zone->CanAccessObject(checkable) && zone != endpointZone) {
+						double now = Utility::GetTime();
+						Dictionary::Ptr executedParams = new Dictionary();
+						executedParams->Set("execution", executionUuid);
+						executedParams->Set("host", params->Get("host"));
+
+						if (params->Contains("service"))
+							executedParams->Set("service", params->Get("service"));
+
+						executedParams->Set("exit", 126);
+						executedParams->Set(
+							"output",
+							"Zone '" + zone->GetName() + "' cannot access to checkable '" + checkable->GetName() + "'."
+						);
+						executedParams->Set("start", now);
+						executedParams->Set("end", now);
+
+						Dictionary::Ptr executedMessage = new Dictionary();
+						executedMessage->Set("jsonrpc", "2.0");
+						executedMessage->Set("method", "event::ExecutedCommand");
+						executedMessage->Set("params", executedParams);
+
+						listener->RelayMessage(nullptr, nullptr, executedMessage, true);
+						return Empty;
 					}
 				}
 			}
@@ -1179,13 +1240,6 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 
 	ObjectLock oLock (checkable);
 
-	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
-			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
-			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
-		return Empty;
-	}
-
 	if (!params->Contains("execution")) {
 		Log(LogNotice, "ClusterEvents")
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
@@ -1210,6 +1264,22 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 		Log(LogNotice, "ClusterEvents")
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Execution '" << uuid << "' missing.";
+		return Empty;
+	}
+
+	Endpoint::Ptr command_endpoint = Endpoint::GetByName(execution->Get("endpoint"));
+	if (!command_endpoint) {
+		Log(LogNotice, "ClusterEvents")
+			<< "Discarding 'update executions API handler' message from '" << origin->FromClient->GetIdentity()
+			<< "': Command endpoint does not exists.";
+
+		return Empty;
+	}
+
+	if (origin->FromZone && !origin->FromZone->CanAccessObject(command_endpoint->GetZone())) {
+		Log(LogNotice, "ClusterEvents")
+			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
+			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
 	}
 
@@ -1303,7 +1373,7 @@ Value ClusterEvents::UpdateExecutionsAPIHandler(const MessageOrigin::Ptr& origin
 	updateMessage->Set("method", "event::UpdateExecutions");
 	updateMessage->Set("params", params);
 
-	listener->RelayMessage(origin, Zone::GetLocalZone(), updateMessage, true);
+	listener->RelayMessage(origin, checkable, updateMessage, true);
 
 	return Empty;
 }


### PR DESCRIPTION
Hi, this is our proposal for fixes #8616


### Configuration for test

**/etc/icinga2/conf.d/test.conf**
Use this configuration on master, satellite and agent

```
object Host "satellite" {
    address = "127.0.0.1"
    check_command = "hostalive"
    zone = "satellite"
    vars.ls_dir = "/tmp/host"
    enable_active_checks = false
}

object Host "agent" {
    address = "127.0.0.1"
    check_command = "hostalive"
    zone = "satellite"
    vars.ls_dir = "/tmp/host"
    enable_active_checks = false
}

object Host "master" {
    address = "127.0.0.1"
    check_command = "hostalive"
}

object CheckCommand "custom_command" {
    command = [ "/usr/bin/ls", "$ls_dir$" ]
    zone = "global-commands"
}
```

## Master

**/etc/icinga2/zones.conf**

```
object Zone "global-commands" {
    global = true
}

object Zone "global-templates" {
    global = true
}

object Zone "director-global" {
    global = true
}

object Endpoint "master" {
}

object Zone "master" {
    endpoints = [ "master" ]
}

object Endpoint "satellite" {
}

object Zone "satellite" {
    endpoints = [ "satellite" ]
    parent = "master"
}

object Endpoint "agent" {
    log_duration = 0s
}

object Zone "agent" {
    endpoints = [ "agent" ]
    parent = "satellite"
}
```

## Satellite

**/etc/icinga2/zones.conf**

```
object Zone "global-commands" {
  global = true
}

object Zone "global-templates" {
    global = true
}

object Zone "director-global" {
    global = true
}

object Endpoint "master" {
    host = "127.0.0.1"
    port = "5665"
}

object Zone "master" {
    endpoints = [ "master" ]
}

object Endpoint "satellite" {
}

object Zone "satellite" {
    endpoints = [ "satellite" ]
    parent = "master"
}

object Endpoint "agent" {
    host = "127.0.0.1"
    port = "5663"
    log_duration = 0s
}

object Zone "agent" {
    endpoints = [ "agent" ]
    parent = "satellite"
}
```

## Agent

**/etc/icinga2/zones.conf**

```
object Zone "global-commands" {
    global = true
}

object Endpoint "satellite" {
    host = "127.0.0.1"
    port = "5664"
}

object Zone "satellite" {
    endpoints = [ "satellite" ]
}

object Endpoint "agent" {
}

object Zone "agent" {
    endpoints = [ "agent" ]
    parent = "satellite"
}

object Zone "global-templates" {
    global = true
}

object Zone "director-global" {
    global = true
}
```

## Test before the fix

**Request**
```
curl -k -sS -u root:admin -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/actions/execute-command' -d '{"type":"Host", "host": "agent", "ttl":"60", "endpoint": "agent", "macros": { "ls_dir":"/tmp/foo" }, "command": "custom_command", "command_type": "CheckCommand" }'
```

**Response**
```
{"results":[{"checkable":"agent","code":202.0,"execution":"beca0a2c-a99d-4804-90a3-9bd7e142b302","status":"Accepted"}]}
```

**Execution status**
```
"beca0a2c-a99d-4804-90a3-9bd7e142b302" = {
    deadline = 1612800769.001815
    pending = true
}
```
**Master logs**

```
[2021-02-08 17:11:49 +0100] notice/ApiListener: New HTTP client
[2021-02-08 17:11:49 +0100] debug/HttpUtility: Request body: '{"type":"Host", "host": "agent", "ttl":"60", "endpoint": "agent", "macros": { "ls_dir":"/tmp/foo" }, "command": "custom_command", "command_type": "CheckCommand" }'
[2021-02-08 17:11:49 +0100] notice/ApiActionHandler: Running action execute-command
[2021-02-08 17:11:49 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
[2021-02-08 17:11:49 +0100] notice/ApiListener: Sending message 'event::UpdateExecutions' to 'satellite'
[2021-02-08 17:11:49 +0100] notice/ApiListener: Relaying 'event::ExecuteCommand' message
[2021-02-08 17:11:49 +0100] notice/ApiListener: Sending message 'event::ExecuteCommand' to 'satellite'
>> {"jsonrpc":"2.0","method":"event::UpdateExecutions","params":{"executions":{"beca0a2c-a99d-4804-90a3-9bd7e142b302":{"deadline":1612800769.001815,"pending":true}},"host":"agent"},"ts":1612800709.00188}
[2021-02-08 17:11:49 +0100] information/HttpServerConnection: Request: POST /v1/actions/execute-command (from [::1]:37268), user: root, agent: curl/7.71.1, status: Accepted).
>> {"jsonrpc":"2.0","method":"event::ExecuteCommand","params":{"command":"custom_command","command_type":"check_command","deadline":1612800769.001815,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"beca0a2c-a99d-4804-90a3-9bd7e142b302"},"ts":1612800709.001983}
[2021-02-08 17:11:49 +0100] information/HttpServerConnection: HTTP client disconnected (from [::1]:37268)
```

**Satellite logs**

```
[2021-02-08 17:11:49 +0100] notice/JsonRpcConnection: Received 'event::UpdateExecutions' message from identity 'master'.
[2021-02-08 17:11:49 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
<< {"jsonrpc":"2.0","method":"event::ExecuteCommand","params":{"command":"custom_command","command_type":"check_command","deadline":1612800769.001815,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"beca0a2c-a99d-4804-90a3-9bd7e142b302"},"ts":1612800709.001983}
[2021-02-08 17:11:49 +0100] notice/JsonRpcConnection: Received 'event::ExecuteCommand' message from identity 'master'.
[2021-02-08 17:11:49 +0100] notice/ApiListener: Relaying 'event::ExecuteCommand' message
[2021-02-08 17:11:49 +0100] notice/ApiListener: Sending message 'event::ExecuteCommand' to 'agent'
>> {"jsonrpc":"2.0","method":"event::ExecuteCommand","originZone":"master","params":{"command":"custom_command","command_type":"check_command","deadline":1612800769.001815,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"beca0a2c-a99d-4804-90a3-9bd7e142b302"},"ts":1612800709.002931}
<< {"jsonrpc":"2.0","method":"event::ExecutedCommand","params":{"end":1612800709.006358,"execution":"beca0a2c-a99d-4804-90a3-9bd7e142b302","exit":2.0,"host":"agent","output":"/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n","start":1612800709.003923}}
[2021-02-08 17:11:49 +0100] notice/JsonRpcConnection: Received 'event::ExecutedCommand' message from identity 'agent'.
[2021-02-08 17:11:49 +0100] notice/ClusterEvents: Discarding 'update executions API handler' message for checkable 'agent' from 'agent': Unauthorized access.
```

**Agent logs**

```
[2021-02-08 17:11:49 +0100] notice/JsonRpcConnection: Received 'event::UpdateExecutions' message from identity 'master'.
[2021-02-08 17:11:49 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
<< {"jsonrpc":"2.0","method":"event::ExecuteCommand","params":{"command":"custom_command","command_type":"check_command","deadline":1612800769.001815,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"beca0a2c-a99d-4804-90a3-9bd7e142b302"},"ts":1612800709.001983}
[2021-02-08 17:11:49 +0100] notice/JsonRpcConnection: Received 'event::ExecuteCommand' message from identity 'master'.
[2021-02-08 17:11:49 +0100] notice/ApiListener: Relaying 'event::ExecuteCommand' message
[2021-02-08 17:11:49 +0100] notice/ApiListener: Sending message 'event::ExecuteCommand' to 'agent'
>> {"jsonrpc":"2.0","method":"event::ExecuteCommand","originZone":"master","params":{"command":"custom_command","command_type":"check_command","deadline":1612800769.001815,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"beca0a2c-a99d-4804-90a3-9bd7e142b302"},"ts":1612800709.002931}
<< {"jsonrpc":"2.0","method":"event::ExecutedCommand","params":{"end":1612800709.006358,"execution":"beca0a2c-a99d-4804-90a3-9bd7e142b302","exit":2.0,"host":"agent","output":"/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n","start":1612800709.003923}}
[2021-02-08 17:11:49 +0100] notice/JsonRpcConnection: Received 'event::ExecutedCommand' message from identity 'agent'.
[2021-02-08 17:11:49 +0100] notice/ClusterEvents: Discarding 'update executions API handler' message for checkable 'agent' from 'agent': Unauthorized access.
```


## Test with the fix

**Request**

```
curl -k -sS -u root:admin -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/actions/execute-command' -d '{"type":"Host", "host": "agent", "ttl":"60", "endpoint": "agent", "macros": { "ls_dir":"/tmp/foo" }, "command": "custom_command", "command_type": "CheckCommand" }'
```

**Response**
```
{"results":[{"checkable":"agent","code":202.0,"execution":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e","status":"Accepted"}]}
```

**Exectuion status***
```
"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e" = {
		deadline = 1612801142.086969
		end = 1612801082.090901
		exit = 2.000000
		output = "/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n"
		start = 1612801082.088762
	}
```


**Master logs**

```
[2021-02-08 17:18:02 +0100] notice/ApiListener: New HTTP client
[2021-02-08 17:18:02 +0100] debug/HttpUtility: Request body: '{"type":"Host", "host": "agent", "ttl":"60", "endpoint": "agent", "macros": { "ls_dir":"/tmp/foo" }, "command": "custom_command", "command_type": "CheckCommand" }'
[2021-02-08 17:18:02 +0100] notice/ApiActionHandler: Running action execute-command
[2021-02-08 17:18:02 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
[2021-02-08 17:18:02 +0100] notice/ApiListener: Sending message 'event::UpdateExecutions' to 'satellite'
[2021-02-08 17:18:02 +0100] notice/ApiListener: Relaying 'event::ExecuteCommand' message
[2021-02-08 17:18:02 +0100] notice/ApiListener: Sending message 'event::ExecuteCommand' to 'satellite'
[2021-02-08 17:18:02 +0100] information/HttpServerConnection: Request: POST /v1/actions/execute-command (from [::1]:38370), user: root, agent: curl/7.71.1, status: Accepted).
>> {"jsonrpc":"2.0","method":"event::UpdateExecutions","params":{"executions":{"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e":{"deadline":1612801142.086969,"pending":true}},"host":"agent"},"ts":1612801082.087048}
>> {"jsonrpc":"2.0","method":"event::ExecuteCommand","params":{"command":"custom_command","command_type":"check_command","deadline":1612801142.086969,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e"},"ts":1612801082.087107}
[2021-02-08 17:18:02 +0100] information/HttpServerConnection: HTTP client disconnected (from [::1]:38370)
<< {"jsonrpc":"2.0","method":"event::UpdateExecutions","params":{"executions":{"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e":{"deadline":1612801142.086969,"end":1612801082.090901,"exit":2.0,"output":"/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n","start":1612801082.088762}},"host":"agent"},"ts":1612801082.091564}
[2021-02-08 17:18:02 +0100] notice/JsonRpcConnection: Received 'event::UpdateExecutions' message from identity 'satellite'.
[2021-02-08 17:18:02 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
```

**Satellite logs**

```
<< {"jsonrpc":"2.0","method":"event::UpdateExecutions","params":{"executions":{"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e":{"deadline":1612801142.086969,"pending":true}},"host":"agent"},"ts":1612801082.087048}
[2021-02-08 17:18:02 +0100] notice/JsonRpcConnection: Received 'event::UpdateExecutions' message from identity 'master'.
[2021-02-08 17:18:02 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
<< {"jsonrpc":"2.0","method":"event::ExecuteCommand","params":{"command":"custom_command","command_type":"check_command","deadline":1612801142.086969,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e"},"ts":1612801082.087107}
[2021-02-08 17:18:02 +0100] notice/JsonRpcConnection: Received 'event::ExecuteCommand' message from identity 'master'.
[2021-02-08 17:18:02 +0100] notice/ApiListener: Relaying 'event::ExecuteCommand' message
[2021-02-08 17:18:02 +0100] notice/ApiListener: Sending message 'event::ExecuteCommand' to 'agent'
>> {"jsonrpc":"2.0","method":"event::ExecuteCommand","originZone":"master","params":{"command":"custom_command","command_type":"check_command","deadline":1612801142.086969,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e"},"ts":1612801082.087914}
<< {"jsonrpc":"2.0","method":"event::ExecutedCommand","params":{"end":1612801082.090901,"execution":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e","exit":2.0,"host":"agent","output":"/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n","start":1612801082.088762}}
[2021-02-08 17:18:02 +0100] notice/JsonRpcConnection: Received 'event::ExecutedCommand' message from identity 'agent'.
[2021-02-08 17:18:02 +0100] notice/ApiListener: Relaying 'event::UpdateExecutions' message
[2021-02-08 17:18:02 +0100] notice/ApiListener: Sending message 'event::UpdateExecutions' to 'master'
>> {"jsonrpc":"2.0","method":"event::UpdateExecutions","params":{"executions":{"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e":{"deadline":1612801142.086969,"end":1612801082.090901,"exit":2.0,"output":"/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n","start":1612801082.088762}},"host":"agent"},"ts":1612801082.091564}
```

**Aagent logs**

```
<< {"jsonrpc":"2.0","method":"event::ExecuteCommand","originZone":"master","params":{"command":"custom_command","command_type":"check_command","deadline":1612801142.086969,"endpoint":"agent","host":"agent","macros":{"ls_dir":"/tmp/foo"},"source":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e"},"ts":1612801082.087914}
[2021-02-08 17:18:02 +0100] notice/JsonRpcConnection: Received 'event::ExecuteCommand' message from identity 'satellite'.
[2021-02-08 17:18:02 +0100] notice/Process: Running command '/usr/bin/ls' '/tmp/foo': PID 1367365
[2021-02-08 17:18:02 +0100] notice/Process: PID 1367365 ('/usr/bin/ls' '/tmp/foo') terminated with exit code 2
[2021-02-08 17:18:02 +0100] notice/ApiListener: Sending message 'event::ExecutedCommand' to 'satellite'
>> {"jsonrpc":"2.0","method":"event::ExecutedCommand","params":{"end":1612801082.090901,"execution":"ce72a2a5-6237-41fe-a21b-a896d2fa1c5e","exit":2.0,"host":"agent","output":"/usr/bin/ls: cannot access '/tmp/foo': No such file or directory\n","start":1612801082.088762}}
```

