### PR TITLE
[ITL] Added --datadir, --language and --perflimit for check_postgres

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2506,6 +2506,9 @@ postgres_query         | **Optional.** Query for "custom_query" action.
 postgres_valtype       | **Optional.** Value type of query result for "custom_query".
 postgres_reverse       | **Optional.** If "postgres_reverse" is set, warning and critical values are reversed for "custom_query" action.
 postgres_tempdir       | **Optional.** Specify directory for temporary files. The default directory is dependent on the OS. More details [here](https://perldoc.perl.org/File/Spec.html).
+postgres_datadir       | **Optional.** Specifies the database directory (PGDATA). This information is required for some actions, such as "bloat", "locks" and "prepared_txns".
+postgres_language      | **Optional.** Specifies the language for messages issued by the plugin. The default language depends on the system configuration.
+postgres_perflimit     | **Optional.** Specifies the maximum number of performance data values returned by the plugin. The default is to return all performance data.
 postgres_pgcontroldata | **Optional.** Full path to the pg_controldata command line utility, e.g. "/usr/pgsql-12/bin/pg_controldata".
 
 #### mongodb <a id="plugin-contrib-command-mongodb"></a>

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -593,6 +593,18 @@ object CheckCommand "postgres" {
 			value = "$postgres_tempdir$"
 			description = "specify directory for temporary files. default depends on the OS"
 		}
+		"--datadir" = {
+			value = "$postgres_datadir$"
+			description = "location of the PostgreSQL data directory"
+		}
+		"--language" = {
+			value = "$postgres_language$"
+			description = "language to use for messages"
+		}
+		"--perflimit" = {
+			value = "$postgres_perflimit$"
+			description = "limit the number of performance data to report"
+		}
 	}
 
 	env = {


### PR DESCRIPTION
This PR contains the check command option definitions for the missing options specified in #8922.

fixes #8922