### PR TITLE
Add support for Windows Event Log and write early log messages to it

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1864,4 +1864,21 @@ Facility Constants:
   FacilityUucp         | LOG\_UUCP     | The UUCP system.
 
 
+### WindowsEventLogLogger <a id="objecttype-windowseventloglogger"></a>
 
+Specifies Icinga 2 logging to the Windows Event Log.
+This configuration object is available as `windowseventlog` [logging feature](14-features.md#logging).
+
+Example:
+
+```
+object WindowsEventLogLogger "windowseventlog" {
+  severity = "warning"
+}
+```
+
+Configuration Attributes:
+
+  Name                      | Type                  | Description
+  --------------------------|-----------------------|----------------------------------
+  severity                  | String                | **Optional.** The minimum severity for this log. Can be "debug", "notice", "information", "warning" or "critical". Defaults to "warning".

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1873,7 +1873,7 @@ Example:
 
 ```
 object WindowsEventLogLogger "windowseventlog" {
-  severity = "warning"
+  severity = "information"
 }
 ```
 
@@ -1881,4 +1881,4 @@ Configuration Attributes:
 
   Name                      | Type                  | Description
   --------------------------|-----------------------|----------------------------------
-  severity                  | String                | **Optional.** The minimum severity for this log. Can be "debug", "notice", "information", "warning" or "critical". Defaults to "warning".
+  severity                  | String                | **Optional.** The minimum severity for this log. Can be "debug", "notice", "information", "warning" or "critical". Defaults to "information".

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -11,11 +11,12 @@ Icinga 2 supports three different types of logging:
 You can enable additional loggers using the `icinga2 feature enable`
 and `icinga2 feature disable` commands to configure loggers:
 
-Feature  | Description
----------|------------
-debuglog | Debug log (path: `/var/log/icinga2/debug.log`, severity: `debug` or higher)
-mainlog  | Main log (path: `/var/log/icinga2/icinga2.log`, severity: `information` or higher)
-syslog   | Syslog (severity: `warning` or higher)
+Feature         | Description
+----------------|------------
+debuglog        | Debug log (path: `/var/log/icinga2/debug.log`, severity: `debug` or higher)
+mainlog         | Main log (path: `/var/log/icinga2/icinga2.log`, severity: `information` or higher)
+syslog          | Syslog (severity: `warning` or higher)
+windowseventlog | Windows Event Log (severity: `warning` or higher)
 
 By default file the `mainlog` feature is enabled. When running Icinga 2
 on a terminal log messages with severity `information` or higher are

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -16,7 +16,7 @@ Feature         | Description
 debuglog        | Debug log (path: `/var/log/icinga2/debug.log`, severity: `debug` or higher)
 mainlog         | Main log (path: `/var/log/icinga2/icinga2.log`, severity: `information` or higher)
 syslog          | Syslog (severity: `warning` or higher)
-windowseventlog | Windows Event Log (severity: `warning` or higher)
+windowseventlog | Windows Event Log (severity: `information` or higher)
 
 By default file the `mainlog` feature is enabled. When running Icinga 2
 on a terminal log messages with severity `information` or higher are

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -39,6 +39,8 @@ install_if_not_exists(icinga2/features-available/debuglog.conf ${ICINGA2_CONFIGD
 install_if_not_exists(icinga2/features-available/mainlog.conf ${ICINGA2_CONFIGDIR}/features-available)
 if(NOT WIN32)
   install_if_not_exists(icinga2/features-available/syslog.conf ${ICINGA2_CONFIGDIR}/features-available)
+else()
+  install_if_not_exists(icinga2/features-available/windowseventlog.conf ${ICINGA2_CONFIGDIR}/features-available)
 endif()
 install_if_not_exists(icinga2/scripts/mail-host-notification.sh ${ICINGA2_CONFIGDIR}/scripts)
 install_if_not_exists(icinga2/scripts/mail-service-notification.sh ${ICINGA2_CONFIGDIR}/scripts)

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -56,7 +56,7 @@ if(NOT WIN32)
 
   install(FILES bash_completion.d/icinga2 DESTINATION ${BASHCOMPLETION_DIR})
 else()
-  install_if_not_exists(icinga2/features-enabled/mainlog.conf ${ICINGA2_CONFIGDIR}/features-enabled)
+  install_if_not_exists(icinga2/features-enabled/windowseventlog.conf ${ICINGA2_CONFIGDIR}/features-enabled)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "(Linux|Solaris|SunOS)")

--- a/etc/icinga2/features-available/windowseventlog.conf
+++ b/etc/icinga2/features-available/windowseventlog.conf
@@ -1,0 +1,8 @@
+/**
+ * The WindowsEventLogLogger type writes log information to the Windows Event Log.
+ */
+
+object WindowsEventLogLogger "windowseventlog" {
+    severity = "warning"
+}
+

--- a/etc/icinga2/features-available/windowseventlog.conf
+++ b/etc/icinga2/features-available/windowseventlog.conf
@@ -3,6 +3,6 @@
  */
 
 object WindowsEventLogLogger "windowseventlog" {
-    severity = "warning"
+    severity = "information"
 }
 

--- a/etc/icinga2/features-enabled/mainlog.conf
+++ b/etc/icinga2/features-enabled/mainlog.conf
@@ -1,1 +1,0 @@
-include "../features-available/mainlog.conf"

--- a/etc/icinga2/features-enabled/windowseventlog.conf
+++ b/etc/icinga2/features-enabled/windowseventlog.conf
@@ -1,0 +1,1 @@
+include "../features-available/windowseventlog.conf"

--- a/icinga-installer/icinga2.wixpatch.cmake
+++ b/icinga-installer/icinga2.wixpatch.cmake
@@ -20,6 +20,20 @@
       <Custom Action="XtraUninstall" Before="RemoveExistingProducts">$CM_CP_sbin.icinga2_installer.exe=2 AND NOT SUPPRESS_XTRA</Custom>
     </InstallExecuteSequence>
 
+    <!--
+      Write the path to eventprovider.dll to the registry so that the Event Viewer is able to find
+      the message definitions and properly displays our log messages.
+
+      See also: https://docs.microsoft.com/en-us/windows/win32/eventlog/reporting-an-event
+    -->
+    <FeatureRef Id="ProductFeature" IgnoreParent="yes">
+      <Component Id="EventProviderRegistryEntry" Guid="*" Directory="INSTALL_ROOT">
+        <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\EventLog\Application\Icinga 2" Action="createAndRemoveOnUninstall">
+          <RegistryValue Name="EventMessageFile" Type="string" Value="[#CM_FP_sbin.eventprovider.dll]" />
+        </RegistryKey>
+      </Component>
+    </FeatureRef>
+
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Run Icinga 2 setup wizard" />
 
     <Property Id="WixShellExecTarget" Value="[#CM_FP_sbin.Icinga2SetupAgent.exe]" />

--- a/lib/base/CMakeLists.txt
+++ b/lib/base/CMakeLists.txt
@@ -85,6 +85,33 @@ set(base_SOURCES
   workqueue.cpp workqueue.hpp
 )
 
+if(WIN32)
+  mkclass_target(windowseventloglogger.ti windowseventloglogger-ti.cpp windowseventloglogger-ti.hpp)
+  list(APPEND base_SOURCES windowseventloglogger.cpp windowseventloglogger.hpp windowseventloglogger-ti.hpp)
+
+  # Generate a DLL containing message definitions for the Windows Event Viewer.
+  # See also: https://docs.microsoft.com/en-us/windows/win32/eventlog/reporting-an-event
+  add_custom_command(
+    OUTPUT windowseventloglogger-provider.rc windowseventloglogger-provider.h
+    COMMAND mc ARGS -U ${CMAKE_CURRENT_SOURCE_DIR}/windowseventloglogger-provider.mc
+    DEPENDS windowseventloglogger-provider.mc
+  )
+
+  list(APPEND base_SOURCES windowseventloglogger-provider.h)
+
+  add_custom_command(
+    OUTPUT windowseventloglogger-provider.res
+    COMMAND rc ARGS windowseventloglogger-provider.rc
+    DEPENDS windowseventloglogger-provider.rc
+  )
+
+  add_library(eventprovider MODULE windowseventloglogger-provider.res windowseventloglogger-provider.rc)
+  set_target_properties(eventprovider PROPERTIES LINKER_LANGUAGE CXX)
+  target_link_libraries(eventprovider PRIVATE -noentry)
+
+  install(TARGETS eventprovider LIBRARY DESTINATION ${CMAKE_INSTALL_SBINDIR})
+endif()
+
 set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/application-version.cpp PROPERTY EXCLUDE_UNITY_BUILD TRUE)
 
 if(ICINGA2_UNITY_BUILD)

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -9,6 +9,9 @@
 #include "base/objectlock.hpp"
 #include "base/context.hpp"
 #include "base/scriptglobal.hpp"
+#ifdef _WIN32
+#include "base/windowseventloglogger.hpp"
+#endif /* _WIN32 */
 #include <iostream>
 #include <utility>
 
@@ -29,6 +32,7 @@ REGISTER_TYPE(Logger);
 std::set<Logger::Ptr> Logger::m_Loggers;
 std::mutex Logger::m_Mutex;
 bool Logger::m_ConsoleLogEnabled = true;
+std::atomic<bool> Logger::m_EarlyLoggingEnabled (true);
 bool Logger::m_TimestampEnabled = true;
 LogSeverity Logger::m_ConsoleLogSeverity = LogInformation;
 
@@ -157,6 +161,14 @@ LogSeverity Logger::GetConsoleLogSeverity()
 	return m_ConsoleLogSeverity;
 }
 
