### PR TITLE
pass nwc_health check SNMPv3 args only if needed

### DIFF
--- a/itl/plugins-contrib.d/network-components.conf
+++ b/itl/plugins-contrib.d/network-components.conf
@@ -525,27 +525,27 @@ object CheckCommand "nwc_health" {
 		"--username" = {
 			value = "$nwc_health_username$"
 			description = "The securityName for the USM security model (SNMPv3 only)"
-			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
+			set_if = {{ string(macro("$nwc_health_protocol$")) == "3" }}
 		}
 		"--authpassword" = {
 			value = "$nwc_health_authpassword$"
 			description = "The authentication password for SNMPv3"
-			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
+			set_if = {{ string(macro("$nwc_health_protocol$")) == "3" }}
 		}
 		"--authprotocol" = {
 			value = "$nwc_health_authprotocol$"
 			description = "The authentication protocol for SNMPv3 (md5|sha)"
-			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
+			set_if = {{ string(macro("$nwc_health_protocol$")) == "3" }}
 		}
 		"--privpassword" = {
 			value = "$nwc_health_privpassword$"
 			description = "The password for authPriv security level"
-			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
+			set_if = {{ string(macro("$nwc_health_protocol$")) == "3" }}
 		}
 		"--privprotocol" = {
 			value = "$nwc_health_privprotocol$"
 			description = "The private protocol for SNMPv3 (des|aes|aes128|3des|3desde)"
-			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
+			set_if = {{ string(macro("$nwc_health_protocol$")) == "3" }}
 		}
 		"--contextengineid" = {
 			value = "$nwc_health_contextengineid$"

--- a/itl/plugins-contrib.d/network-components.conf
+++ b/itl/plugins-contrib.d/network-components.conf
@@ -525,22 +525,27 @@ object CheckCommand "nwc_health" {
 		"--username" = {
 			value = "$nwc_health_username$"
 			description = "The securityName for the USM security model (SNMPv3 only)"
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--authpassword" = {
 			value = "$nwc_health_authpassword$"
 			description = "The authentication password for SNMPv3"
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--authprotocol" = {
 			value = "$nwc_health_authprotocol$"
 			description = "The authentication protocol for SNMPv3 (md5|sha)"
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--privpassword" = {
 			value = "$nwc_health_privpassword$"
 			description = "The password for authPriv security level"
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--privprotocol" = {
 			value = "$nwc_health_privprotocol$"
 			description = "The private protocol for SNMPv3 (des|aes|aes128|3des|3desde)"
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--contextengineid" = {
 			value = "$nwc_health_contextengineid$"

--- a/itl/plugins-contrib.d/network-components.conf
+++ b/itl/plugins-contrib.d/network-components.conf
@@ -525,27 +525,27 @@ object CheckCommand "nwc_health" {
 		"--username" = {
 			value = "$nwc_health_username$"
 			description = "The securityName for the USM security model (SNMPv3 only)"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
 		}
 		"--authpassword" = {
 			value = "$nwc_health_authpassword$"
 			description = "The authentication password for SNMPv3"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
 		}
 		"--authprotocol" = {
 			value = "$nwc_health_authprotocol$"
 			description = "The authentication protocol for SNMPv3 (md5|sha)"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
 		}
 		"--privpassword" = {
 			value = "$nwc_health_privpassword$"
 			description = "The password for authPriv security level"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
 		}
 		"--privprotocol" = {
 			value = "$nwc_health_privprotocol$"
 			description = "The private protocol for SNMPv3 (des|aes|aes128|3des|3desde)"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").to_string() == "3" }}
 		}
 		"--contextengineid" = {
 			value = "$nwc_health_contextengineid$"

--- a/itl/plugins-contrib.d/network-components.conf
+++ b/itl/plugins-contrib.d/network-components.conf
@@ -525,27 +525,27 @@ object CheckCommand "nwc_health" {
 		"--username" = {
 			value = "$nwc_health_username$"
 			description = "The securityName for the USM security model (SNMPv3 only)"
-			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--authpassword" = {
 			value = "$nwc_health_authpassword$"
 			description = "The authentication password for SNMPv3"
-			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--authprotocol" = {
 			value = "$nwc_health_authprotocol$"
 			description = "The authentication protocol for SNMPv3 (md5|sha)"
-			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--privpassword" = {
 			value = "$nwc_health_privpassword$"
 			description = "The password for authPriv security level"
-			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--privprotocol" = {
 			value = "$nwc_health_privprotocol$"
 			description = "The private protocol for SNMPv3 (des|aes|aes128|3des|3desde)"
-			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
 		}
 		"--contextengineid" = {
 			value = "$nwc_health_contextengineid$"

--- a/itl/plugins-contrib.d/network-components.conf
+++ b/itl/plugins-contrib.d/network-components.conf
@@ -525,27 +525,27 @@ object CheckCommand "nwc_health" {
 		"--username" = {
 			value = "$nwc_health_username$"
 			description = "The securityName for the USM security model (SNMPv3 only)"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
 		}
 		"--authpassword" = {
 			value = "$nwc_health_authpassword$"
 			description = "The authentication password for SNMPv3"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
 		}
 		"--authprotocol" = {
 			value = "$nwc_health_authprotocol$"
 			description = "The authentication protocol for SNMPv3 (md5|sha)"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
 		}
 		"--privpassword" = {
 			value = "$nwc_health_privpassword$"
 			description = "The password for authPriv security level"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
 		}
 		"--privprotocol" = {
 			value = "$nwc_health_privprotocol$"
 			description = "The private protocol for SNMPv3 (des|aes|aes128|3des|3desde)"
-			set_if = {{ macro("$nwc_health_protocol$") == "3" }}
+			set_if = {{ macro("$nwc_health_protocol$").string() == "3" }}
 		}
 		"--contextengineid" = {
 			value = "$nwc_health_contextengineid$"


### PR DESCRIPTION
The `check_nwc_health` plugin fails if any of its SNMPv3 arguments were passed but
the SNMP version 3 protocol was not requested. This poses a problem for instance 
if the SNMPv3 nwc_health arguments were inherited from some template but the host
supports SNMPv1 or SNMPv2c only.

The following works:

```
	check_nwc_health --hostname 192.0.2.3 --mode cpu-load \
		--protocol 1 --community public
```
But the following plugin invocation results in an error:

```
	check_nwc_health --hostname 192.0.2.3 --mode cpu-load \
		--protocol 1 --community public \
		--username joe --authpassword xxx
```
This PR makes rendering of all SNMPv3 plugin arguments conditional and based on the presence of `--protocol 3` argument. This also results in a cleaner command line when
inspecting the command invocation through the _Inspect_ link in the Icinga Web interface.
