### PR TITLE
Add option to show inode perfdata for check_disk

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -336,6 +336,7 @@ disk\_wfree      	| **Optional.** The free space warning threshold. Defaults to 
 disk\_cfree      	| **Optional.** The free space critical threshold. Defaults to "10%". If the percent sign is omitted, units from `disk_units` are used.
 disk\_inode\_wfree 	| **Optional.** The free inode warning threshold.
 disk\_inode\_cfree 	| **Optional.** The free inode critical threshold.
+disk\_inode\_perfdata      | **Optional.** Display inode usage in perfdata. (Requires: monitoring-plugins >= 2.3)
 disk\_partition		| **Optional.** The partition. **Deprecated in 2.3.**
 disk\_partition\_excluded  | **Optional.** The excluded partition. **Deprecated in 2.3.**
 disk\_partitions 	| **Optional.** The partition(s). Multiple partitions must be defined as array.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1395,6 +1395,10 @@ object CheckCommand "disk" {
 			set_if = "$disk_ignore_reserved$"
 			description = "Don't account root-reserved blocks into freespace in perfdata"
 		}
+		"-P" = {
+			set_if = "$disk_inode_perfdata$"
+			description = "Display inode usage in perfdata"
+		}
 		"-g" = {
 			value = "$disk_group$"
 			description = "Group paths. Thresholds apply to (free-)space of all partitions together"


### PR DESCRIPTION
Since monitoring-plugins >= 2.3 a new command line argument is available for the check_disk command to output also the inode information in the perfdata output. See commit monitoring-plugins/monitoring-plugins@270e7cba3830328424e3f2b6b9a6989b1ea5f89b This PR adds this new argument.

This might not be compatible with the check_disk command from nagios-plugins/nagios-plugins@ba1cef187150fde92da79ed8c5885c936f64283d.