### PR TITLE
Icinga DB: Change redis key prefix to 'icinga:*'

### DIFF
--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -48,7 +48,7 @@ IcingaDB::IcingaDB()
 
 	m_WorkQueue.SetName("IcingaDB");
 
-	m_PrefixConfigObject = "icinga:config:";
+	m_PrefixConfigObject = "icinga:";
 	m_PrefixConfigCheckSum = "icinga:checksum:";
 	m_PrefixStateObject = "icinga:config:state:";
 }


### PR DESCRIPTION
Using the prefix `icinga:config:*` isn't really helpful, if we want to sync things like state using the same methods. `icinga:*` is all we really need here.