### PR TITLE
Set downtime trigger time deterministically

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -327,7 +327,7 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 	}
 
 	if (!IsStateOK(new_state))
-		TriggerDowntimes();
+		TriggerDowntimes(cr->GetExecutionEnd());
 
 	/* statistics for external tools */
 	Checkable::UpdateStatistics(cr, checkableType);

--- a/lib/icinga/checkable-downtime.cpp
+++ b/lib/icinga/checkable-downtime.cpp
@@ -16,10 +16,10 @@ void Checkable::RemoveAllDowntimes()
 	}
 }
 
-void Checkable::TriggerDowntimes()
+void Checkable::TriggerDowntimes(double triggerTime)
 {
 	for (const Downtime::Ptr& downtime : GetDowntimes()) {
-		downtime->TriggerDowntime();
+		downtime->TriggerDowntime(triggerTime);
 	}
 }
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -139,7 +139,7 @@ public:
 	int GetDowntimeDepth() const final;
 
 	void RemoveAllDowntimes();
-	void TriggerDowntimes();
+	void TriggerDowntimes(double triggerTime);
 	bool IsInDowntime() const;
 	bool IsAcknowledged() const;
 

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -57,7 +57,7 @@ public:
 	void UnregisterChild(const Downtime::Ptr& downtime);
 	std::set<Downtime::Ptr> GetChildren() const;
 
-	void TriggerDowntime();
+	void TriggerDowntime(double triggerTime);
 
 	static String GetDowntimeIDFromLegacyID(int id);
 


### PR DESCRIPTION
When triggering a downtime, the time of the causing event is now passed on as the trigger time. That time is:

* For fixed downtimes: the later one of start and entry time.
* If a check result triggers the downtime: The execution end of the check result.
* If another downtime triggers the downtime: The trigger time of the first downtime.

This is done so two nodes in a HA setup can write consistent Icinga DB downtime history streams.

### Tests
Tests are in https://github.com/Icinga/icingadb/pull/422 and can be used to check that now the history streams are consistent for the event types generated by these tests.

```
git merge origin/bugfix/sync-missing-history-information origin/bugfix/downtime-trigger-time
# build docker image and tag as icinga/icinga2:master
# run tests from https://github.com/Icinga/icingadb/pull/422
```

Passes locally, in the GH Actions output over there you can see what these tests detect that has been fixed by these two PRs (this PR fixes the `trigger_time` attribute).

refs #9101
closes #9043