### PR TITLE
Fix building with Boost 1.71.

### DIFF
--- a/third-party/cmake/BoostTestTargets.cmake
+++ b/third-party/cmake/BoostTestTargets.cmake
@@ -47,27 +47,11 @@ set(BOOST_TEST_TARGET_PREFIX "boosttest")
 if(NOT Boost_FOUND)
 	find_package(Boost 1.34.0 QUIET)
 endif()
-if("${Boost_VERSION}0" LESS "1034000")
-	set(_shared_msg
-		"NOTE: boost::test-based targets and tests cannot "
-		"be added: boost >= 1.34.0 required but not found. "
-		"(found: '${Boost_VERSION}'; want >=103400) ")
-	if(BUILD_TESTING)
-		message(FATAL_ERROR
-			${_shared_msg}
-			"You may disable BUILD_TESTING to continue without the "
-			"tests.")
-	else()
-		message(STATUS
-			${_shared_msg}
-			"BUILD_TESTING disabled, so continuing anyway.")
-	endif()
-endif()
 
 include(GetForceIncludeDefinitions)
 include(CopyResourcesToBuildTree)
 
-if(Boost_FOUND AND NOT "${Boost_VERSION}0" LESS "1034000")
+if(Boost_FOUND)
 	set(_boosttesttargets_libs)
 	set(_boostConfig "BoostTestTargetsIncluded.h")
 	if(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY)
@@ -144,7 +128,7 @@ function(add_boost_test _name)
 			"Syntax error in use of add_boost_test: at least one source file required!")
 	endif()
 
-	if(Boost_FOUND AND NOT "${Boost_VERSION}0" LESS "1034000")
+	if(Boost_FOUND)
 
 		include_directories(${Boost_INCLUDE_DIRS})
 
@@ -236,7 +220,7 @@ function(add_boost_test _name)
 			set(_test_command ${_target_name})
 		endif()
 
-		if(TESTS AND "${Boost_VERSION}" VERSION_GREATER "103799")
+		if(TESTS)
 			foreach(_test ${TESTS})
 				add_test(NAME
 					${_name}-${_test}


### PR DESCRIPTION
The CMake file that detects Boost.Test version uses an older version
format, and incorrectly thinks that the available Boost version is
very old. This patch removes the version check, since Debian already
has a sufficiently recent Boost version.

Backport of #7780