### PR TITLE
Icinga DB init. dump: flush both buffered states and state checksums

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -310,8 +310,10 @@ void IcingaDB::UpdateAllConfigObjects()
 				}
 			}
 
-			if (states.size() > 2)
+			if (states.size() > 2) {
 				transaction.emplace_back(std::move(states));
+				transaction.emplace_back(std::move(statesChksms));
+			}
 
 			if (transaction.size() > 1) {
 				transaction.push_back({"EXEC"});


### PR DESCRIPTION
not to dump x states, but only x - (x % bulk) state checksums.