### PR TITLE
Send problem notifications after downtime end for checkables in child zones

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1434,7 +1434,7 @@ Message updates will be dropped when:
 * Checkable does not exist.
 * Origin endpoint's zone is not allowed to access this checkable.
 
-#### event::SuppressedNotifications <a id="technical-concepts-json-rpc-messages-event-setsupressednotifications"></a>
+#### event::SetSuppressedNotifications <a id="technical-concepts-json-rpc-messages-event-setsupressednotifications"></a>
 
 > Location: `clusterevents.cpp`
 
@@ -1443,7 +1443,7 @@ Message updates will be dropped when:
 Key       | Value
 ----------|---------
 jsonrpc   | 2.0
-method    | event::SuppressedNotifications
+method    | event::SetSuppressedNotifications
 params    | Dictionary
 
 ##### Params
@@ -1459,6 +1459,8 @@ supressed\_notifications | Number 	 | Bitmask for suppressed notifications.
 Event Sender: `Checkable::OnSuppressedNotificationsChanged`
 Event Receiver: `SuppressedNotificationsChangedAPIHandler`
 
+Used to sync the notification state of a host or service object within the same HA zone.
+
 ##### Permissions
 
 The receiver will not process messages from not configured endpoints.
@@ -1466,7 +1468,7 @@ The receiver will not process messages from not configured endpoints.
 Message updates will be dropped when:
 
 * Checkable does not exist.
-* Origin endpoint's zone is not allowed to access this checkable.
+* Origin endpoint is not within the local zone.
 
 #### event::SetSuppressedNotificationTypes <a id="technical-concepts-json-rpc-messages-event-setsuppressednotificationtypes"></a>
 
@@ -1487,6 +1489,8 @@ Key         		 | Type   | Description
 notification             | String | Notification name
 supressed\_notifications | Number | Bitmask for suppressed notifications.
 
+Used to sync the state of a notification object within the same HA zone.
+
 ##### Functions
 
 Event Sender: `Notification::OnSuppressedNotificationsChanged`
@@ -1499,7 +1503,7 @@ The receiver will not process messages from not configured endpoints.
 Message updates will be dropped when:
 
 * Notification does not exist.
-* Origin endpoint's zone is not allowed to access this notification.
+* Origin endpoint is not within the local zone.
 
 
 #### event::SetNextNotification <a id="technical-concepts-json-rpc-messages-event-setnextnotification"></a>
@@ -1705,6 +1709,9 @@ text      | String        | Notification text
 Event Sender: `Checkable::OnNotificationsRequested`
 Event Receiver: `SendNotificationsAPIHandler`
 
+Signals that notifications have to be sent within the same HA zone. This is relevant if the checkable and its
+notifications are active on different endpoints.
+
 ##### Permissions
 
 The receiver will not process messages from not configured endpoints.
@@ -1712,7 +1719,7 @@ The receiver will not process messages from not configured endpoints.
 Message updates will be dropped when:
 
 * Checkable does not exist.
-* Origin endpoint's zone the same as the receiver. This binds notification messages to the HA zone.
+* Origin endpoint is not within the local zone.
 
 #### event::NotificationSentUser <a id="technical-concepts-json-rpc-messages-event-notificationsentuser"></a>
 

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -324,7 +324,7 @@ void ClusterEvents::SuppressedNotificationsChangedHandler(const Checkable::Ptr& 
 	message->Set("method", "event::SetSuppressedNotifications");
 	message->Set("params", params);
 
-	listener->RelayMessage(origin, checkable, message, true);
+	listener->RelayMessage(origin, nullptr, message, true);
 }
 
 Value ClusterEvents::SuppressedNotificationsChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
