### PR TITLE
Fix match function signature to match its description

### DIFF
--- a/doc/18-library-reference.md
+++ b/doc/18-library-reference.md
@@ -380,7 +380,7 @@ null
 Signature:
 
 ```
-function match(pattern, text, mode)
+function match(pattern, value, mode)
 ```
 
 Returns true if the wildcard (`?*`) `pattern` matches the `value`, false otherwise.


### PR DESCRIPTION
Small doc fix.

`function match` description uses the term `value`. Its signature uses `text`.

Replaced `text` by `value` to match `regex` signature and description naming convention.