### PR TITLE
Add missing #include <iostream>

### DIFF
--- a/lib/base/stdiostream.hpp
+++ b/lib/base/stdiostream.hpp
@@ -6,6 +6,7 @@
 #include "base/i2-base.hpp"
 #include "base/stream.hpp"
 #include <iosfwd>
+#include <iostream>
 
 namespace icinga {
 


### PR DESCRIPTION
Fixes the following build error:

    /home/jbrost/dev/icinga2/lib/base/stdiostream.cpp: In member function ‘virtual size_t icinga::StdioStream::Read(void*, size_t, bool)’:
    /home/jbrost/dev/icinga2/lib/base/stdiostream.cpp:28:15: error: invalid use of incomplete type ‘std::iostream’ {aka ‘class std::basic_iostream<char>’}
       28 |  m_InnerStream->read(static_cast<char *>(buffer), size);
          |               ^~