### PR TITLE
Alternative to just install monitoring-plugins on openSUSE

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -351,6 +351,11 @@ Please make sure to enable this repository beforehand.
 ```bash
 zypper install monitoring-plugins
 ```
+If you want to get more plugins, try to install the `monitoring-plugins-all` package instead. This package recommends all official plugins and additional packages that are available in the [server:monitoring repository](https://build.opensuse.org/project/repositories/server:monitoring):
+```bash
+zypper install monitoring-plugins-all
+```
+
 
 ### FreeBSD <a id="setting-up-check-plugins-freebsd"></a>
 


### PR DESCRIPTION
As alternative to install just the monitoring-plugins on openSUSE and SLE, users can also install the `monitoring-plugins-all` package, which requires monitoring-plugins and additional packages from the server:monitoring repository. These additional packages are just recommended, so - in case a dependency can not be fulfilled - which allows to get more (useful) plugins installed in the first run.