### PR TITLE
Add new check_nrpe parameter -D to disable logging to syslog

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -887,6 +887,7 @@ nrpe_key	| **Optional.** The client key file to use for PKI. Defaults to none.
 nrpe_ssl_version	| **Optional.** The SSL/TLS version to use. Defaults to TLSv1+.
 nrpe_cipher_list	| **Optional.** The list of SSL ciphers to use. Default depends on check_nrpe version.
 nrpe_dh_opt	| **Optional.** Anonymous Diffie Hellman use: 0 = deny, 1 = allow, 2 = force. Default depends on check_nrpe version.
+nrpe_no_logging	| **Optional.** Disable logging of check_nrpe to syslog facilities (requires check_nrpe >= 4.0).
 
 
 ### nscp <a id="plugin-check-command-nscp"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2345,6 +2345,10 @@ object CheckCommand "nrpe" {
 			value = "$nrpe_dh_opt$"
 			description = "Anonymous Diffie Hellman use: 0 = deny, 1 = allow, 2 = force"
 		}
+		"-D" = {
+			set_if = "$nrpe_no_logging$"
+			description = "Disable check_nrpe plugin from logging to syslog (requires check_nrpe >= 4.0)"
+		}
 	}
 
 	vars.nrpe_address = "$check_address$"


### PR DESCRIPTION
The check_nrpe plugin added a new parameter `-D` / `--disable-syslog` in version 4.0.0. 
Without this parameter, check_nrpe (may) will log a lot of events when communicating with older NRPE server versions:

```
Sep 29 09:49:02 icinga check_nrpe: Remote 192.168.252.211 does not support version 3/4 packets
Sep 29 09:49:02 icinga check_nrpe: Remote 192.168.253.12 does not support version 3/4 packets
Sep 29 09:49:02 icinga check_nrpe: Remote 10.150.79.140 does not support version 3/4 packets
Sep 29 09:49:02 icinga check_nrpe: Remote 10.10.217.123 accepted a version 2 packet
Sep 29 09:49:02 icinga check_nrpe: Remote 192.168.252.211 accepted a version 2 packet
Sep 29 09:49:02 icinga check_nrpe: Remote 10.10.216.143 does not support version 3/4 packets
Sep 29 09:49:02 icinga check_nrpe: Remote 192.168.253.12 accepted a version 2 packet
Sep 29 09:49:02 icinga check_nrpe: Remote 10.150.79.140 accepted a version 2 packet
Sep 29 09:49:03 icinga check_nrpe: Remote 10.10.216.143 accepted a version 2 packet
```

This PR adds the new parameter to ITL.

check_nrpe (NRPE) 4.0.0 is part of Ubuntu 20.04 packages just in case you're wondering whether this applies to anyone ;-).

Maybe make `nrpe_no_logging` even default in the CheckCommand.