### PR TITLE
Make base_value/format test easier to understand

### DIFF
--- a/test/base-value.cpp
+++ b/test/base-value.cpp
@@ -46,7 +46,8 @@ BOOST_AUTO_TEST_CASE(format)
 	std::istringstream ibuf("3");
 	ibuf >> v;
 
-	BOOST_CHECK(v != 3);
+	BOOST_CHECK_MESSAGE(v.IsString(), "type of v should be String (is " << v.GetTypeName() << ")");
+	BOOST_CHECK_MESSAGE(v == "3", "v should be '3' (is '" << v << "')");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The old test looked really strange where it reads 3 into a `Value` and then checks that it's not 3. However, what's going on there is that `operator>>` for `Value` actually always reads a `String`, so instead check for what `v` should be, not what it should not be.