### PR TITLE
API Action "remove-downtime": Also remove child downtimes

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -408,7 +408,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 				<< "Creating downtime for service " << hostService->GetName() << " on host " << host->GetName();
 
 			Downtime::Ptr serviceDowntime = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
-				fixed, triggerName, duration);
+				fixed, triggerName, duration, String(), String(), downtimeName);
 			String serviceDowntimeName = serviceDowntime->GetName();
 
 			serviceDowntimes.push_back(new Dictionary({
@@ -490,6 +490,8 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 	auto author (HttpUtility::GetLastParameter(params, "author"));
 	Checkable::Ptr checkable = dynamic_pointer_cast<Checkable>(object);
 
+	size_t childCount = 0;
+
 	if (checkable) {
 		std::set<Downtime::Ptr> downtimes = checkable->GetDowntimes();
 
@@ -499,8 +501,10 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 				downtime->SetRemovedBy(author);
 			}
 
+			childCount += downtime->GetChildren().size();
+
 			try {
-				Downtime::RemoveDowntime(downtime->GetName(), true);
+				Downtime::RemoveDowntime(downtime->GetName(), true, true);
 			} catch (const invalid_downtime_removal_error& error) {
 				Log(LogWarning, "ApiActions") << error.what();
 
@@ -508,7 +512,8 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 			}
 		}
 
-		return ApiActions::CreateResult(200, "Successfully removed all downtimes for object '" + checkable->GetName() + "'.");
+		return ApiActions::CreateResult(200, "Successfully removed all downtimes for object '" +
+			checkable->GetName() + "' and " + std::to_string(childCount) + " child downtimes.");
 	}
 
 	Downtime::Ptr downtime = static_pointer_cast<Downtime>(object);
@@ -521,12 +526,14 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 		downtime->SetRemovedBy(author);
 	}
 
