### PR TITLE
[ITL] Added --proxy for check_ssl_cert

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5725,6 +5725,7 @@ Name                      | Description
 --------------------------|--------------
 ssl_cert_address              | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
 ssl_cert_port                 | **Optional.** TCP port number (default: 443).
+ssl_cert_proxy                | **Optional.** Proxy server to use for connecting to the host. Sets http_proxy and the s_client -proxy option.
 ssl_cert_file                 | **Optional.** Local file path. Works only if `ssl_cert_address` is set to "localhost".
 ssl_cert_warn                 | **Optional.** Minimum number of days a certificate has to be valid.
 ssl_cert_critical             | **Optional.** Minimum number of days a certificate has to be valid to issue a critical status.

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -380,6 +380,10 @@ object CheckCommand "ssl_cert" {
 			value = "$ssl_cert_port$"
 			description = "TCP port number (default: 443)"
 		}
+		"--proxy" = {
+			value = "$ssl_cert_proxy$"
+			description = "Sets http_proxy and the s_client -proxy option"
+		}
 		"-f" = {
 			value = "$ssl_cert_file$"
 			description = "Local file path (works with -H localhost only)"


### PR DESCRIPTION
This PR contains the check command option definitions for the missing option specified in #8925.

fixes  #8925