### PR TITLE
Icinga DB: Make sure object relationships are handled correctly during runtime updates

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -235,10 +235,10 @@ Object::Ptr Dictionary::Clone() const
 }
 
 /**
- * Returns an array containing all keys
+ * Returns an ordered vector containing all keys
  * which are currently set in this directory.
  *
- * @returns an array of key names
+ * @returns an ordered vector of key names
  */
 std::vector<String> Dictionary::GetKeys() const
 {

--- a/lib/icinga/command.ti
+++ b/lib/icinga/command.ti
@@ -11,11 +11,11 @@ namespace icinga
 abstract class Command : CustomVarObject
 {
 	[config] Value command (CommandLine);
-	[config] Value arguments;
+	[config, signal_with_old_value] Value arguments;
 	[config] int timeout {
 		default {{{ return 60; }}}
 	};
-	[config] Dictionary::Ptr env;
+	[config, signal_with_old_value] Dictionary::Ptr env;
 	[config, required] Function::Ptr execute;
 };
 

--- a/lib/icinga/customvarobject.ti
+++ b/lib/icinga/customvarobject.ti
@@ -9,7 +9,7 @@ namespace icinga
 
 abstract class CustomVarObject : ConfigObject
 {
-	[config] Dictionary::Ptr vars;
+	[config, signal_with_old_value] Dictionary::Ptr vars;
 };
 
 }

--- a/lib/icinga/host.ti
+++ b/lib/icinga/host.ti
@@ -15,7 +15,7 @@ class Host : Checkable
 	load_after Endpoint;
 	load_after Zone;
 
-	[config, no_user_modify, required] array(name(HostGroup)) groups {
+	[config, no_user_modify, required, signal_with_old_value] array(name(HostGroup)) groups {
 		default {{{ return new Array(); }}}
 	};
 

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -133,6 +133,9 @@ void Notification::Start(bool runtimeCreated)
 	if (ApiListener::IsHACluster() && GetNextNotification() < Utility::GetTime() + 60)
 		SetNextNotification(Utility::GetTime() + 60, true);
 
+	for (const UserGroup::Ptr& group : GetUserGroups())
+		group->AddNotification(this);
+
 	ObjectImpl<Notification>::Start(runtimeCreated);
 }
 
@@ -144,6 +147,9 @@ void Notification::Stop(bool runtimeRemoved)
 
 	if (obj)
 		obj->UnregisterNotification(this);
+
+	for (const UserGroup::Ptr& group : GetUserGroups())
+		group->RemoveNotification(this);
 }
 
 Checkable::Ptr Notification::GetCheckable() const

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -36,8 +36,8 @@ class Notification : CustomVarObject < NotificationNameComposer
 			return TimePeriod::GetByName(GetPeriodRaw());
 		}}}
 	};
-	[config, protected] array(name(User)) users (UsersRaw);
-	[config, protected] array(name(UserGroup)) user_groups (UserGroupsRaw);
+	[config, signal_with_old_value] array(name(User)) users (UsersRaw);
+	[config, signal_with_old_value] array(name(UserGroup)) user_groups (UserGroupsRaw);
 	[config] Dictionary::Ptr times;
 	[config] array(Value) types;
 	[no_user_view, no_user_modify] int type_filter_real (TypeFilter);

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -27,7 +27,7 @@ class Service : Checkable < ServiceNameComposer
 	load_after Host;
 	load_after Zone;
 
-	[config, no_user_modify, required] array(name(ServiceGroup)) groups {
+	[config, no_user_modify, required, signal_with_old_value] array(name(ServiceGroup)) groups {
 		default {{{ return new Array(); }}}
 	};
 

--- a/lib/icinga/timeperiod.ti
+++ b/lib/icinga/timeperiod.ti
@@ -18,15 +18,15 @@ class TimePeriod : CustomVarObject
 				return m_DisplayName.m_Value;
 		}}}
 	};
-	[config] Dictionary::Ptr ranges;
+	[config, signal_with_old_value] Dictionary::Ptr ranges;
 	[config, required] Function::Ptr update;
 	[config] bool prefer_includes {
 		default {{{ return true; }}}
 	};
