### PR TITLE
Icinga DB: Remove unused Redis key 'icinga:zone:parent'

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -538,8 +538,6 @@ std::vector<String> IcingaDB::GetTypeOverwriteKeys(const String& type)
 		keys.emplace_back(m_PrefixConfigObject + type + ":override:include");
 		keys.emplace_back(m_PrefixConfigObject + type + ":override:exclude");
 		keys.emplace_back(m_PrefixConfigObject + type + ":range");
-	} else if (type == "zone") {
-		keys.emplace_back(m_PrefixConfigObject + type + ":parent");
 	} else if (type == "notification") {
 		keys.emplace_back(m_PrefixConfigObject + type + ":user");
 		keys.emplace_back(m_PrefixConfigObject + type + ":usergroup");
@@ -572,8 +570,6 @@ std::vector<String> IcingaDB::GetTypeDumpSignalKeys(const Type::Ptr& type)
 		keys.emplace_back(m_PrefixConfigObject + lcType + ":override:include");
 		keys.emplace_back(m_PrefixConfigObject + lcType + ":override:exclude");
 		keys.emplace_back(m_PrefixConfigObject + lcType + ":range");
-	} else if (type == Zone::TypeInstance) {
-		keys.emplace_back(m_PrefixConfigObject + lcType + ":parent");
 	} else if (type == Notification::TypeInstance) {
 		keys.emplace_back(m_PrefixConfigObject + lcType + ":user");
 		keys.emplace_back(m_PrefixConfigObject + lcType + ":usergroup");
@@ -818,32 +814,6 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 			if (runtimeUpdate) {
 				AddObjectDataToRuntimeUpdates(runtimeUpdates, id, m_PrefixConfigObject + typeName + ":override:exclude", data);
 			}
-		}
-
-		return;
-	}
-
-	if (type == Zone::TypeInstance) {
-		Zone::Ptr zone = static_pointer_cast<Zone>(object);
-
-		Array::Ptr parents(new Array);
-		auto parentsRaw (zone->GetAllParentsRaw());
-
-		parents->Reserve(parentsRaw.size());
-
-		auto& parnts (hMSets[m_PrefixConfigObject + typeName + ":parent"]);
-
-		for (auto& parent : parentsRaw) {
-			String id = HashValue(new Array(Prepend(env, Prepend(GetObjectIdentifiersWithoutEnv(parent), GetObjectIdentifiersWithoutEnv(object)))));
-			parnts.emplace_back(id);
-			Dictionary::Ptr data = new Dictionary({{"zone_id", objectKey}, {"environment_id", m_EnvironmentId}, {"parent_id", GetObjectIdentifier(parent)}});
-			parnts.emplace_back(JsonEncode(data));
-
-			if (runtimeUpdate) {
-				AddObjectDataToRuntimeUpdates(runtimeUpdates, id, m_PrefixConfigObject + typeName + ":parent", data);
-			}
-
-			parents->Add(GetObjectIdentifier(parent));
 		}
 
 		return;
@@ -1177,22 +1147,6 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 	}
 
 	if (type == Endpoint::TypeInstance) {
-		return true;
-	}
-
-	if (type == Zone::TypeInstance) {
-		Zone::Ptr zone = static_pointer_cast<Zone>(object);
-
-		attributes->Set("is_global", zone->GetGlobal());
-
-		Zone::Ptr parent = zone->GetParent();
-		if (parent) {
-			attributes->Set("parent_id", GetObjectIdentifier(zone));
-		}
-
-		auto parentsRaw (zone->GetAllParentsRaw());
-		attributes->Set("depth", parentsRaw.size());
-
 		return true;
 	}
 


### PR DESCRIPTION
`icinga:zone:parent` isn't used anywhere in Icinga DB nor needed for anything we have planed.