### PR TITLE
ConfigPackageUtility::ValidateName: replace broken regex

### DIFF
--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 #include <algorithm>
+#include <cctype>
 #include <fstream>
 
 using namespace icinga;
@@ -375,9 +376,9 @@ bool ConfigPackageUtility::ValidateName(const String& name)
 	if (ContainsDotDot(name))
 		return false;
 
-	boost::regex expr("^[^a-zA-Z0-9_\\-]*$", boost::regex::icase);
-	boost::smatch what;
-	return (!boost::regex_search(name.GetData(), what, expr));
+	return std::all_of(name.Begin(), name.End(), [](char c) {
+		return std::isalnum(c, std::locale::classic()) || c == '_' || c == '-';
+	});
 }
 
 std::mutex& ConfigPackageUtility::GetStaticPackageMutex()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(base_test_SOURCES
   icinga-macros.cpp
   icinga-notification.cpp
   icinga-perfdata.cpp
+  remote-configpackageutility.cpp
   remote-url.cpp
   ${base_OBJS}
   $<TARGET_OBJECTS:config>
@@ -148,6 +149,7 @@ add_boost_test(base
     icinga_perfdata/multi
     icinga_perfdata/scientificnotation
     icinga_perfdata/parse_edgecases
+    remote_configpackageutility/ValidateName
     remote_url/id_and_path
     remote_url/parameters
     remote_url/get_and_set

--- a/test/remote-configpackageutility.cpp
+++ b/test/remote-configpackageutility.cpp
@@ -1,0 +1,25 @@
+/* Icinga 2 | (c) 2021 Icinga GmbH | GPLv2+ */
+
+#include "remote/configpackageutility.hpp"
+#include <vector>
+#include <string>
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+BOOST_AUTO_TEST_SUITE(remote_configpackageutility)
+
+BOOST_AUTO_TEST_CASE(ValidateName)
+{
+	std::vector<std::string> validNames {"foo", "foo-bar", "FooBar", "Foo123", "_Foo-", "123bar"};
+	for (const std::string& n : validNames) {
+		BOOST_CHECK_MESSAGE(ConfigPackageUtility::ValidateName(n), "'" << n << "' should be valid");
+	}
+
+	std::vector<std::string> invalidNames {"", ".", "..", "foo.bar", "foo/../bar", "foo/bar", "foo:bar"};
+	for (const std::string& n : invalidNames) {
+		BOOST_CHECK_MESSAGE(!ConfigPackageUtility::ValidateName(n), "'" << n << "' should not be valid");
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The old validation regex matched if the name consists only of invalid character, not that it does not contain them, i.e. something like "foo/bar" was considered valid.

This commit replaces the regex with a check that all characters in the name are allowed characters.

## Backwards compatibility

This change could cause trouble in existing installations as package names could have worked before that weren't supposed to be valid. We could also be more permissive then what I suppose was intended with the original implementation.

## Before

Running the new tests with the old implementation:
```
/home/jbrost/dev/icinga2/test/remote-configpackageutility.cpp(21): error: in "remote_configpackageutility/ValidateName": 'foo.bar' should not be valid
/home/jbrost/dev/icinga2/test/remote-configpackageutility.cpp(21): error: in "remote_configpackageutility/ValidateName": 'foo/bar' should not be valid
/home/jbrost/dev/icinga2/test/remote-configpackageutility.cpp(21): error: in "remote_configpackageutility/ValidateName": 'foo:bar' should not be valid
```

## After

New tests pass