### PR TITLE
Icinga DB: stream runtime state updates only to icinga:runtime:state

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1076,8 +1076,7 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 		m_Rcon->FireAndForgetQuery({"HSET", m_PrefixConfigCheckSum + typeName + ":state", objectKey, JsonEncode(new Dictionary({{"checksum", checksum}}))}, Prio::RuntimeStateSync);
 
 		if (runtimeUpdate) {
-			state->Set("checksum", checksum);
-			AddObjectDataToRuntimeUpdates(runtimeUpdates, objectKey, m_PrefixConfigObject + typeName + ":state", state);
+			SendStatusUpdate(checkable);
 		}
 	}
 


### PR DESCRIPTION
... where they belong to, not to icinga:runtime.