### PR TITLE
Downtime#Start(): trigger fixed downtimes immediately instead of waiting for the timer

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -127,6 +127,14 @@ void Downtime::Start(bool runtimeCreated)
 			<< " Triggering downtime now.";
 		TriggerDowntime();
 	}
+
+	if (GetFixed() && CanBeTriggered()) {
+		/* Send notifications. */
+		OnDowntimeStarted(this);
+
+		/* Trigger fixed downtime immediately. */
+		TriggerDowntime();
+	}
 }
 
 void Downtime::Stop(bool runtimeRemoved)


### PR DESCRIPTION
... not to cause e.g. notifications if a problem occurs
between the downtime start time and the timer routine.

ref/IP/31129