### PR TITLE
Send problem notifications after downtime end for checkables in child zones (2.11)

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1397,7 +1397,7 @@ Message updates will be dropped when:
 * Checkable does not exist.
 * Origin endpoint's zone is not allowed to access this checkable.
 
-#### event::SuppressedNotifications <a id="technical-concepts-json-rpc-messages-event-setsupressednotifications"></a>
+#### event::SetSuppressedNotifications <a id="technical-concepts-json-rpc-messages-event-setsupressednotifications"></a>
 
 > Location: `clusterevents.cpp`
 
@@ -1406,7 +1406,7 @@ Message updates will be dropped when:
 Key       | Value
 ----------|---------
 jsonrpc   | 2.0
-method    | event::SuppressedNotifications
+method    | event::SetSuppressedNotifications
 params    | Dictionary
 
 ##### Params
@@ -1422,6 +1422,8 @@ supressed\_notifications | Number 	 | Bitmask for suppressed notifications.
 Event Sender: `Checkable::OnSuppressedNotificationsChanged`
 Event Receiver: `SuppressedNotificationsChangedAPIHandler`
 
+Used to sync the notification state of a host or service object within the same HA zone.
+
 ##### Permissions
 
 The receiver will not process messages from not configured endpoints.
@@ -1429,7 +1431,7 @@ The receiver will not process messages from not configured endpoints.
 Message updates will be dropped when:
 
 * Checkable does not exist.
-* Origin endpoint's zone is not allowed to access this checkable.
+* Origin endpoint is not within the local zone.
 
 
 #### event::SetNextNotification <a id="technical-concepts-json-rpc-messages-event-setnextnotification"></a>
@@ -1635,6 +1637,9 @@ text      | String        | Notification text
 Event Sender: `Checkable::OnNotificationsRequested`
 Event Receiver: `SendNotificationsAPIHandler`
 
+Signals that notifications have to be sent within the same HA zone. This is relevant if the checkable and its
+notifications are active on different endpoints.
+
 ##### Permissions
 
 The receiver will not process messages from not configured endpoints.
@@ -1642,7 +1647,7 @@ The receiver will not process messages from not configured endpoints.
 Message updates will be dropped when:
 
 * Checkable does not exist.
-* Origin endpoint's zone the same as the receiver. This binds notification messages to the HA zone.
+* Origin endpoint is not within the local zone.
 
 #### event::NotificationSentUser <a id="technical-concepts-json-rpc-messages-event-notificationsentuser"></a>
 

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -256,7 +256,7 @@ void ClusterEvents::SuppressedNotificationsChangedHandler(const Checkable::Ptr& 
 	message->Set("method", "event::SetSuppressedNotifications");
 	message->Set("params", params);
 
-	listener->RelayMessage(origin, checkable, message, true);
+	listener->RelayMessage(origin, nullptr, message, true);
 }
 
 Value ClusterEvents::SuppressedNotificationsChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
@@ -284,7 +284,7 @@ Value ClusterEvents::SuppressedNotificationsChangedAPIHandler(const MessageOrigi
 	if (!checkable)
 		return Empty;
 
-	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
+	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
 		Log(LogNotice, "ClusterEvents")
 			<< "Discarding 'suppressed notifications changed' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";


### PR DESCRIPTION
backport of #8681

Diff looks a bit different as SetSuppressedNotificationTypes doesn't exist in 2.11 (please double check this when reviewing).