+	childCount += downtime->GetChildren().size();
+
 	try {
 		String downtimeName = downtime->GetName();
+		Downtime::RemoveDowntime(downtimeName, true, true);
 
-		Downtime::RemoveDowntime(downtimeName, true);
-
-		return ApiActions::CreateResult(200, "Successfully removed downtime '" + downtimeName + "'.");
+		return ApiActions::CreateResult(200, "Successfully removed downtime '" + downtimeName +
+			"' and " + std::to_string(childCount) + " child downtimes.");
 	} catch (const invalid_downtime_removal_error& error) {
 		Log(LogWarning, "ApiActions") << error.what();
 

--- a/lib/icinga/checkable-downtime.cpp
+++ b/lib/icinga/checkable-downtime.cpp
@@ -12,7 +12,7 @@ using namespace icinga;
 void Checkable::RemoveAllDowntimes()
 {
 	for (const Downtime::Ptr& downtime : GetDowntimes()) {
-		Downtime::RemoveDowntime(downtime->GetName(), true, true);
+		Downtime::RemoveDowntime(downtime->GetName(), true, true, true);
 	}
 }
 

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -48,10 +48,14 @@ public:
 	static Ptr AddDowntime(const intrusive_ptr<Checkable>& checkable, const String& author,
 		const String& comment, double startTime, double endTime, bool fixed,
 		const String& triggeredBy, double duration, const String& scheduledDowntime = String(),
-		const String& scheduledBy = String(), const String& id = String(),
+		const String& scheduledBy = String(), const String& parent = String(), const String& id = String(),
 		const MessageOrigin::Ptr& origin = nullptr);
 
-	static void RemoveDowntime(const String& id, bool cancelled, bool expired = false, const MessageOrigin::Ptr& origin = nullptr);
+	static void RemoveDowntime(const String& id, bool includeChildren, bool cancelled, bool expired = false, const MessageOrigin::Ptr& origin = nullptr);
+
+	void RegisterChild(const Downtime::Ptr& downtime);
+	void UnregisterChild(const Downtime::Ptr& downtime);
+	std::set<Downtime::Ptr> GetChildren() const;
 
 	void TriggerDowntime();
 
@@ -69,6 +73,9 @@ protected:
 
 private:
 	ObjectImpl<Checkable>::Ptr m_Checkable;
+
+	std::set<Downtime::Ptr> m_Children;
+	mutable std::mutex m_ChildrenMutex;
 
 	bool CanBeTriggered();
 

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -63,6 +63,7 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	[config] Timestamp duration;
 	[config] String triggered_by;
 	[config] String scheduled_by;
+	[config] String parent;
 	[state] Array::Ptr triggers {
 		default {{{ return new Array(); }}}
 	};

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -986,7 +986,7 @@ void ExternalCommandProcessor::DelSvcDowntime(double, const std::vector<String>&
 	String rid = Downtime::GetDowntimeIDFromLegacyID(id);
 
 	try {
-		Downtime::RemoveDowntime(rid, true);
+		Downtime::RemoveDowntime(rid, false, true);
 
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Removed downtime ID " << arguments[0];
@@ -1094,7 +1094,7 @@ void ExternalCommandProcessor::DelHostDowntime(double, const std::vector<String>
 	String rid = Downtime::GetDowntimeIDFromLegacyID(id);
 
 	try {
-		Downtime::RemoveDowntime(rid, true);
+		Downtime::RemoveDowntime(rid, false, true);
 
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Removed downtime ID " << arguments[0];
@@ -1129,7 +1129,7 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 	for (const Downtime::Ptr& downtime : host->GetDowntimes()) {
 		try {
 			String downtimeName = downtime->GetName();
-			Downtime::RemoveDowntime(downtimeName, true);
+			Downtime::RemoveDowntime(downtimeName, false, true);
 
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Removed downtime '" << downtimeName << "'.";
@@ -1151,7 +1151,7 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 
 			try {
 				String downtimeName = downtime->GetName();
-				Downtime::RemoveDowntime(downtimeName, true);
+				Downtime::RemoveDowntime(downtimeName, false, true);
 
 				Log(LogNotice, "ExternalCommandProcessor")
 					<< "Removed downtime '" << downtimeName << "'.";

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1386,6 +1386,11 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 			attributes->Set("scheduled_by", scheduledBy);
 		}
 
+		auto parent (Downtime::GetByName(downtime->GetParent()));
+		if (parent) {
+			attributes->Set("parent_id", GetObjectIdentifier(parent));
+		}
+
 		return true;
 	}
 
@@ -1739,6 +1744,13 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 		xAdd.emplace_back(GetObjectIdentifier(endpoint));
 	}
 
+	auto parent (Downtime::GetByName(downtime->GetParent()));
+
+	if (parent) {
+		xAdd.emplace_back("parent_id");
+		xAdd.emplace_back(GetObjectIdentifier(parent));
+	}
+
 	m_Rcon->FireAndForgetQuery(std::move(xAdd), Prio::History);
 }
 
@@ -1810,6 +1822,13 @@ void IcingaDB::SendRemovedDowntime(const Downtime::Ptr& downtime)
 	if (endpoint) {
 		xAdd.emplace_back("endpoint_id");
 		xAdd.emplace_back(GetObjectIdentifier(endpoint));
+	}
+
+	auto parent (Downtime::GetByName(downtime->GetParent()));
+
+	if (parent) {
+		xAdd.emplace_back("parent_id");
+		xAdd.emplace_back(GetObjectIdentifier(parent));
 	}
 
 	m_Rcon->FireAndForgetQuery(std::move(xAdd), Prio::History);


### PR DESCRIPTION
This PR adds the attribute `parent` to the `Downtime` object. This allows us to delete downtimes that have been created as child downtimes on a hosts services (using API parameter `all_services`) while deleting the hosts downtime.

Attribute PR in Icinga DB (used for testing): https://github.com/Icinga/icingadb/pull/323

## Testing

### Config
```
var serviceCount = 3

object Host "DowntimeTestHost" {
        check_command = "dummy"
}

for (s in range(serviceCount)) {
        object Service "DowntimeTestService-" + s {
                check_command = "dummy"
                host_name = "DowntimeTestHost"
        }
}
```

### Steps

1. Schedule downtimes with `all_services` option:
```
curl -k -s -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
 -d '{ "type": "Host", "filter": "host.name==\"DowntimeTestHost\"", "start_time": 1446388806, "end_time": 1746389806, "author": "icingaadmin", "comment": "test", "pretty": true, "all_services": true }'
```
2. Select all downtimes from Icinga DB database:
```
mysql icingadb -e "select id, parent_id, object_type from downtime order by object_type;"
```
3. Delete parent downtime:
```
curl -k -s -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/remove-downtime' \
 -d '{ "downtime": "<DOWNTIME-NAME>", "pretty": true }'
```
4. Again select all downtimes from Icinga DB database to validate the removal of all services downtimes:
```
mysql icingadb -e "select id, parent_id, object_type from downtime order by object_type;"
```

### Results

#### Before

1. Create downtimes
```
[noah@NoH-MB ~ ]$ curl -k -s -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
 -d '{ "type": "Host", "filter": "host.name==\"DowntimeTestHost\"", "start_time": 1446388806, "end_time": 1746389806, "author": "icingaadmin", "comment": "test", "pretty": true, "all_services": true }'
{
    "results": [
        {
            "code": 200,
            "legacy_id": 1,
            "name": "DowntimeTestHost!b6ad0a3b-7c8f-4a2c-968e-dc0e8fbda103",
            "service_downtimes": [
                {
                    "legacy_id": 2,
                    "name": "DowntimeTestHost!DowntimeTestService-0!58a333db-13cf-43e4-9f8b-22f60d8b3c91"
                },
                {
                    "legacy_id": 3,
                    "name": "DowntimeTestHost!DowntimeTestService-1!4dd12ad7-3b0d-49b4-b575-f81a09f694b1"
                },
                {
                    "legacy_id": 4,
                    "name": "DowntimeTestHost!DowntimeTestService-2!fb172915-0ab9-44bf-92c2-232d41b18b0e"
                }
            ],
            "status": "Successfully scheduled downtime 'DowntimeTestHost!b6ad0a3b-7c8f-4a2c-968e-dc0e8fbda103' for object 'DowntimeTestHost'."
        }
    ]
}
```

2. Select from Icinga DB database
```
[noah@NoH-MB ~ ]$ mysql icingadb -e "select id, object_type from downtime order by object_type;"
+--------------------------------------------+-------------+
| id                                         | object_type |
+--------------------------------------------+-------------+
| 0x1498918DDF6288BCCAA8885C48950272915149ED | host        |
| 0x31CA087DCFAE8A312FF773B13923A2E314EB3685 | service     |
| 0x9A0426DBC927DC8E4188FE0DEB7344349DF2BC3E | service     |
| 0xE8427CECB1E2652403E73E8A52A9D40A41ADB32A | service     |
+--------------------------------------------+-------------+
```

3. Remove parent downtime
```
[noah@NoH-MB ~ ]$ curl -k -s -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/remove-downtime' \
 -d '{ "downtime": "DowntimeTestHost!b6ad0a3b-7c8f-4a2c-968e-dc0e8fbda103", "pretty": true }'
{
    "results": [
        {
            "code": 200,
            "status": "Successfully removed downtime 'DowntimeTestHost!b6ad0a3b-7c8f-4a2c-968e-dc0e8fbda103'."
        }
    ]
}
```

4. Again select all services from Icinga DB database:
```
[noah@NoH-MB ~ ]$ mysql icingadb -e "select id, object_type from downtime order by object_type;"
+--------------------------------------------+-------------+
| id                                         | object_type |
+--------------------------------------------+-------------+
| 0x31CA087DCFAE8A312FF773B13923A2E314EB3685 | service     |
| 0x9A0426DBC927DC8E4188FE0DEB7344349DF2BC3E | service     |
| 0xE8427CECB1E2652403E73E8A52A9D40A41ADB32A | service     |
+--------------------------------------------+-------------+
// Service downtimes are still there
```

#### After
1. Create downtimes
```
[noah@NoH-MB ~ ]$ curl -k -s -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
 -d '{ "type": "Host", "filter": "host.name==\"DowntimeTestHost\"", "start_time": 1446388806, "end_time": 1746389806, "author": "icingaadmin", "comment": "test", "pretty": true, "all_services": true }'
{
    "results": [
        {
            "code": 200,
            "legacy_id": 1,
            "name": "DowntimeTestHost!e26a4f56-63cd-4388-8975-2db0d8fc8107",
            "service_downtimes": [
                {
                    "legacy_id": 2,
                    "name": "DowntimeTestHost!DowntimeTestService-0!57b60fd9-4cb7-493a-b33d-ef892aacf7b8"
                },
                {
                    "legacy_id": 3,
                    "name": "DowntimeTestHost!DowntimeTestService-1!d2e7793d-db42-40fa-88c2-6ab78f5c823e"
                },
                {
                    "legacy_id": 4,
                    "name": "DowntimeTestHost!DowntimeTestService-2!72393c64-201d-407c-8bdc-396f1601ed0e"
                }
            ],
            "status": "Successfully scheduled downtime 'DowntimeTestHost!e26a4f56-63cd-4388-8975-2db0d8fc8107' for object 'DowntimeTestHost'."
        }
    ]
}
```

2. Select from Icinga DB database (should see `parent_id` set to the hosts downtime id)
```
[noah@NoH-MB ~ ]$ mysql icingadb -e "select id, parent_id, object_type from downtime order by object_type;"
+--------------------------------------------+--------------------------------------------+-------------+
| id                                         | parent_id                                  | object_type |
+--------------------------------------------+--------------------------------------------+-------------+
| 0x1ECE86DE1B6BB9D98222123E7F61059A3EBD4DDF | NULL                                       | host        |
| 0x348EDE862D53874FACAFFE3F71F26584ECF61C28 | 0x1ECE86DE1B6BB9D98222123E7F61059A3EBD4DDF | service     |
| 0x437A5875F7956B16D5AA4ED401540108FC7802EF | 0x1ECE86DE1B6BB9D98222123E7F61059A3EBD4DDF | service     |
| 0xDDBD7297C7B149C58D8D24112E56DD002EC39767 | 0x1ECE86DE1B6BB9D98222123E7F61059A3EBD4DDF | service     |
+--------------------------------------------+--------------------------------------------+-------------+
```

3. Remove parent downtime
```
[noah@NoH-MB ~ ]$ curl -k -s -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/remove-downtime' \
 -d '{ "downtime": "DowntimeTestHost!e26a4f56-63cd-4388-8975-2db0d8fc8107", "pretty": true }'
{
    "results": [
        {
            "code": 200,
            "status": "Successfully removed downtime 'DowntimeTestHost!e26a4f56-63cd-4388-8975-2db0d8fc8107' and 3 child downtimes."
        }
    ]
}
```

4. Again select all services from Icinga DB database:
```
[noah@NoH-MB ~ ]$ mysql icingadb -e "select id, parent_id, object_type from downtime order by object_type;"
[noah@NoH-MB ~ ]$
// Emtpy result set -> All child downtimes have been removed
```