### PR TITLE
Support icinga2 commandline options in safe-reload script.

### DIFF
--- a/etc/initsystem/safe-reload.cmake
+++ b/etc/initsystem/safe-reload.cmake
@@ -10,6 +10,8 @@ if [ "$1" != "" ]; then
 	fi
 fi
 
+shift
+
 # Set defaults, to overwrite see "@ICINGA2_SYSCONFIGFILE@"
 
 : "${ICINGA2_PID_FILE:="@ICINGA2_FULL_INITRUNDIR@/icinga2.pid"}"
@@ -25,7 +27,7 @@ if type selinuxenabled >/dev/null 2>&1; then
 	fi
 fi
 
-if ! "$DAEMON" daemon --validate --color > "$OUTPUTFILE"; then
+if ! "$DAEMON" daemon --validate --color "$@" > "$OUTPUTFILE"; then
 	echo "Failed"
 
 	cat "$OUTPUTFILE"


### PR DESCRIPTION
Per the discussion in #8911, when a custom data directory is used via `-D DataDir=<path>` when starting the service, these options need to be passed to the daemon when reloading the service as well. Otherwise `safe-reload` will fail due to the API certificates not being present in the default data directory when validating the configuration.