### PR TITLE
ConfigObjectUtility::GetObjectConfigPath(): support long names of objects of all types

### DIFF
--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -43,16 +43,9 @@ String ConfigObjectUtility::GetObjectConfigPath(const Type::Ptr& type, const Str
 
 	/*
 	 * The long path may cause trouble due to exceeding the allowed filename length of the filesystem. Therefore, the
-	 * preferred solution would be to use the truncated and hashed version as returned at the end of this function.
-	 * However, for compatibility reasons, we have to keep the old long version in some cases. Notably, this could lead
-	 * to the creation of objects that can't be synced to child nodes if they are running an older version. Thus, for
-	 * now, the fix is only enabled for comments and downtimes, as these are the object types for which the issue is
-	 * most likely triggered but can't be worked around easily (you'd have to rename the host and/or service in order to
-	 * be able to schedule a downtime or add an acknowledgement, which is not feasible) and the impact of not syncing
-	 * these objects through the whole cluster is limited. For other object types, we currently prefer to fail the
-	 * creation early so that configuration inconsistencies throughout the cluster are avoided.
+	 * solution is to use the truncated and hashed version as returned at the end of this function.
 	 */
-	if ((type->GetName() != "Comment" && type->GetName() != "Downtime") || Utility::PathExists(longPath)) {
+	if (Utility::PathExists(longPath)) {
 		return std::move(longPath);
 	}
 


### PR DESCRIPTION
... not just Comment and Downtime.

Doesn't break anything as it affects only not yet existing objects.

refs #8022