### PR TITLE
JsonEncode(): serialize integers w/o trailing .0

### DIFF
--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -365,7 +365,25 @@ inline
 void JsonEncoder<prettyPrint>::NumberFloat(double value)
 {
 	BeforeItem();
-	AppendJson(value);
+
+	// Make sure 0.0 is serialized as 0, so e.g. Icinga DB can parse it as int.
+	if (value < 0) {
+		long long i = value;
+
+		if (i == value) {
+			AppendJson(i);
+		} else {
+			AppendJson(value);
+		}
+	} else {
+		unsigned long long i = value;
+
+		if (i == value) {
+			AppendJson(i);
+		} else {
+			AppendJson(value);
+		}
+	}
 }
 
 template<bool prettyPrint>

--- a/test/base-json.cpp
+++ b/test/base-json.cpp
@@ -31,11 +31,11 @@ BOOST_AUTO_TEST_CASE(encode)
     ],
     "false": false,
     "float": -1.25,
-    "int": -42.0,
+    "int": -42,
     "null": null,
     "string": "LF\nTAB\tAUml\u00e4Ill\ufffd",
     "true": true,
-    "uint": 23.0
+    "uint": 23
 }
 )EOF");
 
@@ -55,11 +55,11 @@ BOOST_AUTO_TEST_CASE(decode)
     ],
     "false": false,
     "float": -1.25,
-    "int": -42.0,
+    "int": -42,
     "null": null,
     "string": "LF\nTAB\tAUmlIll",
     "true": true,
-    "uint": 23.0
+    "uint": 23
 }
 )EOF");
 


### PR DESCRIPTION
... so Icinga DB can parse them as integers.