### PR TITLE
Avoid "type" key in dicts being part of object state attrs

### DIFF
--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -74,7 +74,7 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 							<< "Notification '" << notification->GetName() << "': there are some stashed notifications. Stashing notification to preserve order.";
 
 						stashedNotifications->Add(new Dictionary({
-							{"type", type},
+							{"notification_type", type},
 							{"cr", cr},
 							{"force", force},
 							{"reminder", false},
@@ -99,7 +99,7 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 				<< "Notification '" << notification->GetName() << "': object authority hasn't been updated, yet. Stashing notification.";
 
 			notification->GetStashedNotifications()->Add(new Dictionary({
-				{"type", type},
+				{"notification_type", type},
 				{"cr", cr},
 				{"force", force},
 				{"reminder", false},

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -186,7 +186,7 @@ void NotificationComponent::NotificationTimerHandler()
 							<< "Attempting to send stashed notification '" << notificationName << "'.";
 
 						notification->BeginExecuteNotification(
-							(NotificationType)(int)unstashedNotification->Get("type"),
+							(NotificationType)(int)unstashedNotification->Get("notification_type"),
 							(CheckResult::Ptr)unstashedNotification->Get("cr"),
 							(bool)unstashedNotification->Get("force"),
 							(bool)unstashedNotification->Get("reminder"),

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -181,6 +181,9 @@ void NotificationComponent::NotificationTimerHandler()
 				ObjectLock olock(unstashedNotifications);
 
 				for (Dictionary::Ptr unstashedNotification : unstashedNotifications) {
+					if (!unstashedNotification)
+						continue;
+
 					try {
 						Log(LogNotice, "NotificationComponent")
 							<< "Attempting to send stashed notification '" << notificationName << "'.";


### PR DESCRIPTION
not to confuse the state file deserializator with e.g. `"type":32` on startup.
That would unexpectedly restore null (not `{"type":32}`) as there's no type "32".

fixes #8186