### PR TITLE
On hard not OK to hard not OK change don't suppress (if needed) notification

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -484,7 +484,9 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 	if (send_notification && !is_flapping) {
 		if (!IsPaused()) {
 			if (suppress_notification) {
-				suppressed_types |= (recovery ? NotificationRecovery : NotificationProblem);
+				if (!(hardChange && old_stateType == StateTypeHard && !IsStateOK(old_state) && !IsStateOK(new_state))) {
+					suppressed_types |= (recovery ? NotificationRecovery : NotificationProblem);
+				}
 			} else {
 				OnNotificationsRequested(this, recovery ? NotificationRecovery : NotificationProblem, cr, "", "", nullptr);
 			}

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -229,7 +229,7 @@ bool Checkable::NotificationReasonApplies(NotificationType type)
 		case NotificationRecovery:
 			{
 				auto cr (GetLastCheckResult());
-				return cr && IsStateOK(cr->GetState());
+				return cr && (IsStateOK(cr->GetState()) || GetStateType() == StateTypeSoft);
 			}
 		case NotificationFlappingStart:
 			return IsFlapping();

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -53,6 +53,16 @@ enum FlappingStateFilter
 	FlappingStateFilterUnknown = 8,
 };
 
+/**
+ * @ingroup icinga
+ */
+enum class NotifyReasonApplies : uint_fast8_t
+{
+	No,
+	Yes,
+	NotSure
+};
+
 class CheckCommand;
 class EventCommand;
 class Dependency;
@@ -187,7 +197,7 @@ public:
 	void ValidateRetryInterval(const Lazy<double>& lvalue, const ValidationUtils& value) final;
 	void ValidateMaxCheckAttempts(const Lazy<int>& lvalue, const ValidationUtils& value) final;
 
-	bool NotificationReasonApplies(NotificationType type);
+	NotifyReasonApplies NotificationReasonApplies(NotificationType type);
 	bool NotificationReasonSuppressed(NotificationType type);
 	bool IsLikelyToBeCheckedSoon();
 

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -82,9 +82,15 @@ void FireSuppressedNotifications(const Notification::Ptr& notification)
 	auto checkable (notification->GetCheckable());
 
 	for (auto type : {NotificationProblem, NotificationRecovery, NotificationFlappingStart, NotificationFlappingEnd}) {
-		if ((suppressedTypes & type) && !checkable->NotificationReasonApplies(type)) {
-			subtract |= type;
-			suppressedTypes &= ~type;
+		if (suppressedTypes & type) {
+			switch (checkable->NotificationReasonApplies(type)) {
+				case NotifyReasonApplies::Yes:
+					break;
+				case NotifyReasonApplies::No:
+					subtract |= type;
+				default:
+					suppressedTypes &= ~type;
+			}
 		}
 	}
 


### PR DESCRIPTION
but discard it for the case of a recovery to be also suppressed (e.g. during downtime).

Before:

1. Checkable became hard critical
2. Problem notification was sent
3. Downtime started
4. Checkable became hard unknown (notification was suppressed)
5. Checkable became OK (notification was not suppressed,
   but discarted together with the unknown one)
6. Downtime ended
7. No recovery notification

After:

1. Checkable becomes hard critical
2. Problem notification is sent
3. Downtime starts
4. Checkable becomes hard unknown
   (notification isn't suppressed, but discarted)  <-- THIS PATCH
5. Checkable becomes OK (notification is suppressed)
6. Downtime ends
7. Recovery notification is (unsuppressed and) sent

refs #9054
closes #9146