### PR TITLE
Override exit code on process timeout

### DIFF
--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -1133,8 +1133,14 @@ bool Process::DoEvents()
 	} else if (WIFEXITED(status)) {
 		exitcode = WEXITSTATUS(status);
 
-		Log(LogNotice, "Process")
-			<< "PID " << m_PID << " (" << PrettyPrintArguments(m_Arguments) << ") terminated with exit code " << exitcode;
+		Log msg(LogNotice, "Process");
+		msg << "PID " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
+			<< ") terminated with exit code " << exitcode;
+
+		if (m_SentSigterm) {
+			exitcode = 128;
+			msg << " after sending SIGTERM";
+		}
 	} else if (WIFSIGNALED(status)) {
 		int signum = WTERMSIG(status);
 		const char *zsigname = strsignal(signum);


### PR DESCRIPTION
As Icinga first sends a SIGTERM to a check plugin on timeout to allow it to terminate gracefully, this is not really part of the plugin API specification and we cannot assume that plugins will handle this correctly and still exit with an exit code that maps to UNKNOWN. Therefore, once Icinga decides to kill a process, force its exit code to 128 to be sure the state will be UNKNOWN
after a timeout.

Note on Windows: `TerminateProcess(m_Process, 3);` is used there and the second parameter sets the exit code, so this is fine. There's only a small race condition where Icinga may do this right when the process exits by itself. Then the call to `TerminateProcess()` may fail because it already exited but Icinga would still write "<Timeout exceeded.>" to the output. The exit code is intact though.

### Test
```
object CheckCommand "sigterm-exit-1" {
	command = ["sh", "-c", "trap 'printf TERM; exit 1' TERM; printf 'check start'; sleep inf & wait $$!"]
	timeout = 10
}
```

#### Before
![20210727_09h42m11s_grim](https://user-images.githubusercontent.com/18552/127129063-398719de-6234-453f-9c43-94f16c250f08.png)

#### After
![20210727_09h52m58s_grim](https://user-images.githubusercontent.com/18552/127129085-7cb0dd3a-bc51-4cc2-980b-c25fc2786aff.png)

fixes #8931