### PR TITLE
RedisConnection: copy callback before calling it

### DIFF
--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -323,8 +323,10 @@ void RedisConnection::Connect(asio::yield_context& yc)
 
 			Log(m_Parent ? LogNotice : LogInformation, "IcingaDB", "Connected to Redis server");
 
-			if (m_ConnectedCallback) {
-				m_ConnectedCallback(yc);
+			// Operate on a copy so that the callback can set a new callback without destroying itself while running.
+			auto callback (m_ConnectedCallback);
+			if (callback) {
+				callback(yc);
 			}
 
 			break;


### PR DESCRIPTION
This allows the callback to call RedisConnection::SetConnectedCallback() to set another callback for this connection. This sets m_ConnectedCallback and thereby destroys the std::function while it's running resulting in undefined behavior. By operating on a copy, m_ConnectedCallback can be set without affecting the currently running callback.

This fixes a bug introduced by #8933 (with that PR, the callback is replaced from within the callback). In my case, this showed by IcingaDB deadlocking.