### PR TITLE
Change capitalization of the PowerTools command

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -151,7 +151,7 @@ CentOS 8 additionally needs the PowerTools repository for EPEL:
 
 ```bash
 dnf install 'dnf-command(config-manager)'
-dnf config-manager --set-enabled PowerTools
+dnf config-manager --set-enabled powertools
 
 dnf install epel-release
 ```


### PR DESCRIPTION
While testing Icinga2 on CentOS8, I noticed that when closely following the installation documentation, the command `dnf config-manager --set-enabled PowerTools` failed on me with `Error: No matching repo to modify: PowerTools.`

This was alleviated by lowercasing the name of the repo, something that was suggested after a quick research online. I've tried it and it worked, so I suggest changing the documentation accordingly. 