### PR TITLE
Checkable::NotifyDowntimeEnd(): don't send Downtime end notification unless triggered

### DIFF
--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -256,8 +256,8 @@ void Checkable::NotifyDowntimeInternal(const Downtime::Ptr& downtime)
 
 void Checkable::NotifyDowntimeEnd(const Downtime::Ptr& downtime)
 {
-	/* don't send notifications for flexible downtimes which never triggered */
-	if (!downtime->GetFixed() && !downtime->IsTriggered())
+	/* don't send notifications for downtimes which never triggered */
+	if (!downtime->IsTriggered())
 		return;
 
 	Checkable::Ptr checkable = downtime->GetCheckable();


### PR DESCRIPTION
... for fixed Downtimes as well.