+void Logger::DisableEarlyLogging() {
+	m_EarlyLoggingEnabled = false;
+}
+
+bool Logger::IsEarlyLoggingEnabled() {
+	return m_EarlyLoggingEnabled;
+}
+
 void Logger::DisableTimestamp()
 {
 	m_TimestampEnabled = false;
@@ -242,6 +254,12 @@ Log::~Log()
 		 * then cout will not flush lines automatically. */
 		std::cout << std::flush;
 	}
+
+#ifdef _WIN32
+	if (Logger::IsEarlyLoggingEnabled() && entry.Severity >= Logger::GetConsoleLogSeverity()) {
+		WindowsEventLogLogger::WriteToWindowsEventLog(entry);
+	}
+#endif /* _WIN32 */
 }
 
 Log& Log::operator<<(const char *val)

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -67,6 +67,8 @@ public:
 	static void DisableConsoleLog();
 	static void EnableConsoleLog();
 	static bool IsConsoleLogEnabled();
+	static void DisableEarlyLogging();
+	static bool IsEarlyLoggingEnabled();
 	static void DisableTimestamp();
 	static void EnableTimestamp();
 	static bool IsTimestampEnabled();
@@ -84,6 +86,7 @@ private:
 	static std::mutex m_Mutex;
 	static std::set<Logger::Ptr> m_Loggers;
 	static bool m_ConsoleLogEnabled;
