### PR TITLE
ScheduledDowntime::TimerProc(): Catch exceptions to make sure other downtimes are still created

### DIFF
--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -87,8 +87,15 @@ void ScheduledDowntime::Start(bool runtimeCreated)
 void ScheduledDowntime::TimerProc()
 {
 	for (const ScheduledDowntime::Ptr& sd : ConfigType::GetObjectsByType<ScheduledDowntime>()) {
-		if (sd->IsActive() && !sd->IsPaused())
-			sd->CreateNextDowntime();
+		if (sd->IsActive() && !sd->IsPaused()) {
+			try {
+				sd->CreateNextDowntime();
+			} catch (const std::exception& ex) {
+				Log(LogCritical, "ScheduledDowntime")
+					<< "Exception occurred during creation of next downtime for scheduled downtime '"
+					<< sd->GetName() << "': " << DiagnosticInformation(ex, false);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Without this PR one broken scheduled downtime can prevent the creation of other downtimes because an exception kills the whole timer task.

## Tests

### Setup
```
var numHosts = 10000

for (hid in range(numHosts)) {
    object Host "TestHost1 - " + hid use (hid) {
        check_command = "dummy"
        enable_active_checks = true
    }
}

apply ScheduledDowntime "downtime-test" to Host {
    author = "admin"
    comment = "test"
    fixed = true
    ranges = {
        "friday"        = "00:00-08:00,08:00-16:00,16:00-24:00"
        "monday"        = "00:00-08:00,08:00-16:00,16:00-24:00"
        "saturday"      = "00:00-08:00,08:00-16:00,16:00-24:00"
        "sunday"        = "00:00-08:00,08:00-16:00,16:00-24:00"
        "thursday"      = "00:00-08:00,08:00-16:00,16:00-24:00"
        "tuesday"       = "00:00-08:00,08:00-16:00,16:00-24:00"
        "wednesday"     = "00:00-08:00,08:00-16:00,16:00-24:00"
    }

    assign where host.name
}
```

### Test

1. Start Icinga 2 and wait until you see the first downtimes getting created (The creation of all 10k downtimes will take a while and that's what we want): 
```
[2021-06-24 13:09:58 +0200] information/Downtime: Added downtime 'TestHost1 - 462!d78196e1-9adc-428c-b4fb-119664016e70' between '2021-06-24 08:00:00' and '2021-06-24 16:00:00', author: 'admin', fixed
```
2. Change the  permissions of the downtimes directory inside the `_api` package to prevent Icinga from creating new downtimes:
```
chmod 000 /var/lib/icinga2/api/packages/_api/*/conf.d/downtimes
```

3. See expected results below 
4. Fix the permissions (after testing):
```
chmod 700 /var/lib/icinga2/api/packages/_api/*/conf.d/downtimes
```

### Before
Without this PR you should see only one exception and no other downtime creation related logs after that. You should see the next exception 1 minute later when the timer runs again.
```
[2021-06-24 13:34:17 +0200] information/Downtime: Added downtime 'TestHost1 - 2088!5a80bf87-19c5-4279-b6ed-aae892c48861' between '2021-06-24 08:00:00' and '2021-06-24 16:00:00', author: 'admin', fixed
[2021-06-24 13:34:17 +0200] information/ConfigObjectUtility: Created and activated object 'TestHost1 - 1094!f4398773-3d18-4a9a-873d-4d4a1a03f26e' of type 'Downtime'.
[2021-06-24 13:34:17 +0200] information/Downtime: Added downtime 'TestHost1 - 1094!f4398773-3d18-4a9a-873d-4d4a1a03f26e' between '2021-06-24 08:00:00' and '2021-06-24 16:00:00', author: 'admin', fixed
[2021-06-24 13:34:17 +0200] information/ConfigObjectUtility: Created and activated object 'TestHost1 - 9833!149b245c-b2d5-4c36-a639-531b9db90a60' of type 'Downtime'.
[2021-06-24 13:34:17 +0200] information/Downtime: Added downtime 'TestHost1 - 9833!149b245c-b2d5-4c36-a639-531b9db90a60' between '2021-06-24 08:00:00' and '2021-06-24 16:00:00', author: 'admin', fixed
[2021-06-24 13:34:17 +0200] critical/ThreadPool: Exception thrown in event handler:
Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 5997!8a2de671-8978-409d-88e6-538dcf2d8caf.conf' failed with error code 13, 'Permission denied'

	(0) Compiling configuration file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 5997!8a2de671-8978-409d-88e6-538dcf2d8caf.conf'
```

### After
With this PR you should see many exceptions being thrown after another (which means they don't kill the timer task any more)
```
[2021-06-24 13:19:05 +0200] information/ConfigObjectUtility: Created and activated object 'TestHost1 - 4359!6757ea22-a765-4ee2-983d-5ee5a6bfa9e4' of type 'Downtime'.
[2021-06-24 13:19:05 +0200] information/Downtime: Added downtime 'TestHost1 - 4359!6757ea22-a765-4ee2-983d-5ee5a6bfa9e4' between '2021-06-24 08:00:00' and '2021-06-24 16:00:00', author: 'admin', fixed
[2021-06-24 13:19:06 +0200] information/Downtime: Triggering downtime 'TestHost1 - 8687!9278507d-22cc-410a-8eb5-61c03025de13' for checkable 'TestHost1 - 8687'.
[2021-06-24 13:19:06 +0200] information/ConfigObjectUtility: Created and activated object 'TestHost1 - 8687!9278507d-22cc-410a-8eb5-61c03025de13' of type 'Downtime'.
[2021-06-24 13:19:06 +0200] information/Downtime: Added downtime 'TestHost1 - 8687!9278507d-22cc-410a-8eb5-61c03025de13' between '2021-06-24 08:00:00' and '2021-06-24 16:00:00', author: 'admin', fixed
[2021-06-24 13:19:06 +0200] critical/ScheduledDowntime: Exception occurred during creation of next downtime for scheduled downtime 'TestHost1 - 567!downtime-test': Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 567!2c2f4547-4240-4271-9c0d-5ebd8d282dac.conf' failed with error code 13, 'Permission denied'

	(0) Compiling configuration file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 567!2c2f4547-4240-4271-9c0d-5ebd8d282dac.conf'
[2021-06-24 13:19:06 +0200] critical/ScheduledDowntime: Exception occurred during creation of next downtime for scheduled downtime 'TestHost1 - 4830!downtime-test': Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 4830!05ac2262-8fc6-4404-b73f-de6b6e9d8c68.conf' failed with error code 13, 'Permission denied'

	(0) Compiling configuration file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 4830!05ac2262-8fc6-4404-b73f-de6b6e9d8c68.conf'
[2021-06-24 13:19:06 +0200] critical/ScheduledDowntime: Exception occurred during creation of next downtime for scheduled downtime 'TestHost1 - 8766!downtime-test': Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 8766!a3b68846-4466-4c80-8c6b-aefedd897952.conf' failed with error code 13, 'Permission denied'

	(0) Compiling configuration file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 8766!a3b68846-4466-4c80-8c6b-aefedd897952.conf'
[2021-06-24 13:19:06 +0200] critical/ScheduledDowntime: Exception occurred during creation of next downtime for scheduled downtime 'TestHost1 - 6317!downtime-test': Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 6317!df19d8fa-7dfa-4077-ace6-6b3aec32dc26.conf' failed with error code 13, 'Permission denied'

	(0) Compiling configuration file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 6317!df19d8fa-7dfa-4077-ace6-6b3aec32dc26.conf'
[2021-06-24 13:19:06 +0200] critical/ScheduledDowntime: Exception occurred during creation of next downtime for scheduled downtime 'TestHost1 - 3052!downtime-test': Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 3052!69e5f2b8-3374-44d3-ac2a-0c12c97569a2.conf' failed with error code 13, 'Permission denied'

	(0) Compiling configuration file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 3052!69e5f2b8-3374-44d3-ac2a-0c12c97569a2.conf'
[2021-06-24 13:19:06 +0200] critical/ScheduledDowntime: Exception occurred during creation of next downtime for scheduled downtime 'TestHost1 - 76!downtime-test': Error: Function call 'std::ifstream::open' for file '/Users/noah/i2/var/lib/icinga2/api/packages/_api/58b95a7f-55ec-4b41-9134-a345a9caf7c7/conf.d/downtimes/TestHost1 - 76!814b2f2f-4874-4760-8606-7fe16405647b.conf' failed with error code 13, 'Permission denied'
```
