### PR TITLE
Set a default severity for loggers

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1835,7 +1835,7 @@ Configuration Attributes:
 
   Name                      | Type                  | Description
   --------------------------|-----------------------|----------------------------------
-  severity                  | String                | **Optional.** The minimum severity for this log. Can be "debug", "notice", "information", "warning" or "critical". Defaults to "warning".
+  severity                  | String                | **Optional.** The minimum severity for this log. Can be "debug", "notice", "information", "warning" or "critical". Defaults to "information".
   facility                  | String                | **Optional.** Defines the facility to use for syslog entries. This can be a facility constant like `FacilityDaemon`. Defaults to `FacilityUser`.
 
 Facility Constants:

--- a/lib/base/logger.ti
+++ b/lib/base/logger.ti
@@ -9,7 +9,9 @@ namespace icinga
 
 abstract class Logger : ConfigObject
 {
-	[config] String severity;
+	[config] String severity {
+		default {{{ return "information"; }}}
+	};
 };
 
 }


### PR DESCRIPTION
So far, the documentation has claimed that loggers have a default severity (`information` for `FileLogger` and `warning` for `SyslogLogger`). However, this was not the case and not setting the severity resulted in a configuration error.

This commit changes the default value to be `information` for all loggers.

## Before

### FileLogger
```
object FileLogger "test" {
  path = "/dev/null"
}
```
```
[2021-06-23 16:54:26 +0200] critical/config: Error: Validation failed for object 'test' of type 'FileLogger'; Attribute 'severity': Invalid severity specified: 
Location: in data/etc/icinga2/conf.d/logger.conf: 1:0-1:23
data/etc/icinga2/conf.d/logger.conf(1): object FileLogger "test" {
                                        ^^^^^^^^^^^^^^^^^^^^^^^^
data/etc/icinga2/conf.d/logger.conf(2):   path = "/dev/null"
data/etc/icinga2/conf.d/logger.conf(3): }
[2021-06-23 16:54:26 +0200] critical/config: 1 error
[2021-06-23 16:54:26 +0200] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

### SyslogLogger
```
object SyslogLogger "test" {}
```
```
[2021-06-23 16:55:23 +0200] critical/config: Error: Validation failed for object 'test' of type 'SyslogLogger'; Attribute 'severity': Invalid severity specified: 
Location: in data/etc/icinga2/conf.d/logger.conf: 1:0-1:25
data/etc/icinga2/conf.d/logger.conf(1): object SyslogLogger "test" {}
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
[2021-06-23 16:55:23 +0200] critical/config: 1 error
[2021-06-23 16:55:23 +0200] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

## After

Config validation succeeds with both config snippets.