### PR TITLE
Docs: fix heading level of cluster event messages

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1866,7 +1866,7 @@ The returned messages are synced directly to the sender's endpoint, no cluster b
 
 > **Note**: EventCommand errors are just logged on the remote endpoint.
 
-### event::UpdateExecutions <a id="technical-concepts-json-rpc-messages-event-updateexecutions"></a>
+#### event::UpdateExecutions <a id="technical-concepts-json-rpc-messages-event-updateexecutions"></a>
 
 > Location: `clusterevents.cpp`
 
@@ -1900,7 +1900,7 @@ Message updates will be dropped when:
 * Checkable does not exist.
 * Origin endpoint's zone is not allowed to access this checkable.
 
-### event::ExecutedCommand <a id="technical-concepts-json-rpc-messages-event-executedcommand"></a>
+#### event::ExecutedCommand <a id="technical-concepts-json-rpc-messages-event-executedcommand"></a>
 
 > Location: `clusterevents.cpp`
 


### PR DESCRIPTION
All other sections for `event::*` are level 4 headings, only these were level 3.