### PR TITLE
check_icmp: double packet loss thresholds

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -700,9 +700,9 @@ Name            | Description
 ----------------|--------------
 icmp_address    | **Optional.** The host's address. This can either be a single address or an array of addresses. Defaults to "$address$".
 icmp_wrta       | **Optional.** The RTA warning threshold in milliseconds. Defaults to 100.
-icmp_wpl        | **Optional.** The packet loss warning threshold in %. Defaults to 5.
+icmp_wpl        | **Optional.** The packet loss warning threshold in %. Defaults to 10.
 icmp_crta       | **Optional.** The RTA critical threshold in milliseconds. Defaults to 200.
-icmp_cpl        | **Optional.** The packet loss critical threshold in %. Defaults to 15.
+icmp_cpl        | **Optional.** The packet loss critical threshold in %. Defaults to 30.
 icmp_source     | **Optional.** The source IP address to send packets from.
 icmp_packets    | **Optional.** The number of packets to send. Defaults to 5.
 icmp_packet_interval | **Optional** The maximum packet interval. Defaults to 80 (milliseconds).

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2437,11 +2437,11 @@ object CheckCommand "icmp" {
 		}
 		"-w" = {
 			value = "$icmp_wrta$,$icmp_wpl$%"
-			description = "warning threshold (currently 200.000ms,40%)"
+			description = "warning threshold (currently 200.000ms,10%)"
 		}
 		"-c" = {
 			value = "$icmp_crta$,$icmp_cpl$%"
-			description = "critical threshold (currently 500.000ms,80%)"
+			description = "critical threshold (currently 500.000ms,30%)"
 		}
 		"-s" = {
 			value = "$icmp_source$"
@@ -2479,9 +2479,9 @@ object CheckCommand "icmp" {
 
 	vars.icmp_address = "$address$"
 	vars.icmp_wrta = 100
-	vars.icmp_wpl = 5
+	vars.icmp_wpl = 10
 	vars.icmp_crta = 200
-	vars.icmp_cpl = 15
+	vars.icmp_cpl = 30
 }
 
 object CheckCommand "ldap" {


### PR DESCRIPTION
... to get not instantly critical after 1 packet lost (20%), but after 2.

fixes #8606