### PR TITLE
Icinga DB: priorize state > config

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1532,7 +1532,7 @@ void IcingaDB::SendStatusUpdate(const ConfigObject::Ptr& object, const CheckResu
 	objectAttrs->Set("runtime_type", "upsert");
 	objectAttrs->Set("checksum", HashValue(objectAttrs));
 
-	std::vector<String> streamadd({"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*"});
+	std::vector<String> streamadd({"XADD", "icinga:runtime:state", "MAXLEN", "~", "1000000", "*"});
 	ObjectLock olock(objectAttrs);
 	for (const Dictionary::Pair& kv : objectAttrs) {
 		streamadd.emplace_back(kv.first);

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -136,10 +136,10 @@ void IcingaDB::UpdateAllConfigObjects()
 	std::vector<Type::Ptr> types = GetTypes();
 
 	m_Rcon->SuppressQueryKind(Prio::CheckResult);
-	m_Rcon->SuppressQueryKind(Prio::State);
+	m_Rcon->SuppressQueryKind(Prio::RuntimeStateSync);
 
 	Defer unSuppress ([this]() {
-		m_Rcon->UnsuppressQueryKind(Prio::State);
+		m_Rcon->UnsuppressQueryKind(Prio::RuntimeStateSync);
 		m_Rcon->UnsuppressQueryKind(Prio::CheckResult);
 	});
 
@@ -1078,8 +1078,8 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable)
 
 	Dictionary::Ptr stateAttrs = SerializeState(checkable);
 
-	m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigObject + objectType + ":state", objectKey, JsonEncode(stateAttrs)}, Prio::State);
-	m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigCheckSum + objectType + ":state", objectKey, JsonEncode(new Dictionary({{"checksum", HashValue(stateAttrs)}}))}, Prio::State);
+	m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigObject + objectType + ":state", objectKey, JsonEncode(stateAttrs)}, Prio::RuntimeStateSync);
+	m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigCheckSum + objectType + ":state", objectKey, JsonEncode(new Dictionary({{"checksum", HashValue(stateAttrs)}}))}, Prio::RuntimeStateSync);
 
 }
 
@@ -1101,8 +1101,8 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 		Dictionary::Ptr state = SerializeState(checkable);
 		String checksum = HashValue(state);
 
-		m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigObject + typeName + ":state", objectKey, JsonEncode(state)}, Prio::State);
-		m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigCheckSum + typeName + ":state", objectKey, JsonEncode(new Dictionary({{"checksum", checksum}}))}, Prio::State);
+		m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigObject + typeName + ":state", objectKey, JsonEncode(state)}, Prio::RuntimeStateSync);
+		m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigCheckSum + typeName + ":state", objectKey, JsonEncode(new Dictionary({{"checksum", checksum}}))}, Prio::RuntimeStateSync);
 
 		if (runtimeUpdate) {
 			state->Set("checksum", checksum);
@@ -1539,7 +1539,7 @@ void IcingaDB::SendStatusUpdate(const ConfigObject::Ptr& object, const CheckResu
 		streamadd.emplace_back(IcingaToStreamValue(kv.second));
 	}
 
-	m_Rcon->FireAndForgetQuery(std::move(streamadd), Prio::State);
+	m_Rcon->FireAndForgetQuery(std::move(streamadd), Prio::RuntimeStateStream);
 
 	int hard_state;
 	if (!cr) {

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -76,7 +76,7 @@ void IcingaDB::Start(bool runtimeCreated)
 	m_WorkQueue.SetName("IcingaDB");
 
 	m_Rcon->SuppressQueryKind(Prio::CheckResult);
-	m_Rcon->SuppressQueryKind(Prio::State);
+	m_Rcon->SuppressQueryKind(Prio::RuntimeStateSync);
 }
 
 void IcingaDB::ExceptionHandler(boost::exception_ptr exp)

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -62,8 +62,9 @@ namespace icinga
 		enum class QueryPriority : unsigned char
 		{
 			Heartbeat,
-			Config,
-			State,
+			RuntimeStateStream, // runtime state updates, doesn't affect initially synced states
+			Config, // includes initially synced states
+			RuntimeStateSync, // updates initially synced states at runtime, in parallel to config dump, therefore must be < Config
 			History,
 			CheckResult,
 			SyncConnection = 255


### PR DESCRIPTION
I.e. do the following in parallel (highest priority first):

* Stream state changes to icinga:runtime:state
* Sync config and initial state,
  then let queued runtime updates to the just synced state pass