### PR TITLE
ApiListener: Choose bind host default based on OS IPv6 support

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1095,7 +1095,7 @@ Configuration Attributes:
   ca\_path                              | String                | **Deprecated.** Path to the CA certificate file.
   ticket\_salt                          | String                | **Optional.** Private key for [CSR auto-signing](06-distributed-monitoring.md#distributed-monitoring-setup-csr-auto-signing). **Required** for a signing master instance.
   crl\_path                             | String                | **Optional.** Path to the CRL file.
-  bind\_host                            | String                | **Optional.** The IP address the api listener should be bound to. If not specified, the ApiListener is bound to `::` and listens for both IPv4 and IPv6 connections.
+  bind\_host                            | String                | **Optional.** The IP address the api listener should be bound to. If not specified, the ApiListener is bound to `::` and listens for both IPv4 and IPv6 connections or to `0.0.0.0` if IPv6 is not supported by the operating system.
   bind\_port                            | Number                | **Optional.** The port the api listener should be bound to. Defaults to `5665`.
   accept\_config                        | Boolean               | **Optional.** Accept zone configuration. Defaults to `false`.
   accept\_commands                      | Boolean               | **Optional.** Accept remote commands. Defaults to `false`.

--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -504,7 +504,7 @@ Environment         |**Read-write.** The name of the Icinga environment. Include
 RunAsUser           |**Read-write.** Defines the user the Icinga 2 daemon is running as. Set in the Icinga 2 sysconfig.
 RunAsGroup          |**Read-write.** Defines the group the Icinga 2 daemon is running as. Set in the Icinga 2 sysconfig.
 MaxConcurrentChecks |**Read-write.** The number of max checks run simultaneously. Defaults to `512`.
-ApiBindHost         |**Read-write.** Overrides the default value for the ApiListener `bind_host` attribute. Defaults to `::`.
+ApiBindHost         |**Read-write.** Overrides the default value for the ApiListener `bind_host` attribute. Defaults to `::` if IPv6 is supported by the operating system and to `0.0.0.0` otherwise.
 ApiBindPort         |**Read-write.** Overrides the default value for the ApiListener `bind_port` attribute. Not set by default.
 
 #### Application Runtime Constants <a id="icinga-constants-application-runtime"></a>

--- a/lib/base/configuration.cpp
+++ b/lib/base/configuration.cpp
@@ -8,7 +8,20 @@ using namespace icinga;
 
 REGISTER_TYPE(Configuration);
 
-String Configuration::ApiBindHost{"::"};
+String Configuration::ApiBindHost = []() {
+#ifndef _WIN32
+	// Automatically fall back to an IPv4 default if socket() tells us that IPv6 is not supported.
+	int fd = socket(AF_INET6, SOCK_STREAM, 0);
+	if (fd < 0 && errno == EAFNOSUPPORT) {
+		return "0.0.0.0";
+	} else if (fd >= 0) {
+		close(fd);
+	}
+#endif /* _WIN32 */
+
+	return "::";
+}();
+
 String Configuration::ApiBindPort{"5665"};
 bool Configuration::AttachDebugger{false};
 String Configuration::CacheDir;


### PR DESCRIPTION
#8535 set the default for `ApiListener.bind_host` to `::`. On systems that have IPv6 disables so that the OS doesn't even know that `AF_INET6` exists, this results in an error when trying to bind to this address. Try to be nice and set the default depending on the presence of IPv6 support.

This PR detects the support for IPv6 by attempting to open a socket for it (which is never bound to an address). If someone knows a simpler way, I'm happy to know.

Note on Windows: The code is deliberately in an `#ifndef _WIN32` because I don't know if there's a way to disable IPv6 so hard that any current version of Windows doesn't know it even exists. If it later turns out there is, we can still handle it then.

### Tests
1. Install on a Linux system and enable the API -> listens on `[::]:5665`
2. Reboot with `ipv6.disable=1` appended to the kernel command line -> now listens on `0.0.0.0:5665`

fixes #8949
refs #8535