### PR TITLE
Make MySQL schema version in full schema file and upgrade files consistent

### DIFF
--- a/lib/db_ido_mysql/schema/upgrade/2.12.7.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.12.7.sql
@@ -1,0 +1,15 @@
+-- -----------------------------------------
+-- upgrade path for Icinga 2.12.7
+--
+-- -----------------------------------------
+-- Icinga 2 | (c) 2021 Icinga GmbH | GPLv2+
+--
+-- Please check https://docs.icinga.com for upgrading information!
+-- -----------------------------------------
+
+SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
+
+-- -------------
+-- set dbversion
+-- -------------
+INSERT INTO icinga_dbversion (name, version, create_time, modify_time) VALUES ('idoutils', '1.15.0', NOW(), NOW()) ON DUPLICATE KEY UPDATE version='1.15.0', modify_time=NOW();

--- a/lib/db_ido_mysql/schema/upgrade/2.13.3.sql
+++ b/lib/db_ido_mysql/schema/upgrade/2.13.3.sql
@@ -1,5 +1,5 @@
 -- -----------------------------------------
--- upgrade path for Icinga 2.13.1
+-- upgrade path for Icinga 2.13.3
 --
 -- -----------------------------------------
 -- Icinga 2 | (c) 2021 Icinga GmbH | GPLv2+


### PR DESCRIPTION
In the 2.12.6 release, the full schema file sets the version to 1.14.3, whereas the latest available upgrade file 2.11.0.sql sets it to 1.15.0. Therefore, ship a new upgrade file 2.12.7.sql for all users who imported their schema with version 2.11.0 or later and never performed an upgrade since then. Their databases incorrectly state schema version 1.14.3 and is bumped to the correct
version 1.15.0 by the upgrade.

In the 2.13.2 release, the full schema file sets the version to 1.15.0, whereas the latest available upgrade file 2.13.0.sql sets it to 1.15.1. Therefore, rename the incorrectly named upgrade file 2.13.1.sql (it was not shipped in this or any other release so far) to 2.13.3.sql for users who imported their schema with version 2.13.0 or later and never performed an upgrade since then. Their databases incorrectly state schema version 1.15.0 and are bumped to the correct version 1.15.1 by the upgrade.

The full schema is not touched by this commit as for the current branch, this was already fixed by 815533b334395c0c1007b2de9e6c317fee50713e.