### PR TITLE
ConfigPackageUtility::ValidatePackageName(): always tolerate already existing packages

### DIFF
--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -52,12 +52,12 @@ bool ConfigFilesHandler::HandleRequest(
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 	String stageName = HttpUtility::GetLastParameter(params, "stage");
 
-	if (!ConfigPackageUtility::ValidateName(packageName)) {
+	if (!ConfigPackageUtility::ValidatePackageName(packageName)) {
 		HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
 		return true;
 	}
 
-	if (!ConfigPackageUtility::ValidateName(stageName)) {
+	if (!ConfigPackageUtility::ValidateStageName(stageName)) {
 		HttpUtility::SendJsonError(response, params, 400, "Invalid stage name.");
 		return true;
 	}

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -105,7 +105,7 @@ void ConfigPackagesHandler::HandlePost(
 
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 
-	if (!ConfigPackageUtility::ValidateName(packageName)) {
+	if (!ConfigPackageUtility::ValidatePackageName(packageName)) {
 		HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 		return;
 	}
@@ -151,7 +151,7 @@ void ConfigPackagesHandler::HandleDelete(
 
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 
-	if (!ConfigPackageUtility::ValidateName(packageName)) {
+	if (!ConfigPackageUtility::ValidatePackageName(packageName)) {
 		HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 		return;
 	}

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -367,7 +367,12 @@ bool ConfigPackageUtility::ContainsDotDot(const String& path)
 	return false;
 }
 
-bool ConfigPackageUtility::ValidateName(const String& name)
+bool ConfigPackageUtility::ValidatePackageName(const String& packageName)
+{
+	return ValidateFreshName(packageName);
+}
+
+bool ConfigPackageUtility::ValidateFreshName(const String& name)
 {
 	if (name.IsEmpty())
 		return false;

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -65,7 +65,8 @@ std::vector<String> ConfigPackageUtility::GetPackages()
 
 bool ConfigPackageUtility::PackageExists(const String& name)
 {
-	return Utility::PathExists(GetPackageDir() + "/" + name);
+	auto packages (GetPackages());
+	return std::find(packages.begin(), packages.end(), name) != packages.end();
 }
 
 String ConfigPackageUtility::CreateStage(const String& packageName, const Dictionary::Ptr& files)

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -370,7 +370,7 @@ bool ConfigPackageUtility::ContainsDotDot(const String& path)
 
 bool ConfigPackageUtility::ValidatePackageName(const String& packageName)
 {
-	return ValidateFreshName(packageName);
+	return ValidateFreshName(packageName) || PackageExists(packageName);
 }
 
 bool ConfigPackageUtility::ValidateFreshName(const String& name)

--- a/lib/remote/configpackageutility.hpp
+++ b/lib/remote/configpackageutility.hpp
@@ -42,7 +42,13 @@ public:
 	static std::vector<std::pair<String, bool> > GetFiles(const String& packageName, const String& stageName);
 
 	static bool ContainsDotDot(const String& path);
-	static bool ValidateName(const String& name);
+	static bool ValidatePackageName(const String& packageName);
+
+	static inline
+	bool ValidateStageName(const String& stageName)
+	{
+		return ValidateFreshName(stageName);
+	}
 
 	static std::mutex& GetStaticPackageMutex();
 	static std::mutex& GetStaticActiveStageMutex();
@@ -54,6 +60,8 @@ private:
 	static void WriteStageConfig(const String& packageName, const String& stageName);
 
 	static void TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName, bool activate, bool reload);
+
+	static bool ValidateFreshName(const String& name);
 };
 
 }

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -60,10 +60,10 @@ void ConfigStagesHandler::HandleGet(
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 	String stageName = HttpUtility::GetLastParameter(params, "stage");
 
-	if (!ConfigPackageUtility::ValidateName(packageName))
+	if (!ConfigPackageUtility::ValidatePackageName(packageName))
 		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
-	if (!ConfigPackageUtility::ValidateName(stageName))
+	if (!ConfigPackageUtility::ValidateStageName(stageName))
 		return HttpUtility::SendJsonError(response, params, 400, "Invalid stage name '" + stageName + "'.");
 
 	ArrayData results;
@@ -104,7 +104,7 @@ void ConfigStagesHandler::HandlePost(
 
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 
-	if (!ConfigPackageUtility::ValidateName(packageName))
+	if (!ConfigPackageUtility::ValidatePackageName(packageName))
 		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
 	bool reload = true;
@@ -184,10 +184,10 @@ void ConfigStagesHandler::HandleDelete(
 	String packageName = HttpUtility::GetLastParameter(params, "package");
 	String stageName = HttpUtility::GetLastParameter(params, "stage");
 
-	if (!ConfigPackageUtility::ValidateName(packageName))
+	if (!ConfigPackageUtility::ValidatePackageName(packageName))
 		return HttpUtility::SendJsonError(response, params, 400, "Invalid package name '" + packageName + "'.");
 
-	if (!ConfigPackageUtility::ValidateName(stageName))
+	if (!ConfigPackageUtility::ValidateStageName(stageName))
 		return HttpUtility::SendJsonError(response, params, 400, "Invalid stage name '" + stageName + "'.");
 
 	try {

--- a/test/remote-configpackageutility.cpp
+++ b/test/remote-configpackageutility.cpp
@@ -13,12 +13,12 @@ BOOST_AUTO_TEST_CASE(ValidateName)
 {
 	std::vector<std::string> validNames {"foo", "foo-bar", "FooBar", "Foo123", "_Foo-", "123bar"};
 	for (const std::string& n : validNames) {
-		BOOST_CHECK_MESSAGE(ConfigPackageUtility::ValidateName(n), "'" << n << "' should be valid");
+		BOOST_CHECK_MESSAGE(ConfigPackageUtility::ValidatePackageName(n), "'" << n << "' should be valid");
 	}
 
 	std::vector<std::string> invalidNames {"", ".", "..", "foo.bar", "foo/../bar", "foo/bar", "foo:bar"};
 	for (const std::string& n : invalidNames) {
-		BOOST_CHECK_MESSAGE(!ConfigPackageUtility::ValidateName(n), "'" << n << "' should not be valid");
+		BOOST_CHECK_MESSAGE(!ConfigPackageUtility::ValidatePackageName(n), "'" << n << "' should not be valid");
 	}
 }
 


### PR DESCRIPTION
... not to require migrating invalid ones.