+	static std::atomic<bool> m_EarlyLoggingEnabled;
 	static bool m_TimestampEnabled;
 	static LogSeverity m_ConsoleLogSeverity;
 };

--- a/lib/base/windowseventloglogger-provider.mc
+++ b/lib/base/windowseventloglogger-provider.mc
@@ -1,0 +1,5 @@
+MessageId=0x1
+SymbolicName=MSG_PLAIN_LOG_ENTRY
+Language=English
+%1
+.

--- a/lib/base/windowseventloglogger.cpp
+++ b/lib/base/windowseventloglogger.cpp
@@ -1,0 +1,71 @@
+/* Icinga 2 | (c) 2021 Icinga GmbH | GPLv2+ */
+
+#ifdef _WIN32
+#include "base/windowseventloglogger.hpp"
+#include "base/windowseventloglogger-ti.cpp"
+#include "base/windowseventloglogger-provider.h"
+#include "base/configtype.hpp"
+#include "base/statsfunction.hpp"
+#include <windows.h>
+
+using namespace icinga;
+
+REGISTER_TYPE(WindowsEventLogLogger);
+
+REGISTER_STATSFUNCTION(WindowsEventLogLogger, &WindowsEventLogLogger::StatsFunc);
+
+INITIALIZE_ONCE(&WindowsEventLogLogger::StaticInitialize);
+
+static HANDLE l_EventLog = nullptr;
+
+void WindowsEventLogLogger::StaticInitialize()
+{
+	l_EventLog = RegisterEventSourceA(nullptr, "Icinga 2");
+}
+
+void WindowsEventLogLogger::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
+{
+	DictionaryData nodes;
+
+	for (const WindowsEventLogLogger::Ptr& logger : ConfigType::GetObjectsByType<WindowsEventLogLogger>()) {
+		nodes.emplace_back(logger->GetName(), 1);
+	}
+
+	status->Set("windowseventloglogger", new Dictionary(std::move(nodes)));
+}
+
+/**
+ * Processes a log entry and outputs it to the Windows Event Log.
+ *
+ * @param entry The log entry.
+ */
+void WindowsEventLogLogger::ProcessLogEntry(const LogEntry& entry)
+{
+	if (l_EventLog != nullptr) {
+		std::string message = Logger::SeverityToString(entry.Severity) + "/" + entry.Facility + ": " + entry.Message;
+		std::array<const char *, 1> strings{
+			message.c_str()
+		};
+
+		WORD eventType;
+		switch (entry.Severity) {
+			case LogCritical:
+				eventType = EVENTLOG_ERROR_TYPE;
+				break;
+			case LogWarning:
+				eventType = EVENTLOG_WARNING_TYPE;
+				break;
+			default:
+				eventType = EVENTLOG_INFORMATION_TYPE;
+		}
+
+		ReportEventA(l_EventLog, eventType, 0, MSG_PLAIN_LOG_ENTRY, NULL, strings.size(), 0, strings.data(), NULL);
+	}
+}
+
+void WindowsEventLogLogger::Flush()
+{
+	/* Nothing to do here. */
+}
+
+#endif /* _WIN32 */

