### PR TITLE
Additional GRANT options for MySQL

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -711,17 +711,20 @@ Set up a MySQL database for Icinga 2:
 # mysql -u root -p
 
 CREATE DATABASE icinga;
-GRANT SELECT, INSERT, UPDATE, DELETE, DROP, CREATE VIEW, INDEX, EXECUTE ON icinga.* TO 'icinga'@'localhost' IDENTIFIED BY 'icinga';
+GRANT ALTER, CREATE, SELECT, INSERT, UPDATE, DELETE, DROP, CREATE VIEW, INDEX, EXECUTE ON icinga.* TO 'icinga'@'localhost' IDENTIFIED BY 'icinga';
 quit
 ```
+
+Please note that the example above uses the very simple password 'icinga' (in `IDENTIFIED BY 'icinga'`). 
+Please choose a better password for your installation.
 
 ![setting up the database on CentOS 7](images/installation/mariadb-centos7.png "Setting up the database on CentOS 7")
 
 After creating the database you can import the Icinga 2 IDO schema using the
-following command. Enter the root password into the prompt when asked.
+following command. Enter the icinga password into the prompt when asked.
 
 ```bash
-mysql -u root -p icinga < /usr/share/icinga2-ido-mysql/schema/mysql.sql
+mysql -u icinga -p icinga < /usr/share/icinga2-ido-mysql/schema/mysql.sql
 ```
 
 #### Enabling the IDO MySQL module <a id="enabling-ido-mysql"></a>


### PR DESCRIPTION
We are using a central DB-Cluster, therefor Icinga2 got a database on this remote cluster.
We used the icinga DB user, created during the step before, to import the DB schema. 

For this, the additional GRANT options `ALTER` and `CREATE` where needed to install the schema successfully via:
```bash
mysql -u icinga -p icinga < /usr/share/icinga2-ido-mysql/schema/mysql.sql
```

Someone may find this a security problem. But I see two benefits:
* these GRANT options are only set for the icinga.* database
* this setup allows to execute also all later UPGRADE commands as the database user `icinga` - and not as the DB Administrator.

Two additional notes:
* I also included a small warning about the used default DB password
* sadly, I have no way to change this also in the provided mariadb-centos7.png image, so this is left unchanged at the moment