### PR TITLE
Fix unsafe concurrent access to m_DataBuffer in InfluxdbCommonWriter

### DIFF
--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -402,6 +402,7 @@ void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dic
 
 	// Buffer the data point
 	m_DataBuffer.emplace_back(msgbuf.str());
+	m_DataBufferSize = m_DataBuffer.size();
 
 	// Flush if we've buffered too much to prevent excessive memory use
 	if (static_cast<int>(m_DataBuffer.size()) >= GetFlushThreshold()) {
@@ -447,6 +448,7 @@ void InfluxdbCommonWriter::FlushWQ()
 
 	String body = boost::algorithm::join(m_DataBuffer, "\n");
 	m_DataBuffer.clear();
+	m_DataBufferSize = 0;
 
 	OptionalTlsStream stream;
 

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -14,6 +14,7 @@
 #include "remote/url.hpp"
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
+#include <atomic>
 #include <fstream>
 
 namespace icinga
@@ -49,6 +50,7 @@ private:
 	Timer::Ptr m_FlushTimer;
 	WorkQueue m_WorkQueue{10000000, 1};
 	std::vector<String> m_DataBuffer;
+	std::atomic_size_t m_DataBufferSize{0};
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void CheckResultHandlerWQ(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
@@ -77,7 +79,7 @@ void InfluxdbCommonWriter::StatsFunc(const Dictionary::Ptr& status, const Array:
 	for (const typename InfluxWriter::Ptr& influxwriter : ConfigType::GetObjectsByType<InfluxWriter>()) {
 		size_t workQueueItems = influxwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = influxwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
-		size_t dataBufferItems = influxwriter->m_DataBuffer.size();
+		size_t dataBufferItems = influxwriter->m_DataBufferSize;
 
 		nodes.emplace_back(influxwriter->GetName(), new Dictionary({
 			{ "work_queue_items", workQueueItems },

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -36,9 +36,6 @@ public:
 	void ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils) override;
 
 protected:
-	WorkQueue m_WorkQueue{10000000, 1};
-	std::vector<String> m_DataBuffer;
-
 	void OnConfigLoaded() override;
 	void Resume() override;
 	void Pause() override;
@@ -50,6 +47,8 @@ protected:
 
 private:
 	Timer::Ptr m_FlushTimer;
+	WorkQueue m_WorkQueue{10000000, 1};
+	std::vector<String> m_DataBuffer;
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void CheckResultHandlerWQ(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
@@ -57,7 +56,7 @@ private:
 		const String& label, const Dictionary::Ptr& fields, double ts);
 	void FlushTimeout();
 	void FlushTimeoutWQ();
-	void Flush();
+	void FlushWQ();
 
 	static String EscapeKeyOrTagValue(const String& str);
 	static String EscapeValue(const Value& value);


### PR DESCRIPTION
There is no explicit synchronization of access to `m_DataBuffer` which is fine if it is only accessed from the single-threaded work queue. However, there were two exceptions which are fixed by this PR:
1. `Stop()` also called `Flush()` in another thread which modifies `m_DataBuffer`, this is fixed by also using the work queue.
2. `StatsFunc()`: called `m_DataBuffer.size()` which is unsafe if `m_DataBuffer` is modified concurrently. This is fixed by adding a new `std::atomic_size_t` to communicate the current size from the work queue to the stats function.

Other changes in this PR:
* `Flush()` is renamed to `FlushWQ()` to show that it should only be called from the work queue. Additionally, it now asserts that it is running on the work queue.
* Visibility of some data members is changed from protected to private. No other classes have to access these at the moment. By this change, accidental concurrent access from derived classes in the future is prevented.

### Tests

As this is supposed to fix a race-condition that's not easy to trigger reliably and there should be no other change in behavior, I just did some basic tests to confirm that (1) data is still written to InfluxDB and (2) `/v1/status` returns a plausible number for `data_buffer_items`.

fixes #9102