--- a/lib/base/windowseventloglogger.cpp
+++ b/lib/base/windowseventloglogger.cpp
@@ -37,9 +37,21 @@ void WindowsEventLogLogger::StatsFunc(const Dictionary::Ptr& status, const Array
 /**
  * Processes a log entry and outputs it to the Windows Event Log.
  *
+ * This function implements the interface expected by the Logger base class and passes
+ * the log entry to WindowsEventLogLogger::WriteToWindowsEventLog().
+ *
  * @param entry The log entry.
  */
-void WindowsEventLogLogger::ProcessLogEntry(const LogEntry& entry)
+void WindowsEventLogLogger::ProcessLogEntry(const LogEntry& entry) {
+	WindowsEventLogLogger::WriteToWindowsEventLog(entry);
+}
+
+/**
+ * Writes a LogEntry object to the Windows Event Log.
+ *
+ * @param entry The log entry.
+ */
+void WindowsEventLogLogger::WriteToWindowsEventLog(const LogEntry& entry)
 {
 	if (l_EventLog != nullptr) {
 		std::string message = Logger::SeverityToString(entry.Severity) + "/" + entry.Facility + ": " + entry.Message;

--- a/lib/base/windowseventloglogger.hpp
+++ b/lib/base/windowseventloglogger.hpp
@@ -1,0 +1,35 @@
+/* Icinga 2 | (c) 2021 Icinga GmbH | GPLv2+ */
+
+#ifndef WINDOWSEVENTLOGLOGGER_H
+#define WINDOWSEVENTLOGLOGGER_H
+
+#ifdef _WIN32
+#include "base/i2-base.hpp"
+#include "base/windowseventloglogger-ti.hpp"
+
+namespace icinga
+{
+
+/**
+ * A logger that logs to the Windows Event Log.
+ *
+ * @ingroup base
+ */
+class WindowsEventLogLogger final : public ObjectImpl<WindowsEventLogLogger>
+{
+public:
+	DECLARE_OBJECT(WindowsEventLogLogger);
+	DECLARE_OBJECTNAME(WindowsEventLogLogger);
+
+	static void StaticInitialize();
+	static void StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata);
+
+protected:
+	void ProcessLogEntry(const LogEntry& entry) override;
+	void Flush() override;
+};
+
+}
+#endif /* _WIN32 */
+
+#endif /* WINDOWSEVENTLOGLOGGER_H */

--- a/lib/base/windowseventloglogger.hpp
+++ b/lib/base/windowseventloglogger.hpp
@@ -24,6 +24,8 @@ public:
 	static void StaticInitialize();
 	static void StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata);
 
+	static void WriteToWindowsEventLog(const LogEntry& entry);
+
 protected:
 	void ProcessLogEntry(const LogEntry& entry) override;
 	void Flush() override;

--- a/lib/base/windowseventloglogger.ti
+++ b/lib/base/windowseventloglogger.ti
@@ -1,0 +1,15 @@
+/* Icinga 2 | (c) 2021 Icinga GmbH | GPLv2+ */
+
+#include "base/logger.hpp"
+
+library base;
+
+namespace icinga
+{
+
+class WindowsEventLogLogger : Logger
+{
+	activation_priority -100;
+};
+
+}

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -276,7 +276,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 		}
 
 		// activate config only after daemonization: it starts threads and that is not compatible with fork()
