### PR TITLE
Allow using E in perfdata both as exponent and unit prefix

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,6 +147,7 @@ add_boost_test(base
     icinga_perfdata/invalid
     icinga_perfdata/multi
     icinga_perfdata/scientificnotation
+    icinga_perfdata/parse_edgecases
     remote_url/id_and_path
     remote_url/parameters
     remote_url/get_and_set

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -296,6 +296,13 @@ BOOST_AUTO_TEST_CASE(invalid)
 {
 	BOOST_CHECK_THROW(PerfdataValue::Parse("123456"), boost::exception);
 	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1,23456"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=123_456"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test="), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=123,456;1;1;1;1"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;123,456;1;1;1"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;1;123,456;1;1"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;1;1;123,456;1"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;1;1;1;123,456"), boost::exception);
 }
 
 BOOST_AUTO_TEST_CASE(multi)
@@ -352,6 +359,25 @@ BOOST_AUTO_TEST_CASE(scientificnotation)
 
 	str = pdv->Format();
 	BOOST_CHECK(str == "test=0.110000;12;0.130000;0.014000;150");
+}
+
+BOOST_AUTO_TEST_CASE(parse_edgecases)
+{
+	// Trailing decimal point
+	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=23.");
+	BOOST_CHECK(pv);
+	BOOST_CHECK(pv->GetValue() == 23.0);
+
+	// Leading decimal point
+	pv = PerfdataValue::Parse("test=.42");
+	BOOST_CHECK(pv);
+	BOOST_CHECK(pv->GetValue() == 0.42);
+
+	// E both as exponent and unit prefix
+	pv = PerfdataValue::Parse("test=+1.5E-15EB");
+	BOOST_CHECK(pv);
+	BOOST_CHECK(pv->GetValue() == 1.5e3);
+	BOOST_CHECK(pv->GetUnit() == "bytes");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Merging both #7871 and #8492 resulted in a failing test because 'E' can now be used both as exponent (`1E10`) and as unit prefix (`1EB`). This PR changes how perfdata values and units are split to support both, even at the same time (`1E10EB`). It also adds tests for this and some parsing edge cases that came to my mind.

The old implementation interprets the longest prefix of the value string that looks somewhat like floating point literal as the value (`valueStr.FindFirstNotOf("+-0123456789.eE");` which also includes 'E' when part of a unit prefix).

The new implementation first splits the value string at `;` (therefore splitting off the warn/crit/min/max values) and then taking the longest suffix that does not contain a digit or a decimal point as the unit.