### PR TITLE
JsonEncode(): encode non-[]/{} objects as strings, not null

### DIFF
--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -166,16 +166,18 @@ void Encode(JsonEncoder<prettyPrint>& stateMachine, const Value& value)
 					}
 				}
 
-				Array::Ptr arr = dynamic_pointer_cast<Array>(obj);
-				if (arr) {
-					EncodeArray(stateMachine, arr);
-					break;
+				{
+					Array::Ptr arr = dynamic_pointer_cast<Array>(obj);
+					if (arr) {
+						EncodeArray(stateMachine, arr);
+						break;
+					}
 				}
+
+				// obj is most likely a function => "Object of type 'Function'"
+				Encode(stateMachine, obj->ToString());
+				break;
 			}
-
-			stateMachine.Null();
-
-			break;
 
 		case ValueEmpty:
 			stateMachine.Null();

--- a/test/base-json.cpp
+++ b/test/base-json.cpp
@@ -1,6 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 #include "base/dictionary.hpp"
+#include "base/function.hpp"
 #include "base/namespace.hpp"
 #include "base/array.hpp"
 #include "base/objectlock.hpp"
@@ -18,6 +19,7 @@ BOOST_AUTO_TEST_CASE(encode)
 		{ "array", new Array({ new Namespace() }) },
 		{ "false", false },
 		{ "float", -1.25 },
+		{ "fx", new Function("<test>", []() {}) },
 		{ "int", -42 },
 		{ "null", Value() },
 		{ "string", "LF\nTAB\tAUml\xC3\xA4Ill\xC3" },
@@ -31,6 +33,7 @@ BOOST_AUTO_TEST_CASE(encode)
     ],
     "false": false,
     "float": -1.25,
+    "fx": "Object of type 'Function'",
     "int": -42,
     "null": null,
     "string": "LF\nTAB\tAUml\u00e4Ill\ufffd",
@@ -42,6 +45,7 @@ BOOST_AUTO_TEST_CASE(encode)
 	BOOST_CHECK(JsonEncode(input, true) == output);
 
 	boost::algorithm::replace_all(output, " ", "");
+	boost::algorithm::replace_all(output, "Objectoftype'Function'", "Object of type 'Function'");
 	boost::algorithm::replace_all(output, "\n", "");
 
 	BOOST_CHECK(JsonEncode(input, false) == output);


### PR DESCRIPTION
... to represent function custom vars as such in Icinga DB.