-		if (!ConfigItem::ActivateItems(newItems, false, false, true)) {
+		if (!ConfigItem::ActivateItems(newItems, false, true, true)) {
 			Log(LogCritical, "cli", "Error activating configuration.");
 			return EXIT_FAILURE;
 		}

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -675,6 +675,14 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 		return false;
 	});
 
+	/* Find the last logger type to be activated. */
+	Type::Ptr lastLoggerType = nullptr;
+	for (const Type::Ptr& type : types) {
+		if (Logger::TypeInstance->IsAssignableFrom(type)) {
+			lastLoggerType = type;
+		}
+	}
+
 	for (const Type::Ptr& type : types) {
 		for (const ConfigItem::Ptr& item : newItems) {
 			if (!item->m_Object)
@@ -694,6 +702,12 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 #endif /* I2_DEBUG */
 
 			object->Activate(runtimeCreated, cookie);
+		}
+
+		// TODO: find a better name for silent
+		if (!silent && type == lastLoggerType) {
+			/* Disable early logging configuration once the last logger type was activated. */
+			Logger::DisableEarlyLogging();
 		}
 	}
 

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -54,7 +54,7 @@ public:
 
 	static bool CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent = false);
 	static bool ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated = false,
-		bool silent = false, bool withModAttrs = false, const Value& cookie = Empty);
+		bool mainConfigActivation = false, bool withModAttrs = false, const Value& cookie = Empty);
 
 	static bool RunWithActivationContext(const Function::Ptr& function);
 

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -224,7 +224,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		 * uq, items, runtimeCreated, silent, withModAttrs, cookie
 		 * IMPORTANT: Forward the cookie aka origin in order to prevent sync loops in the same zone!
 		 */
