### PR TITLE
Icinga DB: Write IDs of notified users into notification history stream

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1672,6 +1672,15 @@ void IcingaDB::SendSentNotification(
 		xAdd.emplace_back(GetObjectIdentifier(endpoint));
 	}
 
+	if (!users.empty()) {
+		Array::Ptr users_notified = new Array();
+		for (const User::Ptr& user : users) {
+			users_notified->Add(GetObjectIdentifier(user));
+		}
+		xAdd.emplace_back("users_notified_ids");
+		xAdd.emplace_back(JsonEncode(users_notified));
+	}
+
 	m_Rcon->FireAndForgetQuery(std::move(xAdd), Prio::History);
 
 	for (const User::Ptr& user : users) {


### PR DESCRIPTION
This is the first pull request in a series of three with the goal to add foreign key constraints to the history tables in Icinga DB.

* https://github.com/Icinga/icinga2/pull/9001 (this PR)
* https://github.com/Icinga/icingadb/pull/364
* https://github.com/Icinga/icinga2/pull/9002

This PR adds a new value `users_notified_ids` to the `icinga:history:stream:notification` stream. This is done so that Icinga DB can read one item from the stream and create rows in multiple tables in an order that satisfies foreign key constrains without having to synchronize between different Redis streams. For now, this information is redundant with the `icinga:history:stream:usernotification` stream which will later be removed in #9002.