### PR TITLE
Icinga DB: ensure icinga:*command:argument#order is an int

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1009,6 +1009,15 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 					}
 				}
 
+				{
+					Value order;
+
+					// Intify if set.
+					if (values->Get("order", &order)) {
+						values->Set("order", (int)order);
+					}
+				}
+
 				values->Set(objectKeyName, objectKey);
 				values->Set("argument_key", kv.first);
 				values->Set("environment_id", m_EnvironmentId);


### PR DESCRIPTION
The config parser requires *Command#arguments#order to be a Number, i.e. 42,
4.2 or even "4.2". That's int-casted where needed, now also for Icinga DB.

Before:

```
object CheckCommand "9117" {
	command = [ "true" ]
	arguments = {
		"4.2" = { order = "4.2" }
	}
}
```

2022-01-03T13:25:07.166+0100	FATAL	icingadb	json: cannot unmarshal string into Go value of type int64

closes #9117