-		if (!ConfigItem::ActivateItems(newItems, true, true, false, cookie)) {
+		if (!ConfigItem::ActivateItems(newItems, true, false, false, cookie)) {
 			if (errors) {
 				Log(LogNotice, "ConfigObjectUtility")
 					<< "Failed to activate config object '" << fullName << "'. Aborting and removing config path '" << path << "'.";

--- a/tools/syntax/vim/syntax/icinga2.vim
+++ b/tools/syntax/vim/syntax/icinga2.vim
@@ -60,7 +60,7 @@ syn keyword		icinga2ObjType		IcingaApplication IdoMysqlConnection IdoPgsqlConnec
 syn keyword		icinga2ObjType		InfluxdbWriter LivestatusListener Notification NotificationCommand
 syn keyword		icinga2ObjType		NotificationComponent OpenTsdbWriter PerfdataWriter
 syn keyword		icinga2ObjType		ScheduledDowntime Service ServiceGroup SyslogLogger
-syn keyword		icinga2ObjType		TimePeriod User UserGroup Zone
+syn keyword		icinga2ObjType		TimePeriod User UserGroup WindowsEventLogLogger Zone
 
 " Object/Template marker (simplified)
 syn match		icinga2ObjDef		"\(object\|template\)[ \t]\+.*"


### PR DESCRIPTION
When starting Icinga 2 as a service on Windows, early log messages (these generated before the final logger config objects are loaded and activated) are only written to the console log, which is discarded in this case with no easy way to change this behavior.

This PR adds a new `WindowsEventLogLogger` (the name feels a bit redundant but is consistent with `SyslogLogger`) that implements writing to the Windows Event Log and can be configured like any other logger. Additionally, all early log messages are always passed to this logger.

![20210409_13h03m22s_grim](https://user-images.githubusercontent.com/18552/114171046-09669900-9934-11eb-81af-dad3d251189e.png)

## Config migration in Windows installer

<details>
<summary>Fresh installation</summary>

`windowseventlog` feature is enabled by default, `mainlog` is still available as a fallback to configure if required.

```
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\
ls : Cannot find path 'C:\ProgramData\icinga2\' because it does not exist.
At line:1 char:1
+ ls C:\ProgramData\icinga2\
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\ProgramData\icinga2\:String) [Get-ChildItem], ItemNotFoundException
    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetChildItemCommand

PS C:\Users\Administrator> msiexec /i C:\Users\Administrator\Downloads\Icinga2-snapshot-feature-windows-event-log-x86_64.msi /passive
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  10:37 AM            245 debuglog.conf
-a----         6/4/2021  10:37 AM            167 mainlog.conf
-a----         6/4/2021  10:37 AM            177 windowseventlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  10:37 AM             54 windowseventlog.conf
```
</details>

<details>
<summary>Upgrading 2.12.4 -> Snapshot (i.e. 2.12.4 -> 2.13.0 upgrade once released)</summary>

The installer disables the existing `mainlog` feature, makes the `windowseventlog` feature available and automatically enables it.

```
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM            245 debuglog.conf
-a----        5/27/2021   9:21 AM            167 mainlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM             46 mainlog.conf


PS C:\Users\Administrator> msiexec /i C:\Users\Administrator\Downloads\Icinga2-snapshot-feature-windows-event-log-x86_64.msi /passive
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM            245 debuglog.conf
-a----        5/27/2021   9:21 AM            167 mainlog.conf
-a----         6/4/2021  10:37 AM            177 windowseventlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  10:37 AM             54 windowseventlog.conf
```
</details>

<details>
<summary>Installing snapshot after the config was already installed once (i.e. 2.13.0 -> 2.13.1 upgrades once released)</summary>

Available and enabled features are not updated by the installer.

```
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM            245 debuglog.conf
-a----        5/27/2021   9:21 AM            167 mainlog.conf
-a----         6/4/2021  10:37 AM            177 windowseventlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  10:37 AM             54 windowseventlog.conf


PS C:\Users\Administrator> msiexec /i C:\Users\Administrator\Downloads\Icinga2-snapshot-feature-windows-event-log-x86_64.msi /passive
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM            245 debuglog.conf
-a----        5/27/2021   9:21 AM            167 mainlog.conf
-a----         6/4/2021  10:37 AM            177 windowseventlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  10:37 AM             54 windowseventlog.conf
```
</details>

<details>
<summary>Reinstalling snapshot after upgrading and re-enabling mainlog (i.e. 2.13.0 -> 2.13.1 upgrade once released after rolling back logging configuration)</summary>

Available and enabled features are not updated by the installer.

```
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM            245 debuglog.conf
-a----        5/27/2021   9:21 AM            167 mainlog.conf
-a----         6/4/2021  10:37 AM            177 windowseventlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  11:32 AM             46 mainlog.conf


PS C:\Users\Administrator> msiexec /i C:\Users\Administrator\Downloads\Icinga2-snapshot-feature-windows-event-log-x86_64.msi /passive
PS C:\Users\Administrator> ls C:\ProgramData\icinga2\etc\icinga2\features-*\*log*


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-available


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        5/27/2021   9:21 AM            245 debuglog.conf
-a----        5/27/2021   9:21 AM            167 mainlog.conf
-a----         6/4/2021  10:37 AM            177 windowseventlog.conf


    Directory: C:\ProgramData\icinga2\etc\icinga2\features-enabled


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----         6/4/2021  11:32 AM             46 mainlog.conf
```
</details>

fixes #5399
closes #8009