### PR TITLE
Icinga DB: ensure all connections are ready on first use

### DIFF
--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -68,6 +68,16 @@ void IcingaDB::Start(bool runtimeCreated)
 		GetEnableTls(), GetInsecureNoverify(), GetCertPath(), GetKeyPath(), GetCaPath(), GetCrlPath(),
 		GetTlsProtocolmin(), GetCipherList(), GetConnectTimeout(), GetDebugInfo());
 
+	for (const Type::Ptr& type : GetTypes()) {
+		auto ctype (dynamic_cast<ConfigType*>(type.get()));
+		if (!ctype)
+			continue;
+
+		m_Rcons[ctype] = new RedisConnection(GetHost(), GetPort(), GetPath(), GetPassword(), GetDbIndex(),
+			GetEnableTls(), GetInsecureNoverify(), GetCertPath(), GetKeyPath(), GetCaPath(), GetCrlPath(),
+			GetTlsProtocolmin(), GetCipherList(), GetConnectTimeout(), GetDebugInfo(), m_Rcon);
+	}
+
 	auto connectedCallback ([this](boost::asio::yield_context& yc) {
 		m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
 	});
@@ -81,16 +91,6 @@ void IcingaDB::Start(bool runtimeCreated)
 		connectedCallback(yc);
 	});
 	m_Rcon->Start();
-
-	for (const Type::Ptr& type : GetTypes()) {
-		auto ctype (dynamic_cast<ConfigType*>(type.get()));
-		if (!ctype)
-			continue;
-
-		m_Rcons[ctype] = new RedisConnection(GetHost(), GetPort(), GetPath(), GetPassword(), GetDbIndex(),
-			GetEnableTls(), GetInsecureNoverify(), GetCertPath(), GetKeyPath(), GetCaPath(), GetCrlPath(),
-			GetTlsProtocolmin(), GetCipherList(), GetConnectTimeout(), GetDebugInfo(), m_Rcon);
-	}
 
 	m_StatsTimer = new Timer();
 	m_StatsTimer->SetInterval(1);

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -73,22 +73,31 @@ void IcingaDB::Start(bool runtimeCreated)
 		if (!ctype)
 			continue;
 
-		m_Rcons[ctype] = new RedisConnection(GetHost(), GetPort(), GetPath(), GetPassword(), GetDbIndex(),
+		RedisConnection::Ptr con = new RedisConnection(GetHost(), GetPort(), GetPath(), GetPassword(), GetDbIndex(),
 			GetEnableTls(), GetInsecureNoverify(), GetCertPath(), GetKeyPath(), GetCaPath(), GetCrlPath(),
 			GetTlsProtocolmin(), GetCipherList(), GetConnectTimeout(), GetDebugInfo(), m_Rcon);
+
+		con->SetConnectedCallback([this, con](boost::asio::yield_context& yc) {
+			con->SetConnectedCallback(nullptr);
+
+			size_t pending = --m_PendingRcons;
+			Log(LogDebug, "IcingaDB") << pending << " pending child connections remaining";
+			if (pending == 0) {
+				m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
+			}
+		});
+
+		m_Rcons[ctype] = std::move(con);
 	}
 
-	auto connectedCallback ([this](boost::asio::yield_context& yc) {
-		m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
-	});
+	m_PendingRcons = m_Rcons.size();
 
-	m_Rcon->SetConnectedCallback([this, connectedCallback](boost::asio::yield_context& yc) {
+	m_Rcon->SetConnectedCallback([this](boost::asio::yield_context& yc) {
+		m_Rcon->SetConnectedCallback(nullptr);
+
 		for (auto& kv : m_Rcons) {
 			kv.second->Start();
 		}
-
-		m_Rcon->SetConnectedCallback(connectedCallback);
-		connectedCallback(yc);
 	});
 	m_Rcon->Start();
 

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -13,6 +13,7 @@
 #include "icinga/downtime.hpp"
 #include "remote/messageorigin.hpp"
 #include <boost/thread/once.hpp>
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -169,6 +170,7 @@ private:
 
 	RedisConnection::Ptr m_Rcon;
 	std::unordered_map<ConfigType*, RedisConnection::Ptr> m_Rcons;
+	std::atomic_size_t m_PendingRcons;
 
 	struct {
 		DumpedGlobals CustomVar, ActionUrl, NotesUrl, IconImage;


### PR DESCRIPTION
This PR supersedes #8932 and #8939. It mostly does the same as these two combined but without outstanding merge conflicts, slightly simpler code in my opinion (no nested callbacks), and in a single reviewable unit (when reviewing the other PRs individually, there are still problems with the resulting code as they both fix bugs at the very same location in the code).

Fixed issues:
* The callback of the parent connection accessed the map of child connections `m_Rcons` without proper synchronization. This is fixed by starting the parent connection only after `m_Rcons` is fully initialized.
* The initial config sync would use child connections that were not yet established. This is fixed by waiting for all child connections before starting the sync.

```
[2021-07-28 15:34:12 +0200] information/IcingaDB: 'icingadb' started.
[2021-07-28 15:34:12 +0200] information/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] information/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Trying to connect to Redis server (async) on host 'redis-1:6379'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 14 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 13 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 12 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 11 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 10 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 9 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 8 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 7 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 6 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 5 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 4 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 3 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 2 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 1 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Connected to Redis server
[2021-07-28 15:34:17 +0200] debug/IcingaDB: 0 pending child connections remaining
[2021-07-28 15:34:17 +0200] notice/WorkQueue: Spawning WorkQueue threads for 'IcingaDB'
[2021-07-28 15:34:17 +0200] notice/IcingaDB: Firing and forgetting query: 'XADD' 'icinga:stats' 'MAXLEN' '1' '*' 'ApiListener' '{"perfdata":[{"counter":false,"crit":null,"label":"api_num_co...' ...
[2021-07-28 15:34:17 +0200] information/IcingaDB: Starting initial config/status dump
```

closes #8932
closes #8939