### PR TITLE
Icinga DB: serialize icinga:config:checkcommand:argument#value and #set_if as expected

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -972,12 +972,20 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 					values = new Dictionary({{"value", kv.second}});
 				}
 
-				{
+				for (const char *attr : {"value", "set_if"}) {
 					Value value;
 
-					// JsonEncode() the value if it's set.
-					if (values->Get("value", &value)) {
-						values->Set("value", JsonEncode(value));
+					// Stringify if set.
+					if (values->Get(attr, &value)) {
+						switch (value.GetType()) {
+							case ValueString:
+								break;
+							case ValueObject:
+								values->Set(attr, value.Get<Object::Ptr>()->ToString());
+								break;
+							default:
+								values->Set(attr, JsonEncode(value));
+						}
 					}
 				}
 


### PR DESCRIPTION
    I.e. keep the serializations as simple as possible:

    null          => null
    true          => true
    42.0          => 42
    "foobar"      => foobar
    ["foobar"]    => ["foobar"]
    {"foo"="bar"} => {"foo":"bar"}
    {{42}}        => Object of type 'Function'