### PR TITLE
Fix scheduling of downtimes for all services on child hosts

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1448,6 +1448,9 @@ Send a `POST` request to the URL endpoint `/v1/actions/remove-downtime`.
 
 In addition to these parameters a [filter](12-icinga2-api.md#icinga2-api-filters) must be provided. The valid types for this action are `Host`, `Service` and `Downtime`.
 
+When removing a host downtime, service downtimes on this host are automatically deleted if they were created using
+the `all_services` option. Other downtimes created using the `child_options` option are not affected.
+
 Example for a simple filter using the `downtime` URL parameter:
 
 ```bash

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -458,12 +458,12 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 			if (allServices && !childService) {
 				ArrayData childServiceDowntimes;
 
-				for (const Service::Ptr& hostService : host->GetServices()) {
+				for (const Service::Ptr& childService : childHost->GetServices()) {
 					Log(LogNotice, "ApiActions")
-						<< "Creating downtime for service " << hostService->GetName() << " on child host " << host->GetName();
+						<< "Creating downtime for service " << childService->GetName() << " on child host " << childHost->GetName();
 
-					Downtime::Ptr serviceDowntime = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
-						fixed, triggerName, duration);
+					Downtime::Ptr serviceDowntime = Downtime::AddDowntime(childService, author, comment, startTime, endTime,
+						fixed, triggerName, duration, String(), String(), childDowntimeName);
 					String serviceDowntimeName = serviceDowntime->GetName();
 
 					childServiceDowntimes.push_back(new Dictionary({

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -434,7 +434,21 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 
 		ArrayData childDowntimes;
 
-		for (const Checkable::Ptr& child : checkable->GetAllChildren()) {
+		std::set<Checkable::Ptr> allChildren = checkable->GetAllChildren();
+		for (const Checkable::Ptr& child : allChildren) {
+			Host::Ptr childHost;
+			Service::Ptr childService;
+			tie(childHost, childService) = GetHostService(child);
+
+			if (allServices && childService &&
+					allChildren.find(static_pointer_cast<Checkable>(childHost)) != allChildren.end()) {
+				/* When scheduling downtimes for all service and all children, the current child is a service, and its
+				 * host is also a child, skip it here. The downtime for this service will be scheduled below together
+				 * with the downtimes of all services for that host. Scheduling it below ensures that the relation
+				 * from the child service downtime to the child host downtime is set properly. */
+				continue;
+			}
+
 			Log(LogNotice, "ApiActions")
 				<< "Scheduling downtime for child object " << child->GetName();
 
@@ -451,10 +465,6 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 			});
 
 			/* For a host, also schedule all service downtimes if requested. */
-			Host::Ptr childHost;
-			Service::Ptr childService;
-			tie(childHost, childService) = GetHostService(child);
-
 			if (allServices && !childService) {
 				ArrayData childServiceDowntimes;
 


### PR DESCRIPTION
Fundamentally, scheduling downtimes for all services on child hosts was implemented, it just iterated over the services of the wrong host resulting in duplicate downtimes being scheduled for services of the parent host. This PR fixes this loop and in addition prevents the creation of duplicate downtimes for individual services in case that both the service and its host are children of the parent checkable.

### Tests

Test config: 3 hosts, each with two services, `service` on on hosts `child1` and `child2` depends on host `parent`, additionally, host `child1` depends on host `parent`.

```
object Host "github-8989-parent" {
	check_command = "dummy"
}

object Host "github-8989-child1" {
	check_command = "dummy"
}

object Host "github-8989-child2" {
	check_command = "dummy"
}

apply Service "github-8989-service" for (name in ["1", "2"]) {
	check_command = "dummy"
	assign where match("github-8989-*", host.name)
}

object Dependency "github-8989-c1" {
	parent_host_name = "github-8989-parent"
	child_host_name = "github-8989-child1"
}

object Dependency "github-8989-c1-s1" {
	parent_host_name = "github-8989-parent"
	child_host_name = "github-8989-child1"
	child_service_name = "github-8989-service1"
}

object Dependency "github-8989-c2-s1" {
	parent_host_name = "github-8989-parent"
	child_host_name = "github-8989-child2"
	child_service_name = "github-8989-service1"
}
```

Please ignore the service `keep-state` in the following output, that's just an additional service I apply to every host in my test cluster.

#### Before
```console
$ curl -iskSu root:icinga -H 'Accept: application/json' -X POST "https://127.0.0.1:5665/v1/actions/schedule-downtime" -d '{"type":"Host", "filter":"host.name == \"github-8989-parent\"", "start_time":'$(date +%s)', "end_time":'$(date -d +5min +%s)', "author":"icingaadmin", "comment":"42", "pretty":true, "all_services":1, "child_options":"DowntimeTriggeredChildren"}'
HTTP/1.1 200 OK
Server: Icinga/v2.13.0-22-g95cdc00ad
Content-Type: application/json
Content-Length: 2172

{
    "results": [
        {
            "child_downtimes": [
                {
                    "legacy_id": 18,
                    "name": "github-8989-child1!65a4a10e-473c-4ae1-9e46-96cf4ce7e463",
                    "service_downtimes": [
                        {
                            "legacy_id": 19,
                            "name": "github-8989-parent!github-8989-service1!8a7ad4e7-cd20-4c4e-8d7c-caeea1249503"
                        },
                        {
                            "legacy_id": 20,
                            "name": "github-8989-parent!github-8989-service2!f563e60f-7b9d-48fb-a92d-c99c51da14b3"
                        },
                        {
                            "legacy_id": 21,
                            "name": "github-8989-parent!keep-state!15a20b8b-7ba6-49c2-882f-440494443f50"
                        }
                    ]
                },
                {
                    "legacy_id": 22,
                    "name": "github-8989-child2!github-8989-service1!1673890d-ed43-43d0-8f19-787657fce90c"
                },
                {
                    "legacy_id": 23,
                    "name": "github-8989-child1!github-8989-service1!bf162feb-f79b-4286-a310-0694073005c8"
                }
            ],
            "code": 200,
            "legacy_id": 14,
            "name": "github-8989-parent!4aca458c-2c6c-49f6-ac87-e9e57f284726",
            "service_downtimes": [
                {
                    "legacy_id": 15,
                    "name": "github-8989-parent!github-8989-service1!df16c710-fd6f-48f6-973b-cbcaaad53738"
                },
                {
                    "legacy_id": 16,
                    "name": "github-8989-parent!github-8989-service2!f3f3b6a5-6b94-4e09-8266-da0ff6bafed2"
                },
                {
                    "legacy_id": 17,
                    "name": "github-8989-parent!keep-state!290c7080-6712-4d3a-befb-fadaaaa4dd99"
                }
            ],
            "status": "Successfully scheduled downtime 'github-8989-parent!4aca458c-2c6c-49f6-ac87-e9e57f284726' for object 'github-8989-parent'."
        }
    ]
}
```

Note how the `service_downtimes` of downtime `github-8989-child1!65a4a10e-473c-4ae1-9e46-96cf4ce7e463` lists downtime for `github-8989-parent`.

#### After
```console
$ curl -iskSu root:icinga -H 'Accept: application/json' -X POST "https://127.0.0.1:5665/v1/actions/schedule-downtime" -d '{"type":"Host", "filter":"host.name == \"github-8989-parent\"", "start_time":'$(date +%s)', "end_time":'$(date -d +5min +%s)', "author":"icingaadmin", "comment":"42", "pretty":true, "all_services":1, "child_options":"DowntimeTriggeredChildren"}'
HTTP/1.1 200 OK
Server: Icinga/v2.13.0-24-gbb0dcdf0b
Content-Type: application/json
Content-Length: 1991

{
    "results": [
        {
            "child_downtimes": [
                {
                    "legacy_id": 21,
                    "name": "github-8989-child2!github-8989-service1!a8d2f679-1b12-493d-97a1-d080d87a02f1"
                },
                {
                    "legacy_id": 22,
                    "name": "github-8989-child1!82279e74-7225-477b-bfe0-b150c637afaa",
                    "service_downtimes": [
                        {
                            "legacy_id": 23,
                            "name": "github-8989-child1!github-8989-service1!8c488f11-b76e-47f0-b264-7fb1b5cb8fd0"
                        },
                        {
                            "legacy_id": 24,
                            "name": "github-8989-child1!github-8989-service2!5bddb234-a4b6-4957-a42f-c45012e0c9d6"
                        },
                        {
                            "legacy_id": 25,
                            "name": "github-8989-child1!keep-state!d7d3b838-1fa2-4d17-81d1-89c985bc25cd"
                        }
                    ]
                }
            ],
            "code": 200,
            "legacy_id": 17,
            "name": "github-8989-parent!4cc56eef-6d6b-4a00-a575-3489c17e185c",
            "service_downtimes": [
                {
                    "legacy_id": 18,
                    "name": "github-8989-parent!github-8989-service1!7a59a20a-eeb0-442a-8890-aeeb3b2a50a7"
                },
                {
                    "legacy_id": 19,
                    "name": "github-8989-parent!github-8989-service2!b320919a-f888-46e5-940c-9384ab3ff369"
                },
                {
                    "legacy_id": 20,
                    "name": "github-8989-parent!keep-state!65cf7935-adb4-43ec-9605-11720322bf94"
                }
            ],
            "status": "Successfully scheduled downtime 'github-8989-parent!4cc56eef-6d6b-4a00-a575-3489c17e185c' for object 'github-8989-parent'."
        }
    ]
}
```

Now `service_downtimes` for `github-8989-child1!82279e74-7225-477b-bfe0-b150c637afaa` indeed contains downtimes for all services of host `github-8989-child1`. Also note that `github-8989-child2!service1`  part of that list and there is no duplicate downtime for it in `child_downtimes`.

Deleting the downtime for `parent` also deletes the downtimes created for services of that host but leaves downtimes of other hosts and their services unaffected. Deleting the downtime for `child1` also deletes the downtimes for all its serivces (including `service1` which is a child itself).

Special thanks to @NicolasGoeddel for [pointing out the cause of this bug](https://github.com/Icinga/icingaweb2/issues/2938#issuecomment-905621195).

fixes #8989