-	[config, required] array(name(TimePeriod)) excludes {
+	[config, required, signal_with_old_value] array(name(TimePeriod)) excludes {
 		default {{{ return new Array(); }}}
 	};
-	[config, required] array(name(TimePeriod)) includes {
+	[config, required, signal_with_old_value] array(name(TimePeriod)) includes {
 		default {{{ return new Array(); }}}
 	};
 	[state, no_user_modify] Value valid_begin;

--- a/lib/icinga/user.ti
+++ b/lib/icinga/user.ti
@@ -19,7 +19,7 @@ class User : CustomVarObject
 				return m_DisplayName.m_Value;
 		}}}
 	};
-	[config, no_user_modify, required] array(name(UserGroup)) groups {
+	[config, no_user_modify, required, signal_with_old_value] array(name(UserGroup)) groups {
 		default {{{ return new Array(); }}}
 	};
 	[config, navigation] name(TimePeriod) period (PeriodRaw) {

--- a/lib/icinga/usergroup.cpp
+++ b/lib/icinga/usergroup.cpp
@@ -76,6 +76,24 @@ void UserGroup::RemoveMember(const User::Ptr& user)
 	m_Members.erase(user);
 }
 
+std::set<Notification::Ptr> UserGroup::GetNotifications() const
+{
+	std::unique_lock<std::mutex> lock(m_UserGroupMutex);
+	return m_Notifications;
+}
+
+void UserGroup::AddNotification(const Notification::Ptr& notification)
+{
+	std::unique_lock<std::mutex> lock(m_UserGroupMutex);
+	m_Notifications.insert(notification);
+}
+
+void UserGroup::RemoveNotification(const Notification::Ptr& notification)
+{
+	std::unique_lock<std::mutex> lock(m_UserGroupMutex);
+	m_Notifications.erase(notification);
+}
+
 bool UserGroup::ResolveGroupMembership(const User::Ptr& user, bool add, int rstack) {
 
 	if (add && rstack > 20) {

--- a/lib/icinga/usergroup.hpp
+++ b/lib/icinga/usergroup.hpp
@@ -11,6 +11,7 @@ namespace icinga
 {
 
 class ConfigItem;
+class Notification;
 
 /**
  * An Icinga user group.
@@ -27,6 +28,10 @@ public:
 	void AddMember(const User::Ptr& user);
 	void RemoveMember(const User::Ptr& user);
 
+	std::set<intrusive_ptr<Notification>> GetNotifications() const;
+	void AddNotification(const intrusive_ptr<Notification>& notification);
+	void RemoveNotification(const intrusive_ptr<Notification>& notification);
+
 	bool ResolveGroupMembership(const User::Ptr& user, bool add = true, int rstack = 0);
 
 	static void EvaluateObjectRules(const User::Ptr& user);
@@ -34,6 +39,7 @@ public:
 private:
 	mutable std::mutex m_UserGroupMutex;
 	std::set<User::Ptr> m_Members;
+	std::set<intrusive_ptr<Notification>> m_Notifications;
 
 	static bool EvaluateObjectRule(const User::Ptr& user, const intrusive_ptr<ConfigItem>& group);
 };

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1160,10 +1160,11 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 void IcingaDB::AddObjectDataToRuntimeUpdates(std::vector<Dictionary::Ptr>& runtimeUpdates, const String& objectKey,
 		const String& redisKey, const Dictionary::Ptr& data)
 {
-	data->Set("id", objectKey);
-	data->Set("redis_key", redisKey);
-	data->Set("runtime_type", "upsert");
-	runtimeUpdates.emplace_back(data);
+	Dictionary::Ptr dataClone = data->ShallowClone();
+	dataClone->Set("id", objectKey);
+	dataClone->Set("redis_key", redisKey);
+	dataClone->Set("runtime_type", "upsert");
+	runtimeUpdates.emplace_back(dataClone);
 }
 
 // Takes object and collects IcingaDB relevant attributes and computes checksums. Returns whether the object is relevant

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -79,6 +79,7 @@ private:
 	void SendStateChange(const ConfigObject::Ptr& object, const CheckResult::Ptr& cr, StateType type);
 	void AddObjectDataToRuntimeUpdates(std::vector<Dictionary::Ptr>& runtimeUpdates, const String& objectKey,
 			const String& redisKey, const Dictionary::Ptr& data);
+	void DeleteRelationship(const String& id, const String& redisKeyWithoutPrefix, bool hasChecksum = false);
 
 	void SendSentNotification(
 		const Notification::Ptr& notification, const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
@@ -93,6 +94,16 @@ private:
 	void SendNextUpdate(const Checkable::Ptr& checkable);
 	void SendAcknowledgementSet(const Checkable::Ptr& checkable, const String& author, const String& comment, AcknowledgementType type, bool persistent, double changeTime, double expiry);
 	void SendAcknowledgementCleared(const Checkable::Ptr& checkable, const String& removedBy, double changeTime, double ackLastChange);
+	void SendNotificationUsersChanged(const Notification::Ptr& notification, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	void SendNotificationUserGroupsChanged(const Notification::Ptr& notification, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	void SendTimePeriodRangesChanged(const TimePeriod::Ptr& timeperiod, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	void SendTimePeriodIncludesChanged(const TimePeriod::Ptr& timeperiod, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	void SendTimePeriodExcludesChanged(const TimePeriod::Ptr& timeperiod, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	template<class T>
+	void SendGroupsChanged(const ConfigObject::Ptr& command, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	void SendCommandEnvChanged(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	void SendCommandArgumentsChanged(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	void SendCustomVarsChanged(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
 
 	std::vector<String> UpdateObjectAttrs(const ConfigObject::Ptr& object, int fieldType, const String& typeNameOverride);
 	Dictionary::Ptr SerializeState(const Checkable::Ptr& checkable);
@@ -105,11 +116,13 @@ private:
 	static String FormatCommandLine(const Value& commandLine);
 	static long long TimestampToMilliseconds(double timestamp);
 	static String IcingaToStreamValue(const Value& value);
+	static std::vector<Value> GetArrayDeletedValues(const Array::Ptr& arrayOld, const Array::Ptr& arrayNew);
+	static std::vector<String> GetDictionaryDeletedKeys(const Dictionary::Ptr& dictOld, const Dictionary::Ptr& dictNew);
 
 	static String GetObjectIdentifier(const ConfigObject::Ptr& object);
 	static String CalcEventID(const char* eventType, const ConfigObject::Ptr& object, double eventTime = 0, NotificationType nt = NotificationType(0));
-	static Dictionary::Ptr SerializeVars(const CustomVarObject::Ptr& object);
 	static const char* GetNotificationTypeByEnum(NotificationType type);
+	static Dictionary::Ptr SerializeVars(const Dictionary::Ptr& vars);
 
 	static String HashValue(const Value& value);
 	static String HashValue(const Value& value, const std::set<String>& propertiesBlacklist, bool propertiesWhitelist = false);
@@ -135,6 +148,17 @@ private:
 	static void NextCheckChangedHandler(const Checkable::Ptr& checkable);
 	static void AcknowledgementSetHandler(const Checkable::Ptr& checkable, const String& author, const String& comment, AcknowledgementType type, bool persistent, double changeTime, double expiry);
 	static void AcknowledgementClearedHandler(const Checkable::Ptr& checkable, const String& removedBy, double changeTime);
+	static void NotificationUsersChangedHandler(const Notification::Ptr& notification, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	static void NotificationUserGroupsChangedHandler(const Notification::Ptr& notification, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	static void TimePeriodRangesChangedHandler(const TimePeriod::Ptr& timeperiod, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	static void TimePeriodIncludesChangedHandler(const TimePeriod::Ptr& timeperiod, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	static void TimePeriodExcludesChangedHandler(const TimePeriod::Ptr& timeperiod, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	static void UserGroupsChangedHandler(const User::Ptr& user, const Array::Ptr&, const Array::Ptr& newValues);
+	static void HostGroupsChangedHandler(const Host::Ptr& host, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	static void ServiceGroupsChangedHandler(const Service::Ptr& service, const Array::Ptr& oldValues, const Array::Ptr& newValues);
+	static void CommandEnvChangedHandler(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	static void CommandArgumentsChangedHandler(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	static void CustomVarsChangedHandler(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
 
 	void AssertOnWorkQueue();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ add_boost_test(base
     base_dictionary/remove
     base_dictionary/clone
     base_dictionary/json
+    base_dictionary/keys_ordered
     base_fifo/construct
     base_fifo/io
     base_json/encode

--- a/test/base-dictionary.cpp
+++ b/test/base-dictionary.cpp
@@ -3,6 +3,8 @@
 #include "base/dictionary.hpp"
 #include "base/objectlock.hpp"
 #include "base/json.hpp"
+#include "base/string.hpp"
+#include "base/utility.hpp"
 #include <BoostTestTargetConfig.h>
 
 using namespace icinga;
@@ -181,6 +183,18 @@ BOOST_AUTO_TEST_CASE(json)
 	BOOST_CHECK(deserialized->GetLength() == 2);
 	BOOST_CHECK(deserialized->Get("test1") == 7);
 	BOOST_CHECK(deserialized->Get("test2") == "hello world");
+}
+
+BOOST_AUTO_TEST_CASE(keys_ordered)
+{
+	Dictionary::Ptr dictionary = new Dictionary();
+
+	for (int i = 0; i < 100; i++) {
+		dictionary->Set(std::to_string(Utility::Random()), Utility::Random());
+	}
+
+	std::vector<String> keys = dictionary->GetKeys();
+	BOOST_CHECK(std::is_sorted(keys.begin(), keys.end()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tools/mkclass/class_lexer.ll
+++ b/tools/mkclass/class_lexer.ll
@@ -134,6 +134,7 @@ no_user_view			{ yylval->num = FANoUserView; return T_FIELD_ATTRIBUTE; }
 deprecated			{ yylval->num = FADeprecated; return T_FIELD_ATTRIBUTE; }
 get_virtual			{ yylval->num = FAGetVirtual; return T_FIELD_ATTRIBUTE; }
 set_virtual			{ yylval->num = FASetVirtual; return T_FIELD_ATTRIBUTE; }
+signal_with_old_value			{ yylval->num = FASignalWithOldValue; return T_FIELD_ATTRIBUTE; }
 virtual				{ yylval->num = FAGetVirtual | FASetVirtual; return T_FIELD_ATTRIBUTE; }
 navigation			{ return T_NAVIGATION; }
 validator			{ return T_VALIDATOR; }

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -830,10 +830,10 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				m_Impl << "void ObjectImpl<" << klass.Name << ">::Set" << field.GetFriendlyName() << "(" << field.Type.GetArgumentType() << " value, bool suppress_events, const Value& cookie)" << std::endl
 					<< "{" << std::endl;
 
-				if (field.Type.IsName || !field.TrackAccessor.empty())
-					m_Impl << "\t" << "Value oldValue = Get" << field.GetFriendlyName() << "();" << std::endl;
+				if (field.Type.IsName || !field.TrackAccessor.empty() || field.Attributes & FASignalWithOldValue)
+					m_Impl << "\t" << "Value oldValue = Get" << field.GetFriendlyName() << "();" << std::endl
+						<< "\t" << "auto *dobj = dynamic_cast<ConfigObject *>(this);" << std::endl;
 
-					
 				if (field.SetAccessor.empty() && !(field.Attributes & FANoStorage))
 					m_Impl << "\t" << "m_" << field.GetFriendlyName() << ".store(value);" << std::endl;
 				else
@@ -841,16 +841,22 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 				if (field.Type.IsName || !field.TrackAccessor.empty()) {
 					if (field.Name != "active") {
-						m_Impl << "\t" << "auto *dobj = dynamic_cast<ConfigObject *>(this);" << std::endl
-							<< "\t" << "if (!dobj || dobj->IsActive())" << std::endl
+						m_Impl << "\t" << "if (!dobj || dobj->IsActive())" << std::endl
 							<< "\t";
 					}
 
 					m_Impl << "\t" << "Track" << field.GetFriendlyName() << "(oldValue, value);" << std::endl;
 				}
 
-				m_Impl << "\t" << "if (!suppress_events)" << std::endl
-					<< "\t\t" << "Notify" << field.GetFriendlyName() << "(cookie);" << std::endl
+				m_Impl << "\t" << "if (!suppress_events) {" << std::endl
+					<< "\t\t" << "Notify" << field.GetFriendlyName() << "(cookie);" << std::endl;
+
+				if (field.Attributes & FASignalWithOldValue) {
+					m_Impl << "\t\t" << "if (!dobj || dobj->IsActive())" << std::endl
+						   << "\t\t\t" << "On" << field.GetFriendlyName() << "ChangedWithOldValue(static_cast<" << klass.Name << " *>(this), oldValue, value);" << std::endl;
+				}
+
+				m_Impl << "\t" "}" << std::endl << std::endl
 					<< "}" << std::endl << std::endl;
 			}
 		}
@@ -1053,6 +1059,15 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		for (const Field& field : klass.Fields) {
 			m_Header << "\t" << "static boost::signals2::signal<void (const intrusive_ptr<" << klass.Name << ">&, const Value&)> On" << field.GetFriendlyName() << "Changed;" << std::endl;
 			m_Impl << std::endl << "boost::signals2::signal<void (const intrusive_ptr<" << klass.Name << ">&, const Value&)> ObjectImpl<" << klass.Name << ">::On" << field.GetFriendlyName() << "Changed;" << std::endl << std::endl;
+
+			if (field.Attributes & FASignalWithOldValue) {
+				m_Header << "\t" << "static boost::signals2::signal<void (const intrusive_ptr<" << klass.Name
+					<< ">&, const Value&, const Value&)> On" << field.GetFriendlyName() << "ChangedWithOldValue;"
+					<< std::endl;
+				m_Impl << std::endl << "boost::signals2::signal<void (const intrusive_ptr<" << klass.Name
+					<< ">&, const Value&, const Value&)> ObjectImpl<" << klass.Name << ">::On"
+					<< field.GetFriendlyName() << "ChangedWithOldValue;" << std::endl << std::endl;
+			}
 		}
 	}
 

--- a/tools/mkclass/classcompiler.hpp
+++ b/tools/mkclass/classcompiler.hpp
@@ -60,7 +60,8 @@ enum FieldAttribute
 	FADeprecated = 4096,
 	FAGetVirtual = 8192,
 	FASetVirtual = 16384,
-	FAActivationPriority = 32768
+	FAActivationPriority = 32768,
+	FASignalWithOldValue = 65536,
 };
 
 struct FieldType


### PR DESCRIPTION
This PR adds the following missing object relationship runtime updates:
- Insert
  - `icinga:notification:recipient` => Insert on user creation for groups that have notifications
- Delete
  - `icinga:*:customvar`
  - `icinga:notification:recipient`
  - `icinga:notification:user`
  - `icinga:notification:usergroup`
  - `icinga:{check,event,notification}command:argument`
  - `icinga:{check,event,notification}command:envvar`
  - `icinga:{user,host,service}group:member`
  - `icinga:timeperiod:override:exclude`
  - `icinga:timeperiod:override:include`
  - `icinga:timeperiod:override:range`

This fix addresses the issue for Redis keys and the runtime stream.

Implementing a new signal(`On*ChangedWithOldValue`) on config object attributes was needed to let the Icinga DB feature know which relations have been deleted on object modification. Our current signals only include the new value of attributes, but not the old ones. This made it impossible to know what has changed.

Notification recipients need special treatment, because they can change by adding a user to a group without touching the notification object (indirect relationship). Although a users groups can't be modified during runtime, user creation and deletion is possible (which modifies notification recipients via the users groups). To easily update recipients on user creation/deletion, groups now keep track of all notifications they are assigned to.

Note: API calls that change multiple attributes of an object at the same time are affected by a race condition where the update and delete events aren't handled in order by Icinga DB. This can result in relations not getting deleted.

- [x] Blocked by #9059 