### PR TITLE
PluginUtility: Fix PerfData parsing for values separated with multiple spaces

### DIFF
--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -140,6 +140,7 @@ Array::Ptr PluginUtility::SplitPerfdata(const String& perfdata)
 			break;
 
 		String label = perfdata.SubStr(begin, eqp - begin);
+		boost::algorithm::trim_left(label);
 
 		if (label.GetLength() > 2 && label[0] == '\'' && label[label.GetLength() - 1] == '\'')
 			label = label.SubStr(1, label.GetLength() - 2);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,6 +147,7 @@ add_boost_test(base
     icinga_perfdata/simple
     icinga_perfdata/quotes
     icinga_perfdata/multiple
+    icinga_perfdata/multiline
     icinga_perfdata/normalize
     icinga_perfdata/uom
     icinga_perfdata/warncritminmax

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -43,6 +43,21 @@ BOOST_AUTO_TEST_CASE(multiple)
 	BOOST_CHECK(str == "testA=123456 testB=123456");
 }
 
+BOOST_AUTO_TEST_CASE(multiline)
+{
+	Array::Ptr pd = PluginUtility::SplitPerfdata(" 'testA'=123456  'testB'=123456");
+	BOOST_CHECK(pd->GetLength() == 2);
+
+	String str = PluginUtility::FormatPerfdata(pd);
+	BOOST_CHECK(str == "testA=123456 testB=123456");
+
+	pd = PluginUtility::SplitPerfdata(" 'testA'=123456  \n'testB'=123456");
+	BOOST_CHECK(pd->GetLength() == 2);
+
+	str = PluginUtility::FormatPerfdata(pd);
+	BOOST_CHECK(str == "testA=123456 testB=123456");
+}
+
 BOOST_AUTO_TEST_CASE(normalize)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=2m;3;4;1;5 testB=2foobar");


### PR DESCRIPTION
The problem was that some PerfData labels contained several whitespace characters and therefore it was parsed incorrectly in `SplitPerfdata()`. I.e. this condition checks whether the first and (last-1) character is a normal quote, but since the label can contain spaces at the beginning and at the end respectively, this caused the problems.

https://github.com/Icinga/icinga2/blob/852d674ec07041dd7f97bbaa10017696dc02c3da/lib/icinga/pluginutility.cpp#L142-L145

This PR fixes the problem by removing all leading and trailing white spaces from the string,
before starting to parse the actual label.

resolves #8912 