### PR TITLE
TimePeriod/ScheduledDowntime: improve DST handling

### DIFF
--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -13,12 +13,23 @@ using namespace icinga;
 
 REGISTER_FUNCTION_NONCONST(Internal, LegacyTimePeriod, &LegacyTimePeriod::ScriptFunc, "tp:begin:end");
 
-bool LegacyTimePeriod::IsInTimeRange(tm *begin, tm *end, int stride, tm *reference)
+/**
+ * Returns the same as mktime() but does not modify its argument and takes a const pointer.
+ *
+ * @param t struct tm to convert to time_t
+ * @return time_t representing the timestamp given by t
+ */
+static time_t mktime_const(const tm *t) {
+	tm copy = *t;
+	return mktime(&copy);
+}
+
+bool LegacyTimePeriod::IsInTimeRange(const tm *begin, const tm *end, int stride, const tm *reference)
 {
 	time_t tsbegin, tsend, tsref;
-	tsbegin = mktime(begin);
-	tsend = mktime(end);
-	tsref = mktime(reference);
+	tsbegin = mktime_const(begin);
+	tsend = mktime_const(end);
+	tsref = mktime_const(reference);
 
 	if (tsref < tsbegin || tsref > tsend)
 		return false;
@@ -31,8 +42,22 @@ bool LegacyTimePeriod::IsInTimeRange(tm *begin, tm *end, int stride, tm *referen
 	return true;
 }
 
+/**
+ * Update all day-related fields of reference (tm_year, tm_mon, tm_mday, tm_wday, tm_yday) to reference the n-th
+ * occurrence of a weekday (given by wday) in the month represented by the original value of reference.
+ *
+ * If n is negative, counting is done from the end of the month, so for example with wday=1 and n=-1, the result will be
+ * the last Monday in the month given by reference.
+ *
+ * @param wday Weekday (0 = Sunday, 1 = Monday, ..., 6 = Saturday, like tm_wday)
+ * @param n Search the n-th weekday (given by wday) in the month given by reference
+ * @param reference Input for the current month and output for the given day of that moth
+ */
 void LegacyTimePeriod::FindNthWeekday(int wday, int n, tm *reference)
 {
+	// Work on a copy to only update specific fields of reference (as documented).
+	tm t = *reference;
+
 	int dir, seen = 0;
 
 	if (n > 0) {
@@ -42,25 +67,38 @@ void LegacyTimePeriod::FindNthWeekday(int wday, int n, tm *reference)
 		dir = -1;
 
 		/* Negative days are relative to the next month. */
-		reference->tm_mon++;
+		t.tm_mon++;
 	}
 
 	ASSERT(n > 0);
 
-	reference->tm_mday = 1;
+	t.tm_mday = 1;
 
 	for (;;) {
-		mktime(reference);
+		// Always operate on 00:00:00 with automatic DST detection, otherwise days could
+		// be skipped or counted twice if +-24 hours is not on the next or previous day.
+		t.tm_hour = 0;
+		t.tm_min = 0;
+		t.tm_sec = 0;
+		t.tm_isdst = -1;
 
-		if (reference->tm_wday == wday) {
+		mktime(&t);
+
+		if (t.tm_wday == wday) {
 			seen++;
 
 			if (seen == n)
-				return;
+				break;
 		}
 
-		reference->tm_mday += dir;
+		t.tm_mday += dir;
 	}
+
+	reference->tm_year = t.tm_year;
+	reference->tm_mon  = t.tm_mon;
+	reference->tm_mday = t.tm_mday;
+	reference->tm_wday = t.tm_wday;
+	reference->tm_yday = t.tm_yday;
 }
 
 int LegacyTimePeriod::WeekdayFromString(const String& daydef)
@@ -120,11 +158,17 @@ boost::gregorian::date LegacyTimePeriod::GetEndOfMonthDay(int year, int month)
 	return d.end_of_month();
 }
 
-void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end, tm *reference)
+/**
+ * Finds the first day on or after the day given by reference and writes the beginning and end time of that day to
+ * the output parameters begin and end.
+ *
+ * @param timespec Day to find, for example "2021-10-20", "sunday", ...
+ * @param begin if != nullptr, set to 00:00:00 on that day
+ * @param end if != nullptr, set to 24:00:00 on that day (i.e. 00:00:00 of the next day)
+ * @param reference Time to begin the search at
+ */
+void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end, const tm *reference)
 {
-	/* Let mktime() figure out whether we're in DST or not. */
-	reference->tm_isdst = -1;
-
 	/* YYYY-MM-DD */
 	if (timespec.GetLength() == 10 && timespec[4] == '-' && timespec[7] == '-') {
 		int year = Convert::ToLong(timespec.SubStr(0, 4));
@@ -144,6 +188,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			begin->tm_hour = 0;
 			begin->tm_min = 0;
 			begin->tm_sec = 0;
+			begin->tm_isdst = -1;
 		}
 
 		if (end) {
@@ -154,6 +199,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			end->tm_hour = 24;
 			end->tm_min = 0;
 			end->tm_sec = 0;
+			end->tm_isdst = -1;
 		}
 
 		return;
@@ -176,6 +222,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			begin->tm_hour = 0;
 			begin->tm_min = 0;
 			begin->tm_sec = 0;
+			begin->tm_isdst = -1;
 
 			/* day -X: Negative days are relative to the next month. */
 			if (mday < 0) {
@@ -198,6 +245,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 			end->tm_hour = 24;
 			end->tm_min = 0;
 			end->tm_sec = 0;
+			end->tm_isdst = -1;
 
 			/* day -X: Negative days are relative to the next month. */
 			if (mday < 0) {
@@ -223,6 +271,7 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 
 	if (tokens.size() >= 1 && (wday = WeekdayFromString(tokens[0])) != -1) {
 		tm myref = *reference;
+		myref.tm_isdst = -1;
 
 		if (tokens.size() > 2) {
 			mon = MonthFromString(tokens[2]);
@@ -271,7 +320,22 @@ void LegacyTimePeriod::ParseTimeSpec(const String& timespec, tm *begin, tm *end,
 	BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid time specification: " + timespec));
 }
 
-void LegacyTimePeriod::ParseTimeRange(const String& timerange, tm *begin, tm *end, int *stride, tm *reference)
+/**
+ * Parse a range of days.
+ *
+ * The input can have the following formats:
+ *   begin
+ *   begin - end
+ *   begin / stride
+ *   begin - end / stride
+ *
+ * @param timerange Text representation of a day range or a single day, for example "2021-10-20", "monday - friday", ...
+ * @param begin Output parameter set to 00:00:00 of the first day of the range
+ * @param end Output parameter set to 24:00:00 of the last day of the range (i.e. 00:00:00 of the day after)
+ * @param stride Output parameter for the stride (for every n-th day)
+ * @param reference Expand the range relative to this timestamp
+ */
+void LegacyTimePeriod::ParseTimeRange(const String& timerange, tm *begin, tm *end, int *stride, const tm *reference)
 {
 	String def = timerange;
 
@@ -323,7 +387,7 @@ void LegacyTimePeriod::ParseTimeRange(const String& timerange, tm *begin, tm *en
 	}
 }
 
-bool LegacyTimePeriod::IsInDayDefinition(const String& daydef, tm *reference)
+bool LegacyTimePeriod::IsInDayDefinition(const String& daydef, const tm *reference)
 {
 	tm begin, end;
 	int stride;
@@ -338,7 +402,7 @@ bool LegacyTimePeriod::IsInDayDefinition(const String& daydef, tm *reference)
 }
 
 static inline
-void ProcessTimeRaw(const String& in, tm *reference, tm *out)
+void ProcessTimeRaw(const String& in, const tm *reference, tm *out)
 {
 	*out = *reference;
 
@@ -359,7 +423,7 @@ void ProcessTimeRaw(const String& in, tm *reference, tm *out)
 	out->tm_min = Convert::ToLong(hd[1]);
 }
 
-void LegacyTimePeriod::ProcessTimeRangeRaw(const String& timerange, tm *reference, tm *begin, tm *end)
+void LegacyTimePeriod::ProcessTimeRangeRaw(const String& timerange, const tm *reference, tm *begin, tm *end)
 {
 	std::vector<String> times = timerange.Split("-");
 
@@ -374,7 +438,7 @@ void LegacyTimePeriod::ProcessTimeRangeRaw(const String& timerange, tm *referenc
 		end->tm_hour += 24;
 }
 
-Dictionary::Ptr LegacyTimePeriod::ProcessTimeRange(const String& timestamp, tm *reference)
+Dictionary::Ptr LegacyTimePeriod::ProcessTimeRange(const String& timestamp, const tm *reference)
 {
 	tm begin, end;
 
@@ -386,7 +450,14 @@ Dictionary::Ptr LegacyTimePeriod::ProcessTimeRange(const String& timestamp, tm *
 	});
 }
 
-void LegacyTimePeriod::ProcessTimeRanges(const String& timeranges, tm *reference, const Array::Ptr& result)
+/**
+ * Takes a list of timeranges end expands them to concrete timestamp based on a reference time.
+ *
+ * @param timeranges String of comma separated time ranges, for example "10:00-12:00", "12:15:30-12:23:43,16:00-18:00"
+ * @param reference Starting point for searching the segments
+ * @param result For each range, a dict with keys "begin" and "end" is added
+ */
+void LegacyTimePeriod::ProcessTimeRanges(const String& timeranges, const tm *reference, const Array::Ptr& result)
 {
 	std::vector<String> ranges = timeranges.Split(",");
 
@@ -400,13 +471,13 @@ void LegacyTimePeriod::ProcessTimeRanges(const String& timeranges, tm *reference
 	}
 }
 
-Dictionary::Ptr LegacyTimePeriod::FindRunningSegment(const String& daydef, const String& timeranges, tm *reference)
+Dictionary::Ptr LegacyTimePeriod::FindRunningSegment(const String& daydef, const String& timeranges, const tm *reference)
 {
 	tm begin, end, iter;
 	time_t tsend, tsiter, tsref;
 	int stride;
 
-	tsref = mktime(reference);
+	tsref = mktime_const(reference);
 
 	ParseTimeRange(daydef, &begin, &end, &stride, reference);
 
@@ -450,7 +521,7 @@ Dictionary::Ptr LegacyTimePeriod::FindRunningSegment(const String& daydef, const
 	return nullptr;
 }
 
-Dictionary::Ptr LegacyTimePeriod::FindNextSegment(const String& daydef, const String& timeranges, tm *reference)
+Dictionary::Ptr LegacyTimePeriod::FindNextSegment(const String& daydef, const String& timeranges, const tm *reference)
 {
 	tm begin, end, iter, ref;
 	time_t tsend, tsiter, tsref;

--- a/lib/icinga/legacytimeperiod.hpp
+++ b/lib/icinga/legacytimeperiod.hpp
@@ -21,18 +21,18 @@ class LegacyTimePeriod
 public:
 	static Array::Ptr ScriptFunc(const TimePeriod::Ptr& tp, double start, double end);
 
-	static bool IsInTimeRange(tm *begin, tm *end, int stride, tm *reference);
+	static bool IsInTimeRange(const tm *begin, const tm *end, int stride, const tm *reference);
 	static void FindNthWeekday(int wday, int n, tm *reference);
 	static int WeekdayFromString(const String& daydef);
 	static int MonthFromString(const String& monthdef);
-	static void ParseTimeSpec(const String& timespec, tm *begin, tm *end, tm *reference);
-	static void ParseTimeRange(const String& timerange, tm *begin, tm *end, int *stride, tm *reference);
-	static bool IsInDayDefinition(const String& daydef, tm *reference);
-	static void ProcessTimeRangeRaw(const String& timerange, tm *reference, tm *begin, tm *end);
-	static Dictionary::Ptr ProcessTimeRange(const String& timerange, tm *reference);
-	static void ProcessTimeRanges(const String& timeranges, tm *reference, const Array::Ptr& result);
-	static Dictionary::Ptr FindNextSegment(const String& daydef, const String& timeranges, tm *reference);
-	static Dictionary::Ptr FindRunningSegment(const String& daydef, const String& timeranges, tm *reference);
+	static void ParseTimeSpec(const String& timespec, tm *begin, tm *end, const tm *reference);
+	static void ParseTimeRange(const String& timerange, tm *begin, tm *end, int *stride, const tm *reference);
+	static bool IsInDayDefinition(const String& daydef, const tm *reference);
+	static void ProcessTimeRangeRaw(const String& timerange, const tm *reference, tm *begin, tm *end);
+	static Dictionary::Ptr ProcessTimeRange(const String& timerange, const tm *reference);
+	static void ProcessTimeRanges(const String& timeranges, const tm *reference, const Array::Ptr& result);
+	static Dictionary::Ptr FindNextSegment(const String& daydef, const String& timeranges, const tm *reference);
+	static Dictionary::Ptr FindRunningSegment(const String& daydef, const String& timeranges, const tm *reference);
 
 private:
 	LegacyTimePeriod();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,6 +139,7 @@ add_boost_test(base
     icinga_macros/simple
     icinga_legacytimeperiod/simple
     icinga_legacytimeperiod/advanced
+    icinga_legacytimeperiod/dst
     icinga_perfdata/empty
     icinga_perfdata/simple
     icinga_perfdata/quotes

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -7,6 +7,8 @@
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #include <boost/date_time/gregorian/conversion.hpp>
 #include <boost/date_time/date.hpp>
+#include <boost/optional.hpp>
+#include <iomanip>
 #include <BoostTestTargetConfig.h>
 
 using namespace icinga;
@@ -17,13 +19,13 @@ struct GlobalTimezoneFixture
 {
 	char *tz;
 
-	GlobalTimezoneFixture()
+	GlobalTimezoneFixture(const char *fixed_tz = "")
 	{
 		tz = getenv("TZ");
 #ifdef _WIN32
-		_putenv_s("TZ", "UTC");
+		_putenv_s("TZ", fixed_tz == "" ? "UTC" : fixed_tz);
 #else
-		setenv("TZ", "", 1);
+		setenv("TZ", fixed_tz, 1);
 #endif
 		tzset();
 	}
@@ -263,6 +265,381 @@ BOOST_AUTO_TEST_CASE(advanced)
 	AdvancedHelper("09:00:01-30:00", {{2014, 9, 24}, {9, 0, 1}}, {{2014, 9, 25}, {6, 0, 0}});
 	AdvancedHelper("09:00-30:00:02", {{2014, 9, 24}, {9, 0, 0}}, {{2014, 9, 25}, {6, 0, 2}});
 	AdvancedHelper("09:00:03-30:00:04", {{2014, 9, 24}, {9, 0, 3}}, {{2014, 9, 25}, {6, 0, 4}});
+}
+
+tm make_tm(std::string s)
+{
+	int dst = -1;
+	size_t l = strlen("YYYY-MM-DD HH:MM:SS");
+	if (s.size() > l) {
+		std::string zone = s.substr(l);
+		if (zone == " PST") {
+			dst = 0;
+		} else if (zone == " PDT") {
+			dst = 1;
+		} else {
+			// tests should only use PST/PDT (for now)
+			BOOST_CHECK_MESSAGE(false, "invalid or unknown time time: " << zone);
+		}
+	}
+
+	std::tm t = {};
+#if defined(__GNUC__) && __GNUC__ < 5
+	// GCC did not implement std::get_time() until version 5
+	strptime(s.c_str(), "%Y-%m-%d %H:%M:%S", &t);
+#else /* defined(__GNUC__) && __GNUC__ < 5 */
+	std::istringstream stream(s);
+	stream >> std::get_time(&t, "%Y-%m-%d %H:%M:%S");
+#endif /* defined(__GNUC__) && __GNUC__ < 5 */
+	t.tm_isdst = dst;
+
+	return t;
+}
+
+time_t make_time_t(const tm* t)
+{
+	tm copy = *t;
+	return mktime(&copy);
+}
+
+time_t make_time_t(std::string s)
+{
+	tm t = make_tm(s);
+	return mktime(&t);
+}
+
+struct Segment
+{
+	time_t begin, end;
+
+	Segment(time_t begin, time_t end) : begin(begin), end(end) {}
+	Segment(std::string begin, std::string end) : begin(make_time_t(begin)), end(make_time_t(end)) {}
+
+	bool operator==(const Segment& o) const
+	{
+		return o.begin == begin && o.end == end;
+	}
+};
+
+std::string pretty_time(const tm& t)
+{
+#if defined(__GNUC__) && __GNUC__ < 5
+	// GCC did not implement std::put_time() until version 5
+	char buf[128];
+	size_t n = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", &t);
+	return std::string(buf, n);
+#else /* defined(__GNUC__) && __GNUC__ < 5 */
+	std::ostringstream stream;
+	stream << std::put_time(&t, "%Y-%m-%d %H:%M:%S %Z");
+	return stream.str();
+#endif /* defined(__GNUC__) && __GNUC__ < 5 */
+}
+
+std::string pretty_time(time_t t)
+{
+	return pretty_time(Utility::LocalTime(t));
+}
+
+std::ostream& operator<<(std::ostream& o, const Segment& s)
+{
+	return o << "(" << pretty_time(s.begin) << " (" << s.begin << ") .. " << pretty_time(s.end) << " (" << s.end << "))";
+}
+
+std::ostream& operator<<(std::ostream& o, const boost::optional<Segment>& s)
+{
+	if (s) {
+		return o << *s;
+	} else {
+		return o << "none";
+	}
+}
+
+BOOST_AUTO_TEST_CASE(dst)
+{
+	// DST changes in America/Los_Angeles:
+	// 2021-03-14: 01:59:59 PST (UTC-8) -> 03:00:00 PDT (UTC-7)
+	// 2021-11-07: 01:59:59 PDT (UTC-7) -> 01:00:00 PST (UTC-8)
+#ifndef _WIN32
+	GlobalTimezoneFixture tz("America/Los_Angeles");
+#else /* _WIN32 */
+	// Tests are using pacific time because Windows only really supports timezones following US DST rules with the TZ
+	// environment variable. Format is "[Standard TZ][negative UTC offset][DST TZ]".
+	// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/tzset?view=msvc-160#remarks
+	GlobalTimezoneFixture tz("PST8PDT");
+#endif /* _WIN32 */
+
+	// Self-tests for helper functions
+	BOOST_CHECK_EQUAL(make_tm("2021-11-07 02:30:00").tm_isdst, -1);
+	BOOST_CHECK_EQUAL(make_tm("2021-11-07 02:30:00 PST").tm_isdst, 0);
+	BOOST_CHECK_EQUAL(make_tm("2021-11-07 02:30:00 PDT").tm_isdst, 1);
+	BOOST_CHECK_EQUAL(make_time_t("2021-11-07 01:30:00 PST"), 1636277400); // date -d '2021-11-07 01:30:00 PST' +%s
+	BOOST_CHECK_EQUAL(make_time_t("2021-11-07 01:30:00 PDT"), 1636273800); // date -d '2021-11-07 01:30:00 PDT' +%s
+
+	struct TestData {
+		std::string day;
+		std::string ranges;
+		std::vector<tm> before;
+		std::vector<tm> during;
+		boost::optional<Segment> expected;
+	};
+
+	// Some of the following test cases have comments describing the current behavior. This might not necessarily be the
+	// best possible behavior, especially that it differs on Windows. So it might be perfectly valid to change this.
+	// These cases are just there to actually notice these changes in this case.
+	std::vector<TestData> tests;
+
+	// 2021-03-14: 01:59:59 PST (UTC-8) -> 03:00:00 PDT (UTC-7)
+	for (const std::string& day : {"2021-03-14", "sunday", "sunday 2", "sunday -3"}) {
+		// range before DST change
+		tests.push_back(TestData{
+			day, "00:30-01:30",
+			{make_tm("2021-03-14 00:00:00 PST")},
+			{make_tm("2021-03-14 01:00:00 PST")},
+			Segment("2021-03-14 00:30:00 PST", "2021-03-14 01:30:00 PST"),
+		});
+
+		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
+			// range end actually does not exist on that day
+			tests.push_back(TestData{
+				day, "01:30-02:30",
+				{make_tm("2021-03-14 01:00:00 PST")},
+				{make_tm("2021-03-14 01:59:59 PST")},
+#ifndef _WIN32
+				// As 02:30 does not exist on this day, it is parsed as if it was 02:30 PST which is actually 03:30 PDT.
+				Segment("2021-03-14 01:30:00 PST", "2021-03-14 03:30:00 PDT"),
+#else
+				// Windows interpretes 02:30 as 01:30 PST, so it is an empty segment.
+				boost::none,
+#endif
+			});
+		}
+
+		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
+			// range beginning does not actually exist on that day
+			tests.push_back(TestData{
+				day, "02:30-03:30",
+				{make_tm("2021-03-14 01:00:00 PST")},
+				{make_tm("2021-03-14 03:00:00 PDT")},
+#ifndef _WIN32
+				// As 02:30 does not exist on this day, it is parsed as if it was 02:30 PST which is actually 03:30 PDT.
+				// Therefore, the result is a segment from 03:30 PDT to 03:30 PDT with a duration of 0, i.e. no segment.
+				boost::none,
+#else
+				// Windows parses non-existing 02:30 as 01:30 PST, resulting in an 1 hour segment.
+				Segment("2021-03-14 01:30:00 PST", "2021-03-14 03:30:00 PDT"),
+#endif
+			});
+		}
+
+		// another range where the beginning does not actually exist on that day
+		tests.push_back(TestData{
+			day, "02:15-03:45",
+			{make_tm("2021-03-14 01:00:00 PST")},
+			{make_tm("2021-03-14 03:30:00 PDT")},
+#ifndef _WIN32
+			// As 02:15 does not exist on this day, it is parsed as if it was 02:15 PST which is actually 03:15 PDT.
+			Segment("2021-03-14 03:15:00 PDT", "2021-03-14 03:45:00 PDT"),
+#else
+			// Windows interprets 02:15 as 01:15 PST though.
+			Segment("2021-03-14 01:15:00 PST", "2021-03-14 03:45:00 PDT"),
+#endif
+		});
+
+		// range after DST change
+		tests.push_back(TestData{
+			day, "03:30-04:30",
+			{make_tm("2021-03-14 01:00:00 PST"), make_tm("2021-03-14 03:00:00 PDT")},
+			{make_tm("2021-03-14 04:00:00 PDT")},
+			Segment("2021-03-14 03:30:00 PDT", "2021-03-14 04:30:00 PDT"),
+		});
+
+		// range containing DST change
+		tests.push_back(TestData{
+			day, "01:30-03:30",
+			{make_tm("2021-03-14 01:00:00 PST")},
+			{make_tm("2021-03-14 01:45:00 PST"), make_tm("2021-03-14 03:15:00 PDT")},
+			Segment("2021-03-14 01:30:00 PST", "2021-03-14 03:30:00 PDT"),
+		});
+	}
+
+	// 2021-11-07: 01:59:59 PDT (UTC-7) -> 01:00:00 PST (UTC-8)
+	for (const std::string& day : {"2021-11-07", "sunday", "sunday 1", "sunday -4"}) {
+		// range before DST change
+		tests.push_back(TestData{
+			day, "00:15-00:45",
+			{make_tm("2021-11-07 00:00:00 PDT")},
+			{make_tm("2021-11-07 00:30:00 PDT")},
+			Segment("2021-11-07 00:15:00 PDT", "2021-11-07 00:45:00 PDT"),
+		});
+
+		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
+			// range existing twice during DST change (first instance)
+#ifndef _WIN32
+			tests.push_back(TestData{
+				day, "01:15-01:45",
+				{make_tm("2021-11-07 01:00:00 PDT")},
+				{make_tm("2021-11-07 01:30:00 PDT")},
+				// Duplicate times are interpreted as the first occurrence.
+				Segment("2021-11-07 01:15:00 PDT", "2021-11-07 01:45:00 PDT"),
+			});
+#else
+			tests.push_back(TestData{
+				day, "01:15-01:45",
+				{make_tm("2021-11-07 01:00:00 PDT")},
+				{make_tm("2021-11-07 01:30:00 PST")},
+				// However, Windows always uses the second occurrence.
+				Segment("2021-11-07 01:15:00 PST", "2021-11-07 01:45:00 PST"),
+			});
+#endif
+		}
+
+		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
+			// range existing twice during DST change (second instance)
+			tests.push_back(TestData{
+				day, "01:15-01:45",
+				{make_tm("2021-11-07 01:00:00 PST")},
+				{make_tm("2021-11-07 01:30:00 PST")},
+#ifndef _WIN32
+				// Interpreted as the first occurrence, so it's in the past.
+				boost::none,
+#else
+				// On Windows, it's the second occurrence, so it's still in the present/future and is found.
+				Segment("2021-11-07 01:15:00 PST", "2021-11-07 01:45:00 PST"),
+#endif
+			});
+		}
+
+		// range after DST change
+		tests.push_back(TestData{
+			day, "03:30-04:30",
+			{make_tm("2021-11-07 01:00:00 PDT"), make_tm("2021-11-07 03:00:00 PST")},
+			{make_tm("2021-11-07 04:00:00 PST")},
+			Segment("2021-11-07 03:30:00 PST", "2021-11-07 04:30:00 PST"),
+		});
+
+		// range containing DST change
+		tests.push_back(TestData{
+			day, "00:30-02:30",
+			{make_tm("2021-11-07 00:00:00 PDT")},
+			{make_tm("2021-11-07 00:45:00 PDT"), make_tm("2021-11-07 01:30:00 PDT"),
+			make_tm("2021-11-07 01:30:00 PST"), make_tm("2021-11-07 02:15:00 PST")},
+			Segment("2021-11-07 00:30:00 PDT", "2021-11-07 02:30:00 PST"),
+		});
+
+		// range ending during duplicate DST hour (first instance)
+		tests.push_back(TestData{
+			day, "00:30-01:30",
+			{make_tm("2021-11-07 00:00:00 PDT")},
+			{make_tm("2021-11-07 01:00:00 PDT")},
+#ifndef _WIN32
+			// Both times are interpreted as the first instance on that day (i.e both PDT).
+			Segment("2021-11-07 00:30:00 PDT", "2021-11-07 01:30:00 PDT")
+#else
+			// Windows interprets duplicate times as the second instance (i.e. both PST).
+			Segment("2021-11-07 00:30:00 PDT", "2021-11-07 01:30:00 PST")
+#endif
+		});
+
+		// range beginning during duplicate DST hour (first instance)
+		tests.push_back(TestData{
+			day, "01:30-02:30",
+			{make_tm("2021-11-07 01:00:00 PDT")},
+			{make_tm("2021-11-07 02:00:00 PST")},
+#ifndef _WIN32
+			// 01:30 is interpreted as the first occurrence (PDT) but since there's no 02:30 PDT, it's PST.
+			Segment("2021-11-07 01:30:00 PDT", "2021-11-07 02:30:00 PST")
+#else
+			// Windows interprets both as PST though.
+			Segment("2021-11-07 01:30:00 PST", "2021-11-07 02:30:00 PST")
+#endif
+		});
+
+		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
+			// range ending during duplicate DST hour (second instance)
+#ifndef _WIN32
+			tests.push_back(TestData{
+				day, "00:30-01:30",
+				{make_tm("2021-11-07 00:00:00 PST")},
+				{make_tm("2021-11-07 01:00:00 PST")},
+				// Both times are parsed as PDT. Thus, 00:00 PST (01:00 PDT) is during the segment and
+				// 01:00 PST (02:00 PDT) is after the segment.
+				boost::none,
+			});
+#else
+			tests.push_back(TestData{
+				day, "00:30-01:30",
+				{make_tm("2021-11-07 00:00:00 PDT")},
+				{make_tm("2021-11-07 01:00:00 PST")},
+				// As Windows interprets the end as PST, it's still in the future and the segment is found.
+				Segment("2021-11-07 00:30:00 PDT", "2021-11-07 01:30:00 PST"),
+			});
+#endif
+		}
+
+		// range beginning during duplicate DST hour (second instance)
+		tests.push_back(TestData{
+			day, "01:30-02:30",
+			{make_tm("2021-11-07 01:00:00 PDT")},
+			{make_tm("2021-11-07 02:00:00 PST")},
+#ifndef _WIN32
+			// As 01:30 always refers to the first occurrence (PDT), this is actually a 2 hour segment.
+			Segment("2021-11-07 01:30:00 PDT", "2021-11-07 02:30:00 PST"),
+#else
+			// On Windows, it refers t the second occurrence (PST), therefore it's an 1 hour segment.
+			Segment("2021-11-07 01:30:00 PST", "2021-11-07 02:30:00 PST"),
+#endif
+		});
+	}
+
+	auto seg = [](const Dictionary::Ptr& segment) -> boost::optional<Segment> {
+		if (segment == nullptr) {
+			return boost::none;
+		}
+
+		BOOST_CHECK(segment->Contains("begin"));
+		BOOST_CHECK(segment->Contains("end"));
+
+		return Segment{time_t(segment->Get("begin")), time_t(segment->Get("end"))};
+	};
+
+	for (const TestData& t : tests) {
+		for (const tm& ref : t.during) {
+			if (t.expected) {
+				// test data sanity check
+				time_t ref_ts = make_time_t(&ref);
+				BOOST_CHECK_MESSAGE(t.expected->begin < ref_ts, "[day='" << t.day << "' ranges='" << t.ranges
+					<< "'] expected.begin='"<< pretty_time(t.expected->begin) << "' < ref='" << pretty_time(ref_ts)
+					<< "' violated");
+				BOOST_CHECK_MESSAGE(ref_ts < t.expected->end, "[day='" << t.day << "' ranges='" << t.ranges
+					<< "'] ref='" << pretty_time(ref_ts) << "' < expected.end='" << pretty_time(t.expected->end)
+					<< "' violated");
+			}
+
+			tm mutRef = ref;
+			auto runningSeg = seg(LegacyTimePeriod::FindRunningSegment(t.day, t.ranges, &mutRef));
+			BOOST_CHECK_MESSAGE(runningSeg == t.expected, "FindRunningSegment(day='" << t.day
+				<< "' ranges='" << t.ranges << "' ref='" << pretty_time(ref) << "'): got=" << runningSeg
+				<< " expected=" << t.expected);
+		}
+
+		for (const tm& ref : t.before) {
+			if (t.expected) {
+				// test data sanity check
+				time_t ref_ts = make_time_t(&ref);
+				BOOST_CHECK_MESSAGE(ref_ts < t.expected->begin, "[day='" << t.day << "' ranges='" << t.ranges
+					<< "'] ref='"<< pretty_time(ref_ts) << "' < expected.begin='" << pretty_time(t.expected->begin)
+					<< "' violated");
+				BOOST_CHECK_MESSAGE(t.expected->begin < t.expected->end, "[day='" << t.day << "' ranges='" << t.ranges
+					<< "'] expected.begin='" << pretty_time(t.expected->begin)
+					<< "' < expected.end='" << pretty_time(t.expected->end) << "' violated");
+			}
+
+			tm mutRef = ref;
+			auto nextSeg = seg(LegacyTimePeriod::FindNextSegment(t.day, t.ranges, &mutRef));
+			BOOST_CHECK_MESSAGE(nextSeg == t.expected, "FindNextSegment(day='" << t.day << "' ranges='" << t.ranges
+				<< "' ref='" << pretty_time(ref) << "'): got=" << nextSeg << " expected=" << t.expected);
+		}
+	}
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR fixes the bug that on days with a DST change, scheduled downtimes on that day after that DST change are off by one hour. Evaluating these time ranges relies on the `mktime()` function which does two things:
1. Convert a `struct tm` (containing a point in time broken down into fields like `tm_year`, `tm_day`, etc.) into a `time_t` (Unix timestamp).
2. Normalize the values within the `struct tm` passed as an parameter. For example, if the day of the month is out of range, overflow into the next/previous month so that the day of month is within the allowed range again. And more importantly here, there is a field `tm_isdst` that specifies if DST is active at that time. If that is set to `-1`, this is derived from the timezone information and set to a proper value (`0` or `>0`).

`mktime()` always does both and thus, code like the following may show surprising behavior:
```c++
#include <iostream>
#include <ctime>

int main() {
	tm t = {};

	// Initialize to 2021-03-28 01:23:42
	t.tm_year = 2021 - 1900;
	t.tm_mon = 3 - 1;
	t.tm_mday = 28;
	t.tm_hour = 1;
	t.tm_min = 23;
	t.tm_sec = 42;
	t.tm_isdst = -1; // auto-detect DST

	std::cout << "2021-03-28 01:23:42 -> " << mktime(&t) << std::endl;

	// Move to the next day, expecting 2021-03-29 01:23:42 as the result
	t.tm_mday++;

	std::cout << "2021-03-29 01:23:42 -> " << mktime(&t) << std::endl;
}
```

When running this, you'll receive the following result (in timezone Europe/Berlin):
```
2021-03-28 01:23:42 -> 1616891022
2021-03-29 01:23:42 -> 1616977422
```

This looks fine at first, both timestamps are exactly 24 hours apart, however, in this timezone, those timestamps represent the following actual times:
```
$ date -d@1616891022
Sun 28 Mar 2021 01:23:42 CET
$ date -d@1616977422
Mon 29 Mar 2021 02:23:42 CEST
```

As you can see, the second time is actually 02:23:42. You can also see that the timezone changed from CET (UTC+1) to CEST (UTC+2), i.e. DST started. This is the very same behavior that leads to the 1 hour offset with scheduled downtimes.

This PR addresses this problem by changing the code to use `const tm *` parameters to pass `struct tm` to prevent accidental modifications. For this, it adds a `mktime_const()` function which also converts a `struct tm` to a timestamp but does not modify its argument. Furthermore it adds documentation comments and tests for some of the underlying code.

Reasoning why I think this fix is preferable over #7955:
* I don't follow the underlying claim of that PR that `mktime()` is broken in the way that it should actually behave as if it was always called with `tm_isdst = -1` (i.e. always auto-detect DST), this also results in internal functions returning time segments in the past when they shouldn't (see https://github.com/Icinga/icinga2/pull/7955#discussion_r660468977, https://github.com/Icinga/icinga2/pull/7955#issuecomment-882529235)
* This PR adds tests and thus presumably received better testing and also reduces the risk of accidentally breaking this again in the future.

### Test with ScheduledDowntime

#### Before

```
object ScheduledDowntime "8921-before" {
  host_name = "master-1"

  author = "DST is fun"
  comment = "before #8921"

  fixed = true

  ranges = {
    "2021-10-31" = "10:00-20:00"
  }
}
```
![20210722_17h41m19s_grim](https://user-images.githubusercontent.com/18552/126667939-213d3b97-de53-4386-8fd7-05a0eec14391.png)

#### After

```
object ScheduledDowntime "8921-after" {
  host_name = "master-1"

  author = "DST is fun"
  comment = "after #8921"

  fixed = true

  ranges = {
    "2021-10-31" = "10:00-20:00"
  }
}

```

![20210722_17h45m56s_grim](https://user-images.githubusercontent.com/18552/126668539-e8edc2c8-7816-46f5-bf10-5ec4fcda1146.png)

fixes #7066
closes #7955
closes #8860