### PR TITLE
CheckCommand "icingacli-businessprocess" adding new arguments

### DIFF
--- a/itl/plugins-contrib.d/icingacli.conf
+++ b/itl/plugins-contrib.d/icingacli.conf
@@ -10,7 +10,15 @@ object CheckCommand "icingacli-businessprocess" {
 	command += [ "businessprocess", "process", "check" ]
 
 	arguments = {
-		"--config" = {
+		"--ack-is-ok" = {
+                        set_if = "$icingacli_businessprocess_ackisok$"
+                        description = "set state to OK if node is acknowledged"
+                }
+                "--blame" = {
+                        set_if = "$icingacli_businessprocess_blame$"
+                        description = "only showing nodes that have the same state as the process itself"
+                }
+                "--config" = {
 			value = "$icingacli_businessprocess_config$"
 			description = "Configuration file containing your business process without file extension"
 		}
@@ -18,6 +26,14 @@ object CheckCommand "icingacli-businessprocess" {
 			set_if = "$icingacli_businessprocess_details$"
 			description = "Get details for root cause analysis"
 		}
+                 "--downtime-is-ok" = {
+                        set_if = "$icingacli_businessprocess_downtimeisok$"
+                        description = "set state to OK if maintenance is set for node"
+                }
+                "--root-cause" = {
+                        set_if = "$icingacli_businessprocess_rootcause$"
+                        description = "shows only the path that causes a problem"
+                }
 		"--state-type" = {
 			value = "$icingacli_businessprocess_statetype$"
 			description = "Define which state type to look at. Could be either soft or hard, overrides an eventually configured default"
@@ -30,8 +46,11 @@ object CheckCommand "icingacli-businessprocess" {
 			order = -1
 		}
 	}
-
-	vars.icingacli_businessprocess_details = false
+        vars.icingacli_businessprocess_ackisok = false
+	vars.icingacli_businessprocess_blame = false
+        vars.icingacli_businessprocess_details = false
+        vars.icingacli_businessprocess_downtimeisok = false
+        vars.icingacli_businessprocess_rootcause = false
 }
 
 object CheckCommand "icingacli-director" {


### PR DESCRIPTION
new arguments from icingacli.conf can now be used in business-process-monitoring
#9107