### PR TITLE
Retry file rename operations on Windows for some errors

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -742,7 +742,59 @@ void Utility::RenameFile(const String& source, const String& target)
 {
 	namespace fs = boost::filesystem;
 
-	fs::rename(fs::path(source.Begin(), source.End()), fs::path(target.Begin(), target.End()));
+	fs::path sourcePath(source.Begin(), source.End()), targetPath(target.Begin(), target.End());
+
+#ifndef _WIN32
+	fs::rename(sourcePath, targetPath);
+#else /* _WIN32 */
+	/*
+	 * Renaming files can be tricky on Windows, especially if your application is built around POSIX filesystem
+	 * semantics. For example, the quite common pattern of replacing a file by writing a new version to a temporary
+	 * location and then moving it to the final location can fail if the destination file already exists and any
+	 * process has an open file handle to it.
+	 *
+	 * We try to handle this situation as best as we can by retrying the rename operation a few times hoping the other
+	 * process closes its file handle in the meantime. This is similar to what for example Go does internally in some
+	 * situations (https://golang.org/pkg/cmd/go/internal/robustio/#Rename):
+	 *
+	 *    robustio.Rename is like os.Rename, but on Windows retries errors that may occur if the file is concurrently
+	 *    read or overwritten. (See https://golang.org/issue/31247 and https://golang.org/issue/32188)
+	 */
+
+	double sleep = 0.1;
+	int last_error = ERROR_SUCCESS;
+
+	for (int retries = 0, remaining = 15;; retries++, remaining--) {
+		try {
+			fs::rename(sourcePath, targetPath);
+
+			if (retries > 0) {
+				Log(LogWarning, "Utility") << "Renaming '" << source << "' to '" << target
+					<< "' succeeded after " << retries << " retries";
+			}
+
+			break;
+		} catch (const fs::filesystem_error& ex) {
+			int error = ex.code().value();
+			bool ephemeral = error == ERROR_ACCESS_DENIED ||
+				error == ERROR_FILE_NOT_FOUND ||
+				error == ERROR_SHARING_VIOLATION;
+
+			if (remaining <= 0 || !ephemeral) {
+				throw; // giving up
+			}
+
+			if (error != last_error) {
+				Log(LogWarning, "Utility") << "Renaming '" << source << "' to '" << target << "' failed: "
+					<< ex.code().message() << " (trying up to " << remaining << " more times)";
+				last_error = error;
+			}
+
+			Utility::Sleep(sleep);
+			sleep *= 1.3;
+		}
+	}
+#endif /* _WIN32 */
 }
 
 /*


### PR DESCRIPTION
I have identified a situation that might cause problems like described in #8480: Renaming `icinga2.vars.tmp` to `icinga2.vars` fails with `ERROR_ACCESS_DENIED` error if some process has an open file handle to `icinga2.vars`. That other process might for example be some antivirus software performing a regular scan, which could then lead to an error or even crash in Icinga.

This PR tries to improve this by retrying the rename operation a few times, hoping that the other process closes the file in the meantime. Of course this is not a bulletproof solution but should fix the most common causes. Note that we are only observing this issue quite infrequently, so this should be good enough.

The current behavior of the PR is that up to 16 attempts in total are done in about 16 seconds (but with exponential backoff).

Go does something very similar (https://golang.org/pkg/cmd/go/internal/robustio/#Rename) and this is also where the list of error codes considered ephemeral is taken from (https://golang.org/src/cmd/go/internal/robustio/robustio_windows.go).

New behavior:

```
[2021-03-23 10:19:28 +0100] warning/Utility: Renaming 'C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars.42BPvA' to 'C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars' failed: Access is denied (trying up to 15 more times)
[2021-03-23 10:19:31 +0100] warning/Utility: Renaming 'C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars.42BPvA' to 'C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars' succeeded after 9 retries

[2021-03-23 10:20:22 +0100] warning/Utility: Renaming 'C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars.4UdfGB' to 'C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars' failed: Access is denied (trying up to 15 more times)
[2021-03-23 10:20:38 +0100] critical/cli: Could not write vars file: Error: boost::filesystem::rename: Access is denied: "C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars.4UdfGB", "C:/Users/jbrost/dev/icinga2/data/var/cache/icinga2/icinga2.vars"
```

The error can be forced by running `$File = [System.IO.File]::Open(".\dev\icinga2\data\var\cache\icinga2\icinga2.vars", "Open", "Read")` in PowerShell. `$File.Close()` can then be used to close the file handle.