### PR TITLE
ConfigWriter: Fix don't also write ignore_on_error attr into the config

### DIFF
--- a/lib/base/configwriter.cpp
+++ b/lib/base/configwriter.cpp
@@ -156,7 +156,7 @@ void ConfigWriter::EmitIdentifier(std::ostream& fp, const String& identifier, bo
 }
 
 void ConfigWriter::EmitConfigItem(std::ostream& fp, const String& type, const String& name, bool isTemplate,
-	bool ignoreOnError, const Array::Ptr& imports, const Dictionary::Ptr& attrs)
+	const Array::Ptr& imports, const Dictionary::Ptr& attrs)
 {
 	if (isTemplate)
 		fp << "template ";
@@ -166,9 +166,6 @@ void ConfigWriter::EmitConfigItem(std::ostream& fp, const String& type, const St
 	EmitIdentifier(fp, type, false);
 	fp << " ";
 	EmitString(fp, name);
-
-	if (ignoreOnError)
-		fp << " ignore_on_error";
 
 	fp << " ";
 	EmitScope(fp, 1, attrs, imports, true);

--- a/lib/base/configwriter.hpp
+++ b/lib/base/configwriter.hpp
@@ -51,7 +51,7 @@ public:
 
 	static void EmitIdentifier(std::ostream& fp, const String& identifier, bool inAssignment);
 	static void EmitConfigItem(std::ostream& fp, const String& type, const String& name, bool isTemplate,
-		bool ignoreOnError, const Array::Ptr& imports, const Dictionary::Ptr& attrs);
+		const Array::Ptr& imports, const Dictionary::Ptr& attrs);
 
 	static void EmitComment(std::ostream& fp, const String& text);
 	static void EmitFunctionCall(std::ostream& fp, const String& name, const Array::Ptr& arguments);

--- a/lib/icinga/comment.cpp
+++ b/lib/icinga/comment.cpp
@@ -161,7 +161,7 @@ String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryTyp
 	if (!zone.IsEmpty())
 		attrs->Set("zone", zone);
 
-	String config = ConfigObjectUtility::CreateObjectConfig(Comment::TypeInstance, fullName, true, nullptr, attrs);
+	String config = ConfigObjectUtility::CreateObjectConfig(Comment::TypeInstance, fullName, nullptr, attrs);
 
 	Array::Ptr errors = new Array();
 

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -269,7 +269,7 @@ Downtime::Ptr Downtime::AddDowntime(const Checkable::Ptr& checkable, const Strin
 	if (!zone.IsEmpty())
 		attrs->Set("zone", zone);
 
-	String config = ConfigObjectUtility::CreateObjectConfig(Downtime::TypeInstance, fullName, true, nullptr, attrs);
+	String config = ConfigObjectUtility::CreateObjectConfig(Downtime::TypeInstance, fullName, nullptr, attrs);
 
 	Array::Ptr errors = new Array();
 

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -108,7 +108,7 @@ String ConfigObjectUtility::EscapeName(const String& name)
 }
 
 String ConfigObjectUtility::CreateObjectConfig(const Type::Ptr& type, const String& fullName,
-	bool ignoreOnError, const Array::Ptr& templates, const Dictionary::Ptr& attrs)
+	const Array::Ptr& templates, const Dictionary::Ptr& attrs)
 {
 	auto *nc = dynamic_cast<NameComposer *>(type.get());
 	Dictionary::Ptr nameParts;
@@ -148,7 +148,7 @@ String ConfigObjectUtility::CreateObjectConfig(const Type::Ptr& type, const Stri
 	allAttrs->Set("version", Utility::GetTime());
 
 	std::ostringstream config;
-	ConfigWriter::EmitConfigItem(config, type->GetName(), name, false, ignoreOnError, templates, allAttrs);
+	ConfigWriter::EmitConfigItem(config, type->GetName(), name, false, templates, allAttrs);
 	ConfigWriter::EmitRaw(config, "\n");
 
 	return config.str();

--- a/lib/remote/configobjectutility.hpp
+++ b/lib/remote/configobjectutility.hpp
@@ -27,7 +27,7 @@ public:
 	static void CreateStorage();
 
 	static String CreateObjectConfig(const Type::Ptr& type, const String& fullName,
-		bool ignoreOnError, const Array::Ptr& templates, const Dictionary::Ptr& attrs);
+		const Array::Ptr& templates, const Dictionary::Ptr& attrs);
 
 	static bool CreateObject(const Type::Ptr& type, const String& fullName,
 		const String& config, const Array::Ptr& errors, const Array::Ptr& diagnosticInformation, const Value& cookie = Empty);

--- a/lib/remote/createobjecthandler.cpp
+++ b/lib/remote/createobjecthandler.cpp
@@ -98,7 +98,7 @@ bool CreateObjectHandler::HandleRequest(
 	 * We can't use SendJsonError() here.
 	 */
 	try {
-		config = ConfigObjectUtility::CreateObjectConfig(type, name, ignoreOnError, templates, attrs);
+		config = ConfigObjectUtility::CreateObjectConfig(type, name, templates, attrs);
 	} catch (const std::exception& ex) {
 		errors->Add(DiagnosticInformation(ex, false));
 		diagnosticInformation->Add(DiagnosticInformation(ex));


### PR DESCRIPTION
Just created a host object via API with ``ignore_on_error`` flag set and the ``ConfigWriter`` mistakenly writes this flag in the config file, which leads to a config validation error and crashes icinga2 occasionally.

Please test this with (#8819), the error only appears after that fix.