@@ -352,7 +352,7 @@ Value ClusterEvents::SuppressedNotificationsChangedAPIHandler(const MessageOrigi
 	if (!checkable)
 		return Empty;
 
-	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
+	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
 		Log(LogNotice, "ClusterEvents")
 			<< "Discarding 'suppressed notifications changed' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
@@ -380,7 +380,7 @@ void ClusterEvents::SuppressedNotificationTypesChangedHandler(const Notification
 	message->Set("method", "event::SetSuppressedNotificationTypes");
 	message->Set("params", params);
 
-	listener->RelayMessage(origin, notification, message, true);
+	listener->RelayMessage(origin, nullptr, message, true);
 }
 
 Value ClusterEvents::SuppressedNotificationTypesChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
@@ -398,7 +398,7 @@ Value ClusterEvents::SuppressedNotificationTypesChangedAPIHandler(const MessageO
 	if (!notification)
 		return Empty;
 
-	if (origin->FromZone && !origin->FromZone->CanAccessObject(notification)) {
+	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
 		Log(LogNotice, "ClusterEvents")
 			<< "Discarding 'suppressed notification types changed' message for notification '" << notification->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";


### PR DESCRIPTION
There was a discrepancy between how different message types were forwarded in the cluster leading to missing notifications:

* `event::SendNotification`: This message is only accepted from nodes within the same zone
* `event::SetSuppressedNotifications` and `event::SetSuppressedNotificationTypes`: These messages are accepted from any node that can access the object, therefore also from child nodes

The following code also runs on nodes that do not send notifications, which can incorrectly clear suppressed notifications in the parent zone before it actually sends the suppressed notifications: https://github.com/Icinga/icinga2/blob/160d0ea37193a1f2de3b20573747ad8e2676e8b1/lib/icinga/checkable-check.cpp#L491-L511

With this PR, these messages are now rejected in the parent zone. The current cluster message routing in Icinga does not support sending messages only within the local zone, but also always includes the parent zone. Therefore, the messages will still be sent to the parent zone but are rejected there.

### Alternatives

I think it would be better if only nodes that actually send notifications even care about the suppressed notification bit sets, however the code is currently split between the notification the checkable code. So doing this would probably need quite a bit of refactoring.

### Before

See https://github.com/Icinga/icinga2/issues/8679#issue-829035898

### After

Now there's also a PROBLEM notification for the service in the child zone (second screenshot):

#### master-1
![20210318_12h21m48s_grim](https://user-images.githubusercontent.com/18552/111618367-9494b900-87e4-11eb-8126-78064d71b0e0.png)

#### agent-a-2
![20210318_12h22m00s_grim](https://user-images.githubusercontent.com/18552/111618368-952d4f80-87e4-11eb-85d0-1f1027aff16a.png)

### Additional Tests

<details>
<summary>Notifications suppressed by time periods</summary>

Additionally I verified that notifications that were suppressed by a time period also still work. In the screenshots below you can see that the notification to `dummy` is sent instantly, whereas the one for `github-8681` is only sent when the time period begins.

Note that the times in the config file are UTC, whereas in the browser, UTC+1 is displayed, therefore there's a difference of 1 hour.

#### Config

```
object User "github-8681" {}

object TimePeriod "github-8681" {
	ranges = {
		thursday = "11:50-20:00"
	}
}

apply Notification "github-8681" to Service {
	command = "dummy"
	users = ["github-8681"]
	period = "github-8681"
	assign where true
}
```

#### Screenshots

![20210318_12h51m02s_grim](https://user-images.githubusercontent.com/18552/111622299-49c97000-87e9-11eb-99ce-ea5f2e77d6a1.png)
![20210318_12h51m15s_grim](https://user-images.githubusercontent.com/18552/111622305-4afa9d00-87e9-11eb-8644-37bb40d79ffb.png)

</details>

### TODO
* [x] Update documentation of cluster messages accordingly
* [x] Also test `event::SetSuppressedNotificationTypes` (I believe that this shows the same behavior, I still have to verify this though) -> see https://github.com/Icinga/icinga2/pull/8681#issuecomment-800188609

fixes #8679