### PR TITLE
Add package parameter in object creation API

### DIFF
--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -110,6 +110,10 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	bool newObject = false;
 
+	String package = "_api";
+	if (params->Contains("package"))
+		package = params->Get("package");
+
 	if (!object && !config.IsEmpty()) {
 		newObject = true;
 
@@ -120,7 +124,8 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 		 * Create the config object through our internal API.
 		 * IMPORTANT: Pass the origin to prevent cluster sync loops.
 		 */
-		if (!ConfigObjectUtility::CreateObject(ptype, objName, config, errors, nullptr, origin)) {
+		if (!ConfigObjectUtility::CreateObject(ptype, objName, config, errors, nullptr, origin,
+			package)) {
 			Log(LogCritical, "ApiListener")
 				<< "Could not create object '" << objName << "':";
 
@@ -266,12 +271,6 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 		return Empty;
 	}
 
-	if (object->GetPackage() != "_api") {
-		Log(LogCritical, "ApiListener")
-			<< "Could not delete object '" << objName << "': Not created by the API.";
-		return Empty;
-	}
-
 	Log(LogNotice, "ApiListener")
 		<< "Processing config delete"
 		<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
@@ -311,9 +310,6 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 		}
 	}
 
-	if (object->GetPackage() != "_api" && object->GetVersion() == 0)
-		return;
-
 	Dictionary::Ptr params = new Dictionary();
 
 	Dictionary::Ptr message = new Dictionary({
@@ -326,25 +322,25 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 	params->Set("type", object->GetReflectionType()->GetName());
 	params->Set("version", object->GetVersion());
 	params->Set("zone", object->GetZoneName());
+	params->Set("package", object->GetPackage());
 
-	if (object->GetPackage() == "_api") {
-		String file;
+	String file;
 
-		try {
-			file = ConfigObjectUtility::GetObjectConfigPath(object->GetReflectionType(), object->GetName());
-		} catch (const std::exception& ex) {
-			Log(LogNotice, "ApiListener")
-				<< "Cannot sync object '" << object->GetName() << "': " << ex.what();
-			return;
-		}
-
-		std::ifstream fp(file.CStr(), std::ifstream::binary);
-		if (!fp)
-			return;
-
-		String content((std::istreambuf_iterator<char>(fp)), std::istreambuf_iterator<char>());
-		params->Set("config", content);
+	try {
+		file = ConfigObjectUtility::GetObjectConfigPath(object->GetReflectionType(), object->GetName(),
+			object->GetPackage());
+	} catch (const std::exception& ex) {
+		Log(LogNotice, "ApiListener")
+			<< "Cannot sync object '" << object->GetName() << "': " << ex.what();
+		return;
 	}
+
+	std::ifstream fp(file.CStr(), std::ifstream::binary);
+	if (!fp)
+		return;
+
+	String content((std::istreambuf_iterator<char>(fp)), std::istreambuf_iterator<char>());
+	params->Set("config", content);
 
 	Dictionary::Ptr original_attributes = object->GetOriginalAttributes();
 	Dictionary::Ptr modified_attributes = new Dictionary();
@@ -392,9 +388,6 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,
 	const JsonRpcConnection::Ptr& client)
 {
-	if (object->GetPackage() != "_api")
-		return;
-
 	/* only send objects to zones which have access to the object */
 	if (client) {
 		Zone::Ptr target_zone = client->GetEndpoint()->GetZone();

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -18,24 +18,24 @@
 
 using namespace icinga;
 
-String ConfigObjectUtility::GetConfigDir()
+String ConfigObjectUtility::GetConfigDir(const String& package)
 {
-	String prefix = ConfigPackageUtility::GetPackageDir() + "/_api/";
-	String activeStage = ConfigPackageUtility::GetActiveStage("_api");
+	String prefix = ConfigPackageUtility::GetPackageDir() + "/" + package + "/";
+	String activeStage = ConfigPackageUtility::GetActiveStage(package);
 
 	if (activeStage.IsEmpty())
-		RepairPackage("_api");
+		RepairPackage(package);
 
 	return prefix + activeStage;
 }
 
-String ConfigObjectUtility::GetObjectConfigPath(const Type::Ptr& type, const String& fullName)
+String ConfigObjectUtility::GetObjectConfigPath(const Type::Ptr& type, const String& fullName, const String& package)
 {
 	String typeDir = type->GetPluralName();
 	boost::algorithm::to_lower(typeDir);
 
 	/* This may throw an exception the caller above must handle. */
-	String prefix = GetConfigDir();
+	String prefix = GetConfigDir(package);
 
 	auto old (prefix + "/conf.d/" + typeDir + "/" + EscapeName(fullName) + ".conf");
 
@@ -84,12 +84,9 @@ void ConfigObjectUtility::RepairPackage(const String& package)
 	}
 }
 
-void ConfigObjectUtility::CreateStorage()
+void ConfigObjectUtility::CreateStorage(const String& package)
 {
 	std::unique_lock<std::mutex> lock(ConfigPackageUtility::GetStaticPackageMutex());
-
-	/* For now, we only use _api as our creation target. */
-	String package = "_api";
 
 	if (!ConfigPackageUtility::PackageExists(package)) {
 		Log(LogNotice, "ConfigObjectUtility")
@@ -155,9 +152,10 @@ String ConfigObjectUtility::CreateObjectConfig(const Type::Ptr& type, const Stri
 }
 
 bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& fullName,
-	const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation, const Value& cookie)
+	const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation, const Value& cookie,
+	const String& package)
 {
-	CreateStorage();
+	CreateStorage(package);
 
 	{
 		auto configType (dynamic_cast<ConfigType*>(type.get()));
@@ -171,7 +169,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 	String path;
 
 	try {
-		path = GetObjectConfigPath(type, fullName);
+		path = GetObjectConfigPath(type, fullName, package);
 	} catch (const std::exception& ex) {
 		errors->Add("Config package broken: " + DiagnosticInformation(ex, false));
 		return false;
@@ -183,7 +181,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 	fp << config;
 	fp.close();
 
-	std::unique_ptr<Expression> expr = ConfigCompiler::CompileFile(path, String(), "_api");
+	std::unique_ptr<Expression> expr = ConfigCompiler::CompileFile(path, String(), package);
 
 	try {
 		ActivationScope ascope;
@@ -335,7 +333,7 @@ bool ConfigObjectUtility::DeleteObjectHelper(const ConfigObject::Ptr& object, bo
 	String path;
 
 	try {
-		path = GetObjectConfigPath(object->GetReflectionType(), name);
+		path = GetObjectConfigPath(object->GetReflectionType(), name, object->GetPackage());
 	} catch (const std::exception& ex) {
 		errors->Add("Config package broken: " + DiagnosticInformation(ex, false));
 		return false;
@@ -352,12 +350,5 @@ bool ConfigObjectUtility::DeleteObjectHelper(const ConfigObject::Ptr& object, bo
 bool ConfigObjectUtility::DeleteObject(const ConfigObject::Ptr& object, bool cascade, const Array::Ptr& errors,
 	const Array::Ptr& diagnosticInformation, const Value& cookie)
 {
-	if (object->GetPackage() != "_api") {
-		if (errors)
-			errors->Add("Object cannot be deleted because it was not created using the API.");
-
-		return false;
-	}
-
 	return DeleteObjectHelper(object, cascade, errors, diagnosticInformation, cookie);
 }

--- a/lib/remote/configobjectutility.hpp
+++ b/lib/remote/configobjectutility.hpp
@@ -21,16 +21,17 @@ class ConfigObjectUtility
 {
 
 public:
-	static String GetConfigDir();
-	static String GetObjectConfigPath(const Type::Ptr& type, const String& fullName);
+	static String GetConfigDir(const String &package = "_api");
+	static String GetObjectConfigPath(const Type::Ptr& type, const String& fullName, const String &package = "_api");
 	static void RepairPackage(const String& package);
-	static void CreateStorage();
+	static void CreateStorage(const String& package = "_api");
 
 	static String CreateObjectConfig(const Type::Ptr& type, const String& fullName,
 		bool ignoreOnError, const Array::Ptr& templates, const Dictionary::Ptr& attrs);
 
 	static bool CreateObject(const Type::Ptr& type, const String& fullName,
-		const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation, const Value& cookie = Empty);
+		const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation, const Value& cookie = Empty,
+		const String& package = "_api");
 
 	static bool DeleteObject(const ConfigObject::Ptr& object, bool cascade, const Array::Ptr& errors,
 		const Array::Ptr& diagnosticInformation, const Value& cookie = Empty);

--- a/lib/remote/createobjecthandler.cpp
+++ b/lib/remote/createobjecthandler.cpp
@@ -94,6 +94,10 @@ bool CreateObjectHandler::HandleRequest(
 	if (params)
 		verbose = HttpUtility::GetLastParameter(params, "verbose");
 
+	String package = "_api";
+	if (params->Contains("package"))
+		package = HttpUtility::GetLastParameter(params, "package");
+
 	/* Object creation can cause multiple errors and optionally diagnostic information.
 	 * We can't use SendJsonError() here.
 	 */
@@ -116,7 +120,7 @@ bool CreateObjectHandler::HandleRequest(
 		return true;
 	}
 
-	if (!ConfigObjectUtility::CreateObject(type, name, config, errors, diagnosticInformation)) {
+	if (!ConfigObjectUtility::CreateObject(type, name, config, errors, diagnosticInformation, nullptr, package)) {
 		result1->Set("errors", errors);
 		result1->Set("code", 500);
 		result1->Set("status", "Object could not be created.");


### PR DESCRIPTION
Hi, this is our proposed implementation for #8639

## Test: create an object in a custom package

Request
```
curl -X PUT -v -k -H 'Accept: application/json' -u "root:admin" "https://localhost:5665/v1/objects/hosts/test_host1" -d '{"package": "custom_package", "attrs": { "address": "192.168.1.1", "check_command": "hostalive", "vars.os" : "Linux", "zone": "master" }}'
```
Response 
```
{"results":[{"code":200.0,"status":"Object was created"}]}
```

Logs
```
[2021-02-16 11:57:57 +0100] information/ApiListener: New client connection from [::1]:42740 (no client certificate)
[2021-02-16 11:57:57 +0100] notice/ApiListener: New HTTP client
[2021-02-16 11:57:57 +0100] debug/HttpUtility: Request body: '{"package": "custom_package", "attrs": { "address": "192.168.1.1", "check_command": "hostalive", "vars.os" : "Linux", "zone": "master" }}'
[2021-02-16 11:57:57 +0100] notice/ConfigObjectUtility: Package custom_package doesn't exist yet, creating it.
[2021-02-16 11:57:57 +0100] notice/ConfigCompiler: Compiling config file: /home/iciga2/tests/master/var/lib/icinga2/api/packages/custom_package/9c7d6049-a95d-48e8-9a7b-71148be832ba/conf.d/hosts/test_host1.conf
[2021-02-16 11:57:57 +0100] debug/configitem: Committing 1 new items.
[2021-02-16 11:57:57 +0100] notice/WorkQueue: Spawning WorkQueue threads for 'ConfigObjectUtility::CreateObject'
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Commit called for ConfigItem Type=Host, Name=test_host1
[2021-02-16 11:57:57 +0100] debug/configitem: Committed 1 items of type 'Host'.
[2021-02-16 11:57:57 +0100] debug/configitem: Committed 1 items.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent OnAllConfigLoaded to 1 items of type 'Host'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 1 items of type 'Service'.
[2021-02-16 11:57:57 +0100] debug/configitem: Committing 2 new items.
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Commit called for ConfigItem Type=Service, Name=ping
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Commit called for ConfigItem Type=Service, Name=custom_service
[2021-02-16 11:57:57 +0100] debug/configitem: Committed 2 items of type 'Service'.
[2021-02-16 11:57:57 +0100] debug/configitem: Committed 2 items.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent OnAllConfigLoaded to 2 items of type 'Service'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 2 items of type 'ScheduledDowntime'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 2 items of type 'Downtime'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 2 items of type 'Dependency'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 2 items of type 'Notification'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 2 items of type 'Comment'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 1 items of type 'ScheduledDowntime'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 1 items of type 'Downtime'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 1 items of type 'Dependency'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 1 items of type 'Notification'.
[2021-02-16 11:57:57 +0100] debug/configitem: Committing 1 new items.
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Commit called for ConfigItem Type=Notification, Name=MyNotification
[2021-02-16 11:57:57 +0100] debug/configitem: Committed 1 items of type 'Notification'.
[2021-02-16 11:57:57 +0100] debug/configitem: Committed 1 items.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent OnAllConfigLoaded to 1 items of type 'Notification'.
[2021-02-16 11:57:57 +0100] debug/configitem: Sent CreateChildObjects to 1 items of type 'Comment'.
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Setting 'active' to true for object 'test_host1' of type 'Host'
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Setting 'active' to true for object 'test_host1!ping' of type 'Service'
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Setting 'active' to true for object 'test_host1!custom_service' of type 'Service'
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Setting 'active' to true for object 'test_host1!MyNotification' of type 'Notification'
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Activating object 'test_host1' of type 'Host' with priority 0
[2021-02-16 11:57:57 +0100] notice/ApiListener: Relaying 'event::SetNextCheck' message
[2021-02-16 11:57:57 +0100] debug/ApiListener: Sent update for object 'test_host1': {"config":"object Host \"test_host1\" {\n\taddress = \"192.168.1.1\"\n\tcheck_command = \"hostalive\"\n\tvars[\"os\"] = \"Linux\"\n\tversion = 1613473077.747474\n\tzone = \"master\"\n}\n","modified_attributes":{},"name":"test_host1","original_attributes":[],"package":"custom_package","type":"Host","version":1613473077.747474,"zone":"master"}
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Activating object 'test_host1!MyNotification' of type 'Notification' with priority 0
[2021-02-16 11:57:57 +0100] notice/ApiListener: Relaying 'config::UpdateObject' message
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Activating object 'test_host1!ping' of type 'Service' with priority 0
[2021-02-16 11:57:57 +0100] notice/ApiListener: Relaying 'event::SetNextCheck' message
[2021-02-16 11:57:57 +0100] debug/ConfigItem: Activating object 'test_host1!custom_service' of type 'Service' with priority 0
[2021-02-16 11:57:57 +0100] notice/ApiListener: Relaying 'event::SetNextCheck' message
[2021-02-16 11:57:57 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'master'.
[2021-02-16 11:57:57 +0100] information/ConfigObjectUtility: Created and activated object 'test_host1' of type 'Host'.
[2021-02-16 11:57:57 +0100] notice/WorkQueue: Stopped WorkQueue threads for 'ConfigObjectUtility::CreateObject'
[2021-02-16 11:57:57 +0100] information/HttpServerConnection: Request: PUT /v1/objects/hosts/test_host1 (from [::1]:42740), user: root, agent: curl/7.71.1, status: OK).
[2021-02-16 11:57:57 +0100] information/HttpServerConnection: HTTP client disconnected (from [::1]:42740)
```

## Test: create an object of a custom package

Request
```
curl -X DELETE -v -k -H 'Accept: application/json' -u "root:admin" "https://localhost:5665/v1/objects/hosts/test_host1?cascade=1" 
```

Response
```
{"results":[{"code":200.0,"errors":[],"name":"test_host1","status":"Object was deleted.","type":"Host"}]}
```

Logs
```
[2021-02-16 11:59:59 +0100] information/ApiListener: New client connection from [::1]:42756 (no client certificate)
[2021-02-16 11:59:59 +0100] notice/ApiListener: New HTTP client
[2021-02-16 11:59:59 +0100] debug/ApiListener: Sent delete for object 'test_host1!custom_service': {"name":"test_host1!custom_service","type":"Service","version":0.0}
[2021-02-16 11:59:59 +0100] notice/ApiListener: Relaying 'config::DeleteObject' message
[2021-02-16 11:59:59 +0100] information/ConfigObjectUtility: Deleted object 'test_host1!custom_service' of type 'Service'.
[2021-02-16 11:59:59 +0100] debug/ApiListener: Sent delete for object 'test_host1!ping': {"name":"test_host1!ping","type":"Service","version":0.0}
[2021-02-16 11:59:59 +0100] information/ConfigObjectUtility: Deleted object 'test_host1!ping' of type 'Service'.
[2021-02-16 11:59:59 +0100] notice/ApiListener: Relaying 'config::DeleteObject' message
[2021-02-16 11:59:59 +0100] debug/ApiListener: Sent delete for object 'test_host1!MyNotification': {"name":"test_host1!MyNotification","type":"Notification","version":0.0}
[2021-02-16 11:59:59 +0100] information/ConfigObjectUtility: Deleted object 'test_host1!MyNotification' of type 'Notification'.
[2021-02-16 11:59:59 +0100] notice/ApiListener: Relaying 'config::DeleteObject' message
[2021-02-16 11:59:59 +0100] debug/ApiListener: Sent delete for object 'test_host1': {"name":"test_host1","type":"Host","version":1613473077.747474}
[2021-02-16 11:59:59 +0100] notice/ApiListener: Relaying 'config::DeleteObject' message
[2021-02-16 11:59:59 +0100] information/ConfigObjectUtility: Deleted object 'test_host1' of type 'Host'.
[2021-02-16 11:59:59 +0100] information/HttpServerConnection: Request: DELETE /v1/objects/hosts/test_host1?cascade=1 (from [::1]:42756), user: root, agent: curl/7.71.1, status: OK).
[2021-02-16 11:59:59 +0100] information/HttpServerConnection: HTTP client disconnected (from [::1]:42756)
```