### PR TITLE
Add missing include to fix non-unity builds

### DIFF
--- a/lib/icinga/usergroup.cpp
+++ b/lib/icinga/usergroup.cpp
@@ -2,6 +2,7 @@
 
 #include "icinga/usergroup.hpp"
 #include "icinga/usergroup-ti.cpp"
+#include "icinga/notification.hpp"
 #include "config/objectrule.hpp"
 #include "config/configitem.hpp"
 #include "base/configtype.hpp"


### PR DESCRIPTION
This commit fixes the following build error:

    [ 55%] Building CXX object lib/icinga/CMakeFiles/icinga.dir/usergroup.cpp.o
    lib/icinga/usergroup.cpp:79:24: error: incomplete type ‘icinga::Notification’ used in nested name specifier
       79 | std::set<Notification::Ptr> UserGroup::GetNotifications() const
          |                        ^~~

Backport of #9092