### PR TITLE
Fix non-unity builds in support/2.11

### DIFF
--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -49,10 +49,6 @@ String SHA256(const String& s);
 String RandomString(int length);
 
 bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::shared_ptr<X509>& certificate, const String& crlFile);
-bool IsCa(const std::shared_ptr<X509>& cacert);
-int GetCertificateVersion(const std::shared_ptr<X509>& cert);
-String GetSignatureAlgorithm(const std::shared_ptr<X509>& cert);
-Array::Ptr GetSubjectAltNames(const std::shared_ptr<X509>& cert);
 
 class openssl_error : virtual public std::exception, virtual public boost::exception { };
 


### PR DESCRIPTION
Remove unused function declarations in `tlsutility.hpp`. These were introduced in c510fe4dfed0f65824bb259433faa0988caa2447, probably when resolving a merge conflict. However, these functions do not exist in 2.11, but refer to the Array type which is not included in the header, leading to non-unity build failing.

This commit simply removes these declarations and thus restores non-unity builds in 2.11.