### PR TITLE
Support TLS 1.3

### DIFF
--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -33,6 +33,7 @@ void AddCRLToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& context, c
 void AddCRLToSSLContext(X509_STORE *x509_store, const String& crlPath);
 void SetCipherListToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& context, const String& cipherList);
 void SetTlsProtocolminToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& context, const String& tlsProtocolmin);
+int ResolveTlsProtocolVersion(const std::string& version);
 
 String GetCertificateCN(const std::shared_ptr<X509>& certificate);
 std::shared_ptr<X509> GetX509Certificate(const String& pemfile);

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1802,10 +1802,10 @@ void ApiListener::ValidateTlsProtocolmin(const Lazy<String>& lvalue, const Valid
 {
 	ObjectImpl<ApiListener>::ValidateTlsProtocolmin(lvalue, utils);
 
-	if (lvalue() != SSL_TXT_TLSV1_2) {
-		String message = "Invalid TLS version. Must be '" SSL_TXT_TLSV1_2 "'";
-
-		BOOST_THROW_EXCEPTION(ValidationError(this, { "tls_protocolmin" }, message));
+	try {
+		ResolveTlsProtocolVersion(lvalue());
+	} catch (const std::exception& ex) {
+		BOOST_THROW_EXCEPTION(ValidationError(this, { "tls_protocolmin" }, ex.what()));
 	}
 }
 


### PR DESCRIPTION
This PR adds support for TLS 1.3.

Unfortunately, there's no method value for `ssl::context` that specifies TLS 1.2 or newer but only any TLS version, i.e. TLS 1.0 or newer (https://www.boost.org/doc/libs/1_75_0/doc/html/boost_asio/reference/ssl__context/method.html). That's not too much of an issue though as the call to `SetupSslContext()` will disable TLS 1.0 and 1.1.

fixes #8715