### PR TITLE
Icinga DB: set value in milliseconds for program_start in stats/heartbeat

### DIFF
--- a/lib/icingadb/icingadb-stats.cpp
+++ b/lib/icingadb/icingadb-stats.cpp
@@ -1,6 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 #include "icingadb/icingadb.hpp"
+#include "base/application.hpp"
 #include "base/json.hpp"
 #include "base/logger.hpp"
 #include "base/serializer.hpp"
@@ -38,13 +39,14 @@ Dictionary::Ptr IcingaDB::GetStats()
 		}));
 	}
 
+	typedef Dictionary::Ptr DP;
+	DP app = DP(DP(DP(stats->Get("IcingaApplication"))->Get("status"))->Get("icingaapplication"))->Get("app");
+
+	app->Set("program_start", TimestampToMilliseconds(Application::GetStartTime()));
+
 	auto localEndpoint (Endpoint::GetLocalEndpoint());
-
 	if (localEndpoint) {
-		typedef Dictionary::Ptr DP;
-
-		DP(DP(DP(DP(stats->Get("IcingaApplication"))->Get("status"))->Get("icingaapplication"))->Get("app"))
-			->Set("endpoint_id", GetObjectIdentifier(localEndpoint));
+		app->Set("endpoint_id", GetObjectIdentifier(localEndpoint));
 	}
 
 	return stats;


### PR DESCRIPTION
`program_start` seems to be the only timestamp that's written to Redis in seconds (as a float). This PR changes this to milliseconds to be in line with all the other timestamps.

### Before

```
$ redis-cli XREAD BLOCK 0 STREAMS icinga:stats '$' | grep -o -e '"program_start".*$'
"program_start":1631289654.607549,"version":"v2.13.0-22-g95cdc00ad"}}}}
```

### After

```
$ redis-cli XREAD BLOCK 0 STREAMS icinga:stats '$' | grep -o -e '"program_start".*$'
"program_start":1631289753018,"version":"v2.13.0-23-ge81db2bf3"}}}}
```

refs #8991