### PR TITLE
IcingaDB: actually write parent to parent_id of zones

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1187,7 +1187,7 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 
 		Zone::Ptr parent = zone->GetParent();
 		if (parent) {
-			attributes->Set("parent_id", GetObjectIdentifier(zone));
+			attributes->Set("parent_id", GetObjectIdentifier(parent));
 		}
 
 		auto parentsRaw (zone->GetAllParentsRaw());


### PR DESCRIPTION
This fixes that the code used the wrong variable. Previously, it was written to Redis that each zone is its own parent (if it has a parent at all).

### Before

For zone `agent-1` (`id=d07ea609f9c4300568230ffa3630dbffbd0de74c`), `parent_id=d07ea609f9c4300568230ffa3630dbffbd0de74c`, wrongly referencing itself there.

```
172.23.0.23:6379> HGETALL icinga:zone
[...]
21) "d07ea609f9c4300568230ffa3630dbffbd0de74c"
22) "{\"depth\":1,\"environment_id\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"is_global\":false,\"name\":\"agent-1\",\"name_checksum\":\"9304ba937a3dd2774a5e0e68ad77dc9d81be09d0\",\"parent_id\":\"d07ea609f9c4300568230ffa3630dbffbd0de74c\",\"zone\":\"master\",\"zone_id\":\"71162003eb79101b896769ef78ec5f423e4c3007\"}"
[...]
```

### After

Now, `parent_id=71162003eb79101b896769ef78ec5f423e4c3007`, correctly referencing its parent zone `master`.

```
172.23.0.23:6379> HGETALL icinga:zone
 1) "d07ea609f9c4300568230ffa3630dbffbd0de74c"
 2) "{\"depth\":1,\"environment_id\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"is_global\":false,\"name\":\"agent-1\",\"name_checksum\":\"9304ba937a3dd2774a5e0e68ad77dc9d81be09d0\",\"parent_id\":\"71162003eb79101b896769ef78ec5f423e4c3007\",\"zone\":\"master\",\"zone_id\":\"71162003eb79101b896769ef78ec5f423e4c3007\"}"
[...]
19) "71162003eb79101b896769ef78ec5f423e4c3007"
20) "{\"depth\":0,\"environment_id\":\"da39a3ee5e6b4b0d3255bfef95601890afd80709\",\"is_global\":false,\"name\":\"master\",\"name_checksum\":\"4f26aeafdb2367620a393c973eddbe8f8b846ebd\"}"
[...]
```