### PR TITLE
Windows build scripts: allow setting BITS=32 to use 32 bit dependency paths by default

### DIFF
--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -19,17 +19,24 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
   $env:CMAKE_GENERATOR = 'Visual Studio 16 2019'
 }
+if (-not (Test-Path env:BITS)) {
+  $env:BITS = 64
+}
 if (-not (Test-Path env:CMAKE_GENERATOR_PLATFORM)) {
-  $env:CMAKE_GENERATOR_PLATFORM = 'x64'
+  if ($env:BITS -eq 32) {
+    $env:CMAKE_GENERATOR_PLATFORM = 'Win32'
+  } else {
+    $env:CMAKE_GENERATOR_PLATFORM = 'x64'
+  }
 }
 if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
-  $env:OPENSSL_ROOT_DIR = 'c:\local\OpenSSL_1_1_1k-Win64'
+  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_1_1_1k-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = 'c:\local\boost_1_76_0-Win64'
+  $env:BOOST_ROOT = "c:\local\boost_1_76_0-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_76_0-Win64\lib64-msvc-14.2'
+  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_76_0-Win${env:BITS}\lib${env:BITS}-msvc-14.2"
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'


### PR DESCRIPTION
This will allow removing the variables for which defaults are set from the https://git.icinga.com/packaging/windows-icinga2 repo which will in turn allow different branches in this repo to build with different dependency versions (i.e. build support/2.12 with Boost 1.71 and master with Boost 1.76).

Test pipeline in GitLab: https://git.icinga.com/packaging/windows-icinga2/-/compare/master...feature%2Fdont-set-dependency-versions
Diff in packaging/windows-icinga2: https://git.icinga.com/packaging/windows-icinga2/-/compare/master...feature%2Fdont-set-dependency-versions