### PR TITLE
IDO: Use own transaction for program status and make sure InternalNewTransaction() gets executed

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -160,8 +160,7 @@ void IdoMysqlConnection::NewTransaction()
 		<< "Scheduling new transaction and finishing async queries.";
 #endif /* I2_DEBUG */
 
-	m_QueryQueue.Enqueue([this]() { InternalNewTransaction(); }, PriorityNormal);
-	m_QueryQueue.Enqueue([this]() { FinishAsyncQueries(); }, PriorityNormal);
+	m_QueryQueue.Enqueue([this]() { InternalNewTransaction(); }, PriorityHigh);
 }
 
 void IdoMysqlConnection::InternalNewTransaction()
@@ -175,6 +174,8 @@ void IdoMysqlConnection::InternalNewTransaction()
 
 	AsyncQuery("COMMIT");
 	AsyncQuery("BEGIN");
+
+	FinishAsyncQueries();
 }
 
 void IdoMysqlConnection::ReconnectTimerHandler()


### PR DESCRIPTION
This PR fixes issues with deadlocks during program status updates. It also makes sure to execute InternalNewTransaction() and FinishAsyncQueries() during high load, which fixes program status updates being late.