### PR TITLE
Put `-latomic` to the other `-l`s

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,10 +432,7 @@ if(NOT MSVC)
   # ARM settings
   if("${ARCH}" STREQUAL "arm")
     check_cxx_source_compiles( "include <atomic>; int main(){ std::atomic<uint_fast64_t> x; x.fetch_add(1); x.sub_add(1);  }" CXX_ATOMIC)
-
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -latomic")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -latomic")
-    set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -latomic")
+    link_libraries(atomic)
   endif()
 
 else()


### PR DESCRIPTION
to make it compiling on Raspberry Pi OS bullseye.