### PR TITLE
Fix/check ssl cert itl 8925

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2506,6 +2506,9 @@ postgres_query       | **Optional.** Query for "custom_query" action.
 postgres_valtype     | **Optional.** Value type of query result for "custom_query".
 postgres_reverse     | **Optional.** If "postgres_reverse" is set, warning and critical values are reversed for "custom_query" action.
 postgres_tempdir     | **Optional.** Specify directory for temporary files. The default directory is dependent on the OS. More details [here](https://perldoc.perl.org/File/Spec.html).
+postgres_datadir     | **Optional.** Specifies the database directory (PGDATA). This information is required for some actions, such as "bloat", "locks" and "prepared_txns".
+postgres_language    | **Optional.** Specifies the language for messages issued by the plugin. The default language depends on the system configuration.
+postgres_perflimit   | **Optional.** Specifies the maximum number of performance data values returned by the plugin. The default is to return all performance data.
 
 #### mongodb <a id="plugin-contrib-command-mongodb"></a>
 

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5728,6 +5728,7 @@ Name                      | Description
 --------------------------|--------------
 ssl_cert_address              | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
 ssl_cert_port                 | **Optional.** TCP port number (default: 443).
+ssl_cert_proxy                | **Optional.** Proxy server to use for connecting to the host. Sets http_proxy and the s_client -proxy option.
 ssl_cert_file                 | **Optional.** Local file path. Works only if `ssl_cert_address` is set to "localhost".
 ssl_cert_warn                 | **Optional.** Minimum number of days a certificate has to be valid.
 ssl_cert_critical             | **Optional.** Minimum number of days a certificate has to be valid to issue a critical status.

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -593,6 +593,18 @@ object CheckCommand "postgres" {
 			value = "$postgres_tempdir$"
 			description = "specify directory for temporary files. default depends on the OS"
 		}
+		"--datadir" = {
+			value = "$postgres_datadir$"
+			description = "location of the PostgreSQL data directory"
+		}
+		"--language" = {
+			value = "$postgres_language$"
+			description = "language to use for messages"
+		}
+		"--perflimit" = {
+			value = "$postgres_perflimit$"
+			description = "limit the number of performance data to report"
+		}
 	}
 
 	vars.postgres_host = "$check_address$"

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -380,6 +380,10 @@ object CheckCommand "ssl_cert" {
 			value = "$ssl_cert_port$"
 			description = "TCP port number (default: 443)"
 		}
+		"--proxy" = {
+			value = "$ssl_cert_proxy$"
+			description = "Sets http_proxy and the s_client -proxy option"
+		}
 		"-f" = {
 			value = "$ssl_cert_file$"
 			description = "Local file path (works with -H localhost only)"


### PR DESCRIPTION
This PR contains the check command option definitions for the missing option specified in #8925.
