### PR TITLE
Add ITL config option for different NRPE payload size/length

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -880,7 +880,8 @@ nrpe_timeout    | **Optional.** The timeout in seconds.
 nrpe_arguments	| **Optional.** Arguments that should be passed to the command. Multiple arguments must be defined as array.
 nrpe_ipv4       | **Optional.** Use IPv4 connection. Defaults to false.
 nrpe_ipv6       | **Optional.** Use IPv6 connection. Defaults to false.
-nrpe_version_2	| **Optional.** Use this if you want to connect using NRPE v2 protocol. Defaults to false.
+nrpe_version_2	| **Optional.** Use this if you want to connect using NRPE v2 protocol (needed for NSClient++). Defaults to false.
+nrpe_payload_size	| **Optional.** Specify non-default payload size for NSClient++. Default is 1024.
 nrpe_ca		| **Optional.** The CA file to use for PKI. Defaults to none.
 nrpe_cert	| **Optional.** The client cert file to use for PKI. Defaults to none.
 nrpe_key	| **Optional.** The client key file to use for PKI. Defaults to none.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2321,6 +2321,10 @@ object CheckCommand "nrpe" {
 			set_if = "$nrpe_version_2$"
 			description = "Use this if you want to connect to NRPE v2"
 		}
+		"-P" = {
+			value = "$nrpe_payload_size$"
+			description = "Specify non-default payload size for NSClient++"
+		}
 		"-A" = {
 			value = "$nrpe_ca$"
 			description = "The CA file to use for PKI"


### PR DESCRIPTION
This PR adds a configuration option for using check_nrpe's `-P` parameter, to define a non-default payload size. 
This parameter was introduced in NRPE v3.
Fixes #8629