### PR TITLE
Don't trigger a fixed downtime like a flexible one

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -127,7 +127,7 @@ void Downtime::Start(bool runtimeCreated)
 	 * this downtime now *after* it has been added (important
 	 * for DB IDO, etc.)
 	 */
-	if (!checkable->IsStateOK(checkable->GetStateRaw())) {
+	if (!GetFixed() && !checkable->IsStateOK(checkable->GetStateRaw())) {
 		Log(LogNotice, "Downtime")
 			<< "Checkable '" << checkable->GetName() << "' already in a NOT-OK state."
 			<< " Triggering downtime now.";


### PR DESCRIPTION
When creating a fixed downtime that starts immediately while the checkable is in a non-OK state, previously the code path for flexible downtimes was used to trigger this downtime. This is fixed by this commit which resolves two issued:

1. Missing downtime start notification: notifications work differently for fixed and flexible downtimes. This resulted in missing downtime start notifications under the conditions described above.
2. Incorrect downtime trigger time: this code path would incorrectly assume the timestamp of the last checkable as the trigger time which is incorrect for fixed downtimes. This was only recently introduced by #9122 and does not affect any released version.

## Tests

### Notifications

#### Before

![20211214_11h01m38s_grim](https://user-images.githubusercontent.com/18552/145979611-54dce423-e0f9-4009-be24-4e1750d3e099.png)

#### After

![20211214_11h12m10s_grim](https://user-images.githubusercontent.com/18552/145979627-8864d1de-8b68-45a1-9680-556de915cacb.png)

### Trigger time

Can be tested with https://github.com/Icinga/icingadb/pull/422, with this PR you should no longer get an inconsistent `trigger_time` in there. But feel free to verify this independently as I claimed the same for #9122 and I'm not really sure how I managed to miss this there.

fixes #5202