### PR TITLE
ApiListener: Add external_ca flag to control renewal behavior

### DIFF
--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1109,6 +1109,7 @@ Configuration Attributes:
   access\_control\_allow\_headers       | String                | **Deprecated.** Used in response to a preflight request to indicate which HTTP headers can be used when making the actual request. Defaults to `Authorization`. [(MDN docs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Headers)
   access\_control\_allow\_methods       | String                | **Deprecated.** Used in response to a preflight request to indicate which HTTP methods can be used when making the actual request. Defaults to `GET, POST, PUT, DELETE`. [(MDN docs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Methods)
   environment                           | String                | **Optional.** Used as suffix in TLS SNI extension name; default from constant `ApiEnvironment`, which is empty.
+  external_ca                           | String                | **Optional.** Certificates used are not managed by Icinga, disables certificate renewal logic inside Icinga's RPC API. Especially useful for external roots with intermediate chain certificates.
 
 The attributes `access_control_allow_credentials`, `access_control_allow_headers` and `access_control_allow_methods`
 are controlled by Icinga 2 and are not changeable by config any more.
@@ -1127,6 +1128,9 @@ copies those files to the new location in `DataDir + "/certs"` unless the
 file(s) there are newer.
 
 Please check the [upgrading chapter](16-upgrading-icinga-2.md#upgrading-to-2-8-certificate-paths) for more details.
+
+When certificates from Puppet or any corporate root CA is used, you should enable `external_ca` to disable some
+certificate handling logic within the API connection routines of Icinga 2.
 
 While Icinga 2 and the underlying OpenSSL library use sane and secure defaults, the attributes
 `cipher_list` and `tls_protocolmin` can be used to increase communication security. A good source

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -770,9 +770,8 @@ void ApiListener::SyncClient(const JsonRpcConnection::Ptr& aclient, const Endpoi
 			endpoint->SetSyncing(true);
 		}
 
-		Zone::Ptr myZone = Zone::GetLocalZone();
-
-		if (myZone->GetParent() == eZone) {
+		// When external_ca is not configured and client is from parent zone, evaluate certificate renewal.
+		if (!GetExternalCa() && Zone::GetLocalZone()->GetParent() == eZone) {
 			Log(LogInformation, "ApiListener")
 				<< "Requesting new certificate for this Icinga instance from endpoint '" << endpoint->GetName() << "'.";
 

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -55,6 +55,7 @@ class ApiListener : ConfigObject
 	[config, deprecated] String access_control_allow_headers;
 	[config, deprecated] String access_control_allow_methods;
 
+	[config] bool external_ca;
 
 	[state, no_user_modify] Timestamp log_message_timestamp;
 

--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -25,11 +25,18 @@ REGISTER_APIFUNCTION(UpdateCertificate, pki, &UpdateCertificateHandler);
 
 Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
+	ApiListener::Ptr listener = ApiListener::GetInstance();
+
+	Dictionary::Ptr result = new Dictionary();
+
+	// When external_ca is configured, ignore any request via RPC.
+	if (listener->GetExternalCa()) {
+		return Empty;
+	}
+
 	String certText = params->Get("cert_request");
 
 	std::shared_ptr<X509> cert;
-
-	Dictionary::Ptr result = new Dictionary();
 
 	/* Use the presented client certificate if not provided. */
 	if (certText.IsEmpty()) {
@@ -48,7 +55,6 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 		return result;
 	}
 
-	ApiListener::Ptr listener = ApiListener::GetInstance();
 	std::shared_ptr<X509> cacert = GetX509Certificate(listener->GetDefaultCaPath());
 
 	String cn = GetCertificateCN(cert);
@@ -328,7 +334,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 
-	if (!listener)
+	if (!listener || listener->GetExternalCa())
 		return Empty;
 
 	std::shared_ptr<X509> oldCert = GetX509Certificate(listener->GetDefaultCertPath());


### PR DESCRIPTION
This will disable checking and renewing certificates with the Icinga master or other parents within the cluster, so it is up for the user to control it.

I named the flag non-specific to being able to control other occasions where a non Icinga CA should be treated differently.

cc @mkayontour 
fixes #7719
closes #8859 

## Notes

In addition it might help improving `VerifyCertificate`, but this is not relevant for the simple connection handling, only when we want to actually verify certificates with a chain for CLI commands or in the renewal logic.

Also this can be used as a one-sided features, so it should be enough to disable on the master side, so log messages are avoided, while it can be changed on satellites and clients once they are updated.

Of course needs more testing...

Open for questions.

ref/NC/729576