### PR TITLE
Checkable#NotificationReasonApplies(): don't discard suppressed recovery notification even during soft not-OK state

### DIFF
--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -144,6 +144,7 @@ static void FireSuppressedNotifications(Checkable* checkable)
 	if (!suppressed_types)
 		return;
 
+	auto stateType (checkable->GetStateType());
 	int subtract = 0;
 
 	{
@@ -173,6 +174,13 @@ static void FireSuppressedNotifications(Checkable* checkable)
 				bool still_applies = checkable->NotificationReasonApplies(type);
 
 				if (still_applies) {
+					switch (type) {
+						case NotificationProblem:
+						case NotificationRecovery:
+							if (stateType == StateTypeSoft)
+								continue;
+					}
+
 					if (!checkable->NotificationReasonSuppressed(type) && !checkable->IsLikelyToBeCheckedSoon() && !wasLastParentRecoveryRecent.Get()) {
 						Checkable::OnNotificationsRequested(checkable, type, checkable->GetLastCheckResult(), "", "", nullptr);
 

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -229,7 +229,7 @@ bool Checkable::NotificationReasonApplies(NotificationType type)
 		case NotificationRecovery:
 			{
 				auto cr (GetLastCheckResult());
-				return cr && IsStateOK(cr->GetState());
+				return cr && (IsStateOK(cr->GetState()) || GetStateType() == StateTypeSoft);
 			}
 		case NotificationFlappingStart:
 			return IsFlapping();


### PR DESCRIPTION
Before:

1. Checkable goes hard critical
2. Downtime starts
3. Checkable goes OK
4. Checkable#suppressed_notifications == 64
5. Checkable goes soft critical
6. Checkable#suppressed_notifications == 0

If the Checkable recovers and the Downtime ends,
I'd expect a recovery notification, but that's lost now.

After:

1. Checkable goes hard critical
2. Downtime starts
3. Checkable goes OK
4. Checkable#suppressed_notifications == 64
5. Checkable goes soft critical
6. Checkable#suppressed_notifications == 64

If the Checkable recovers and the Downtime ends,
I'd get a recovery notification.