### PR TITLE
Downtime::DowntimesExpireTimerHandler: don't copy vector

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -482,13 +482,7 @@ void Downtime::DowntimesStartTimerHandler()
 
 void Downtime::DowntimesExpireTimerHandler()
 {
-	std::vector<Downtime::Ptr> downtimes;
-
 	for (const Downtime::Ptr& downtime : ConfigType::GetObjectsByType<Downtime>()) {
-		downtimes.push_back(downtime);
-	}
-
-	for (const Downtime::Ptr& downtime : downtimes) {
 		/* Only remove downtimes which are activated after daemon start. */
 		if (downtime->IsActive() && (downtime->IsExpired() || !downtime->HasValidConfigOwner()))
 			RemoveDowntime(downtime->GetName(), false, false, true);


### PR DESCRIPTION
`ConfigType::GetObjectsByType<Downtime>()` already returns a `std::vector<Downtime::Ptr>` so there is no point in copying it into another vector of the same type just to then iterate the copied vector instead of the original one.

### Tests

Still expires downtimes, I don't think there's much more to test here.

```
[2021-12-01 13:14:07 +0100] information/Downtime: Removed downtime 'agent-win!eb378f18-fba8-469e-8c5d-6a677d7c1732' from checkable 'agent-win' (Reason: expired at 2021-12-01 13:13:21 +0100).
[2021-12-01 13:14:07 +0100] information/Downtime: Removed downtime 'agent-win!39f278af-2daf-4cc6-8710-554999bd10e6' from checkable 'agent-win' (Reason: expired at 2021-12-01 14:11:43 +0100).
```