### PR TITLE
Substitute `for (const T& x : y) {` with `for (const auto& x : y) {`

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -1088,7 +1088,7 @@ Object locks and guards must be limited to the scope where they are needed. Othe
 ```cpp
 	{
 		ObjectLock olock(frame.Locals);
-		for (const Dictionary::Pair& kv : frame.Locals) {
+		for (const auto& kv : frame.Locals) {
 			AddSuggestion(matches, word, kv.first);
 		}
 	}

--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -412,7 +412,7 @@ static int Main()
 #endif /* _WIN32 */
 
 	if (vm.count("define")) {
-		for (const String& define : vm["define"].as<std::vector<std::string> >()) {
+		for (const auto& define : vm["define"].as<std::vector<std::string> >()) {
 			String key, value;
 			size_t pos = define.FindFirstOf('=');
 			if (pos != String::NPos) {
@@ -460,7 +460,7 @@ static int Main()
 	ConfigCompiler::AddIncludeSearchDir(Configuration::IncludeConfDir);
 
 	if (!autocomplete && vm.count("include")) {
-		for (const String& includePath : vm["include"].as<std::vector<std::string> >()) {
+		for (const auto& includePath : vm["include"].as<std::vector<std::string> >()) {
 			ConfigCompiler::AddIncludeSearchDir(includePath);
 		}
 	}

--- a/icinga-installer/icinga-installer.cpp
+++ b/icinga-installer/icinga-installer.cpp
@@ -257,7 +257,7 @@ static int InstallIcinga(void)
 
 		// Install the new windowseventlog feature. As features-available/windowseventlog.conf is used as a marker file,
 		// copy it as the last step, so that this is run again should the upgrade be interrupted.
-		for (const std::string& d : {"features-enabled", "features-available"}) {
+		for (const auto& d : {"features-enabled", "features-available"}) {
 			std::string sourceFile = skelDir + "/etc/icinga2/" + d + "/windowseventlog.conf";
 			std::string destinationFile = dataDir + "/etc/icinga2/" + d + "/windowseventlog.conf";
 

--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -107,7 +107,7 @@ void Application::Exit(int rc)
 	std::cout.flush();
 	std::cerr.flush();
 
-	for (const Logger::Ptr& logger : Logger::GetLoggers()) {
+	for (const auto& logger : Logger::GetLoggers()) {
 		logger->Flush();
 	}
 
@@ -509,7 +509,7 @@ String Application::GetExePath(const String& argv0)
 			std::vector<String> paths = String(pathEnv).Split(":");
 
 			bool foundPath = false;
-			for (const String& path : paths) {
+			for (const auto& path : paths) {
 				String pathTest = path + "/" + argv0;
 
 				if (access(pathTest.CStr(), X_OK) == 0) {

--- a/lib/base/array-script.cpp
+++ b/lib/base/array-script.cpp
@@ -130,7 +130,7 @@ static Array::Ptr ArrayMap(const Function::Ptr& function)
 	ArrayData result;
 
 	ObjectLock olock(self);
-	for (const Value& item : self) {
+	for (const auto& item : self) {
 		result.push_back(function->Invoke({ item }));
 	}
 
@@ -173,7 +173,7 @@ static Array::Ptr ArrayFilter(const Function::Ptr& function)
 	ArrayData result;
 
 	ObjectLock olock(self);
-	for (const Value& item : self) {
+	for (const auto& item : self) {
 		if (function->Invoke({ item }))
 			result.push_back(item);
 	}
@@ -192,7 +192,7 @@ static bool ArrayAny(const Function::Ptr& function)
 		BOOST_THROW_EXCEPTION(ScriptError("Filter function must be side-effect free."));
 
 	ObjectLock olock(self);
-	for (const Value& item : self) {
+	for (const auto& item : self) {
 		if (function->Invoke({ item }))
 			return true;
 	}
@@ -211,7 +211,7 @@ static bool ArrayAll(const Function::Ptr& function)
 		BOOST_THROW_EXCEPTION(ScriptError("Filter function must be side-effect free."));
 
 	ObjectLock olock(self);
-	for (const Value& item : self) {
+	for (const auto& item : self) {
 		if (!function->Invoke({ item }))
 			return false;
 	}

--- a/lib/base/array.cpp
+++ b/lib/base/array.cpp
@@ -261,7 +261,7 @@ Object::Ptr Array::Clone() const
 	ArrayData arr;
 
 	ObjectLock olock(this);
-	for (const Value& val : m_Data) {
+	for (const auto& val : m_Data) {
 		arr.push_back(val.Clone());
 	}
 
@@ -304,7 +304,7 @@ Value Array::Join(const Value& separator) const
 
 	ObjectLock olock(this);
 
-	for (const Value& item : m_Data) {
+	for (const auto& item : m_Data) {
 		if (first) {
 			first = false;
 		} else {
@@ -323,7 +323,7 @@ Array::Ptr Array::Unique() const
 
 	ObjectLock olock(this);
 
-	for (const Value& item : m_Data) {
+	for (const auto& item : m_Data) {
 		result.insert(item);
 	}
 

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -299,7 +299,7 @@ void ConfigObject::RestoreAttribute(const String& attr, bool updateVersion)
 			}
 		}
 
-		for (const String& attr : restoredAttrs)
+		for (const auto& attr : restoredAttrs)
 			original_attributes->Remove(attr);
 
 
@@ -483,13 +483,13 @@ void ConfigObject::DumpObjects(const String& filename, int attributeTypes)
 
 	StdioStream::Ptr sfp = new StdioStream(&fp, false);
 
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 			Dictionary::Ptr update = Serialize(object, attributeTypes);
 
 			if (!update)
@@ -575,13 +575,13 @@ void ConfigObject::RestoreObjects(const String& filename, int attributeTypes)
 
 	unsigned long no_state = 0;
 
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 			if (!object->GetStateLoaded()) {
 				object->OnStateLoaded();
 				object->SetStateLoaded(true);
@@ -605,13 +605,13 @@ void ConfigObject::StopObjects()
 		return false;
 	});
 
-	for (const Type::Ptr& type : types) {
+	for (const auto& type : types) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 #ifdef I2_DEBUG
 			Log(LogDebug, "ConfigObject")
 				<< "Deactivate() called for config object '" << object->GetName() << "' with type '" << type->GetName() << "'.";
@@ -623,20 +623,20 @@ void ConfigObject::StopObjects()
 
 void ConfigObject::DumpModifiedAttributes(const std::function<void(const ConfigObject::Ptr&, const String&, const Value&)>& callback)
 {
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 			Dictionary::Ptr originalAttributes = object->GetOriginalAttributes();
 
 			if (!originalAttributes)
 				continue;
 
 			ObjectLock olock(originalAttributes);
-			for (const Dictionary::Pair& kv : originalAttributes) {
+			for (const auto& kv : originalAttributes) {
 				String key = kv.first;
 
 				Type::Ptr type = object->GetReflectionType();

--- a/lib/base/configwriter.cpp
+++ b/lib/base/configwriter.cpp
@@ -43,7 +43,7 @@ void ConfigWriter::EmitArrayItems(std::ostream& fp, int indentLevel, const Array
 	bool first = true;
 
 	ObjectLock olock(val);
-	for (const Value& item : val) {
+	for (const auto& item : val) {
 		if (first)
 			first = false;
 		else
@@ -60,7 +60,7 @@ void ConfigWriter::EmitScope(std::ostream& fp, int indentLevel, const Dictionary
 
 	if (imports && imports->GetLength() > 0) {
 		ObjectLock xlock(imports);
-		for (const Value& import : imports) {
+		for (const auto& import : imports) {
 			fp << "\n";
 			EmitIndent(fp, indentLevel);
 			fp << "import \"" << import << "\"";
@@ -71,7 +71,7 @@ void ConfigWriter::EmitScope(std::ostream& fp, int indentLevel, const Dictionary
 
 	if (val) {
 		ObjectLock olock(val);
-		for (const Dictionary::Pair& kv : val) {
+		for (const auto& kv : val) {
 			fp << "\n";
 			EmitIndent(fp, indentLevel);
 

--- a/lib/base/context.cpp
+++ b/lib/base/context.cpp
@@ -38,7 +38,7 @@ void ContextTrace::Print(std::ostream& fp) const
 	fp << "\n";
 
 	int i = 0;
-	for (const String& frame : m_Frames) {
+	for (const auto& frame : m_Frames) {
 		fp << "\t(" << i << ") " << frame << "\n";
 		i++;
 	}

--- a/lib/base/dependencygraph.cpp
+++ b/lib/base/dependencygraph.cpp
@@ -41,7 +41,7 @@ std::vector<Object::Ptr> DependencyGraph::GetParents(const Object::Ptr& child)
 
 	if (it != m_Dependencies.end()) {
 		typedef std::pair<Object *, int> kv_pair;
-		for (const kv_pair& kv : it->second) {
+		for (const auto& kv : it->second) {
 			objects.emplace_back(kv.first);
 		}
 	}

--- a/lib/base/dictionary-script.cpp
+++ b/lib/base/dictionary-script.cpp
@@ -72,7 +72,7 @@ static Array::Ptr DictionaryKeys()
 
 	ArrayData keys;
 	ObjectLock olock(self);
-	for (const Dictionary::Pair& kv : self) {
+	for (const auto& kv : self) {
 		keys.push_back(kv.first);
 	}
 	return new Array(std::move(keys));
@@ -86,7 +86,7 @@ static Array::Ptr DictionaryValues()
 
 	ArrayData values;
 	ObjectLock olock(self);
-	for (const Dictionary::Pair& kv : self) {
+	for (const auto& kv : self) {
 		values.push_back(kv.second);
 	}
 	return new Array(std::move(values));

--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -194,7 +194,7 @@ void Dictionary::CopyTo(const Dictionary::Ptr& dest) const
 {
 	ObjectLock olock(this);
 
-	for (const Dictionary::Pair& kv : m_Data) {
+	for (const auto& kv : m_Data) {
 		dest->Set(kv.first, kv.second);
 	}
 }
@@ -226,7 +226,7 @@ Object::Ptr Dictionary::Clone() const
 
 		dict.reserve(GetLength());
 
-		for (const Dictionary::Pair& kv : m_Data) {
+		for (const auto& kv : m_Data) {
 			dict.emplace_back(kv.first, kv.second.Clone());
 		}
 	}
@@ -246,7 +246,7 @@ std::vector<String> Dictionary::GetKeys() const
 
 	std::vector<String> keys;
 
-	for (const Dictionary::Pair& kv : m_Data) {
+	for (const auto& kv : m_Data) {
 		keys.push_back(kv.first);
 	}
 

--- a/lib/base/exception.cpp
+++ b/lib/base/exception.cpp
@@ -203,7 +203,7 @@ String icinga::DiagnosticInformation(const std::exception& ex, bool verbose, boo
 		Array::Ptr messages;
 
 		if (currentHint) {
-			for (const String& attr : vex->GetAttributePath()) {
+			for (const auto& attr : vex->GetAttributePath()) {
 				Dictionary::Ptr props = currentHint->Get("properties");
 
 				if (!props)
@@ -369,7 +369,7 @@ ValidationError::ValidationError(const ConfigObject::Ptr& object, const std::vec
 {
 	String path;
 
-	for (const String& attribute : attributePath) {
+	for (const auto& attribute : attributePath) {
 		if (!path.IsEmpty())
 			path += " -> ";
 

--- a/lib/base/filelogger.cpp
+++ b/lib/base/filelogger.cpp
@@ -17,7 +17,7 @@ void FileLogger::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 {
 	DictionaryData nodes;
 
-	for (const FileLogger::Ptr& filelogger : ConfigType::GetObjectsByType<FileLogger>()) {
+	for (const auto& filelogger : ConfigType::GetObjectsByType<FileLogger>()) {
 		nodes.emplace_back(filelogger->GetName(), 1); //add more stats
 	}
 

--- a/lib/base/journaldlogger.cpp
+++ b/lib/base/journaldlogger.cpp
@@ -19,7 +19,7 @@ void JournaldLogger::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 {
 	DictionaryData nodes;
 
-	for (const JournaldLogger::Ptr& journaldlogger : ConfigType::GetObjectsByType<JournaldLogger>()) {
+	for (const auto& journaldlogger : ConfigType::GetObjectsByType<JournaldLogger>()) {
 		nodes.emplace_back(journaldlogger->GetName(), 1); //add more stats
 	}
 
@@ -70,11 +70,11 @@ void JournaldLogger::SystemdJournalSend(const std::vector<String>& varJournalFie
 	struct iovec iovec[m_ConfiguredJournalFields.size() + varJournalFields.size()];
 	int iovecCount = 0;
 
-	for (const String& journalField: m_ConfiguredJournalFields) {
+	for (const auto& journalField: m_ConfiguredJournalFields) {
 		iovec[iovecCount] = IovecFromString(journalField);
 		iovecCount++;
 	}
-	for (const String& journalField: varJournalFields) {
+	for (const auto& journalField: varJournalFields) {
 		iovec[iovecCount] = IovecFromString(journalField);
 		iovecCount++;
 	}

--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -93,7 +93,7 @@ void EncodeNamespace(JsonEncoder<prettyPrint>& stateMachine, const Namespace::Pt
 	stateMachine.StartObject();
 
 	ObjectLock olock(ns);
-	for (const Namespace::Pair& kv : ns) {
+	for (const auto& kv : ns) {
 		stateMachine.Key(Utility::ValidateUTF8(kv.first));
 		Encode(stateMachine, kv.second->Get());
 	}
@@ -108,7 +108,7 @@ void EncodeDictionary(JsonEncoder<prettyPrint>& stateMachine, const Dictionary::
 	stateMachine.StartObject();
 
 	ObjectLock olock(dict);
-	for (const Dictionary::Pair& kv : dict) {
+	for (const auto& kv : dict) {
 		stateMachine.Key(Utility::ValidateUTF8(kv.first));
 		Encode(stateMachine, kv.second);
 	}
@@ -123,7 +123,7 @@ void EncodeArray(JsonEncoder<prettyPrint>& stateMachine, const Array::Ptr& arr)
 	stateMachine.StartArray();
 
 	ObjectLock olock(arr);
-	for (const Value& value : arr) {
+	for (const auto& value : arr) {
 		Encode(stateMachine, value);
 	}
 

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -232,7 +232,7 @@ Log::~Log()
 		}
 	}
 
-	for (const Logger::Ptr& logger : Logger::GetLoggers()) {
+	for (const auto& logger : Logger::GetLoggers()) {
 		ObjectLock llock(logger);
 
 		if (!logger->IsActive())

--- a/lib/base/math-script.cpp
+++ b/lib/base/math-script.cpp
@@ -66,7 +66,7 @@ static Value MathMax(const std::vector<Value>& args)
 	bool first = true;
 	Value result = -INFINITY;
 
-	for (const Value& arg : args) {
+	for (const auto& arg : args) {
 		if (first || arg > result) {
 			first = false;
 			result = arg;
@@ -81,7 +81,7 @@ static Value MathMin(const std::vector<Value>& args)
 	bool first = true;
 	Value result = INFINITY;
 
-	for (const Value& arg : args) {
+	for (const auto& arg : args) {
 		if (first || arg < result) {
 			first = false;
 			result = arg;

--- a/lib/base/namespace-script.cpp
+++ b/lib/base/namespace-script.cpp
@@ -48,7 +48,7 @@ static Array::Ptr NamespaceKeys()
 
 	ArrayData keys;
 	ObjectLock olock(self);
-	for (const Namespace::Pair& kv : self) {
+	for (const auto& kv : self) {
 		keys.push_back(kv.first);
 	}
 	return new Array(std::move(keys));
@@ -62,7 +62,7 @@ static Array::Ptr NamespaceValues()
 
 	ArrayData values;
 	ObjectLock olock(self);
-	for (const Namespace::Pair& kv : self) {
+	for (const auto& kv : self) {
 		values.push_back(kv.second->Get());
 	}
 	return new Array(std::move(values));

--- a/lib/base/object-packer.cpp
+++ b/lib/base/object-packer.cpp
@@ -144,7 +144,7 @@ static inline void PackArray(const Array::Ptr& arr, std::string& builder)
 	builder += '\5';
 	PackUInt64BE(arr->GetLength(), builder);
 
-	for (const Value& value : arr) {
+	for (const auto& value : arr) {
 		PackAny(value, builder);
 	}
 }
@@ -159,7 +159,7 @@ static inline void PackDictionary(const Dictionary::Ptr& dict, std::string& buil
 	builder += '\6';
 	PackUInt64BE(dict->GetLength(), builder);
 
-	for (const Dictionary::Pair& kv : dict) {
+	for (const auto& kv : dict) {
 		PackString(kv.first, builder);
 		PackAny(kv.second, builder);
 	}

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -124,7 +124,7 @@ static Value ProcessSpawnImpl(struct msghdr *msgh, const Dictionary::Ptr& reques
 	if (extraEnvironment) {
 		ObjectLock olock(extraEnvironment);
 
-		for (const Dictionary::Pair& kv : extraEnvironment) {
+		for (const auto& kv : extraEnvironment) {
 			String skv = kv.first + "=" + Convert::ToString(kv.second);
 			envp[j] = strdup(skv.CStr());
 			j++;
@@ -554,7 +554,7 @@ Process::Arguments Process::PrepareCommand(const Value& command)
 		Array::Ptr arguments = command;
 
 		ObjectLock olock(arguments);
-		for (const Value& argument : arguments) {
+		for (const auto& argument : arguments) {
 #ifdef _WIN32
 			if (args != "")
 				args += " ";
@@ -633,7 +633,7 @@ void Process::IOThreadProc(int tid)
 
 			int i = 1;
 			typedef std::pair<ProcessHandle, Process::Ptr> kv_pair;
-			for (const kv_pair& kv : l_Processes[tid]) {
+			for (const auto& kv : l_Processes[tid]) {
 				const Process::Ptr& process = kv.second;
 #ifdef _WIN32
 				handles[i] = kv.first;
@@ -888,7 +888,7 @@ void Process::Run(const std::function<void(const ProcessResult&)>& callback)
 	if (m_ExtraEnvironment) {
 		ObjectLock olock(m_ExtraEnvironment);
 
-		for (const Dictionary::Pair& kv : m_ExtraEnvironment) {
+		for (const auto& kv : m_ExtraEnvironment) {
 			String skv = kv.first + "=" + Convert::ToString(kv.second);
 
 			envp = static_cast<char *>(realloc(envp, offset + skv.GetLength() + 1));

--- a/lib/base/scriptglobal.cpp
+++ b/lib/base/scriptglobal.cpp
@@ -92,7 +92,7 @@ void ScriptGlobal::WriteToFile(const String& filename)
 	StdioStream::Ptr sfp = new StdioStream(&fp, false);
 
 	ObjectLock olock(m_Globals);
-	for (const Namespace::Pair& kv : m_Globals) {
+	for (const auto& kv : m_Globals) {
 		Value value = kv.second->Get();
 
 		if (value.IsObject())

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -124,7 +124,7 @@ bool ScriptUtils::Regex(const std::vector<Value>& args)
 		if (texts->GetLength() == 0)
 			return false;
 
-		for (const String& text : texts) {
+		for (const auto& text : texts) {
 			bool res = false;
 			try {
 				boost::smatch what;
@@ -177,7 +177,7 @@ bool ScriptUtils::Match(const std::vector<Value>& args)
 		if (texts->GetLength() == 0)
 			return false;
 
-		for (const String& text : texts) {
+		for (const auto& text : texts) {
 			bool res = Utility::Match(pattern, text);
 
 			if (mode == MatchAny && res)
@@ -223,7 +223,7 @@ bool ScriptUtils::CidrMatch(const std::vector<Value>& args)
 		if (ips->GetLength() == 0)
 			return false;
 
-		for (const String& ip : ips) {
+		for (const auto& ip : ips) {
 			bool res = Utility::CidrMatch(pattern, ip);
 
 			if (mode == MatchAny && res)
@@ -259,12 +259,12 @@ Array::Ptr ScriptUtils::Union(const std::vector<Value>& arguments)
 {
 	std::set<Value> values;
 
-	for (const Value& varr : arguments) {
+	for (const auto& varr : arguments) {
 		Array::Ptr arr = varr;
 
 		if (arr) {
 			ObjectLock olock(arr);
-			for (const Value& value : arr) {
+			for (const auto& value : arr) {
 				values.insert(value);
 			}
 		}
@@ -393,7 +393,7 @@ Array::Ptr ScriptUtils::Keys(const Object::Ptr& obj)
 
 	if (dict) {
 		ObjectLock olock(dict);
-		for (const Dictionary::Pair& kv : dict) {
+		for (const auto& kv : dict) {
 			result.push_back(kv.first);
 		}
 	}
@@ -402,7 +402,7 @@ Array::Ptr ScriptUtils::Keys(const Object::Ptr& obj)
 
 	if (ns) {
 		ObjectLock olock(ns);
-		for (const Namespace::Pair& kv : ns) {
+		for (const auto& kv : ns) {
 			result.push_back(kv.first);
 		}
 	}
@@ -453,7 +453,7 @@ Array::Ptr ScriptUtils::GetTemplates(const Type::Ptr& type)
 
 	ArrayData result;
 
-	for (const ConfigItem::Ptr& item : ConfigItem::GetItems(type)) {
+	for (const auto& item : ConfigItem::GetItems(type)) {
 		if (item->IsAbstract())
 			result.push_back(GetTargetForTemplate(item));
 	}
@@ -490,7 +490,7 @@ Array::Ptr ScriptUtils::GetObjects(const Type::Ptr& type)
 
 	ArrayData result;
 
-	for (const ConfigObject::Ptr& object : ctype->GetObjects())
+	for (const auto& object : ctype->GetObjects())
 		result.push_back(object);
 
 	return new Array(std::move(result));

--- a/lib/base/serializer.cpp
+++ b/lib/base/serializer.cpp
@@ -76,7 +76,7 @@ static Array::Ptr SerializeArray(const Array::Ptr& input, int attributeTypes, Se
 
 	int index = 0;
 
-	for (const Value& value : input) {
+	for (const auto& value : input) {
 		stack.Push(Convert::ToString(index), value);
 		result.emplace_back(SerializeInternal(value, attributeTypes, stack));
 		stack.Pop();
@@ -94,7 +94,7 @@ static Dictionary::Ptr SerializeDictionary(const Dictionary::Ptr& input, int att
 
 	ObjectLock olock(input);
 
-	for (const Dictionary::Pair& kv : input) {
+	for (const auto& kv : input) {
 		stack.Push(kv.first, kv.second);
 		result.emplace_back(kv.first, SerializeInternal(kv.second, attributeTypes, stack));
 		stack.Pop();
@@ -109,7 +109,7 @@ static Dictionary::Ptr SerializeNamespace(const Namespace::Ptr& input, int attri
 
 	ObjectLock olock(input);
 
-	for (const Namespace::Pair& kv : input) {
+	for (const auto& kv : input) {
 		Value val = kv.second->Get();
 		stack.Push(kv.first, val);
 		result.emplace_back(kv.first, Serialize(val, attributeTypes));
@@ -159,7 +159,7 @@ static Array::Ptr DeserializeArray(const Array::Ptr& input, bool safe_mode, int 
 
 	ObjectLock olock(input);
 
-	for (const Value& value : input) {
+	for (const auto& value : input) {
 		result.emplace_back(Deserialize(value, safe_mode, attributeTypes));
 	}
 
@@ -174,7 +174,7 @@ static Dictionary::Ptr DeserializeDictionary(const Dictionary::Ptr& input, bool 
 
 	ObjectLock olock(input);
 
-	for (const Dictionary::Pair& kv : input) {
+	for (const auto& kv : input) {
 		result.emplace_back(kv.first, Deserialize(kv.second, safe_mode, attributeTypes));
 	}
 
@@ -204,7 +204,7 @@ static Object::Ptr DeserializeObject(const Object::Ptr& object, const Dictionary
 		instance = type->Instantiate(std::vector<Value>());
 
 	ObjectLock olock(input);
-	for (const Dictionary::Pair& kv : input) {
+	for (const auto& kv : input) {
 		if (kv.first.IsEmpty())
 			continue;
 

--- a/lib/base/sysloglogger.cpp
+++ b/lib/base/sysloglogger.cpp
@@ -104,7 +104,7 @@ void SyslogLogger::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 {
 	DictionaryData nodes;
 
-	for (const SyslogLogger::Ptr& sysloglogger : ConfigType::GetObjectsByType<SyslogLogger>()) {
+	for (const auto& sysloglogger : ConfigType::GetObjectsByType<SyslogLogger>()) {
 		nodes.emplace_back(sysloglogger->GetName(), 1); //add more stats
 	}
 

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -53,7 +53,7 @@ std::vector<Type::Ptr> Type::GetAllTypes()
 	if (typesNS) {
 		ObjectLock olock(typesNS);
 
-		for (const Namespace::Pair& kv : typesNS) {
+		for (const auto& kv : typesNS) {
 			Value value = kv.second->Get();
 
 			if (value.IsObjectType<Type>())

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -475,7 +475,7 @@ bool Utility::Glob(const String& pathSpec, const std::function<void (const Strin
 			if (!GlobHelper(part1, GlobDirectory, files2, dirs2))
 				return false;
 
-			for (const String& dir : dirs2) {
+			for (const auto& dir : dirs2) {
 				if (!Utility::Glob(dir + "/" + part2, callback, type))
 					return false;
 			}
@@ -527,12 +527,12 @@ bool Utility::Glob(const String& pathSpec, const std::function<void (const Strin
 #endif /* _WIN32 */
 
 	std::sort(files.begin(), files.end());
-	for (const String& cpath : files) {
+	for (const auto& cpath : files) {
 		callback(cpath);
 	}
 
 	std::sort(dirs.begin(), dirs.end());
-	for (const String& cpath : dirs) {
+	for (const auto& cpath : dirs) {
 		callback(cpath);
 	}
 
@@ -653,17 +653,17 @@ bool Utility::GlobRecursive(const String& path, const String& pattern, const std
 #endif /* _WIN32 */
 
 	std::sort(files.begin(), files.end());
-	for (const String& cpath : files) {
+	for (const auto& cpath : files) {
 		callback(cpath);
 	}
 
 	std::sort(dirs.begin(), dirs.end());
-	for (const String& cpath : dirs) {
+	for (const auto& cpath : dirs) {
 		callback(cpath);
 	}
 
 	std::sort(alldirs.begin(), alldirs.end());
-	for (const String& cpath : alldirs) {
+	for (const auto& cpath : alldirs) {
 		GlobRecursive(cpath, pattern, callback, type);
 	}
 
@@ -983,7 +983,7 @@ String Utility::Join(const Array::Ptr& tokens, char separator, bool escapeSepara
 	bool first = true;
 
 	ObjectLock olock(tokens);
-	for (const Value& vtoken : tokens) {
+	for (const auto& vtoken : tokens) {
 		String token = Convert::ToString(vtoken);
 
 		if (escapeSeparator) {

--- a/lib/base/value-operators.cpp
+++ b/lib/base/value-operators.cpp
@@ -273,10 +273,10 @@ Value icinga::operator-(const Value& lhs, const Value& rhs)
 		Array::Ptr right = rhs;
 
 		ObjectLock olock(left);
-		for (const Value& lv : left) {
+		for (const auto& lv : left) {
 			bool found = false;
 			ObjectLock xlock(right);
-			for (const Value& rv : right) {
+			for (const auto& rv : right) {
 				if (lv == rv) {
 					found = true;
 					break;

--- a/lib/base/windowseventloglogger.cpp
+++ b/lib/base/windowseventloglogger.cpp
@@ -27,7 +27,7 @@ void WindowsEventLogLogger::StatsFunc(const Dictionary::Ptr& status, const Array
 {
 	DictionaryData nodes;
 
-	for (const WindowsEventLogLogger::Ptr& logger : ConfigType::GetObjectsByType<WindowsEventLogLogger>()) {
+	for (const auto& logger : ConfigType::GetObjectsByType<WindowsEventLogLogger>()) {
 		nodes.emplace_back(logger->GetName(), 1);
 	}
 

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -26,7 +26,7 @@ void CheckerComponent::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr
 {
 	DictionaryData nodes;
 
-	for (const CheckerComponent::Ptr& checker : ConfigType::GetObjectsByType<CheckerComponent>()) {
+	for (const auto& checker : ConfigType::GetObjectsByType<CheckerComponent>()) {
 		unsigned long idle = checker->GetIdleCheckables();
 		unsigned long pending = checker->GetPendingCheckables();
 

--- a/lib/cli/apisetuputility.cpp
+++ b/lib/cli/apisetuputility.cpp
@@ -124,7 +124,7 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 	Utility::CopyFile(ca, target_ca);
 
 	/* fix permissions: root -> icinga daemon user */
-	for (const String& file : { ca_path, ca, ca_key, target_ca, key, csr, cert }) {
+	for (const auto& file : { ca_path, ca, ca_key, target_ca, key, csr, cert }) {
 		if (!Utility::SetFileOwnership(file, user, group)) {
 			Log(LogWarning, "cli")
 				<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << file << "'.";

--- a/lib/cli/clicommand.cpp
+++ b/lib/cli/clicommand.cpp
@@ -163,7 +163,7 @@ bool CLICommand::ParseCommand(int argc, char **argv, po::options_description& vi
 	int arg_end = 0;
 	bool tried_command = false;
 
-	for (const CLIKeyValue& kv : GetRegistry()) {
+	for (const auto& kv : GetRegistry()) {
 		const std::vector<String>& vname = kv.first;
 
 		std::vector<String>::size_type i;
@@ -232,7 +232,7 @@ void CLICommand::ShowCommands(int argc, char **argv, po::options_description *vi
 	int arg_begin = 0;
 	CLICommand::Ptr command;
 
-	for (const CLIKeyValue& kv : GetRegistry()) {
+	for (const auto& kv : GetRegistry()) {
 		const std::vector<String>& vname = kv.first;
 
 		arg_begin = 0;
@@ -274,7 +274,7 @@ void CLICommand::ShowCommands(int argc, char **argv, po::options_description *vi
 	} else
 		std::cout << "Supported commands: " << std::endl;
 
-	for (const CLIKeyValue& kv : GetRegistry()) {
+	for (const auto& kv : GetRegistry()) {
 		const std::vector<String>& vname = kv.first;
 
 		if (vname.size() < best_match.size() || kv.second->IsHidden())
@@ -346,25 +346,25 @@ void CLICommand::ShowCommands(int argc, char **argv, po::options_description *vi
 		if (odesc->semantic()->min_tokens() == 0)
 			goto complete_option;
 
-		for (const String& suggestion : globalArgCompletionCallback(odesc->long_name(), pword)) {
+		for (const auto& suggestion : globalArgCompletionCallback(odesc->long_name(), pword)) {
 			std::cout << prefix << suggestion << "\n";
 		}
 
-		for (const String& suggestion : command->GetArgumentSuggestions(odesc->long_name(), pword)) {
+		for (const auto& suggestion : command->GetArgumentSuggestions(odesc->long_name(), pword)) {
 			std::cout << prefix << suggestion << "\n";
 		}
 
 		return;
 
 complete_option:
-		for (const boost::shared_ptr<po::option_description>& odesc : visibleDesc->options()) {
+		for (const auto& odesc : visibleDesc->options()) {
 			String cname = "--" + odesc->long_name();
 
 			if (cname.Find(aword) == 0)
 				std::cout << cname << "\n";
 		}
 
-		for (const String& suggestion : command->GetPositionalSuggestions(aword)) {
+		for (const auto& suggestion : command->GetPositionalSuggestions(aword)) {
 			std::cout << suggestion << "\n";
 		}
 	}

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -115,7 +115,7 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 		ConfigCompilerContext::GetInstance()->OpenObjectsFile(objectsFile);
 
 	if (!configs.empty()) {
-		for (const String& configPath : configs) {
+		for (const auto& configPath : configs) {
 			try {
 				std::unique_ptr<Expression> expression = ConfigCompiler::CompileFile(configPath, String(), "_etc");
 				success = ExecuteExpression(&*expression);

--- a/lib/cli/featureutility.cpp
+++ b/lib/cli/featureutility.cpp
@@ -31,7 +31,7 @@ std::vector<String> FeatureUtility::GetFieldCompletionSuggestions(const String& 
 
 	std::sort(cache.begin(), cache.end());
 
-	for (const String& suggestion : cache) {
+	for (const auto& suggestion : cache) {
 		if (suggestion.Find(word) == 0)
 			suggestions.push_back(suggestion);
 	}
@@ -58,7 +58,7 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 
 	std::vector<std::string> errors;
 
-	for (const String& feature : features) {
+	for (const auto& feature : features) {
 		String source = features_available_dir + "/" + feature + ".conf";
 
 		if (!Utility::PathExists(source) ) {
@@ -126,7 +126,7 @@ int FeatureUtility::DisableFeatures(const std::vector<std::string>& features)
 
 	std::vector<std::string> errors;
 
-	for (const String& feature : features) {
+	for (const auto& feature : features) {
 		String target = features_enabled_dir + "/" + feature + ".conf";
 
 		if (!Utility::PathExists(target) ) {
@@ -224,7 +224,7 @@ bool FeatureUtility::CheckFeatureInternal(const String& feature, bool check_disa
 	if (!FeatureUtility::GetFeatures(features, check_disabled))
 		return false;
 
-	for (const String& check_feature : features) {
+	for (const auto& check_feature : features) {
 		if (check_feature == feature)
 			return true;
 	}

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -46,7 +46,7 @@ int NodeUtility::GenerateNodeIcingaConfig(const String& endpointName, const Stri
 
 	Array::Ptr myParentZoneMembers = new Array();
 
-	for (const String& endpoint : endpoints) {
+	for (const auto& endpoint : endpoints) {
 		/* extract all --endpoint arguments and store host,port info */
 		std::vector<String> tokens = endpoint.Split(",");
 
@@ -96,7 +96,7 @@ int NodeUtility::GenerateNodeIcingaConfig(const String& endpointName, const Stri
 		{ "endpoints", new Array({ endpointName }) }
 	}));
 
-	for (const String& globalzone : globalZones) {
+	for (const auto& globalzone : globalZones) {
 		config->Add(new Dictionary({
 			{ "__name", globalzone },
 			{ "__type", "Zone" },
@@ -127,7 +127,7 @@ int NodeUtility::GenerateNodeMasterIcingaConfig(const String& endpointName, cons
 		{ "endpoints", new Array({ endpointName }) }
 	}));
 
-	for (const String& globalzone : globalZones) {
+	for (const auto& globalzone : globalZones) {
 		config->Add(new Dictionary({
 			{ "__name", globalzone },
 			{ "__type", "Zone" },
@@ -174,7 +174,7 @@ bool NodeUtility::WriteNodeConfigObjects(const String& filename, const Array::Pt
 	fp << " */\n\n";
 
 	ObjectLock olock(objects);
-	for (const Dictionary::Ptr& object : objects) {
+	for (const auto& object : objects) {
 		SerializeObject(fp, object);
 	}
 
@@ -225,7 +225,7 @@ void NodeUtility::SerializeObject(std::ostream& fp, const Dictionary::Ptr& objec
 	fp << " {\n";
 
 	ObjectLock olock(object);
-	for (const Dictionary::Pair& kv : object) {
+	for (const auto& kv : object) {
 		if (kv.first == "__type" || kv.first == "__name")
 			continue;
 

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -241,7 +241,7 @@ wizard_endpoint_loop_start:
 	/* Extract parent node information. */
 	String parentHost, parentPort;
 
-	for (const String& endpoint : endpoints) {
+	for (const auto& endpoint : endpoints) {
 		std::vector<String> tokens = endpoint.Split(",");
 
 		if (tokens.size() > 1)

--- a/lib/cli/objectlistcommand.cpp
+++ b/lib/cli/objectlistcommand.cpp
@@ -111,7 +111,7 @@ void ObjectListCommand::PrintTypeCounts(std::ostream& fp, const std::map<String,
 {
 	typedef std::map<String, int>::value_type TypeCount;
 
-	for (const TypeCount& kv : type_count) {
+	for (const auto& kv : type_count) {
 		fp << "Found " << kv.second << " " << kv.first << " object";
 
 		if (kv.second != 1)

--- a/lib/cli/objectlistutility.cpp
+++ b/lib/cli/objectlistutility.cpp
@@ -59,7 +59,7 @@ void ObjectListUtility::PrintProperties(std::ostream& fp, const Dictionary::Ptr&
 	int offset = 2;
 
 	ObjectLock olock(props);
-	for (const Dictionary::Pair& kv : props)
+	for (const auto& kv : props)
 	{
 		String key = kv.first;
 		Value val = kv.second;
@@ -96,7 +96,7 @@ void ObjectListUtility::PrintHints(std::ostream& fp, const Dictionary::Ptr& debu
 	if (messages) {
 		ObjectLock olock(messages);
 
-		for (const Value& msg : messages)
+		for (const auto& msg : messages)
 		{
 			PrintHint(fp, msg, indent);
 		}
@@ -137,7 +137,7 @@ void ObjectListUtility::PrintArray(std::ostream& fp, const Array::Ptr& arr)
 
 	if (arr) {
 		ObjectLock olock(arr);
-		for (const Value& value : arr)
+		for (const auto& value : arr)
 		{
 			if (first)
 				first = false;

--- a/lib/compat/checkresultreader.cpp
+++ b/lib/compat/checkresultreader.cpp
@@ -27,7 +27,7 @@ void CheckResultReader::StatsFunc(const Dictionary::Ptr& status, const Array::Pt
 {
 	DictionaryData nodes;
 
-	for (const CheckResultReader::Ptr& checkresultreader : ConfigType::GetObjectsByType<CheckResultReader>()) {
+	for (const auto& checkresultreader : ConfigType::GetObjectsByType<CheckResultReader>()) {
 		nodes.emplace_back(checkresultreader->GetName(), 1); //add more stats
 	}
 

--- a/lib/compat/compatlogger.cpp
+++ b/lib/compat/compatlogger.cpp
@@ -29,7 +29,7 @@ void CompatLogger::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 {
 	DictionaryData nodes;
 
-	for (const CompatLogger::Ptr& compat_logger : ConfigType::GetObjectsByType<CompatLogger>()) {
+	for (const auto& compat_logger : ConfigType::GetObjectsByType<CompatLogger>()) {
 		nodes.emplace_back(compat_logger->GetName(), 1); // add more stats
 	}
 
@@ -492,7 +492,7 @@ void CompatLogger::ReopenFile(bool rotate)
 	WriteLine("LOG ROTATION: " + GetRotationMethod());
 	WriteLine("LOG VERSION: 2.0");
 
-	for (const Host::Ptr& host : ConfigType::GetObjectsByType<Host>()) {
+	for (const auto& host : ConfigType::GetObjectsByType<Host>()) {
 		String output;
 		CheckResult::Ptr cr = host->GetLastCheckResult();
 
@@ -510,7 +510,7 @@ void CompatLogger::ReopenFile(bool rotate)
 		WriteLine(msgbuf.str());
 	}
 
-	for (const Service::Ptr& service : ConfigType::GetObjectsByType<Service>()) {
+	for (const auto& service : ConfigType::GetObjectsByType<Service>()) {
 		Host::Ptr host = service->GetHost();
 
 		String output;

--- a/lib/compat/externalcommandlistener.cpp
+++ b/lib/compat/externalcommandlistener.cpp
@@ -19,7 +19,7 @@ void ExternalCommandListener::StatsFunc(const Dictionary::Ptr& status, const Arr
 {
 	DictionaryData nodes;
 
-	for (const ExternalCommandListener::Ptr& externalcommandlistener : ConfigType::GetObjectsByType<ExternalCommandListener>()) {
+	for (const auto& externalcommandlistener : ConfigType::GetObjectsByType<ExternalCommandListener>()) {
 		nodes.emplace_back(externalcommandlistener->GetName(), 1); //add more stats
 	}
 

--- a/lib/compat/statusdatawriter.cpp
+++ b/lib/compat/statusdatawriter.cpp
@@ -36,7 +36,7 @@ void StatusDataWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr
 {
 	DictionaryData nodes;
 
-	for (const StatusDataWriter::Ptr& statusdatawriter : ConfigType::GetObjectsByType<StatusDataWriter>()) {
+	for (const auto& statusdatawriter : ConfigType::GetObjectsByType<StatusDataWriter>()) {
 		nodes.emplace_back(statusdatawriter->GetName(), 1); //add more stats
 	}
 
@@ -91,7 +91,7 @@ void StatusDataWriter::DumpComments(std::ostream& fp, const Checkable::Ptr& chec
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	for (const Comment::Ptr& comment : checkable->GetComments()) {
+	for (const auto& comment : checkable->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -125,7 +125,7 @@ void StatusDataWriter::DumpTimePeriod(std::ostream& fp, const TimePeriod::Ptr& t
 
 	if (ranges) {
 		ObjectLock olock(ranges);
-		for (const Dictionary::Pair& kv : ranges) {
+		for (const auto& kv : ranges) {
 			fp << "\t" << kv.first << "\t" << kv.second << "\n";
 		}
 	}
@@ -155,7 +155,7 @@ void StatusDataWriter::DumpDowntimes(std::ostream& fp, const Checkable::Ptr& che
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	for (const Downtime::Ptr& downtime : checkable->GetDowntimes()) {
+	for (const auto& downtime : checkable->GetDowntimes()) {
 		if (downtime->IsExpired())
 			continue;
 
@@ -293,7 +293,7 @@ void StatusDataWriter::DumpHostObject(std::ostream& fp, const Host::Ptr& host)
 	if (groups) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			HostGroup::Ptr hg = HostGroup::GetByName(name);
 
 			if (hg) {
@@ -487,7 +487,7 @@ void StatusDataWriter::DumpServiceObject(std::ostream& fp, const Service::Ptr& s
 	if (groups) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			ServiceGroup::Ptr sg = ServiceGroup::GetByName(name);
 
 			if (sg) {
@@ -518,7 +518,7 @@ void StatusDataWriter::DumpCustomAttributes(std::ostream& fp, const CustomVarObj
 	bool is_json = false;
 
 	ObjectLock olock(vars);
-	for (const Dictionary::Pair& kv : vars) {
+	for (const auto& kv : vars) {
 		if (kv.first.IsEmpty())
 			continue;
 
@@ -553,13 +553,13 @@ void StatusDataWriter::UpdateObjectsCache()
 			"# This file is auto-generated. Do not modify this file." "\n"
 			"\n";
 
-	for (const Host::Ptr& host : ConfigType::GetObjectsByType<Host>()) {
+	for (const auto& host : ConfigType::GetObjectsByType<Host>()) {
 		std::ostringstream tempobjectfp;
 		tempobjectfp << std::fixed;
 		DumpHostObject(tempobjectfp, host);
 		objectfp << tempobjectfp.str();
 
-		for (const Service::Ptr& service : host->GetServices()) {
+		for (const auto& service : host->GetServices()) {
 			std::ostringstream tempobjectfp;
 			tempobjectfp << std::fixed;
 			DumpServiceObject(tempobjectfp, service);
@@ -567,7 +567,7 @@ void StatusDataWriter::UpdateObjectsCache()
 		}
 	}
 
-	for (const HostGroup::Ptr& hg : ConfigType::GetObjectsByType<HostGroup>()) {
+	for (const auto& hg : ConfigType::GetObjectsByType<HostGroup>()) {
 		std::ostringstream tempobjectfp;
 		tempobjectfp << std::fixed;
 
@@ -597,7 +597,7 @@ void StatusDataWriter::UpdateObjectsCache()
 		objectfp << tempobjectfp.str();
 	}
 
-	for (const ServiceGroup::Ptr& sg : ConfigType::GetObjectsByType<ServiceGroup>()) {
+	for (const auto& sg : ConfigType::GetObjectsByType<ServiceGroup>()) {
 		std::ostringstream tempobjectfp;
 		tempobjectfp << std::fixed;
 
@@ -623,7 +623,7 @@ void StatusDataWriter::UpdateObjectsCache()
 		tempobjectfp << "\t" "members" "\t";
 
 		std::vector<String> sglist;
-		for (const Service::Ptr& service : sg->GetMembers()) {
+		for (const auto& service : sg->GetMembers()) {
 			Host::Ptr host = service->GetHost();
 
 			sglist.emplace_back(host->GetName());
@@ -637,7 +637,7 @@ void StatusDataWriter::UpdateObjectsCache()
 		objectfp << tempobjectfp.str();
 	}
 
-	for (const User::Ptr& user : ConfigType::GetObjectsByType<User>()) {
+	for (const auto& user : ConfigType::GetObjectsByType<User>()) {
 		std::ostringstream tempobjectfp;
 		tempobjectfp << std::fixed;
 
@@ -665,7 +665,7 @@ void StatusDataWriter::UpdateObjectsCache()
 		objectfp << tempobjectfp.str();
 	}
 
-	for (const UserGroup::Ptr& ug : ConfigType::GetObjectsByType<UserGroup>()) {
+	for (const auto& ug : ConfigType::GetObjectsByType<UserGroup>()) {
 		std::ostringstream tempobjectfp;
 		tempobjectfp << std::fixed;
 
@@ -681,23 +681,23 @@ void StatusDataWriter::UpdateObjectsCache()
 		objectfp << tempobjectfp.str();
 	}
 
-	for (const Command::Ptr& command : ConfigType::GetObjectsByType<CheckCommand>()) {
+	for (const auto& command : ConfigType::GetObjectsByType<CheckCommand>()) {
 		DumpCommand(objectfp, command);
 	}
 
-	for (const Command::Ptr& command : ConfigType::GetObjectsByType<NotificationCommand>()) {
+	for (const auto& command : ConfigType::GetObjectsByType<NotificationCommand>()) {
 		DumpCommand(objectfp, command);
 	}
 
-	for (const Command::Ptr& command : ConfigType::GetObjectsByType<EventCommand>()) {
+	for (const auto& command : ConfigType::GetObjectsByType<EventCommand>()) {
 		DumpCommand(objectfp, command);
 	}
 
-	for (const TimePeriod::Ptr& tp : ConfigType::GetObjectsByType<TimePeriod>()) {
+	for (const auto& tp : ConfigType::GetObjectsByType<TimePeriod>()) {
 		DumpTimePeriod(objectfp, tp);
 	}
 
-	for (const Dependency::Ptr& dep : ConfigType::GetObjectsByType<Dependency>()) {
+	for (const auto& dep : ConfigType::GetObjectsByType<Dependency>()) {
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent) {
@@ -819,13 +819,13 @@ void StatusDataWriter::StatusTimerHandler()
 	statusfp << "\t" "}" "\n"
 			"\n";
 
-	for (const Host::Ptr& host : ConfigType::GetObjectsByType<Host>()) {
+	for (const auto& host : ConfigType::GetObjectsByType<Host>()) {
 		std::ostringstream tempstatusfp;
 		tempstatusfp << std::fixed;
 		DumpHostStatus(tempstatusfp, host);
 		statusfp << tempstatusfp.str();
 
-		for (const Service::Ptr& service : host->GetServices()) {
+		for (const auto& service : host->GetServices()) {
 			std::ostringstream tempstatusfp;
 			tempstatusfp << std::fixed;
 			DumpServiceStatus(tempstatusfp, service);
@@ -855,7 +855,7 @@ String StatusDataWriter::GetNotificationOptions(const Checkable::Ptr& checkable)
 	unsigned long notification_type_filter = 0;
 	unsigned long notification_state_filter = 0;
 
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		notification_type_filter |= notification->GetTypeFilter();
 		notification_state_filter |= notification->GetStateFilter();
 	}

--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -103,7 +103,7 @@ bool ApplyRule::IsValidTargetType(const String& sourceType, const String& target
 	if (it->second.size() == 1 && targetType == "")
 		return true;
 
-	for (const String& type : it->second) {
+	for (const auto& type : it->second) {
 		if (type == targetType)
 			return true;
 	}
@@ -143,8 +143,8 @@ std::vector<ApplyRule>& ApplyRule::GetRules(const String& type)
 
 void ApplyRule::CheckMatches(bool silent)
 {
-	for (const RuleMap::value_type& kv : m_Rules) {
-		for (const ApplyRule& rule : kv.second) {
+	for (const auto& kv : m_Rules) {
+		for (const auto& rule : kv.second) {
 			if (!rule.HasMatches() && !silent)
 				Log(LogWarning, "ApplyRule")
 					<< "Apply rule '" << rule.GetName() << "' (" << rule.GetDebugInfo() << ") for type '" << kv.first << "' does not match anywhere!";

--- a/lib/config/configcompiler.cpp
+++ b/lib/config/configcompiler.cpp
@@ -125,7 +125,7 @@ std::unique_ptr<Expression> ConfigCompiler::HandleInclude(const String& relative
 	String includePath = upath;
 
 	if (search) {
-		for (const String& dir : m_IncludeSearchDirs) {
+		for (const auto& dir : m_IncludeSearchDirs) {
 			String spath = dir + "/" + path;
 
 			if (Utility::PathExists(spath)) {
@@ -332,7 +332,7 @@ bool ConfigCompiler::HasZoneConfigAuthority(const String& zoneName)
 		std::vector<String> paths;
 		paths.reserve(zoneDirs.size());
 
-		for (const ZoneFragment& zf : zoneDirs) {
+		for (const auto& zf : zoneDirs) {
 			paths.push_back(zf.Path);
 		}
 

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -391,8 +391,8 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	{
 		std::unique_lock<std::mutex> lock(m_Mutex);
 
-		for (const TypeMap::value_type& kv : m_Items) {
-			for (const ItemMap::value_type& kv2 : kv.second) {
+		for (const auto& kv : m_Items) {
+			for (const auto& kv2 : kv.second) {
 				if (kv2.second->m_Abstract || kv2.second->m_Object)
 					continue;
 
@@ -405,7 +405,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 
 		ItemList newUnnamedItems;
 
-		for (const ConfigItem::Ptr& item : m_UnnamedItems) {
+		for (const auto& item : m_UnnamedItems) {
 			if (item->m_ActivationContext != context) {
 				newUnnamedItems.push_back(item);
 				continue;
@@ -438,20 +438,20 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	std::set<Type::Ptr> types;
 	std::set<Type::Ptr> completed_types;
 
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		if (ConfigObject::TypeInstance->IsAssignableFrom(type))
 			types.insert(type);
 	}
 
 	while (types.size() != completed_types.size()) {
-		for (const Type::Ptr& type : types) {
+		for (const auto& type : types) {
 			if (completed_types.find(type) != completed_types.end())
 				continue;
 
 			bool unresolved_dep = false;
 
 			/* skip this type (for now) if there are unresolved load dependencies */
-			for (const String& loadDep : type->GetLoadDependencies()) {
+			for (const auto& loadDep : type->GetLoadDependencies()) {
 				Type::Ptr pLoadDep = Type::GetByName(loadDep);
 				if (types.find(pLoadDep) != types.end() && completed_types.find(pLoadDep) == completed_types.end()) {
 					unresolved_dep = true;
@@ -496,14 +496,14 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	completed_types.clear();
 
 	while (types.size() != completed_types.size()) {
-		for (const Type::Ptr& type : types) {
+		for (const auto& type : types) {
 			if (completed_types.find(type) != completed_types.end())
 				continue;
 
 			bool unresolved_dep = false;
 
 			/* skip this type (for now) if there are unresolved load dependencies */
-			for (const String& loadDep : type->GetLoadDependencies()) {
+			for (const auto& loadDep : type->GetLoadDependencies()) {
 				Type::Ptr pLoadDep = Type::GetByName(loadDep);
 				if (types.find(pLoadDep) != types.end() && completed_types.find(pLoadDep) == completed_types.end()) {
 					unresolved_dep = true;
@@ -554,7 +554,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 				return false;
 
 			notified_items = 0;
-			for (const String& loadDep : type->GetLoadDependencies()) {
+			for (const auto& loadDep : type->GetLoadDependencies()) {
 				upq.ParallelFor(items, [loadDep, &type, &notified_items](const ItemPair& ip) {
 					const ConfigItem::Ptr& item = ip.first;
 
@@ -595,7 +595,7 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 	if (!CommitNewItems(context, upq, newItems)) {
 		upq.ReportExceptions("config");
 
-		for (const ConfigItem::Ptr& item : newItems) {
+		for (const auto& item : newItems) {
 			item->Unregister();
 		}
 
@@ -608,14 +608,14 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 		/* log stats for external parsers */
 		typedef std::map<Type::Ptr, int> ItemCountMap;
 		ItemCountMap itemCounts;
-		for (const ConfigItem::Ptr& item : newItems) {
+		for (const auto& item : newItems) {
 			if (!item->m_Object)
 				continue;
 
 			itemCounts[item->m_Object->GetReflectionType()]++;
 		}
 
-		for (const ItemCountMap::value_type& kv : itemCounts) {
+		for (const auto& kv : itemCounts) {
 			Log(LogInformation, "ConfigItem")
 				<< "Instantiated " << kv.second << " " << (kv.second != 1 ? kv.first->GetPluralName() : kv.first->GetName()) << ".";
 		}
@@ -656,7 +656,7 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 		}
 	}
 
-	for (const ConfigItem::Ptr& item : newItems) {
+	for (const auto& item : newItems) {
 		if (!item->m_Object)
 			continue;
 
@@ -687,14 +687,14 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 
 	/* Find the last logger type to be activated. */
 	Type::Ptr lastLoggerType = nullptr;
-	for (const Type::Ptr& type : types) {
+	for (const auto& type : types) {
 		if (Logger::TypeInstance->IsAssignableFrom(type)) {
 			lastLoggerType = type;
 		}
 	}
 
-	for (const Type::Ptr& type : types) {
-		for (const ConfigItem::Ptr& item : newItems) {
+	for (const auto& type : types) {
+		for (const auto& item : newItems) {
 			if (!item->m_Object)
 				continue;
 
@@ -762,7 +762,7 @@ std::vector<ConfigItem::Ptr> ConfigItem::GetItems(const Type::Ptr& type)
 
 	items.reserve(it->second.size());
 
-	for (const ItemMap::value_type& kv : it->second) {
+	for (const auto& kv : it->second) {
 		items.push_back(kv.second);
 	}
 
@@ -782,7 +782,7 @@ std::vector<ConfigItem::Ptr> ConfigItem::GetDefaultTemplates(const Type::Ptr& ty
 
 	items.reserve(it->second.size());
 
-	for (const ItemMap::value_type& kv : it->second) {
+	for (const auto& kv : it->second) {
 		items.push_back(kv.second);
 	}
 
@@ -793,7 +793,7 @@ void ConfigItem::RemoveIgnoredItems(const String& allowedConfigPath)
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);
 
-	for (const String& path : m_IgnoredItems) {
+	for (const auto& path : m_IgnoredItems) {
 		if (path.Find(allowedConfigPath) == String::NPos)
 			continue;
 

--- a/lib/config/configitembuilder.cpp
+++ b/lib/config/configitembuilder.cpp
@@ -96,7 +96,7 @@ ConfigItem::Ptr ConfigItemBuilder::Compile()
 	if (!m_Abstract) {
 		bool foundDefaultImport = false;
 
-		for (const std::unique_ptr<Expression>& expr : m_Expressions) {
+		for (const auto& expr : m_Expressions) {
 			if (dynamic_cast<ImportDefaultTemplatesExpression *>(expr.get())) {
 				foundDefaultImport = true;
 				break;

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -899,7 +899,7 @@ ExpressionResult ImportDefaultTemplatesExpression::DoEvaluate(ScriptFrame& frame
 	String type = VMOps::GetField(frame.Self, "type", frame.Sandboxed, m_DebugInfo);
 	Type::Ptr ptype = Type::GetByName(type);
 
-	for (const ConfigItem::Ptr& item : ConfigItem::GetDefaultTemplates(ptype)) {
+	for (const auto& item : ConfigItem::GetDefaultTemplates(ptype)) {
 		Dictionary::Ptr scope = item->GetScope();
 
 		if (scope)

--- a/lib/config/vmops.hpp
+++ b/lib/config/vmops.hpp
@@ -196,12 +196,12 @@ public:
 
 			{
 				ObjectLock olock(dict);
-				for (const Dictionary::Pair& kv : dict) {
+				for (const auto& kv : dict) {
 					keys.push_back(kv.first);
 				}
 			}
 
-			for (const String& key : keys) {
+			for (const auto& key : keys) {
 				frame.Locals->Set(fkvar, key);
 				frame.Locals->Set(fvvar, dict->Get(key));
 				ExpressionResult res = expression->Evaluate(frame);
@@ -216,12 +216,12 @@ public:
 
 			{
 				ObjectLock olock(ns);
-				for (const Namespace::Pair& kv : ns) {
+				for (const auto& kv : ns) {
 					keys.push_back(kv.first);
 				}
 			}
 
-			for (const String& key : keys) {
+			for (const auto& key : keys) {
 				frame.Locals->Set(fkvar, key);
 				frame.Locals->Set(fvvar, ns->Get(key));
 				ExpressionResult res = expression->Evaluate(frame);

--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -489,13 +489,13 @@ void DbConnection::UpdateObject(const ConfigObject::Ptr& object)
 
 void DbConnection::UpdateAllObjects()
 {
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 			m_QueryQueue.Enqueue([this, object](){ UpdateObject(object); }, PriorityHigh);
 		}
 	}
@@ -503,7 +503,7 @@ void DbConnection::UpdateAllObjects()
 
 void DbConnection::PrepareDatabase()
 {
-	for (const DbType::Ptr& type : DbType::GetAllTypes()) {
+	for (const auto& type : DbType::GetAllTypes()) {
 		FillIDCache(type);
 	}
 }

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -226,7 +226,7 @@ void DbEvents::ReachabilityChangedHandler(const Checkable::Ptr& checkable, const
 	if (cr->GetState() == ServiceOK)
 		is_reachable = 1;
 
-	for (const Checkable::Ptr& child : children) {
+	for (const auto& child : children) {
 		Host::Ptr host;
 		Service::Ptr service;
 		tie(host, service) = GetHostService(child);
@@ -322,7 +322,7 @@ void DbEvents::AddComments(const Checkable::Ptr& checkable)
 
 	std::vector<DbQuery> queries;
 
-	for (const Comment::Ptr& comment : comments) {
+	for (const auto& comment : comments) {
 		AddCommentInternal(queries, comment, false);
 	}
 
@@ -461,7 +461,7 @@ void DbEvents::AddDowntimes(const Checkable::Ptr& checkable)
 
 	std::vector<DbQuery> queries;
 
-	for (const Downtime::Ptr& downtime : downtimes) {
+	for (const auto& downtime : downtimes) {
 		AddDowntimeInternal(queries, downtime, false);
 	}
 
@@ -883,7 +883,7 @@ void DbEvents::AddNotificationHistory(const Notification::Ptr& notification, con
 
 	std::vector<DbQuery> queries;
 
-	for (const User::Ptr& user : users) {
+	for (const auto& user : users) {
 		DbQuery query2;
 		query2.Table = "contactnotifications";
 		query2.Type = DbQueryInsert;

--- a/lib/db_ido/dbobject.cpp
+++ b/lib/db_ido/dbobject.cpp
@@ -74,7 +74,7 @@ String DbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) const
 	{
 		ObjectLock olock(configFieldsDup);
 
-		for (const Dictionary::Pair& kv : configFieldsDup) {
+		for (const auto& kv : configFieldsDup) {
 			if (kv.second.IsObjectType<ConfigObject>()) {
 				ConfigObject::Ptr obj = kv.second;
 				configFieldsDup->Set(kv.first, obj->GetName());
@@ -218,7 +218,7 @@ void DbObject::SendVarsConfigUpdateHeavy()
 	if (vars) {
 		ObjectLock olock (vars);
 
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			if (kv.first.IsEmpty())
 				continue;
 
@@ -281,7 +281,7 @@ void DbObject::SendVarsStatusUpdate()
 		std::vector<DbQuery> queries;
 		ObjectLock olock (vars);
 
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			if (kv.first.IsEmpty())
 				continue;
 

--- a/lib/db_ido/dbtype.cpp
+++ b/lib/db_ido/dbtype.cpp
@@ -60,7 +60,7 @@ DbType::Ptr DbType::GetByID(long tid)
 {
 	std::unique_lock<std::mutex> lock(GetStaticMutex());
 
-	for (const TypeMap::value_type& kv : GetTypes()) {
+	for (const auto& kv : GetTypes()) {
 		if (kv.second->GetTypeID() == tid)
 			return kv.second;
 	}

--- a/lib/db_ido/hostdbobject.cpp
+++ b/lib/db_ido/hostdbobject.cpp
@@ -161,7 +161,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 
 	if (groups) {
 		ObjectLock olock(groups);
-		for (const String& groupName : groups) {
+		for (const auto& groupName : groups) {
 			HostGroup::Ptr group = HostGroup::GetByName(groupName);
 
 			DbQuery query2;
@@ -196,7 +196,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	queries.emplace_back(std::move(query2));
 
 	/* parents */
-	for (const Checkable::Ptr& checkable : host->GetParents()) {
+	for (const auto& checkable : host->GetParents()) {
 		Host::Ptr parent = dynamic_pointer_cast<Host>(checkable);
 
 		if (!parent)
@@ -235,7 +235,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	});
 	queries.emplace_back(std::move(query3));
 
-	for (const Dependency::Ptr& dep : host->GetDependencies()) {
+	for (const auto& dep : host->GetDependencies()) {
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent) {
@@ -281,7 +281,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	});
 	queries.emplace_back(std::move(query4));
 
-	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(host)) {
+	for (const auto& user : CompatUtility::GetCheckableNotificationUsers(host)) {
 		Log(LogDebug, "HostDbObject")
 			<< "host contacts: " << user->GetName();
 
@@ -313,7 +313,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	});
 	queries.emplace_back(std::move(query5));
 
-	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
+	for (const auto& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
 		Log(LogDebug, "HostDbObject")
 			<< "host contactgroups: " << usergroup->GetName();
 
@@ -366,7 +366,7 @@ String HostDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) co
 	ArrayData parents;
 
 	/* parents */
-	for (const Checkable::Ptr& checkable : host->GetParents()) {
+	for (const auto& checkable : host->GetParents()) {
 		Host::Ptr parent = dynamic_pointer_cast<Host>(checkable);
 
 		if (!parent)
@@ -382,7 +382,7 @@ String HostDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) co
 	ArrayData dependencies;
 
 	/* dependencies */
-	for (const Dependency::Ptr& dep : host->GetDependencies()) {
+	for (const auto& dep : host->GetDependencies()) {
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent)
@@ -401,7 +401,7 @@ String HostDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) co
 
 	ArrayData users;
 
-	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(host)) {
+	for (const auto& user : CompatUtility::GetCheckableNotificationUsers(host)) {
 		users.push_back(user->GetName());
 	}
 
@@ -411,7 +411,7 @@ String HostDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields) co
 
 	ArrayData userGroups;
 
-	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
+	for (const auto& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
 		userGroups.push_back(usergroup->GetName());
 	}
 

--- a/lib/db_ido/servicedbobject.cpp
+++ b/lib/db_ido/servicedbobject.cpp
@@ -159,7 +159,7 @@ void ServiceDbObject::OnConfigUpdateHeavy()
 
 	if (groups) {
 		ObjectLock olock(groups);
-		for (const String& groupName : groups) {
+		for (const auto& groupName : groups) {
 			ServiceGroup::Ptr group = ServiceGroup::GetByName(groupName);
 
 			DbQuery query2;
@@ -194,7 +194,7 @@ void ServiceDbObject::OnConfigUpdateHeavy()
 	});
 	queries.emplace_back(std::move(query2));
 
-	for (const Dependency::Ptr& dep : service->GetDependencies()) {
+	for (const auto& dep : service->GetDependencies()) {
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent) {
@@ -241,7 +241,7 @@ void ServiceDbObject::OnConfigUpdateHeavy()
 	});
 	queries.emplace_back(std::move(query3));
 
-	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(service)) {
+	for (const auto& user : CompatUtility::GetCheckableNotificationUsers(service)) {
 		DbQuery query_contact;
 		query_contact.Table = GetType()->GetTable() + "_contacts";
 		query_contact.Type = DbQueryInsert;
@@ -268,7 +268,7 @@ void ServiceDbObject::OnConfigUpdateHeavy()
 	});
 	queries.emplace_back(std::move(query4));
 
-	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(service)) {
+	for (const auto& usergroup : CompatUtility::GetCheckableNotificationUserGroups(service)) {
 		DbQuery query_contact;
 		query_contact.Table = GetType()->GetTable() + "_contactgroups";
 		query_contact.Type = DbQueryInsert;
@@ -318,7 +318,7 @@ String ServiceDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields)
 	ArrayData dependencies;
 
 	/* dependencies */
-	for (const Dependency::Ptr& dep : service->GetDependencies()) {
+	for (const auto& dep : service->GetDependencies()) {
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent)
@@ -337,7 +337,7 @@ String ServiceDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields)
 
 	ArrayData users;
 
-	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(service)) {
+	for (const auto& user : CompatUtility::GetCheckableNotificationUsers(service)) {
 		users.push_back(user->GetName());
 	}
 
@@ -347,7 +347,7 @@ String ServiceDbObject::CalculateConfigHash(const Dictionary::Ptr& configFields)
 
 	ArrayData userGroups;
 
-	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(service)) {
+	for (const auto& usergroup : CompatUtility::GetCheckableNotificationUserGroups(service)) {
 		userGroups.push_back(usergroup->GetName());
 	}
 

--- a/lib/db_ido/timeperioddbobject.cpp
+++ b/lib/db_ido/timeperioddbobject.cpp
@@ -51,7 +51,7 @@ void TimePeriodDbObject::OnConfigUpdateHeavy()
 
 	time_t refts = Utility::GetTime();
 	ObjectLock olock(ranges);
-	for (const Dictionary::Pair& kv : ranges) {
+	for (const auto& kv : ranges) {
 		int wday = LegacyTimePeriod::WeekdayFromString(kv.first);
 
 		if (wday == -1)
@@ -63,7 +63,7 @@ void TimePeriodDbObject::OnConfigUpdateHeavy()
 		LegacyTimePeriod::ProcessTimeRanges(kv.second, &reference, segments);
 
 		ObjectLock olock(segments);
-		for (const Value& vsegment : segments) {
+		for (const auto& vsegment : segments) {
 			Dictionary::Ptr segment = vsegment;
 			int begin = segment->Get("begin");
 			int end = segment->Get("end");

--- a/lib/db_ido/userdbobject.cpp
+++ b/lib/db_ido/userdbobject.cpp
@@ -79,7 +79,7 @@ void UserDbObject::OnConfigUpdateHeavy()
 
 	if (groups) {
 		ObjectLock olock(groups);
-		for (const String& groupName : groups) {
+		for (const auto& groupName : groups) {
 			UserGroup::Ptr group = UserGroup::GetByName(groupName);
 
 			DbQuery query2;

--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -50,7 +50,7 @@ void IdoMysqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 {
 	DictionaryData nodes;
 
-	for (const IdoMysqlConnection::Ptr& idomysqlconnection : ConfigType::GetObjectsByType<IdoMysqlConnection>()) {
+	for (const auto& idomysqlconnection : ConfigType::GetObjectsByType<IdoMysqlConnection>()) {
 		size_t queryQueueItems = idomysqlconnection->m_QueryQueue.GetLength();
 		double queryQueueItemRate = idomysqlconnection->m_QueryQueue.GetTaskCount(60) / 60.0;
 
@@ -450,7 +450,7 @@ void IdoMysqlConnection::Reconnect()
 
 	EnableActiveChangedHandler();
 
-	for (const DbObject::Ptr& dbobj : activeDbObjs) {
+	for (const auto& dbobj : activeDbObjs) {
 		if (dbobj->GetObject())
 			continue;
 
@@ -953,7 +953,7 @@ bool IdoMysqlConnection::CanExecuteQuery(const DbQuery& query)
 		ObjectLock olock(query.WhereCriteria);
 		Value value;
 
-		for (const Dictionary::Pair& kv : query.WhereCriteria) {
+		for (const auto& kv : query.WhereCriteria) {
 			if (!FieldToEscapedString(kv.first, kv.second, &value))
 				return false;
 		}
@@ -962,7 +962,7 @@ bool IdoMysqlConnection::CanExecuteQuery(const DbQuery& query)
 	if (query.Fields) {
 		ObjectLock olock(query.Fields);
 
-		for (const Dictionary::Pair& kv : query.Fields) {
+		for (const auto& kv : query.Fields) {
 			Value value;
 
 			if (!FieldToEscapedString(kv.first, kv.second, &value))
@@ -988,7 +988,7 @@ void IdoMysqlConnection::InternalExecuteMultipleQueries(const std::vector<DbQuer
 	}
 
 
-	for (const DbQuery& query : queries) {
+	for (const auto& query : queries) {
 		ASSERT(query.Type == DbQueryNewTransaction || query.Category != DbCatInvalid);
 
 		if (!CanExecuteQuery(query)) {
@@ -1004,7 +1004,7 @@ void IdoMysqlConnection::InternalExecuteMultipleQueries(const std::vector<DbQuer
 		}
 	}
 
-	for (const DbQuery& query : queries) {
+	for (const auto& query : queries) {
 		InternalExecuteQuery(query);
 	}
 }
@@ -1063,7 +1063,7 @@ void IdoMysqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 		Value value;
 		bool first = true;
 
-		for (const Dictionary::Pair& kv : query.WhereCriteria) {
+		for (const auto& kv : query.WhereCriteria) {
 			if (!FieldToEscapedString(kv.first, kv.second, &value)) {
 
 #ifdef I2_DEBUG /* I2_DEBUG */
@@ -1138,7 +1138,7 @@ void IdoMysqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 		ObjectLock olock(query.Fields);
 
 		bool first = true;
-		for (const Dictionary::Pair& kv : query.Fields) {
+		for (const auto& kv : query.Fields) {
 			Value value;
 
 			if (!FieldToEscapedString(kv.first, kv.second, &value)) {

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -57,7 +57,7 @@ void IdoPgsqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 {
 	DictionaryData nodes;
 
-	for (const IdoPgsqlConnection::Ptr& idopgsqlconnection : ConfigType::GetObjectsByType<IdoPgsqlConnection>()) {
+	for (const auto& idopgsqlconnection : ConfigType::GetObjectsByType<IdoPgsqlConnection>()) {
 		size_t queryQueueItems = idopgsqlconnection->m_QueryQueue.GetLength();
 		double queryQueueItemRate = idopgsqlconnection->m_QueryQueue.GetTaskCount(60) / 60.0;
 
@@ -419,7 +419,7 @@ void IdoPgsqlConnection::Reconnect()
 
 	EnableActiveChangedHandler();
 
-	for (const DbObject::Ptr& dbobj : activeDbObjs) {
+	for (const auto& dbobj : activeDbObjs) {
 		if (dbobj->GetObject())
 			continue;
 
@@ -757,7 +757,7 @@ bool IdoPgsqlConnection::CanExecuteQuery(const DbQuery& query)
 		ObjectLock olock(query.WhereCriteria);
 		Value value;
 
-		for (const Dictionary::Pair& kv : query.WhereCriteria) {
+		for (const auto& kv : query.WhereCriteria) {
 			if (!FieldToEscapedString(kv.first, kv.second, &value))
 				return false;
 		}
@@ -766,7 +766,7 @@ bool IdoPgsqlConnection::CanExecuteQuery(const DbQuery& query)
 	if (query.Fields) {
 		ObjectLock olock(query.Fields);
 
-		for (const Dictionary::Pair& kv : query.Fields) {
+		for (const auto& kv : query.Fields) {
 			Value value;
 
 			if (!FieldToEscapedString(kv.first, kv.second, &value))
@@ -791,7 +791,7 @@ void IdoPgsqlConnection::InternalExecuteMultipleQueries(const std::vector<DbQuer
 		return;
 	}
 
-	for (const DbQuery& query : queries) {
+	for (const auto& query : queries) {
 		ASSERT(query.Type == DbQueryNewTransaction || query.Category != DbCatInvalid);
 
 		if (!CanExecuteQuery(query)) {
@@ -800,7 +800,7 @@ void IdoPgsqlConnection::InternalExecuteMultipleQueries(const std::vector<DbQuer
 		}
 	}
 
-	for (const DbQuery& query : queries) {
+	for (const auto& query : queries) {
 		InternalExecuteQuery(query);
 	}
 }
@@ -852,7 +852,7 @@ void IdoPgsqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 		Value value;
 		bool first = true;
 
-		for (const Dictionary::Pair& kv : query.WhereCriteria) {
+		for (const auto& kv : query.WhereCriteria) {
 			if (!FieldToEscapedString(kv.first, kv.second, &value)) {
 				m_QueryQueue.Enqueue([this, query]() { InternalExecuteQuery(query, -1); }, query.Priority);
 				return;
@@ -921,7 +921,7 @@ void IdoPgsqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 
 		Value value;
 		bool first = true;
-		for (const Dictionary::Pair& kv : query.Fields) {
+		for (const auto& kv : query.Fields) {
 			if (!FieldToEscapedString(kv.first, kv.second, &value)) {
 				m_QueryQueue.Enqueue([this, query]() { InternalExecuteQuery(query, -1); }, query.Priority);
 				return;

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -187,7 +187,7 @@ Dictionary::Ptr ApiActions::DelayNotification(const ConfigObject::Ptr& object,
 	if (!params->Contains("timestamp"))
 		return ApiActions::CreateResult(400, "A timestamp is required to delay notifications");
 
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		notification->SetNextNotification(HttpUtility::GetLastParameter(params, "timestamp"));
 	}
 
@@ -310,7 +310,7 @@ Dictionary::Ptr ApiActions::RemoveComment(const ConfigObject::Ptr& object,
 	if (checkable) {
 		std::set<Comment::Ptr> comments = checkable->GetComments();
 
-		for (const Comment::Ptr& comment : comments) {
+		for (const auto& comment : comments) {
 			{
 				ObjectLock oLock (comment);
 				comment->SetRemovedBy(author);
@@ -404,7 +404,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 	if (allServices && !service) {
 		ArrayData serviceDowntimes;
 
-		for (const Service::Ptr& hostService : host->GetServices()) {
+		for (const auto& hostService : host->GetServices()) {
 			Log(LogNotice, "ApiActions")
 				<< "Creating downtime for service " << hostService->GetName() << " on host " << host->GetName();
 
@@ -435,7 +435,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 		ArrayData childDowntimes;
 
 		std::set<Checkable::Ptr> allChildren = checkable->GetAllChildren();
-		for (const Checkable::Ptr& child : allChildren) {
+		for (const auto& child : allChildren) {
 			Host::Ptr childHost;
 			Service::Ptr childService;
 			tie(childHost, childService) = GetHostService(child);
@@ -468,7 +468,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 			if (allServices && !childService) {
 				ArrayData childServiceDowntimes;
 
-				for (const Service::Ptr& childService : childHost->GetServices()) {
+				for (const auto& childService : childHost->GetServices()) {
 					Log(LogNotice, "ApiActions")
 						<< "Creating downtime for service " << childService->GetName() << " on child host " << childHost->GetName();
 
@@ -506,7 +506,7 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 	if (checkable) {
 		std::set<Downtime::Ptr> downtimes = checkable->GetDowntimes();
 
-		for (const Downtime::Ptr& downtime : downtimes) {
+		for (const auto& downtime : downtimes) {
 			{
 				ObjectLock oLock (downtime);
 				downtime->SetRemovedBy(author);
@@ -877,12 +877,12 @@ Dictionary::Ptr ApiActions::ExecuteCommand(const ConfigObject::Ptr& object, cons
 	} else {
 		/* Check if the child endpoints have Icinga version >= 2.13 */
 		Zone::Ptr localZone = Zone::GetLocalZone();
-		for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
+		for (const auto& zone : ConfigType::GetObjectsByType<Zone>()) {
 			/* Fetch immediate child zone members */
 			if (zone->GetParent() == localZone && zone->CanAccessObject(endpointPtr->GetZone())) {
 				std::set<Endpoint::Ptr> endpoints = zone->GetEndpoints();
 
-				for (const Endpoint::Ptr& childEndpoint : endpoints) {
+				for (const auto& childEndpoint : endpoints) {
 					if (!(childEndpoint->GetCapabilities() & (uint_fast64_t)ApiCapabilities::ExecuteArbitraryCommand)) {
 						/* Update execution */
 						double now = Utility::GetTime();

--- a/lib/icinga/apievents.cpp
+++ b/lib/icinga/apievents.cpp
@@ -61,7 +61,7 @@ void ApiEvents::CheckResultHandler(const Checkable::Ptr& checkable, const CheckR
 	result->Set("downtime_depth", checkable->GetDowntimeDepth());
 	result->Set("acknowledgement", checkable->IsAcknowledged());
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -97,7 +97,7 @@ void ApiEvents::StateChangeHandler(const Checkable::Ptr& checkable, const CheckR
 	result->Set("downtime_depth", checkable->GetDowntimeDepth());
 	result->Set("acknowledgement", checkable->IsAcknowledged());
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -135,7 +135,7 @@ void ApiEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& notif
 
 	ArrayData userNames;
 
-	for (const User::Ptr& user : users) {
+	for (const auto& user : users) {
 		userNames.push_back(user->GetName());
 	}
 
@@ -145,7 +145,7 @@ void ApiEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& notif
 	result->Set("text", text);
 	result->Set("check_result", Serialize(cr));
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -181,7 +181,7 @@ void ApiEvents::FlappingChangedHandler(const Checkable::Ptr& checkable, const Me
 	result->Set("threshold_low", checkable->GetFlappingThresholdLow());
 	result->Set("threshold_high", checkable->GetFlappingThresholdHigh());
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -222,7 +222,7 @@ void ApiEvents::AcknowledgementSetHandler(const Checkable::Ptr& checkable,
 	result->Set("persistent", persistent);
 	result->Set("expiry", expiry);
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -255,7 +255,7 @@ void ApiEvents::AcknowledgementClearedHandler(const Checkable::Ptr& checkable, c
 	result->Set("state_type", checkable->GetStateType());
 	result->Set("acknowledgement_type", AcknowledgementNone);
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -278,7 +278,7 @@ void ApiEvents::CommentAddedHandler(const Comment::Ptr& comment)
 		{ "comment", Serialize(comment, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -301,7 +301,7 @@ void ApiEvents::CommentRemovedHandler(const Comment::Ptr& comment)
 		{ "comment", Serialize(comment, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -324,7 +324,7 @@ void ApiEvents::DowntimeAddedHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -347,7 +347,7 @@ void ApiEvents::DowntimeRemovedHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -370,7 +370,7 @@ void ApiEvents::DowntimeStartedHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -393,7 +393,7 @@ void ApiEvents::DowntimeTriggeredHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 
@@ -430,7 +430,7 @@ void ApiEvents::SendObjectChangeEvent(const ConfigObject::Ptr& object, const Eve
 		{"object_name", object->GetName()},
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
+	for (const auto& queue : queues) {
 		queue->ProcessEvent(result);
 	}
 

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -290,7 +290,7 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		}
 
 		/* reschedule direct parents */
-		for (const Checkable::Ptr& parent : GetParents()) {
+		for (const auto& parent : GetParents()) {
 			if (parent.get() == this)
 				continue;
 

--- a/lib/icinga/checkable-comment.cpp
+++ b/lib/icinga/checkable-comment.cpp
@@ -14,14 +14,14 @@ using namespace icinga;
 
 void Checkable::RemoveAllComments()
 {
-	for (const Comment::Ptr& comment : GetComments()) {
+	for (const auto& comment : GetComments()) {
 		Comment::RemoveComment(comment->GetName());
 	}
 }
 
 void Checkable::RemoveCommentsByType(int type, const String& removedBy)
 {
-	for (const Comment::Ptr& comment : GetComments()) {
+	for (const auto& comment : GetComments()) {
 		/* Do not remove persistent comments from an acknowledgement */
 		if (comment->GetEntryType() == CommentAcknowledgement && comment->GetPersistent())
 			continue;

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -54,7 +54,7 @@ bool Checkable::IsReachable(DependencyType dt, Dependency::Ptr *failedDependency
 		return false;
 	}
 
-	for (const Checkable::Ptr& checkable : GetParents()) {
+	for (const auto& checkable : GetParents()) {
 		if (!checkable->IsReachable(dt, failedDependency, rstack + 1))
 			return false;
 	}
@@ -77,7 +77,7 @@ bool Checkable::IsReachable(DependencyType dt, Dependency::Ptr *failedDependency
 	int countDeps = deps.size();
 	int countFailed = 0;
 
-	for (const Dependency::Ptr& dep : deps) {
+	for (const auto& dep : deps) {
 		if (!dep->IsAvailable(dt)) {
 			countFailed++;
 
@@ -103,7 +103,7 @@ std::set<Checkable::Ptr> Checkable::GetParents() const
 {
 	std::set<Checkable::Ptr> parents;
 
-	for (const Dependency::Ptr& dep : GetDependencies()) {
+	for (const auto& dep : GetDependencies()) {
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (parent && parent.get() != this)
@@ -117,7 +117,7 @@ std::set<Checkable::Ptr> Checkable::GetChildren() const
 {
 	std::set<Checkable::Ptr> parents;
 
-	for (const Dependency::Ptr& dep : GetReverseDependencies()) {
+	for (const auto& dep : GetReverseDependencies()) {
 		Checkable::Ptr service = dep->GetChild();
 
 		if (service && service.get() != this)
@@ -143,7 +143,7 @@ void Checkable::GetAllChildrenInternal(std::set<Checkable::Ptr>& children, int l
 
 	std::set<Checkable::Ptr> localChildren;
 
-	for (const Checkable::Ptr& checkable : children) {
+	for (const auto& checkable : children) {
 		std::set<Checkable::Ptr> cChildren = checkable->GetChildren();
 
 		if (!cChildren.empty()) {

--- a/lib/icinga/checkable-downtime.cpp
+++ b/lib/icinga/checkable-downtime.cpp
@@ -11,21 +11,21 @@ using namespace icinga;
 
 void Checkable::RemoveAllDowntimes()
 {
-	for (const Downtime::Ptr& downtime : GetDowntimes()) {
+	for (const auto& downtime : GetDowntimes()) {
 		Downtime::RemoveDowntime(downtime->GetName(), true, true, true);
 	}
 }
 
 void Checkable::TriggerDowntimes(double triggerTime)
 {
-	for (const Downtime::Ptr& downtime : GetDowntimes()) {
+	for (const auto& downtime : GetDowntimes()) {
 		downtime->TriggerDowntime(triggerTime);
 	}
 }
 
 bool Checkable::IsInDowntime() const
 {
-	for (const Downtime::Ptr& downtime : GetDowntimes()) {
+	for (const auto& downtime : GetDowntimes()) {
 		if (downtime->IsInEffect())
 			return true;
 	}
@@ -37,7 +37,7 @@ int Checkable::GetDowntimeDepth() const
 {
 	int downtime_depth = 0;
 
-	for (const Downtime::Ptr& downtime : GetDowntimes()) {
+	for (const auto& downtime : GetDowntimes()) {
 		if (downtime->IsInEffect())
 			downtime_depth++;
 	}

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -24,7 +24,7 @@ boost::signals2::signal<void (const Notification::Ptr&, const Checkable::Ptr&, c
 
 void Checkable::ResetNotificationNumbers()
 {
-	for (const Notification::Ptr& notification : GetNotifications()) {
+	for (const auto& notification : GetNotifications()) {
 		ObjectLock olock(notification);
 		notification->ResetNotificationNumber();
 	}
@@ -63,7 +63,7 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 		<< "Checkable '" << checkableName << "' has " << notifications.size()
 		<< " notification(s). Checking filters for type '" << notificationTypeName << "', sends will be logged.";
 
-	for (const Notification::Ptr& notification : notifications) {
+	for (const auto& notification : notifications) {
 		// Re-send stashed notifications from cold startup.
 		if (ApiListener::UpdatedObjectAuthority()) {
 			try {

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -299,7 +299,7 @@ void Checkable::CleanDeadlinedExecutions(const Timer * const&)
 	for (auto& host : ConfigType::GetObjectsByType<Host>()) {
 		executions = host->GetExecutions();
 		if (executions) {
-			for (const String& key : executions->GetKeys()) {
+			for (const auto& key : executions->GetKeys()) {
 				execution = executions->Get(key);
 				if (execution->Contains("deadline") && now > execution->Get("deadline")) {
 					executions->Remove(key);
@@ -311,7 +311,7 @@ void Checkable::CleanDeadlinedExecutions(const Timer * const&)
 	for (auto& service : ConfigType::GetObjectsByType<Service>()) {
 		executions = service->GetExecutions();
 		if (executions) {
-			for (const String& key : executions->GetKeys()) {
+			for (const auto& key : executions->GetKeys()) {
 				execution = executions->Get(key);
 				if (execution->Contains("deadline") && now > execution->Get("deadline")) {
 					executions->Remove(key);

--- a/lib/icinga/cib.cpp
+++ b/lib/icinga/cib.cpp
@@ -66,7 +66,7 @@ CheckableCheckStatistics CIB::CalculateHostCheckStats()
 	int count_execution_time = 0;
 	bool checkresult = false;
 
-	for (const Host::Ptr& host : ConfigType::GetObjectsByType<Host>()) {
+	for (const auto& host : ConfigType::GetObjectsByType<Host>()) {
 		ObjectLock olock(host);
 
 		CheckResult::Ptr cr = host->GetLastCheckResult();
@@ -127,7 +127,7 @@ CheckableCheckStatistics CIB::CalculateServiceCheckStats()
 	int count_execution_time = 0;
 	bool checkresult = false;
 
-	for (const Service::Ptr& service : ConfigType::GetObjectsByType<Service>()) {
+	for (const auto& service : ConfigType::GetObjectsByType<Service>()) {
 		ObjectLock olock(service);
 
 		CheckResult::Ptr cr = service->GetLastCheckResult();
@@ -184,7 +184,7 @@ ServiceStatistics CIB::CalculateServiceStats()
 {
 	ServiceStatistics ss = {};
 
-	for (const Service::Ptr& service : ConfigType::GetObjectsByType<Service>()) {
+	for (const auto& service : ConfigType::GetObjectsByType<Service>()) {
 		ObjectLock olock(service);
 
 		if (service->GetState() == ServiceOK)
@@ -224,7 +224,7 @@ HostStatistics CIB::CalculateHostStats()
 {
 	HostStatistics hs = {};
 
-	for (const Host::Ptr& host : ConfigType::GetObjectsByType<Host>()) {
+	for (const auto& host : ConfigType::GetObjectsByType<Host>()) {
 		ObjectLock olock(host);
 
 		if (host->IsReachable()) {
@@ -268,7 +268,7 @@ std::pair<Dictionary::Ptr, Array::Ptr> CIB::GetFeatureStats()
 	if (statsFunctions) {
 		ObjectLock olock(statsFunctions);
 
-		for (const Namespace::Pair& kv : statsFunctions)
+		for (const auto& kv : statsFunctions)
 			static_cast<Function::Ptr>(kv.second->Get())->Invoke({ status, perfdata });
 	}
 

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -129,7 +129,7 @@ Value ClusterEvents::CheckResultAPIHandler(const MessageOrigin::Ptr& origin, con
 
 	if (vperf) {
 		ObjectLock olock(vperf);
-		for (const Value& vp : vperf) {
+		for (const auto& vp : vperf) {
 			Value p;
 
 			if (vp.IsObjectType<Dictionary>()) {
@@ -773,12 +773,12 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 			}
 
 			/* Check if the child endpoints have Icinga version >= 2.13 */
-			for (const Zone::Ptr &zone : ConfigType::GetObjectsByType<Zone>()) {
+			for (const auto&zone : ConfigType::GetObjectsByType<Zone>()) {
 				/* Fetch immediate child zone members */
 				if (zone->GetParent() == localZone && zone->CanAccessObject(endpointZone)) {
 					std::set<Endpoint::Ptr> endpoints = zone->GetEndpoints();
 
-					for (const Endpoint::Ptr &childEndpoint : endpoints) {
+					for (const auto&childEndpoint : endpoints) {
 						if (!(childEndpoint->GetCapabilities() & (uint_fast64_t)ApiCapabilities::ExecuteArbitraryCommand)) {
 							double now = Utility::GetTime();
 							Dictionary::Ptr executedParams = new Dictionary();
@@ -1020,7 +1020,7 @@ void ClusterEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& n
 	params->Set("notification", notification->GetName());
 
 	ArrayData ausers;
-	for (const User::Ptr& user : users) {
+	for (const auto& user : users) {
 		ausers.push_back(user->GetName());
 	}
 	params->Set("users", new Array(std::move(ausers)));
@@ -1111,7 +1111,7 @@ Value ClusterEvents::NotificationSentToAllUsersAPIHandler(const MessageOrigin::P
 
 	{
 		ObjectLock olock(ausers);
-		for (const String& auser : ausers) {
+		for (const auto& auser : ausers) {
 			User::Ptr user = User::GetByName(auser);
 
 			if (!user)
@@ -1128,7 +1128,7 @@ Value ClusterEvents::NotificationSentToAllUsersAPIHandler(const MessageOrigin::P
 	notification->SetNoMoreNotifications(params->Get("no_more_notifications"));
 
 	ArrayData notifiedProblemUsers;
-	for (const User::Ptr& user : users) {
+	for (const auto& user : users) {
 		notifiedProblemUsers.push_back(user->GetName());
 	}
 

--- a/lib/icinga/command.cpp
+++ b/lib/icinga/command.cpp
@@ -24,7 +24,7 @@ void Command::Validate(int types, const ValidationUtils& utils)
 			BOOST_THROW_EXCEPTION(ValidationError(this, { "command" }, "Attribute 'command' must be an array if the 'arguments' attribute is set."));
 
 		ObjectLock olock(arguments);
-		for (const Dictionary::Pair& kv : arguments) {
+		for (const auto& kv : arguments) {
 			const Value& arginfo = kv.second;
 			Value argval;
 
@@ -55,7 +55,7 @@ void Command::Validate(int types, const ValidationUtils& utils)
 
 	if (env) {
 		ObjectLock olock(env);
-		for (const Dictionary::Pair& kv : env) {
+		for (const auto& kv : env) {
 			const Value& envval = kv.second;
 
 			if (!envval.IsString() || envval.IsEmpty())

--- a/lib/icinga/comment.cpp
+++ b/lib/icinga/comment.cpp
@@ -167,7 +167,7 @@ String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryTyp
 
 	if (!ConfigObjectUtility::CreateObject(Comment::TypeInstance, fullName, config, errors, nullptr)) {
 		ObjectLock olock(errors);
-		for (const String& error : errors) {
+		for (const auto& error : errors) {
 			Log(LogCritical, "Comment", error);
 		}
 
@@ -199,7 +199,7 @@ void Comment::RemoveComment(const String& id, const MessageOrigin::Ptr& origin)
 
 	if (!ConfigObjectUtility::DeleteObject(comment, false, errors, nullptr)) {
 		ObjectLock olock(errors);
-		for (const String& error : errors) {
+		for (const auto& error : errors) {
 			Log(LogCritical, "Comment", error);
 		}
 
@@ -223,11 +223,11 @@ void Comment::CommentsExpireTimerHandler()
 {
 	std::vector<Comment::Ptr> comments;
 
-	for (const Comment::Ptr& comment : ConfigType::GetObjectsByType<Comment>()) {
+	for (const auto& comment : ConfigType::GetObjectsByType<Comment>()) {
 		comments.push_back(comment);
 	}
 
-	for (const Comment::Ptr& comment : comments) {
+	for (const auto& comment : comments) {
 		/* Only remove comments which are activated after daemon start. */
 		if (comment->IsActive() && comment->IsExpired()) {
 			/* Do not remove persistent comments from an acknowledgement */

--- a/lib/icinga/compatutility.cpp
+++ b/lib/icinga/compatutility.cpp
@@ -25,7 +25,7 @@ String CompatUtility::GetCommandLine(const Command::Ptr& command)
 		Array::Ptr args = commandLine;
 
 		ObjectLock olock(args);
-		for (const String& arg : args) {
+		for (const auto& arg : args) {
 			// This is obviously incorrect for non-trivial cases.
 			result += " \"" + EscapeString(arg) + "\"";
 		}
@@ -81,7 +81,7 @@ String CompatUtility::GetCheckableCommandArgs(const Checkable::Ptr& checkable)
 
 		if (command_vars) {
 			ObjectLock olock(command_vars);
-			for (const Dictionary::Pair& kv : command_vars) {
+			for (const auto& kv : command_vars) {
 				String macro = "$" + kv.first + "$"; // this is too simple
 				if (command_line.Contains(macro))
 					args->Set(kv.first, kv.second);
@@ -93,7 +93,7 @@ String CompatUtility::GetCheckableCommandArgs(const Checkable::Ptr& checkable)
 
 		if (host_vars) {
 			ObjectLock olock(host_vars);
-			for (const Dictionary::Pair& kv : host_vars) {
+			for (const auto& kv : host_vars) {
 				String macro = "$" + kv.first + "$"; // this is too simple
 				if (command_line.Contains(macro))
 					args->Set(kv.first, kv.second);
@@ -108,7 +108,7 @@ String CompatUtility::GetCheckableCommandArgs(const Checkable::Ptr& checkable)
 
 			if (service_vars) {
 				ObjectLock olock(service_vars);
-				for (const Dictionary::Pair& kv : service_vars) {
+				for (const auto& kv : service_vars) {
 					String macro = "$" + kv.first + "$"; // this is too simple
 					if (command_line.Contains(macro))
 						args->Set(kv.first, kv.second);
@@ -121,7 +121,7 @@ String CompatUtility::GetCheckableCommandArgs(const Checkable::Ptr& checkable)
 
 		String arg_string;
 		ObjectLock olock(args);
-		for (const Dictionary::Pair& kv : args) {
+		for (const auto& kv : args) {
 			arg_string += Convert::ToString(kv.first) + "=" + Convert::ToString(kv.second) + "!";
 		}
 		return arg_string;
@@ -134,7 +134,7 @@ String CompatUtility::GetCheckableCommandArgs(const Checkable::Ptr& checkable)
 int CompatUtility::GetCheckableNotificationLastNotification(const Checkable::Ptr& checkable)
 {
 	double last_notification = 0.0;
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		if (notification->GetLastNotification() > last_notification)
 			last_notification = notification->GetLastNotification();
 	}
@@ -146,7 +146,7 @@ int CompatUtility::GetCheckableNotificationLastNotification(const Checkable::Ptr
 int CompatUtility::GetCheckableNotificationNextNotification(const Checkable::Ptr& checkable)
 {
 	double next_notification = 0.0;
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		if (next_notification == 0 || notification->GetNextNotification() < next_notification)
 			next_notification = notification->GetNextNotification();
 	}
@@ -158,7 +158,7 @@ int CompatUtility::GetCheckableNotificationNextNotification(const Checkable::Ptr
 int CompatUtility::GetCheckableNotificationNotificationNumber(const Checkable::Ptr& checkable)
 {
 	int notification_number = 0;
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		if (notification->GetNotificationNumber() > notification_number)
 			notification_number = notification->GetNotificationNumber();
 	}
@@ -171,7 +171,7 @@ double CompatUtility::GetCheckableNotificationNotificationInterval(const Checkab
 {
 	double notification_interval = -1;
 
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		if (notification_interval == -1 || notification->GetInterval() < notification_interval)
 			notification_interval = notification->GetInterval();
 	}
@@ -187,7 +187,7 @@ int CompatUtility::GetCheckableNotificationTypeFilter(const Checkable::Ptr& chec
 {
 	unsigned long notification_type_filter = 0;
 
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		ObjectLock olock(notification);
 
 		notification_type_filter |= notification->GetTypeFilter();
@@ -201,7 +201,7 @@ int CompatUtility::GetCheckableNotificationStateFilter(const Checkable::Ptr& che
 {
 	unsigned long notification_state_filter = 0;
 
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		ObjectLock olock(notification);
 
 		notification_state_filter |= notification->GetStateFilter();
@@ -217,14 +217,14 @@ std::set<User::Ptr> CompatUtility::GetCheckableNotificationUsers(const Checkable
 	std::set<User::Ptr> allUsers;
 	std::set<User::Ptr> users;
 
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		ObjectLock olock(notification);
 
 		users = notification->GetUsers();
 
 		std::copy(users.begin(), users.end(), std::inserter(allUsers, allUsers.begin()));
 
-		for (const UserGroup::Ptr& ug : notification->GetUserGroups()) {
+		for (const auto& ug : notification->GetUserGroups()) {
 			std::set<User::Ptr> members = ug->GetMembers();
 			std::copy(members.begin(), members.end(), std::inserter(allUsers, allUsers.begin()));
 		}
@@ -238,10 +238,10 @@ std::set<UserGroup::Ptr> CompatUtility::GetCheckableNotificationUserGroups(const
 {
 	std::set<UserGroup::Ptr> usergroups;
 	/* Service -> Notifications -> UserGroups */
-	for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+	for (const auto& notification : checkable->GetNotifications()) {
 		ObjectLock olock(notification);
 
-		for (const UserGroup::Ptr& ug : notification->GetUserGroups()) {
+		for (const auto& ug : notification->GetUserGroups()) {
 			usergroups.insert(ug);
 		}
 	}

--- a/lib/icinga/customvarobject.cpp
+++ b/lib/icinga/customvarobject.cpp
@@ -27,7 +27,7 @@ int icinga::FilterArrayToInt(const Array::Ptr& typeFilters, const std::map<Strin
 	resultTypeFilter = 0;
 
 	ObjectLock olock(typeFilters);
-	for (const Value& typeFilter : typeFilters) {
+	for (const auto& typeFilter : typeFilters) {
 		if (typeFilter.IsNumber()) {
 			resultTypeFilter = resultTypeFilter | typeFilter;
 			continue;

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -103,7 +103,7 @@ bool Dependency::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyR
 		Array::Ptr arr = vinstances;
 
 		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
+		for (const auto& instance : arr) {
 			String name = rule.GetName();
 
 			if (!rule.GetFKVar().IsEmpty()) {
@@ -120,7 +120,7 @@ bool Dependency::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyR
 
 		Dictionary::Ptr dict = vinstances;
 
-		for (const String& key : dict->GetKeys()) {
+		for (const auto& key : dict->GetKeys()) {
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -301,7 +301,7 @@ Downtime::Ptr Downtime::AddDowntime(const Checkable::Ptr& checkable, const Strin
 
 	if (!ConfigObjectUtility::CreateObject(Downtime::TypeInstance, fullName, config, errors, nullptr)) {
 		ObjectLock olock(errors);
-		for (const String& error : errors) {
+		for (const auto& error : errors) {
 			Log(LogCritical, "Downtime", error);
 		}
 
@@ -346,7 +346,7 @@ void Downtime::RemoveDowntime(const String& id, bool includeChildren, bool cance
 	}
 
 	if (includeChildren) {
-		for (const Downtime::Ptr& child : downtime->GetChildren()) {
+		for (const auto& child : downtime->GetChildren()) {
 			Downtime::RemoveDowntime(child->GetName(), true, true);
 		}
 	}
@@ -357,7 +357,7 @@ void Downtime::RemoveDowntime(const String& id, bool includeChildren, bool cance
 
 	if (!ConfigObjectUtility::DeleteObject(downtime, false, errors, nullptr)) {
 		ObjectLock olock(errors);
-		for (const String& error : errors) {
+		for (const auto& error : errors) {
 			Log(LogCritical, "Downtime", error);
 		}
 
@@ -441,7 +441,7 @@ void Downtime::TriggerDowntime(double triggerTime)
 
 	{
 		ObjectLock olock(triggers);
-		for (const String& triggerName : triggers) {
+		for (const auto& triggerName : triggers) {
 			Downtime::Ptr downtime = Downtime::GetByName(triggerName);
 
 			if (!downtime)
@@ -469,7 +469,7 @@ String Downtime::GetDowntimeIDFromLegacyID(int id)
 void Downtime::DowntimesStartTimerHandler()
 {
 	/* Start fixed downtimes. Flexible downtimes will be triggered on-demand. */
-	for (const Downtime::Ptr& downtime : ConfigType::GetObjectsByType<Downtime>()) {
+	for (const auto& downtime : ConfigType::GetObjectsByType<Downtime>()) {
 		if (downtime->IsActive() &&
 			downtime->CanBeTriggered() &&
 			downtime->GetFixed()) {
@@ -484,7 +484,7 @@ void Downtime::DowntimesStartTimerHandler()
 
 void Downtime::DowntimesExpireTimerHandler()
 {
-	for (const Downtime::Ptr& downtime : ConfigType::GetObjectsByType<Downtime>()) {
+	for (const auto& downtime : ConfigType::GetObjectsByType<Downtime>()) {
 		/* Only remove downtimes which are activated after daemon start. */
 		if (downtime->IsActive() && (downtime->IsExpired() || !downtime->HasValidConfigOwner()))
 			RemoveDowntime(downtime->GetName(), false, false, true);

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -522,7 +522,7 @@ void ExternalCommandProcessor::ScheduleForcedHostSvcChecks(double, const std::ve
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot reschedule forced host service checks for non-existent host '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Rescheduling next check for service '" << service->GetName() << "'";
 
@@ -546,7 +546,7 @@ void ExternalCommandProcessor::ScheduleHostSvcChecks(double, const std::vector<S
 	if (planned_check < Utility::GetTime())
 		planned_check = Utility::GetTime();
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (planned_check > service->GetNextCheck()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Ignoring reschedule request for service '"
@@ -571,7 +571,7 @@ void ExternalCommandProcessor::EnableHostSvcChecks(double, const std::vector<Str
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host service checks for non-existent host '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling active checks for service '" << service->GetName() << "'";
 
@@ -586,7 +586,7 @@ void ExternalCommandProcessor::DisableHostSvcChecks(double, const std::vector<St
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host service checks for non-existent host '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling active checks for service '" << service->GetName() << "'";
 
@@ -748,8 +748,8 @@ void ExternalCommandProcessor::EnableHostgroupSvcChecks(double, const std::vecto
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable hostgroup service checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Enabling active checks for service '" << service->GetName() << "'";
 
@@ -765,8 +765,8 @@ void ExternalCommandProcessor::DisableHostgroupSvcChecks(double, const std::vect
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable hostgroup service checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Disabling active checks for service '" << service->GetName() << "'";
 
@@ -782,7 +782,7 @@ void ExternalCommandProcessor::EnableServicegroupSvcChecks(double, const std::ve
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable servicegroup service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling active checks for service '" << service->GetName() << "'";
 
@@ -797,7 +797,7 @@ void ExternalCommandProcessor::DisableServicegroupSvcChecks(double, const std::v
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable servicegroup service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling active checks for service '" << service->GetName() << "'";
 
@@ -864,7 +864,7 @@ void ExternalCommandProcessor::EnableServicegroupPassiveSvcChecks(double, const 
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable servicegroup passive service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling passive checks for service '" << service->GetName() << "'";
 
@@ -879,7 +879,7 @@ void ExternalCommandProcessor::DisableServicegroupPassiveSvcChecks(double, const
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable servicegroup passive service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling passive checks for service '" << service->GetName() << "'";
 
@@ -894,8 +894,8 @@ void ExternalCommandProcessor::EnableHostgroupPassiveSvcChecks(double, const std
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable hostgroup passive service checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Enabling passive checks for service '" << service->GetName() << "'";
 
@@ -911,8 +911,8 @@ void ExternalCommandProcessor::DisableHostgroupPassiveSvcChecks(double, const st
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable hostgroup passive service checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Disabling passive checks for service '" << service->GetName() << "'";
 
@@ -1037,7 +1037,7 @@ void ExternalCommandProcessor::ScheduleAndPropagateHostDowntime(double, const st
 		Convert::ToBool(is_fixed), triggeredBy, Convert::ToDouble(arguments[5]));
 
 	/* Schedule downtime for all child hosts */
-	for (const Checkable::Ptr& child : host->GetAllChildren()) {
+	for (const auto& child : host->GetAllChildren()) {
 		Host::Ptr host;
 		Service::Ptr service;
 		tie(host, service) = GetHostService(child);
@@ -1073,7 +1073,7 @@ void ExternalCommandProcessor::ScheduleAndPropagateTriggeredHostDowntime(double,
 		Convert::ToBool(is_fixed), triggeredBy, Convert::ToDouble(arguments[5]));
 
 	/* Schedule downtime for all child hosts and explicitely trigger them through the parent host's downtime */
-	for (const Checkable::Ptr& child : host->GetAllChildren()) {
+	for (const auto& child : host->GetAllChildren()) {
 		Host::Ptr host;
 		Service::Ptr service;
 		tie(host, service) = GetHostService(child);
@@ -1126,7 +1126,7 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 		Log(LogWarning, "ExternalCommandProcessor")
 			<< ("Ignoring additional parameters for host '" + arguments[0] + "' downtime deletion.");
 
-	for (const Downtime::Ptr& downtime : host->GetDowntimes()) {
+	for (const auto& downtime : host->GetDowntimes()) {
 		try {
 			String downtimeName = downtime->GetName();
 			Downtime::RemoveDowntime(downtimeName, false, true);
@@ -1138,11 +1138,11 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 		}
 	}
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (!serviceName.IsEmpty() && serviceName != service->GetName())
 			continue;
 
-		for (const Downtime::Ptr& downtime : service->GetDowntimes()) {
+		for (const auto& downtime : service->GetDowntimes()) {
 			if (!startTime.IsEmpty() && downtime->GetStartTime() != Convert::ToDouble(startTime))
 				continue;
 
@@ -1182,7 +1182,7 @@ void ExternalCommandProcessor::ScheduleHostSvcDowntime(double, const std::vector
 		Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
 		Convert::ToBool(is_fixed), triggeredBy, Convert::ToDouble(arguments[5]));
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Creating downtime for service " << service->GetName();
 		(void) Downtime::AddDowntime(service, arguments[6], arguments[7],
@@ -1204,7 +1204,7 @@ void ExternalCommandProcessor::ScheduleHostgroupHostDowntime(double, const std::
 	if (triggeredByLegacy != 0)
 		triggeredBy = Downtime::GetDowntimeIDFromLegacyID(triggeredByLegacy);
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<<  "Creating downtime for host " << host->GetName();
 
@@ -1233,13 +1233,13 @@ void ExternalCommandProcessor::ScheduleHostgroupSvcDowntime(double, const std::v
 
 	std::set<Service::Ptr> services;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			services.insert(service);
 		}
 	}
 
-	for (const Service::Ptr& service : services) {
+	for (const auto& service : services) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Creating downtime for service " << service->GetName();
 		(void) Downtime::AddDowntime(service, arguments[6], arguments[7],
@@ -1267,12 +1267,12 @@ void ExternalCommandProcessor::ScheduleServicegroupHostDowntime(double, const st
 
 	std::set<Host::Ptr> hosts;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 		hosts.insert(host);
 	}
 
-	for (const Host::Ptr& host : hosts) {
+	for (const auto& host : hosts) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Creating downtime for host " << host->GetName();
 		(void) Downtime::AddDowntime(host, arguments[6], arguments[7],
@@ -1294,7 +1294,7 @@ void ExternalCommandProcessor::ScheduleServicegroupSvcDowntime(double, const std
 	if (triggeredByLegacy != 0)
 		triggeredBy = Downtime::GetDowntimeIDFromLegacyID(triggeredByLegacy);
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Creating downtime for service " << service->GetName();
 		(void) Downtime::AddDowntime(service, arguments[6], arguments[7],
@@ -1425,7 +1425,7 @@ void ExternalCommandProcessor::DelayHostNotification(double, const std::vector<S
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Delaying notifications for host '" << host->GetName() << "'";
 
-	for (const Notification::Ptr& notification : host->GetNotifications()) {
+	for (const auto& notification : host->GetNotifications()) {
 		notification->SetNextNotification(Convert::ToDouble(arguments[1]));
 	}
 }
@@ -1440,7 +1440,7 @@ void ExternalCommandProcessor::DelaySvcNotification(double, const std::vector<St
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Delaying notifications for service " << service->GetName();
 
-	for (const Notification::Ptr& notification : service->GetNotifications()) {
+	for (const auto& notification : service->GetNotifications()) {
 		notification->SetNextNotification(Convert::ToDouble(arguments[2]));
 	}
 }
@@ -1507,7 +1507,7 @@ void ExternalCommandProcessor::EnableHostSvcNotifications(double, const std::vec
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Enabling notifications for all services on host '" << arguments[0] << "'";
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling notifications for service '" << service->GetName() << "'";
 
@@ -1525,7 +1525,7 @@ void ExternalCommandProcessor::DisableHostSvcNotifications(double, const std::ve
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Disabling notifications for all services on host '" << arguments[0] << "'";
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling notifications for service '" << service->GetName() << "'";
 
@@ -1540,7 +1540,7 @@ void ExternalCommandProcessor::DisableHostgroupHostChecks(double, const std::vec
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable hostgroup host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling active checks for host '" << host->GetName() << "'";
 
@@ -1555,7 +1555,7 @@ void ExternalCommandProcessor::DisableHostgroupPassiveHostChecks(double, const s
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable hostgroup passive host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling passive checks for host '" << host->GetName() << "'";
 
@@ -1570,7 +1570,7 @@ void ExternalCommandProcessor::DisableServicegroupHostChecks(double, const std::
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable servicegroup host checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
 		Log(LogNotice, "ExternalCommandProcessor")
@@ -1587,7 +1587,7 @@ void ExternalCommandProcessor::DisableServicegroupPassiveHostChecks(double, cons
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable servicegroup passive host checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
 		Log(LogNotice, "ExternalCommandProcessor")
@@ -1604,7 +1604,7 @@ void ExternalCommandProcessor::EnableHostgroupHostChecks(double, const std::vect
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable hostgroup host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling active checks for host '" << host->GetName() << "'";
 
@@ -1619,7 +1619,7 @@ void ExternalCommandProcessor::EnableHostgroupPassiveHostChecks(double, const st
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable hostgroup passive host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling passive checks for host '" << host->GetName() << "'";
 
@@ -1634,7 +1634,7 @@ void ExternalCommandProcessor::EnableServicegroupHostChecks(double, const std::v
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable servicegroup host checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
 		Log(LogNotice, "ExternalCommandProcessor")
@@ -1651,7 +1651,7 @@ void ExternalCommandProcessor::EnableServicegroupPassiveHostChecks(double, const
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable servicegroup passive host checks for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
 		Log(LogNotice, "ExternalCommandProcessor")
@@ -2146,7 +2146,7 @@ void ExternalCommandProcessor::EnableHostgroupHostNotifications(double, const st
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host notifications for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling notifications for host '" << host->GetName() << "'";
 
@@ -2161,8 +2161,8 @@ void ExternalCommandProcessor::EnableHostgroupSvcNotifications(double, const std
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service notifications for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Enabling notifications for service '" << service->GetName() << "'";
 
@@ -2178,7 +2178,7 @@ void ExternalCommandProcessor::DisableHostgroupHostNotifications(double, const s
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host notifications for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling notifications for host '" << host->GetName() << "'";
 
@@ -2193,8 +2193,8 @@ void ExternalCommandProcessor::DisableHostgroupSvcNotifications(double, const st
 	if (!hg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service notifications for non-existent hostgroup '" + arguments[0] + "'"));
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Disabling notifications for service '" << service->GetName() << "'";
 
@@ -2210,7 +2210,7 @@ void ExternalCommandProcessor::EnableServicegroupHostNotifications(double, const
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host notifications for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
 		Log(LogNotice, "ExternalCommandProcessor")
@@ -2227,7 +2227,7 @@ void ExternalCommandProcessor::EnableServicegroupSvcNotifications(double, const 
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service notifications for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Enabling notifications for service '" << service->GetName() << "'";
 
@@ -2242,7 +2242,7 @@ void ExternalCommandProcessor::DisableServicegroupHostNotifications(double, cons
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host notifications for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
 		Log(LogNotice, "ExternalCommandProcessor")
@@ -2259,7 +2259,7 @@ void ExternalCommandProcessor::DisableServicegroupSvcNotifications(double, const
 	if (!sg)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service notifications for non-existent servicegroup '" + arguments[0] + "'"));
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Disabling notifications for service '" << service->GetName() << "'";
 

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -38,7 +38,7 @@ void Host::OnAllConfigLoaded()
 
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			HostGroup::Ptr hg = HostGroup::GetByName(name);
 
 			if (hg)
@@ -71,7 +71,7 @@ void Host::Stop(bool runtimeRemoved)
 	if (groups) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			HostGroup::Ptr hg = HostGroup::GetByName(name);
 
 			if (hg)
@@ -89,7 +89,7 @@ std::vector<Service::Ptr> Host::GetServices() const
 	std::vector<Service::Ptr> services;
 	services.reserve(m_Services.size());
 	typedef std::pair<String, Service::Ptr> ServicePair;
-	for (const ServicePair& kv : m_Services) {
+	for (const auto& kv : m_Services) {
 		services.push_back(kv.second);
 	}
 
@@ -291,7 +291,7 @@ bool Host::ResolveMacro(const String& macro, const CheckResult::Ptr&, Value *res
 			else if (macro == "num_services_critical")
 				filter = ServiceCritical;
 
-			for (const Service::Ptr& service : GetServices()) {
+			for (const auto& service : GetServices()) {
 				if (filter != -1 && service->GetState() != filter)
 					continue;
 

--- a/lib/icinga/hostgroup.cpp
+++ b/lib/icinga/hostgroup.cpp
@@ -47,7 +47,7 @@ void HostGroup::EvaluateObjectRules(const Host::Ptr& host)
 {
 	CONTEXT("Evaluating group memberships for host '" + host->GetName() + "'");
 
-	for (const ConfigItem::Ptr& group : ConfigItem::GetItems(HostGroup::TypeInstance))
+	for (const auto& group : ConfigItem::GetItems(HostGroup::TypeInstance))
 	{
 		if (!group->GetFilter())
 			continue;
@@ -91,7 +91,7 @@ bool HostGroup::ResolveGroupMembership(const Host::Ptr& host, bool add, int rsta
 	if (groups && groups->GetLength() > 0) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			HostGroup::Ptr group = HostGroup::GetByName(name);
 
 			if (group && !group->ResolveGroupMembership(host, add, rstack + 1))

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -70,7 +70,7 @@ void IcingaApplication::StatsFunc(const Dictionary::Ptr& status, const Array::Pt
 {
 	DictionaryData nodes;
 
-	for (const IcingaApplication::Ptr& icingaapplication : ConfigType::GetObjectsByType<IcingaApplication>()) {
+	for (const auto& icingaapplication : ConfigType::GetObjectsByType<IcingaApplication>()) {
 		nodes.emplace_back(icingaapplication->GetName(), new Dictionary({
 			{ "node_name", icingaapplication->GetNodeName() },
 			{ "enable_notifications", icingaapplication->GetEnableNotifications() },

--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -461,7 +461,7 @@ void LegacyTimePeriod::ProcessTimeRanges(const String& timeranges, const tm *ref
 {
 	std::vector<String> ranges = timeranges.Split(",");
 
-	for (const String& range : ranges) {
+	for (const auto& range : ranges) {
 		Dictionary::Ptr segment = ProcessTimeRange(range, reference);
 
 		if (segment->Get("begin") >= segment->Get("end"))
@@ -494,7 +494,7 @@ Dictionary::Ptr LegacyTimePeriod::FindRunningSegment(const String& daydef, const
 			double bestEnd = 0.0;
 
 			ObjectLock olock(segments);
-			for (const Dictionary::Ptr& segment : segments) {
+			for (const auto& segment : segments) {
 				double begin = segment->Get("begin");
 				double end = segment->Get("end");
 
@@ -552,7 +552,7 @@ Dictionary::Ptr LegacyTimePeriod::FindNextSegment(const String& daydef, const St
 				double bestBegin;
 
 				ObjectLock olock(segments);
-				for (const Dictionary::Ptr& segment : segments) {
+				for (const auto& segment : segments) {
 					double begin = segment->Get("begin");
 
 					if (begin < tsref)
@@ -618,7 +618,7 @@ Array::Ptr LegacyTimePeriod::ScriptFunc(const TimePeriod::Ptr& tp, double begin,
 #endif /* I2_DEBUG */
 
 			ObjectLock olock(ranges);
-			for (const Dictionary::Pair& kv : ranges) {
+			for (const auto& kv : ranges) {
 				if (!IsInDayDefinition(kv.first, &reference)) {
 #ifdef I2_DEBUG
 					Log(LogDebug, "LegacyTimePeriod")

--- a/lib/icinga/macroprocessor.cpp
+++ b/lib/icinga/macroprocessor.cpp
@@ -39,7 +39,7 @@ Value MacroProcessor::ResolveMacros(const Value& str, const ResolverList& resolv
 
 		ObjectLock olock(arr);
 
-		for (const Value& arg : arr) {
+		for (const auto& arg : arr) {
 			/* Note: don't escape macros here. */
 			Value value = InternalResolveMacros(arg, resolvers, cr, missingMacro,
 				EscapeCallback(), resolvedMacros, useResolvedMacros, recursionLevel + 1);
@@ -57,7 +57,7 @@ Value MacroProcessor::ResolveMacros(const Value& str, const ResolverList& resolv
 
 		ObjectLock olock(dict);
 
-		for (const Dictionary::Pair& kv : dict) {
+		for (const auto& kv : dict) {
 			/* Note: don't escape macros here. */
 			resultDict->Set(kv.first, InternalResolveMacros(kv.second, resolvers, cr, missingMacro,
 				EscapeCallback(), resolvedMacros, useResolvedMacros, recursionLevel + 1));
@@ -88,7 +88,7 @@ bool MacroProcessor::ResolveMacro(const String& macro, const ResolverList& resol
 		tokens.erase(tokens.begin());
 	}
 
-	for (const ResolverSpec& resolver : resolvers) {
+	for (const auto& resolver : resolvers) {
 		if (!objName.IsEmpty() && objName != resolver.first)
 			continue;
 
@@ -114,7 +114,7 @@ bool MacroProcessor::ResolveMacro(const String& macro, const ResolverList& resol
 		Value ref = resolver.second;
 		bool valid = true;
 
-		for (const String& token : tokens) {
+		for (const auto& token : tokens) {
 			if (ref.IsObjectType<Dictionary>()) {
 				Dictionary::Ptr dict = ref;
 				if (dict->Contains(token)) {
@@ -171,7 +171,7 @@ Value MacroProcessor::EvaluateFunction(const Function::Ptr& func, const Resolver
 {
 	Dictionary::Ptr resolvers_this = new Dictionary();
 
-	for (const ResolverSpec& resolver : resolvers) {
+	for (const auto& resolver : resolvers) {
 		resolvers_this->Set(resolver.first, resolver.second);
 	}
 
@@ -263,7 +263,7 @@ Value MacroProcessor::InternalResolveMacros(const String& str, const ResolverLis
 				ArrayData resolved_arr;
 
 				ObjectLock olock(arr);
-				for (const Value& value : arr) {
+				for (const auto& value : arr) {
 					if (value.IsScalar()) {
 						resolved_arr.push_back(InternalResolveMacros(value,
 							resolvers, cr, missingMacro, EscapeCallback(), nullptr,
@@ -337,7 +337,7 @@ void MacroProcessor::ValidateCustomVars(const ConfigObject::Ptr& object, const D
 
 	/* string, array, dictionary */
 	ObjectLock olock(value);
-	for (const Dictionary::Pair& kv : value) {
+	for (const auto& kv : value) {
 		const Value& varval = kv.second;
 
 		if (varval.IsObjectType<Dictionary>()) {
@@ -345,7 +345,7 @@ void MacroProcessor::ValidateCustomVars(const ConfigObject::Ptr& object, const D
 			Dictionary::Ptr varval_dict = varval;
 
 			ObjectLock xlock(varval_dict);
-			for (const Dictionary::Pair& kv_var : varval_dict) {
+			for (const auto& kv_var : varval_dict) {
 				if (!kv_var.second.IsString())
 					continue;
 
@@ -357,7 +357,7 @@ void MacroProcessor::ValidateCustomVars(const ConfigObject::Ptr& object, const D
 			Array::Ptr varval_arr = varval;
 
 			ObjectLock ylock (varval_arr);
-			for (const Value& arrval : varval_arr) {
+			for (const auto& arrval : varval_arr) {
 				if (!arrval.IsString())
 					continue;
 
@@ -393,7 +393,7 @@ Value MacroProcessor::EscapeMacroShellArg(const Value& value)
 		Array::Ptr arr = value;
 
 		ObjectLock olock(arr);
-		for (const Value& arg : arr) {
+		for (const auto& arg : arr) {
 			if (result.GetLength() > 0)
 				result += " ";
 
@@ -439,7 +439,7 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 		std::vector<CommandArgument> args;
 
 		ObjectLock olock(arguments);
-		for (const Dictionary::Pair& kv : arguments) {
+		for (const auto& kv : arguments) {
 			const Value& arginfo = kv.second;
 
 			CommandArgument arg;
@@ -519,7 +519,7 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 		std::sort(args.begin(), args.end());
 
 		Array::Ptr command_arr = resolvedCommand;
-		for (const CommandArgument& arg : args) {
+		for (const auto& arg : args) {
 
 			if (arg.AValue.IsObjectType<Dictionary>()) {
 				Log(LogWarning, "PluginUtility")
@@ -530,7 +530,7 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 				Array::Ptr arr = static_cast<Array::Ptr>(arg.AValue);
 
 				ObjectLock olock(arr);
-				for (const Value& value : arr) {
+				for (const auto& value : arr) {
 					bool add_key;
 
 					if (first) {

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -102,7 +102,7 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 		Array::Ptr arr = vinstances;
 
 		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
+		for (const auto& instance : arr) {
 			String name = rule.GetName();
 
 			if (!rule.GetFKVar().IsEmpty()) {
@@ -119,7 +119,7 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 
 		Dictionary::Ptr dict = vinstances;
 
-		for (const String& key : dict->GetKeys()) {
+		for (const auto& key : dict->GetKeys()) {
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -133,7 +133,7 @@ void Notification::Start(bool runtimeCreated)
 	if (ApiListener::IsHACluster() && GetNextNotification() < Utility::GetTime() + 60)
 		SetNextNotification(Utility::GetTime() + 60, true);
 
-	for (const UserGroup::Ptr& group : GetUserGroups())
+	for (const auto& group : GetUserGroups())
 		group->AddNotification(this);
 
 	ObjectImpl<Notification>::Start(runtimeCreated);
@@ -148,7 +148,7 @@ void Notification::Stop(bool runtimeRemoved)
 	if (obj)
 		obj->UnregisterNotification(this);
 
-	for (const UserGroup::Ptr& group : GetUserGroups())
+	for (const auto& group : GetUserGroups())
 		group->RemoveNotification(this);
 }
 
@@ -171,7 +171,7 @@ std::set<User::Ptr> Notification::GetUsers() const
 	if (users) {
 		ObjectLock olock(users);
 
-		for (const String& name : users) {
+		for (const auto& name : users) {
 			User::Ptr user = User::GetByName(name);
 
 			if (!user)
@@ -193,7 +193,7 @@ std::set<UserGroup::Ptr> Notification::GetUserGroups() const
 	if (groups) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			UserGroup::Ptr ug = UserGroup::GetByName(name);
 
 			if (!ug)
@@ -395,7 +395,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 	std::set<User::Ptr> users = GetUsers();
 	std::copy(users.begin(), users.end(), std::inserter(allUsers, allUsers.begin()));
 
-	for (const UserGroup::Ptr& ug : GetUserGroups()) {
+	for (const auto& ug : GetUserGroups()) {
 		std::set<User::Ptr> members = ug->GetMembers();
 		std::copy(members.begin(), members.end(), std::inserter(allUsers, allUsers.begin()));
 	}
@@ -403,7 +403,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 	std::set<User::Ptr> allNotifiedUsers;
 	Array::Ptr notifiedProblemUsers = GetNotifiedProblemUsers();
 
-	for (const User::Ptr& user : allUsers) {
+	for (const auto& user : allUsers) {
 		String userName = user->GetName();
 
 		if (!user->GetEnableNotifications()) {
@@ -609,7 +609,7 @@ String Notification::NotificationFilterToString(int filter, const std::map<Strin
 	std::vector<String> sFilters;
 
 	typedef std::pair<String, int> kv_pair;
-	for (const kv_pair& kv : filterMap) {
+	for (const auto& kv : filterMap) {
 		if (filter & kv.second)
 			sFilters.push_back(kv.first);
 	}

--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -50,7 +50,7 @@ void PluginUtility::ExecuteCommand(const Command::Ptr& commandObj, const Checkab
 
 	if (env) {
 		ObjectLock olock(env);
-		for (const Dictionary::Pair& kv : env) {
+		for (const auto& kv : env) {
 			String name = kv.second;
 
 			String missingMacro;
@@ -103,7 +103,7 @@ std::pair<String, String> PluginUtility::ParseCheckOutput(const String& output)
 
 	std::vector<String> lines = output.Split("\r\n");
 
-	for (const String& line : lines) {
+	for (const auto& line : lines) {
 		size_t delim = line.FindFirstOf("|");
 
 		if (!text.IsEmpty())
@@ -186,7 +186,7 @@ String PluginUtility::FormatPerfdata(const Array::Ptr& perfdata, bool normalize)
 	ObjectLock olock(perfdata);
 
 	bool first = true;
-	for (const Value& pdv : perfdata) {
+	for (const auto& pdv : perfdata) {
 		if (!first)
 			result << " ";
 		else

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -101,7 +101,7 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 		Array::Ptr arr = vinstances;
 
 		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
+		for (const auto& instance : arr) {
 			String name = rule.GetName();
 
 			if (!rule.GetFKVar().IsEmpty()) {
@@ -118,7 +118,7 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 
 		Dictionary::Ptr dict = vinstances;
 
-		for (const String& key : dict->GetKeys()) {
+		for (const auto& key : dict->GetKeys()) {
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -90,7 +90,7 @@ void ScheduledDowntime::Start(bool runtimeCreated)
 
 void ScheduledDowntime::TimerProc()
 {
-	for (const ScheduledDowntime::Ptr& sd : ConfigType::GetObjectsByType<ScheduledDowntime>()) {
+	for (const auto& sd : ConfigType::GetObjectsByType<ScheduledDowntime>()) {
 		if (sd->IsActive() && !sd->IsPaused()) {
 			try {
 				sd->CreateNextDowntime();
@@ -145,7 +145,7 @@ std::pair<double, double> ScheduledDowntime::FindRunningSegment(double minEnd)
 	ObjectLock olock(ranges);
 
 	/* Find the longest lasting (and longer than minEnd, if given) segment that's already running */  
-	for (const Dictionary::Pair& kv : ranges) {
+	for (const auto& kv : ranges) {
 		Log(LogDebug, "ScheduledDowntime")
 		    << "Evaluating (running?) segment: " << kv.first << ": " << kv.second;
 
@@ -205,7 +205,7 @@ std::pair<double, double> ScheduledDowntime::FindNextSegment()
 	ObjectLock olock(ranges);
 
 	/* Find the segment starting earliest */
-	for (const Dictionary::Pair& kv : ranges) {
+	for (const auto& kv : ranges) {
 		Log(LogDebug, "ScheduledDowntime")
 			<< "Evaluating segment: " << kv.first << ": " << kv.second;
 
@@ -251,7 +251,7 @@ void ScheduledDowntime::CreateNextDowntime()
 	double minEnd = 0;
 	auto downtimeOptionsHash (HashDowntimeOptions());
 
-	for (const Downtime::Ptr& downtime : GetCheckable()->GetDowntimes()) {
+	for (const auto& downtime : GetCheckable()->GetDowntimes()) {
 		if (downtime->GetScheduledBy() != GetName())
 			continue;
 
@@ -297,7 +297,7 @@ void ScheduledDowntime::CreateNextDowntime()
 		Log(LogNotice, "ScheduledDowntime")
 				<< "Processing child options " << childOptions << " for downtime " << downtimeName;
 
-		for (const Checkable::Ptr& child : GetCheckable()->GetAllChildren()) {
+		for (const auto& child : GetCheckable()->GetAllChildren()) {
 			Log(LogNotice, "ScheduledDowntime")
 				<< "Scheduling downtime for child object " << child->GetName();
 
@@ -318,7 +318,7 @@ void ScheduledDowntime::RemoveObsoleteDowntimes()
 	// Just to be sure start and removal don't happen at the same time
 	auto threshold (Utility::GetTime() + 5 * 60);
 
-	for (const Downtime::Ptr& downtime : GetCheckable()->GetDowntimes()) {
+	for (const auto& downtime : GetCheckable()->GetDowntimes()) {
 		if (downtime->GetScheduledBy() == name && downtime->GetStartTime() > threshold) {
 			auto configOwnerHash (downtime->GetConfigOwnerHash());
 
@@ -341,7 +341,7 @@ void ScheduledDowntime::ValidateRanges(const Lazy<Dictionary::Ptr>& lvalue, cons
 	Array::Ptr segments = new Array();
 
 	ObjectLock olock(lvalue());
-	for (const Dictionary::Pair& kv : lvalue()) {
+	for (const auto& kv : lvalue()) {
 		try {
 			tm begin_tm, end_tm;
 			int stride;

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -90,7 +90,7 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule)
 		Array::Ptr arr = vinstances;
 
 		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
+		for (const auto& instance : arr) {
 			String name = rule.GetName();
 
 			if (!rule.GetFKVar().IsEmpty()) {
@@ -107,7 +107,7 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule)
 
 		Dictionary::Ptr dict = vinstances;
 
-		for (const String& key : dict->GetKeys()) {
+		for (const auto& key : dict->GetKeys()) {
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -65,7 +65,7 @@ void Service::OnAllConfigLoaded()
 
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			ServiceGroup::Ptr sg = ServiceGroup::GetByName(name);
 
 			if (sg)

--- a/lib/icinga/servicegroup.cpp
+++ b/lib/icinga/servicegroup.cpp
@@ -50,7 +50,7 @@ void ServiceGroup::EvaluateObjectRules(const Service::Ptr& service)
 {
 	CONTEXT("Evaluating group membership for service '" + service->GetName() + "'");
 
-	for (const ConfigItem::Ptr& group : ConfigItem::GetItems(ServiceGroup::TypeInstance))
+	for (const auto& group : ConfigItem::GetItems(ServiceGroup::TypeInstance))
 	{
 		if (!group->GetFilter())
 			continue;
@@ -94,7 +94,7 @@ bool ServiceGroup::ResolveGroupMembership(const Service::Ptr& service, bool add,
 	if (groups && groups->GetLength() > 0) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			ServiceGroup::Ptr group = ServiceGroup::GetByName(name);
 
 			if (group && !group->ResolveGroupMembership(service, add, rstack + 1))

--- a/lib/icinga/timeperiod.cpp
+++ b/lib/icinga/timeperiod.cpp
@@ -57,7 +57,7 @@ void TimePeriod::AddSegment(double begin, double end)
 	if (segments) {
 		/* Try to merge the new segment into an existing segment. */
 		ObjectLock dlock(segments);
-		for (const Dictionary::Ptr& segment : segments) {
+		for (const auto& segment : segments) {
 			if (segment->Get("begin") <= begin && segment->Get("end") >= end)
 				return; /* New segment is fully contained in this segment. */
 
@@ -122,7 +122,7 @@ void TimePeriod::RemoveSegment(double begin, double end)
 
 	/* Try to split or adjust an existing segment. */
 	ObjectLock dlock(segments);
-	for (const Dictionary::Ptr& segment : segments) {
+	for (const auto& segment : segments) {
 		/* Fully contained in the specified range? */
 		if (segment->Get("begin") >= begin && segment->Get("end") <= end)
 			// Don't add the old segment, because the segment is fully contained into our range
@@ -193,7 +193,7 @@ void TimePeriod::PurgeSegments(double end)
 
 	/* Remove old segments. */
 	ObjectLock dlock(segments);
-	for (const Dictionary::Ptr& segment : segments) {
+	for (const auto& segment : segments) {
 		if (segment->Get("end") >= end)
 			newSegments->Add(segment);
 	}
@@ -212,7 +212,7 @@ void TimePeriod::Merge(const TimePeriod::Ptr& timeperiod, bool include)
 	if (segments) {
 		ObjectLock dlock(segments);
 		ObjectLock ilock(this);
-		for (const Dictionary::Ptr& segment : segments) {
+		for (const auto& segment : segments) {
 			include ? AddSegment(segment) : RemoveSegment(segment);
 		}
 	}
@@ -239,7 +239,7 @@ void TimePeriod::UpdateRegion(double begin, double end, bool clearExisting)
 
 		if (segments) {
 			ObjectLock dlock(segments);
-			for (const Dictionary::Ptr& segment : segments) {
+			for (const auto& segment : segments) {
 				AddSegment(segment);
 			}
 		}
@@ -252,7 +252,7 @@ void TimePeriod::UpdateRegion(double begin, double end, bool clearExisting)
 
 	if (timeranges) {
 		ObjectLock olock(timeranges);
-		for (const String& name : timeranges) {
+		for (const auto& name : timeranges) {
 			const TimePeriod::Ptr timeperiod = TimePeriod::GetByName(name);
 
 			if (timeperiod)
@@ -265,7 +265,7 @@ void TimePeriod::UpdateRegion(double begin, double end, bool clearExisting)
 
 	if (timeranges) {
 		ObjectLock olock(timeranges);
-		for (const String& name : timeranges) {
+		for (const auto& name : timeranges) {
 			const TimePeriod::Ptr timeperiod = TimePeriod::GetByName(name);
 
 			if (timeperiod)
@@ -290,7 +290,7 @@ bool TimePeriod::IsInside(double ts) const
 
 	if (segments) {
 		ObjectLock dlock(segments);
-		for (const Dictionary::Ptr& segment : segments) {
+		for (const auto& segment : segments) {
 			if (ts > segment->Get("begin") && ts < segment->Get("end"))
 				return true;
 		}
@@ -309,7 +309,7 @@ double TimePeriod::FindNextTransition(double begin)
 
 	if (segments) {
 		ObjectLock dlock(segments);
-		for (const Dictionary::Ptr& segment : segments) {
+		for (const auto& segment : segments) {
 			if (segment->Get("begin") > begin && (segment->Get("begin") < closestTransition || closestTransition == -1))
 				closestTransition = segment->Get("begin");
 
@@ -325,7 +325,7 @@ void TimePeriod::UpdateTimerHandler()
 {
 	double now = Utility::GetTime();
 
-	for (const TimePeriod::Ptr& tp : ConfigType::GetObjectsByType<TimePeriod>()) {
+	for (const auto& tp : ConfigType::GetObjectsByType<TimePeriod>()) {
 		if (!tp->IsActive())
 			continue;
 
@@ -360,7 +360,7 @@ void TimePeriod::Dump()
 
 	if (segments) {
 		ObjectLock dlock(segments);
-		for (const Dictionary::Ptr& segment : segments) {
+		for (const auto& segment : segments) {
 			Log(LogDebug, "TimePeriod")
 				<< "Segment: " << Utility::FormatDateTime("%c", segment->Get("begin")) << " <-> "
 				<< Utility::FormatDateTime("%c", segment->Get("end"));
@@ -381,7 +381,7 @@ void TimePeriod::ValidateRanges(const Lazy<Dictionary::Ptr>& lvalue, const Valid
 	Array::Ptr segments = new Array();
 
 	ObjectLock olock(lvalue());
-	for (const Dictionary::Pair& kv : lvalue()) {
+	for (const auto& kv : lvalue()) {
 		try {
 			tm begin_tm, end_tm;
 			int stride;

--- a/lib/icinga/user.cpp
+++ b/lib/icinga/user.cpp
@@ -33,7 +33,7 @@ void User::OnAllConfigLoaded()
 
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			UserGroup::Ptr ug = UserGroup::GetByName(name);
 
 			if (ug)
@@ -51,7 +51,7 @@ void User::Stop(bool runtimeRemoved)
 	if (groups) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			UserGroup::Ptr ug = UserGroup::GetByName(name);
 
 			if (ug)

--- a/lib/icinga/usergroup.cpp
+++ b/lib/icinga/usergroup.cpp
@@ -48,7 +48,7 @@ void UserGroup::EvaluateObjectRules(const User::Ptr& user)
 {
 	CONTEXT("Evaluating group membership for user '" + user->GetName() + "'");
 
-	for (const ConfigItem::Ptr& group : ConfigItem::GetItems(UserGroup::TypeInstance))
+	for (const auto& group : ConfigItem::GetItems(UserGroup::TypeInstance))
 	{
 		if (!group->GetFilter())
 			continue;
@@ -110,7 +110,7 @@ bool UserGroup::ResolveGroupMembership(const User::Ptr& user, bool add, int rsta
 	if (groups && groups->GetLength() > 0) {
 		ObjectLock olock(groups);
 
-		for (const String& name : groups) {
+		for (const auto& name : groups) {
 			UserGroup::Ptr group = UserGroup::GetByName(name);
 
 			if (group && !group->ResolveGroupMembership(user, add, rstack + 1))

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -281,7 +281,7 @@ void IcingaDB::UpdateAllConfigObjects()
 			bool dumpState = (lcType == "host" || lcType == "service");
 
 			size_t bulkCounter = 0;
-			for (const ConfigObject::Ptr& object : chunk) {
+			for (const auto& object : chunk) {
 				if (lcType != GetLowerCaseTypeNameDB(object))
 					continue;
 
@@ -954,7 +954,7 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 				AddObjectDataToRuntimeUpdates(runtimeUpdates, id, m_PrefixConfigObject + typeName + ":recipient", groupData);
 			}
 
-			for (const User::Ptr& user : usergroup->GetMembers()) {
+			for (const auto& user : usergroup->GetMembers()) {
 				String userId = GetObjectIdentifier(user);
 				String recipientId = HashValue(new Array({m_EnvironmentId, "usergroupuser", user->GetName(), usergroup->GetName(), notification->GetName()}));
 				notificationRecipients.emplace_back(recipientId);
@@ -1136,7 +1136,7 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 		std::vector<String> xAdd({"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*"});
 		ObjectLock olock(objectAttributes);
 
-		for (const Dictionary::Pair& kv : objectAttributes) {
+		for (const auto& kv : objectAttributes) {
 			String value = IcingaToStreamValue(kv.second);
 			if (!value.IsEmpty()) {
 				xAdd.emplace_back(kv.first);
@@ -1601,7 +1601,7 @@ void IcingaDB::SendStatusUpdate(const Checkable::Ptr& checkable)
 	objectAttrs->Set("redis_key", service ? "icinga:service:state" : "icinga:host:state");
 	objectAttrs->Set("runtime_type", "upsert");
 
-	for (const Dictionary::Pair& kv : objectAttrs) {
+	for (const auto& kv : objectAttrs) {
 		streamadd.emplace_back(kv.first);
 		streamadd.emplace_back(IcingaToStreamValue(kv.second));
 	}
@@ -1760,7 +1760,7 @@ void IcingaDB::SendSentNotification(
 
 	if (!users.empty()) {
 		Array::Ptr users_notified = new Array();
-		for (const User::Ptr& user : users) {
+		for (const auto& user : users) {
 			users_notified->Add(GetObjectIdentifier(user));
 		}
 		xAdd.emplace_back("users_notified_ids");
@@ -2289,7 +2289,7 @@ void IcingaDB::SendNotificationUserGroupsChanged(const Notification::Ptr& notifi
 		DeleteRelationship(id, "notification:usergroup");
 		DeleteRelationship(id, "notification:recipient");
 
-		for (const User::Ptr& user : userGroup->GetMembers()) {
+		for (const auto& user : userGroup->GetMembers()) {
 			String userId = HashValue(new Array({m_EnvironmentId, "usergroupuser", user->GetName(), userGroupName, notification->GetName()}));
 			DeleteRelationship(userId, "notification:recipient");
 		}
@@ -2491,7 +2491,7 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	if (checkable->IsAcknowledged()) {
 		Timestamp entry = 0;
 		Comment::Ptr AckComment;
-		for (const Comment::Ptr& c : checkable->GetComments()) {
+		for (const auto& c : checkable->GetComments()) {
 			if (c->GetEntryType() == CommentAcknowledgement) {
 				if (c->GetEntryTime() > entry) {
 					entry = c->GetEntryTime();
@@ -2584,7 +2584,7 @@ void IcingaDB::StateChangeHandler(const ConfigObject::Ptr& object)
 
 void IcingaDB::StateChangeHandler(const ConfigObject::Ptr& object, const CheckResult::Ptr& cr, StateType type)
 {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendStateChange(object, cr, type);
 	}
 }
@@ -2595,14 +2595,14 @@ void IcingaDB::VersionChangedHandler(const ConfigObject::Ptr& object)
 
 	if (object->IsActive()) {
 		// Create or update the object config
-		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+		for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 			if (rw)
 				rw->SendConfigUpdate(object, true);
 		}
 	} else if (!object->IsActive() &&
 			   object->GetExtension("ConfigObjectDeleted")) { // same as in apilistener-configsync.cpp
 		// Delete object config
-		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+		for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 			if (rw)
 				rw->SendConfigDelete(object);
 		}
@@ -2707,67 +2707,67 @@ void IcingaDB::AcknowledgementClearedHandler(const Checkable::Ptr& checkable, co
 }
 
 void IcingaDB::NotificationUsersChangedHandler(const Notification::Ptr& notification, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendNotificationUsersChanged(notification, oldValues, newValues);
 	}
 }
 
 void IcingaDB::NotificationUserGroupsChangedHandler(const Notification::Ptr& notification, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendNotificationUserGroupsChanged(notification, oldValues, newValues);
 	}
 }
 
 void IcingaDB::TimePeriodRangesChangedHandler(const TimePeriod::Ptr& timeperiod, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendTimePeriodRangesChanged(timeperiod, oldValues, newValues);
 	}
 }
 
 void IcingaDB::TimePeriodIncludesChangedHandler(const TimePeriod::Ptr& timeperiod, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendTimePeriodIncludesChanged(timeperiod, oldValues, newValues);
 	}
 }
 
 void IcingaDB::TimePeriodExcludesChangedHandler(const TimePeriod::Ptr& timeperiod, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendTimePeriodExcludesChanged(timeperiod, oldValues, newValues);
 	}
 }
 
 void IcingaDB::UserGroupsChangedHandler(const User::Ptr& user, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendGroupsChanged<UserGroup>(user, oldValues, newValues);
 	}
 }
 
 void IcingaDB::HostGroupsChangedHandler(const Host::Ptr& host, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendGroupsChanged<HostGroup>(host, oldValues, newValues);
 	}
 }
 
 void IcingaDB::ServiceGroupsChangedHandler(const Service::Ptr& service, const Array::Ptr& oldValues, const Array::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendGroupsChanged<ServiceGroup>(service, oldValues, newValues);
 	}
 }
 
 void IcingaDB::CommandEnvChangedHandler(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendCommandEnvChanged(command, oldValues, newValues);
 	}
 }
 
 void IcingaDB::CommandArgumentsChangedHandler(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendCommandArgumentsChanged(command, oldValues, newValues);
 	}
 }
 
 void IcingaDB::CustomVarsChangedHandler(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues) {
-	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
+	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->SendCustomVarsChanged(object, oldValues, newValues);
 	}
 }

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -41,7 +41,7 @@ String IcingaDB::FormatCommandLine(const Value& commandLine)
 		bool first = true;
 
 		ObjectLock olock(args);
-		for (const Value& arg : args) {
+		for (const auto& arg : args) {
 			String token = "'" + Convert::ToString(arg) + "'";
 
 			if (first)

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -103,7 +103,7 @@ void IcingaDB::Start(bool runtimeCreated)
 		GetEnableTls(), GetInsecureNoverify(), GetCertPath(), GetKeyPath(), GetCaPath(), GetCrlPath(),
 		GetTlsProtocolmin(), GetCipherList(), GetConnectTimeout(), GetDebugInfo());
 
-	for (const Type::Ptr& type : GetTypes()) {
+	for (const auto& type : GetTypes()) {
 		auto ctype (dynamic_cast<ConfigType*>(type.get()));
 		if (!ctype)
 			continue;

--- a/lib/livestatus/andfilter.cpp
+++ b/lib/livestatus/andfilter.cpp
@@ -6,7 +6,7 @@ using namespace icinga;
 
 bool AndFilter::Apply(const Table::Ptr& table, const Value& row)
 {
-	for (const Filter::Ptr& filter : m_Filters) {
+	for (const auto& filter : m_Filters) {
 		if (!filter->Apply(table, row))
 			return false;
 	}

--- a/lib/livestatus/attributefilter.cpp
+++ b/lib/livestatus/attributefilter.cpp
@@ -27,7 +27,7 @@ bool AttributeFilter::Apply(const Table::Ptr& table, const Value& row)
 			bool negate = (m_Operator == "<");
 
 			ObjectLock olock(array);
-			for (const String& item : array) {
+			for (const auto& item : array) {
 				if (item == m_Operand)
 					return !negate; /* Item found in list. */
 			}

--- a/lib/livestatus/commandstable.cpp
+++ b/lib/livestatus/commandstable.cpp
@@ -42,17 +42,17 @@ String CommandsTable::GetPrefix() const
 
 void CommandsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const ConfigObject::Ptr& object : ConfigType::GetObjectsByType<CheckCommand>()) {
+	for (const auto& object : ConfigType::GetObjectsByType<CheckCommand>()) {
 		if (!addRowFn(object, LivestatusGroupByNone, Empty))
 			return;
 	}
 
-	for (const ConfigObject::Ptr& object : ConfigType::GetObjectsByType<EventCommand>()) {
+	for (const auto& object : ConfigType::GetObjectsByType<EventCommand>()) {
 		if (!addRowFn(object, LivestatusGroupByNone, Empty))
 			return;
 	}
 
-	for (const ConfigObject::Ptr& object : ConfigType::GetObjectsByType<NotificationCommand>()) {
+	for (const auto& object : ConfigType::GetObjectsByType<NotificationCommand>()) {
 		if (!addRowFn(object, LivestatusGroupByNone, Empty))
 			return;
 	}

--- a/lib/livestatus/commentstable.cpp
+++ b/lib/livestatus/commentstable.cpp
@@ -50,7 +50,7 @@ String CommentsTable::GetPrefix() const
 
 void CommentsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const Comment::Ptr& comment : ConfigType::GetObjectsByType<Comment>()) {
+	for (const auto& comment : ConfigType::GetObjectsByType<Comment>()) {
 		if (!addRowFn(comment, LivestatusGroupByNone, Empty))
 			return;
 	}

--- a/lib/livestatus/contactgroupstable.cpp
+++ b/lib/livestatus/contactgroupstable.cpp
@@ -31,7 +31,7 @@ String ContactGroupsTable::GetPrefix() const
 
 void ContactGroupsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const UserGroup::Ptr& ug : ConfigType::GetObjectsByType<UserGroup>()) {
+	for (const auto& ug : ConfigType::GetObjectsByType<UserGroup>()) {
 		if (!addRowFn(ug, LivestatusGroupByNone, Empty))
 			return;
 	}
@@ -66,7 +66,7 @@ Value ContactGroupsTable::MembersAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const User::Ptr& user : user_group->GetMembers()) {
+	for (const auto& user : user_group->GetMembers()) {
 		result.push_back(user->GetName());
 	}
 

--- a/lib/livestatus/contactstable.cpp
+++ b/lib/livestatus/contactstable.cpp
@@ -51,7 +51,7 @@ String ContactsTable::GetPrefix() const
 
 void ContactsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const User::Ptr& user : ConfigType::GetObjectsByType<User>()) {
+	for (const auto& user : ConfigType::GetObjectsByType<User>()) {
 		if (!addRowFn(user, LivestatusGroupByNone, Empty))
 			return;
 	}
@@ -191,7 +191,7 @@ Value ContactsTable::CustomVariableNamesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			result.push_back(kv.first);
 		}
 	}
@@ -212,7 +212,7 @@ Value ContactsTable::CustomVariableValuesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
 				result.push_back(JsonEncode(kv.second));
 			else
@@ -236,7 +236,7 @@ Value ContactsTable::CustomVariablesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			Value val;
 
 			if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
@@ -269,7 +269,7 @@ Value ContactsTable::CVIsJsonAccessor(const Value& row)
 	bool cv_is_json = false;
 
 	ObjectLock olock(vars);
-	for (const Dictionary::Pair& kv : vars) {
+	for (const auto& kv : vars) {
 		if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
 			cv_is_json = true;
 	}

--- a/lib/livestatus/downtimestable.cpp
+++ b/lib/livestatus/downtimestable.cpp
@@ -50,7 +50,7 @@ String DowntimesTable::GetPrefix() const
 
 void DowntimesTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const Downtime::Ptr& downtime : ConfigType::GetObjectsByType<Downtime>()) {
+	for (const auto& downtime : ConfigType::GetObjectsByType<Downtime>()) {
 		if (!addRowFn(downtime, LivestatusGroupByNone, Empty))
 			return;
 	}

--- a/lib/livestatus/endpointstable.cpp
+++ b/lib/livestatus/endpointstable.cpp
@@ -41,7 +41,7 @@ String EndpointsTable::GetPrefix() const
 
 void EndpointsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const Endpoint::Ptr& endpoint : ConfigType::GetObjectsByType<Endpoint>()) {
+	for (const auto& endpoint : ConfigType::GetObjectsByType<Endpoint>()) {
 		if (!addRowFn(endpoint, LivestatusGroupByNone, Empty))
 			return;
 	}

--- a/lib/livestatus/hostgroupstable.cpp
+++ b/lib/livestatus/hostgroupstable.cpp
@@ -55,7 +55,7 @@ String HostGroupsTable::GetPrefix() const
 
 void HostGroupsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const HostGroup::Ptr& hg : ConfigType::GetObjectsByType<HostGroup>()) {
+	for (const auto& hg : ConfigType::GetObjectsByType<HostGroup>()) {
 		if (!addRowFn(hg, LivestatusGroupByNone, Empty))
 			return;
 	}
@@ -120,7 +120,7 @@ Value HostGroupsTable::MembersAccessor(const Value& row)
 
 	ArrayData members;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		members.push_back(host->GetName());
 	}
 
@@ -136,7 +136,7 @@ Value HostGroupsTable::MembersWithStateAccessor(const Value& row)
 
 	ArrayData members;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		members.push_back(new Array({
 			host->GetName(),
 			host->GetState()
@@ -155,7 +155,7 @@ Value HostGroupsTable::WorstHostStateAccessor(const Value& row)
 
 	int worst_host = HostUp;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		if (host->GetState() > worst_host)
 			worst_host = host->GetState();
 	}
@@ -182,7 +182,7 @@ Value HostGroupsTable::NumHostsPendingAccessor(const Value& row)
 
 	int num_hosts = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		/* no checkresult */
 		if (!host->GetLastCheckResult())
 			num_hosts++;
@@ -200,7 +200,7 @@ Value HostGroupsTable::NumHostsUpAccessor(const Value& row)
 
 	int num_hosts = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		if (host->GetState() == HostUp)
 			num_hosts++;
 	}
@@ -217,7 +217,7 @@ Value HostGroupsTable::NumHostsDownAccessor(const Value& row)
 
 	int num_hosts = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		if (host->GetState() == HostDown)
 			num_hosts++;
 	}
@@ -234,7 +234,7 @@ Value HostGroupsTable::NumHostsUnreachAccessor(const Value& row)
 
 	int num_hosts = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		if (!host->IsReachable())
 			num_hosts++;
 	}
@@ -254,7 +254,7 @@ Value HostGroupsTable::NumServicesAccessor(const Value& row)
 	if (hg->GetMembers().size() == 0)
 		return 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
+	for (const auto& host : hg->GetMembers()) {
 		num_services += host->GetServices().size();
 	}
 
@@ -270,8 +270,8 @@ Value HostGroupsTable::WorstServiceStateAccessor(const Value& row)
 
 	Value worst_service = ServiceOK;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetState() > worst_service)
 				worst_service = service->GetState();
 		}
@@ -289,8 +289,8 @@ Value HostGroupsTable::NumServicesPendingAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (!service->GetLastCheckResult())
 				num_services++;
 		}
@@ -308,8 +308,8 @@ Value HostGroupsTable::NumServicesOkAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetState() == ServiceOK)
 				num_services++;
 		}
@@ -327,8 +327,8 @@ Value HostGroupsTable::NumServicesWarnAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetState() == ServiceWarning)
 				num_services++;
 		}
@@ -346,8 +346,8 @@ Value HostGroupsTable::NumServicesCritAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetState() == ServiceCritical)
 				num_services++;
 		}
@@ -365,8 +365,8 @@ Value HostGroupsTable::NumServicesUnknownAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetState() == ServiceUnknown)
 				num_services++;
 		}
@@ -384,8 +384,8 @@ Value HostGroupsTable::WorstServiceHardStateAccessor(const Value& row)
 
 	Value worst_service = ServiceOK;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetStateType() == StateTypeHard) {
 				if (service->GetState() > worst_service)
 					worst_service = service->GetState();
@@ -405,8 +405,8 @@ Value HostGroupsTable::NumServicesHardOkAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceOK)
 				num_services++;
 		}
@@ -424,8 +424,8 @@ Value HostGroupsTable::NumServicesHardWarnAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceWarning)
 				num_services++;
 		}
@@ -443,8 +443,8 @@ Value HostGroupsTable::NumServicesHardCritAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceCritical)
 				num_services++;
 		}
@@ -462,8 +462,8 @@ Value HostGroupsTable::NumServicesHardUnknownAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Host::Ptr& host : hg->GetMembers()) {
-		for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& host : hg->GetMembers()) {
+		for (const auto& service : host->GetServices()) {
 			if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceUnknown)
 				num_services++;
 		}

--- a/lib/livestatus/hoststable.cpp
+++ b/lib/livestatus/hoststable.cpp
@@ -172,15 +172,15 @@ String HostsTable::GetPrefix() const
 void HostsTable::FetchRows(const AddRowFunction& addRowFn)
 {
 	if (GetGroupByType() == LivestatusGroupByHostGroup) {
-		for (const HostGroup::Ptr& hg : ConfigType::GetObjectsByType<HostGroup>()) {
-			for (const Host::Ptr& host : hg->GetMembers()) {
+		for (const auto& hg : ConfigType::GetObjectsByType<HostGroup>()) {
+			for (const auto& host : hg->GetMembers()) {
 				/* the caller must know which groupby type and value are set for this row */
 				if (!addRowFn(host, LivestatusGroupByHostGroup, hg))
 					return;
 			}
 		}
 	} else {
-		for (const Host::Ptr& host : ConfigType::GetObjectsByType<Host>()) {
+		for (const auto& host : ConfigType::GetObjectsByType<Host>()) {
 			if (!addRowFn(host, LivestatusGroupByNone, Empty))
 				return;
 		}
@@ -863,7 +863,7 @@ Value HostsTable::InNotificationPeriodAccessor(const Value& row)
 	if (!host)
 		return Empty;
 
-	for (const Notification::Ptr& notification : host->GetNotifications()) {
+	for (const auto& notification : host->GetNotifications()) {
 		TimePeriod::Ptr timeperiod = notification->GetPeriod();
 
 		if (!timeperiod || timeperiod->IsInside(Utility::GetTime()))
@@ -898,7 +898,7 @@ Value HostsTable::ContactsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(host)) {
+	for (const auto& user : CompatUtility::GetCheckableNotificationUsers(host)) {
 		result.push_back(user->GetName());
 	}
 
@@ -914,7 +914,7 @@ Value HostsTable::DowntimesAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Downtime::Ptr& downtime : host->GetDowntimes()) {
+	for (const auto& downtime : host->GetDowntimes()) {
 		if (downtime->IsExpired())
 			continue;
 
@@ -933,7 +933,7 @@ Value HostsTable::DowntimesWithInfoAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Downtime::Ptr& downtime : host->GetDowntimes()) {
+	for (const auto& downtime : host->GetDowntimes()) {
 		if (downtime->IsExpired())
 			continue;
 
@@ -956,7 +956,7 @@ Value HostsTable::CommentsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Comment::Ptr& comment : host->GetComments()) {
+	for (const auto& comment : host->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -975,7 +975,7 @@ Value HostsTable::CommentsWithInfoAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Comment::Ptr& comment : host->GetComments()) {
+	for (const auto& comment : host->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -998,7 +998,7 @@ Value HostsTable::CommentsWithExtraInfoAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Comment::Ptr& comment : host->GetComments()) {
+	for (const auto& comment : host->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -1027,7 +1027,7 @@ Value HostsTable::CustomVariableNamesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			result.push_back(kv.first);
 		}
 	}
@@ -1048,7 +1048,7 @@ Value HostsTable::CustomVariableValuesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
 				result.push_back(JsonEncode(kv.second));
 			else
@@ -1072,7 +1072,7 @@ Value HostsTable::CustomVariablesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			Value val;
 
 			if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
@@ -1105,7 +1105,7 @@ Value HostsTable::CVIsJsonAccessor(const Value& row)
 	bool cv_is_json = false;
 
 	ObjectLock olock(vars);
-	for (const Dictionary::Pair& kv : vars) {
+	for (const auto& kv : vars) {
 		if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
 			cv_is_json = true;
 	}
@@ -1122,7 +1122,7 @@ Value HostsTable::ParentsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Checkable::Ptr& parent : host->GetParents()) {
+	for (const auto& parent : host->GetParents()) {
 		Host::Ptr parent_host = dynamic_pointer_cast<Host>(parent);
 
 		if (!parent_host)
@@ -1143,7 +1143,7 @@ Value HostsTable::ChildsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Checkable::Ptr& child : host->GetChildren()) {
+	for (const auto& child : host->GetChildren()) {
 		Host::Ptr child_host = dynamic_pointer_cast<Host>(child);
 
 		if (!child_host)
@@ -1175,7 +1175,7 @@ Value HostsTable::WorstServiceStateAccessor(const Value& row)
 
 	Value worst_service = ServiceOK;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetState() > worst_service)
 			worst_service = service->GetState();
 	}
@@ -1192,7 +1192,7 @@ Value HostsTable::NumServicesOkAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetState() == ServiceOK)
 			num_services++;
 	}
@@ -1209,7 +1209,7 @@ Value HostsTable::NumServicesWarnAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetState() == ServiceWarning)
 			num_services++;
 	}
@@ -1226,7 +1226,7 @@ Value HostsTable::NumServicesCritAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetState() == ServiceCritical)
 			num_services++;
 	}
@@ -1243,7 +1243,7 @@ Value HostsTable::NumServicesUnknownAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetState() == ServiceUnknown)
 			num_services++;
 	}
@@ -1260,7 +1260,7 @@ Value HostsTable::NumServicesPendingAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (!service->GetLastCheckResult())
 			num_services++;
 	}
@@ -1277,7 +1277,7 @@ Value HostsTable::WorstServiceHardStateAccessor(const Value& row)
 
 	Value worst_service = ServiceOK;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetStateType() == StateTypeHard) {
 			if (service->GetState() > worst_service)
 				worst_service = service->GetState();
@@ -1296,7 +1296,7 @@ Value HostsTable::NumServicesHardOkAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceOK)
 			num_services++;
 	}
@@ -1313,7 +1313,7 @@ Value HostsTable::NumServicesHardWarnAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceWarning)
 			num_services++;
 	}
@@ -1330,7 +1330,7 @@ Value HostsTable::NumServicesHardCritAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceCritical)
 			num_services++;
 	}
@@ -1347,7 +1347,7 @@ Value HostsTable::NumServicesHardUnknownAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : host->GetServices()) {
+	for (const auto& service : host->GetServices()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceUnknown)
 			num_services++;
 	}
@@ -1407,7 +1407,7 @@ Value HostsTable::ContactGroupsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
+	for (const auto& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
 		result.push_back(usergroup->GetName());
 	}
 
@@ -1426,7 +1426,7 @@ Value HostsTable::ServicesAccessor(const Value& row)
 	ArrayData result;
 	result.reserve(rservices.size());
 
-	for (const Service::Ptr& service : rservices) {
+	for (const auto& service : rservices) {
 		result.push_back(service->GetShortName());
 	}
 
@@ -1445,7 +1445,7 @@ Value HostsTable::ServicesWithStateAccessor(const Value& row)
 	ArrayData result;
 	result.reserve(rservices.size());
 
-	for (const Service::Ptr& service : rservices) {
+	for (const auto& service : rservices) {
 		result.push_back(new Array({
 			service->GetShortName(),
 			service->GetState(),
@@ -1468,7 +1468,7 @@ Value HostsTable::ServicesWithInfoAccessor(const Value& row)
 	ArrayData result;
 	result.reserve(rservices.size());
 
-	for (const Service::Ptr& service : rservices) {
+	for (const auto& service : rservices) {
 		String output;
 		CheckResult::Ptr cr = service->GetLastCheckResult();
 

--- a/lib/livestatus/livestatuslistener.cpp
+++ b/lib/livestatus/livestatuslistener.cpp
@@ -30,7 +30,7 @@ void LivestatusListener::StatsFunc(const Dictionary::Ptr& status, const Array::P
 {
 	DictionaryData nodes;
 
-	for (const LivestatusListener::Ptr& livestatuslistener : ConfigType::GetObjectsByType<LivestatusListener>()) {
+	for (const auto& livestatuslistener : ConfigType::GetObjectsByType<LivestatusListener>()) {
 		nodes.emplace_back(livestatuslistener->GetName(), new Dictionary({
 			{ "connections", l_Connections }
 		}));

--- a/lib/livestatus/livestatusquery.cpp
+++ b/lib/livestatus/livestatusquery.cpp
@@ -44,7 +44,7 @@ LivestatusQuery::LivestatusQuery(const std::vector<String>& lines, const String&
 	}
 
 	String msg;
-	for (const String& line : lines) {
+	for (const auto& line : lines) {
 		msg += line + "\n";
 	}
 	Log(LogDebug, "LivestatusQuery", msg);
@@ -250,7 +250,7 @@ LivestatusQuery::LivestatusQuery(const std::vector<String>& lines, const String&
 	/* Combine all top-level filters into a single filter. */
 	AndFilter::Ptr top_filter = new AndFilter();
 
-	for (const Filter::Ptr& filter : filters) {
+	for (const auto& filter : filters) {
 		top_filter->AddSubFilter(filter);
 	}
 
@@ -358,7 +358,7 @@ void LivestatusQuery::AppendResultRow(std::ostream& fp, const Array::Ptr& row, b
 		bool first = true;
 
 		ObjectLock rlock(row);
-		for (const Value& value : row) {
+		for (const auto& value : row) {
 			if (first)
 				first = false;
 			else
@@ -391,7 +391,7 @@ void LivestatusQuery::PrintCsvArray(std::ostream& fp, const Array::Ptr& array, i
 	bool first = true;
 
 	ObjectLock olock(array);
-	for (const Value& value : array) {
+	for (const auto& value : array) {
 		if (first)
 			first = false;
 		else
@@ -412,7 +412,7 @@ void LivestatusQuery::PrintPythonArray(std::ostream& fp, const Array::Ptr& rs) c
 
 	bool first = true;
 
-	for (const Value& value : rs) {
+	for (const auto& value : rs) {
 		if (first)
 			first = false;
 		else
@@ -466,17 +466,17 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 		std::vector<ColumnPair> column_objs;
 		column_objs.reserve(columns.size());
 
-		for (const String& columnName : columns)
+		for (const auto& columnName : columns)
 			column_objs.emplace_back(columnName, table->GetColumn(columnName));
 
 		ArrayData header;
 
-		for (const LivestatusRowValue& object : objects) {
+		for (const auto& object : objects) {
 			ArrayData row;
 
 			row.reserve(column_objs.size());
 
-			for (const ColumnPair& cv : column_objs) {
+			for (const auto& cv : column_objs) {
 				if (m_ColumnHeaders)
 					header.push_back(cv.first);
 
@@ -494,10 +494,10 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 		std::map<std::vector<Value>, std::vector<AggregatorState *> > allStats;
 
 		/* add aggregated stats */
-		for (const LivestatusRowValue& object : objects) {
+		for (const auto& object : objects) {
 			std::vector<Value> statsKey;
 
-			for (const String& columnName : m_Columns) {
+			for (const auto& columnName : m_Columns) {
 				Column column = table->GetColumn(columnName);
 				statsKey.emplace_back(column.ExtractValue(object.Row, object.GroupByType, object.GroupByObject));
 			}
@@ -513,7 +513,7 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 
 			int index = 0;
 
-			for (const Aggregator::Ptr& aggregator : m_Aggregators) {
+			for (const auto& aggregator : m_Aggregators) {
 				aggregator->Apply(table, object.Row, &stats[index]);
 				index++;
 			}
@@ -523,7 +523,7 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 		if (m_ColumnHeaders) {
 			ArrayData header;
 
-			for (const String& columnName : m_Columns) {
+			for (const auto& columnName : m_Columns) {
 				header.push_back(columnName);
 			}
 
@@ -539,7 +539,7 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 
 			row.reserve(m_Columns.size() + m_Aggregators.size());
 
-			for (const Value& keyPart : kv.first) {
+			for (const auto& keyPart : kv.first) {
 				row.push_back(keyPart);
 			}
 

--- a/lib/livestatus/orfilter.cpp
+++ b/lib/livestatus/orfilter.cpp
@@ -9,7 +9,7 @@ bool OrFilter::Apply(const Table::Ptr& table, const Value& row)
 	if (m_Filters.empty())
 		return true;
 
-	for (const Filter::Ptr& filter : m_Filters) {
+	for (const auto& filter : m_Filters) {
 		if (filter->Apply(table, row))
 			return true;
 	}

--- a/lib/livestatus/servicegroupstable.cpp
+++ b/lib/livestatus/servicegroupstable.cpp
@@ -46,7 +46,7 @@ String ServiceGroupsTable::GetPrefix() const
 
 void ServiceGroupsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const ServiceGroup::Ptr& sg : ConfigType::GetObjectsByType<ServiceGroup>()) {
+	for (const auto& sg : ConfigType::GetObjectsByType<ServiceGroup>()) {
 		if (!addRowFn(sg, LivestatusGroupByNone, Empty))
 			return;
 	}
@@ -111,7 +111,7 @@ Value ServiceGroupsTable::MembersAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		result.push_back(new Array({
 			service->GetHost()->GetName(),
 			service->GetShortName()
@@ -130,7 +130,7 @@ Value ServiceGroupsTable::MembersWithStateAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		result.push_back(new Array({
 			service->GetHost()->GetName(),
 			service->GetShortName(),
@@ -151,7 +151,7 @@ Value ServiceGroupsTable::WorstServiceStateAccessor(const Value& row)
 
 	Value worst_service = ServiceOK;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetState() > worst_service)
 			worst_service = service->GetState();
 	}
@@ -178,7 +178,7 @@ Value ServiceGroupsTable::NumServicesOkAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetState() == ServiceOK)
 			num_services++;
 	}
@@ -195,7 +195,7 @@ Value ServiceGroupsTable::NumServicesWarnAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetState() == ServiceWarning)
 			num_services++;
 	}
@@ -212,7 +212,7 @@ Value ServiceGroupsTable::NumServicesCritAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetState() == ServiceCritical)
 			num_services++;
 	}
@@ -229,7 +229,7 @@ Value ServiceGroupsTable::NumServicesUnknownAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetState() == ServiceUnknown)
 			num_services++;
 	}
@@ -246,7 +246,7 @@ Value ServiceGroupsTable::NumServicesPendingAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (!service->GetLastCheckResult())
 			num_services++;
 	}
@@ -263,7 +263,7 @@ Value ServiceGroupsTable::NumServicesHardOkAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceOK)
 			num_services++;
 	}
@@ -280,7 +280,7 @@ Value ServiceGroupsTable::NumServicesHardWarnAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceWarning)
 			num_services++;
 	}
@@ -297,7 +297,7 @@ Value ServiceGroupsTable::NumServicesHardCritAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceCritical)
 			num_services++;
 	}
@@ -314,7 +314,7 @@ Value ServiceGroupsTable::NumServicesHardUnknownAccessor(const Value& row)
 
 	int num_services = 0;
 
-	for (const Service::Ptr& service : sg->GetMembers()) {
+	for (const auto& service : sg->GetMembers()) {
 		if (service->GetStateType() == StateTypeHard && service->GetState() == ServiceUnknown)
 			num_services++;
 	}

--- a/lib/livestatus/servicestable.cpp
+++ b/lib/livestatus/servicestable.cpp
@@ -156,19 +156,19 @@ String ServicesTable::GetPrefix() const
 void ServicesTable::FetchRows(const AddRowFunction& addRowFn)
 {
 	if (GetGroupByType() == LivestatusGroupByServiceGroup) {
-		for (const ServiceGroup::Ptr& sg : ConfigType::GetObjectsByType<ServiceGroup>()) {
-			for (const Service::Ptr& service : sg->GetMembers()) {
+		for (const auto& sg : ConfigType::GetObjectsByType<ServiceGroup>()) {
+			for (const auto& service : sg->GetMembers()) {
 				/* the caller must know which groupby type and value are set for this row */
 				if (!addRowFn(service, LivestatusGroupByServiceGroup, sg))
 					return;
 			}
 		}
 	} else if (GetGroupByType() == LivestatusGroupByHostGroup) {
-		for (const HostGroup::Ptr& hg : ConfigType::GetObjectsByType<HostGroup>()) {
+		for (const auto& hg : ConfigType::GetObjectsByType<HostGroup>()) {
 			ObjectLock ylock(hg);
-			for (const Host::Ptr& host : hg->GetMembers()) {
+			for (const auto& host : hg->GetMembers()) {
 				ObjectLock ylock(host);
-				for (const Service::Ptr& service : host->GetServices()) {
+				for (const auto& service : host->GetServices()) {
 					/* the caller must know which groupby type and value are set for this row */
 					if (!addRowFn(service, LivestatusGroupByHostGroup, hg))
 						return;
@@ -176,7 +176,7 @@ void ServicesTable::FetchRows(const AddRowFunction& addRowFn)
 			}
 		}
 	} else {
-		for (const Service::Ptr& service : ConfigType::GetObjectsByType<Service>()) {
+		for (const auto& service : ConfigType::GetObjectsByType<Service>()) {
 			if (!addRowFn(service, LivestatusGroupByNone, Empty))
 				return;
 		}
@@ -904,7 +904,7 @@ Value ServicesTable::InNotificationPeriodAccessor(const Value& row)
 	if (!service)
 		return Empty;
 
-	for (const Notification::Ptr& notification : service->GetNotifications()) {
+	for (const auto& notification : service->GetNotifications()) {
 		TimePeriod::Ptr timeperiod = notification->GetPeriod();
 
 		if (!timeperiod || timeperiod->IsInside(Utility::GetTime()))
@@ -923,7 +923,7 @@ Value ServicesTable::ContactsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(service)) {
+	for (const auto& user : CompatUtility::GetCheckableNotificationUsers(service)) {
 		result.push_back(user->GetName());
 	}
 
@@ -939,7 +939,7 @@ Value ServicesTable::DowntimesAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Downtime::Ptr& downtime : service->GetDowntimes()) {
+	for (const auto& downtime : service->GetDowntimes()) {
 		if (downtime->IsExpired())
 			continue;
 
@@ -958,7 +958,7 @@ Value ServicesTable::DowntimesWithInfoAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Downtime::Ptr& downtime : service->GetDowntimes()) {
+	for (const auto& downtime : service->GetDowntimes()) {
 		if (downtime->IsExpired())
 			continue;
 
@@ -981,7 +981,7 @@ Value ServicesTable::CommentsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Comment::Ptr& comment : service->GetComments()) {
+	for (const auto& comment : service->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -1000,7 +1000,7 @@ Value ServicesTable::CommentsWithInfoAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Comment::Ptr& comment : service->GetComments()) {
+	for (const auto& comment : service->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -1023,7 +1023,7 @@ Value ServicesTable::CommentsWithExtraInfoAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Comment::Ptr& comment : service->GetComments()) {
+	for (const auto& comment : service->GetComments()) {
 		if (comment->IsExpired())
 			continue;
 
@@ -1052,7 +1052,7 @@ Value ServicesTable::CustomVariableNamesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			result.push_back(kv.first);
 		}
 	}
@@ -1073,7 +1073,7 @@ Value ServicesTable::CustomVariableValuesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
 				result.push_back(JsonEncode(kv.second));
 			else
@@ -1097,7 +1097,7 @@ Value ServicesTable::CustomVariablesAccessor(const Value& row)
 
 	if (vars) {
 		ObjectLock olock(vars);
-		for (const Dictionary::Pair& kv : vars) {
+		for (const auto& kv : vars) {
 			Value val;
 
 			if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
@@ -1130,7 +1130,7 @@ Value ServicesTable::CVIsJsonAccessor(const Value& row)
 	bool cv_is_json = false;
 
 	ObjectLock olock(vars);
-	for (const Dictionary::Pair& kv : vars) {
+	for (const auto& kv : vars) {
 		if (kv.second.IsObjectType<Array>() || kv.second.IsObjectType<Dictionary>())
 			cv_is_json = true;
 	}
@@ -1162,7 +1162,7 @@ Value ServicesTable::ContactGroupsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(service)) {
+	for (const auto& usergroup : CompatUtility::GetCheckableNotificationUserGroups(service)) {
 		result.push_back(usergroup->GetName());
 	}
 

--- a/lib/livestatus/statehisttable.cpp
+++ b/lib/livestatus/statehisttable.cpp
@@ -106,7 +106,7 @@ void StateHistTable::UpdateLogEntries(const Dictionary::Ptr& log_entry_attrs, in
 		/* determine service notifications notification_period and compare against current timestamp */
 		bool in_notification_period = true;
 		String notification_period_name;
-		for (const Notification::Ptr& notification : checkable->GetNotifications()) {
+		for (const auto& notification : checkable->GetNotifications()) {
 			TimePeriod::Ptr notification_period = notification->GetPeriod();
 
 			if (notification_period) {
@@ -252,7 +252,7 @@ void StateHistTable::FetchRows(const AddRowFunction& addRowFn)
 	Checkable::Ptr checkable;
 
 	for (const auto& kv : m_CheckablesCache) {
-		for (const Dictionary::Ptr& state_hist_bag : kv.second) {
+		for (const auto& state_hist_bag : kv.second) {
 			/* pass a dictionary from state history array */
 			if (!addRowFn(state_hist_bag, LivestatusGroupByNone, Empty))
 				return;

--- a/lib/livestatus/timeperiodstable.cpp
+++ b/lib/livestatus/timeperiodstable.cpp
@@ -36,7 +36,7 @@ String TimePeriodsTable::GetPrefix() const
 
 void TimePeriodsTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const TimePeriod::Ptr& tp : ConfigType::GetObjectsByType<TimePeriod>()) {
+	for (const auto& tp : ConfigType::GetObjectsByType<TimePeriod>()) {
 		if (!addRowFn(tp, LivestatusGroupByNone, Empty))
 			return;
 	}

--- a/lib/livestatus/zonestable.cpp
+++ b/lib/livestatus/zonestable.cpp
@@ -32,7 +32,7 @@ String ZonesTable::GetPrefix() const
 
 void ZonesTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
+	for (const auto& zone : ConfigType::GetObjectsByType<Zone>()) {
 		if (!addRowFn(zone, LivestatusGroupByNone, Empty))
 			return;
 	}
@@ -74,7 +74,7 @@ Value ZonesTable::EndpointsAccessor(const Value& row)
 
 	ArrayData result;
 
-	for (const Endpoint::Ptr& endpoint : endpoints) {
+	for (const auto& endpoint : endpoints) {
 		result.push_back(endpoint->GetName());
 	}
 

--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -103,7 +103,7 @@ String ClusterCheckTask::FormatArray(const Array::Ptr& arr)
 
 	if (arr) {
 		ObjectLock olock(arr);
-		for (const Value& value : arr) {
+		for (const auto& value : arr) {
 			if (first)
 				first = false;
 			else

--- a/lib/methods/clusterzonechecktask.cpp
+++ b/lib/methods/clusterzonechecktask.cpp
@@ -139,7 +139,7 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 	double bytesSentPerSecond = 0;
 	double bytesReceivedPerSecond = 0;
 
-	for (const Endpoint::Ptr& endpoint : zone->GetEndpoints()) {
+	for (const auto& endpoint : zone->GetEndpoints()) {
 		if (endpoint->GetConnected())
 			connected = true;
 

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -130,7 +130,7 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	double bytesSentPerSecond = 0;
 	double bytesReceivedPerSecond = 0;
 
-	for (const Endpoint::Ptr& endpoint : endpoints)
+	for (const auto& endpoint : endpoints)
 	{
 		if (endpoint->GetLastMessageSent() > lastMessageSent)
 			lastMessageSent = endpoint->GetLastMessageSent();

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -22,7 +22,7 @@ void NotificationComponent::StatsFunc(const Dictionary::Ptr& status, const Array
 {
 	DictionaryData nodes;
 
-	for (const NotificationComponent::Ptr& notification_component : ConfigType::GetObjectsByType<NotificationComponent>()) {
+	for (const auto& notification_component : ConfigType::GetObjectsByType<NotificationComponent>()) {
 		nodes.emplace_back(notification_component->GetName(), 1); //add more stats
 	}
 
@@ -133,7 +133,7 @@ void NotificationComponent::NotificationTimerHandler()
 	/* Function already checks whether 'api' feature is enabled. */
 	Endpoint::Ptr myEndpoint = Endpoint::GetLocalEndpoint();
 
-	for (const Notification::Ptr& notification : ConfigType::GetObjectsByType<Notification>()) {
+	for (const auto& notification : ConfigType::GetObjectsByType<Notification>()) {
 		if (!notification->IsActive())
 			continue;
 

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -60,7 +60,7 @@ void ElasticsearchWriter::StatsFunc(const Dictionary::Ptr& status, const Array::
 {
 	DictionaryData nodes;
 
-	for (const ElasticsearchWriter::Ptr& elasticsearchwriter : ConfigType::GetObjectsByType<ElasticsearchWriter>()) {
+	for (const auto& elasticsearchwriter : ConfigType::GetObjectsByType<ElasticsearchWriter>()) {
 		size_t workQueueItems = elasticsearchwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = elasticsearchwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
 
@@ -152,7 +152,7 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 
 	if (perfdata) {
 		ObjectLock olock(perfdata);
-		for (const Value& val : perfdata) {
+		for (const auto& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 
 			if (val.IsObjectType<PerfdataValue>())
@@ -347,7 +347,7 @@ void ElasticsearchWriter::NotificationSentToAllUsersHandlerInternal(const Notifi
 
 	ArrayData userNames;
 
-	for (const User::Ptr& user : users) {
+	for (const auto& user : users) {
 		userNames.push_back(user->GetName());
 	}
 

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -54,7 +54,7 @@ void GelfWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perf
 {
 	DictionaryData nodes;
 
-	for (const GelfWriter::Ptr& gelfwriter : ConfigType::GetObjectsByType<GelfWriter>()) {
+	for (const auto& gelfwriter : ConfigType::GetObjectsByType<GelfWriter>()) {
 		size_t workQueueItems = gelfwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = gelfwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
 
@@ -322,7 +322,7 @@ void GelfWriter::CheckResultHandlerInternal(const Checkable::Ptr& checkable, con
 
 		if (perfdata) {
 			ObjectLock olock(perfdata);
-			for (const Value& val : perfdata) {
+			for (const auto& val : perfdata) {
 				PerfdataValue::Ptr pdv;
 
 				if (val.IsObjectType<PerfdataValue>())

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -57,7 +57,7 @@ void GraphiteWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& 
 {
 	DictionaryData nodes;
 
-	for (const GraphiteWriter::Ptr& graphitewriter : ConfigType::GetObjectsByType<GraphiteWriter>()) {
+	for (const auto& graphitewriter : ConfigType::GetObjectsByType<GraphiteWriter>()) {
 		size_t workQueueItems = graphitewriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = graphitewriter->m_WorkQueue.GetTaskCount(60) / 60.0;
 
@@ -348,7 +348,7 @@ void GraphiteWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
 	ObjectLock olock(perfdata);
-	for (const Value& val : perfdata) {
+	for (const auto& val : perfdata) {
 		PerfdataValue::Ptr pdv;
 
 		if (val.IsObjectType<PerfdataValue>())
@@ -475,7 +475,7 @@ Value GraphiteWriter::EscapeMacroMetric(const Value& value)
 		ArrayData result;
 
 		ObjectLock olock(arr);
-		for (const Value& arg : arr) {
+		for (const auto& arg : arr) {
 			result.push_back(EscapeMetric(arg));
 		}
 

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -246,7 +246,7 @@ void InfluxdbCommonWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable,
 
 		{
 			ObjectLock olock(tagsClean);
-			for (const Dictionary::Pair& pair : tagsClean) {
+			for (const auto& pair : tagsClean) {
 				String missing_macro;
 				Value value = MacroProcessor::ResolveMacros(pair.second, resolvers, cr, &missing_macro);
 
@@ -265,7 +265,7 @@ void InfluxdbCommonWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable,
 
 	if (perfdata) {
 		ObjectLock olock(perfdata);
-		for (const Value& val : perfdata) {
+		for (const auto& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 
 			if (val.IsObjectType<PerfdataValue>())
@@ -376,7 +376,7 @@ void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dic
 	Dictionary::Ptr tags = tmpl->Get("tags");
 	if (tags) {
 		ObjectLock olock(tags);
-		for (const Dictionary::Pair& pair : tags) {
+		for (const auto& pair : tags) {
 			// Empty macro expansion, no tag
 			if (!pair.second.IsEmpty()) {
 				msgbuf << "," << EscapeKeyOrTagValue(pair.first) << "=" << EscapeKeyOrTagValue(pair.second);
@@ -394,7 +394,7 @@ void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dic
 		bool first = true;
 
 		ObjectLock fieldLock(fields);
-		for (const Dictionary::Pair& pair : fields) {
+		for (const auto& pair : fields) {
 			if (first)
 				first = false;
 			else
@@ -571,7 +571,7 @@ void InfluxdbCommonWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lva
 	Dictionary::Ptr tags = lvalue()->Get("tags");
 	if (tags) {
 		ObjectLock olock(tags);
-		for (const Dictionary::Pair& pair : tags) {
+		for (const auto& pair : tags) {
 			if (!MacroProcessor::ValidateMacroString(pair.second))
 				BOOST_THROW_EXCEPTION(ValidationError(this, { "host_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second));
 		}
@@ -589,7 +589,7 @@ void InfluxdbCommonWriter::ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& 
 	Dictionary::Ptr tags = lvalue()->Get("tags");
 	if (tags) {
 		ObjectLock olock(tags);
-		for (const Dictionary::Pair& pair : tags) {
+		for (const auto& pair : tags) {
 			if (!MacroProcessor::ValidateMacroString(pair.second))
 				BOOST_THROW_EXCEPTION(ValidationError(this, { "service_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second));
 		}

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -75,7 +75,7 @@ void InfluxdbCommonWriter::StatsFunc(const Dictionary::Ptr& status, const Array:
 	DictionaryData nodes;
 	auto typeName (InfluxWriter::TypeInstance->GetName().ToLower());
 
-	for (const typename InfluxWriter::Ptr& influxwriter : ConfigType::GetObjectsByType<InfluxWriter>()) {
+	for (const auto& influxwriter : ConfigType::GetObjectsByType<InfluxWriter>()) {
 		size_t workQueueItems = influxwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = influxwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
 		size_t dataBufferItems = influxwriter->m_DataBuffer.size();

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -54,7 +54,7 @@ void OpenTsdbWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 {
 	DictionaryData nodes;
 
-	for (const OpenTsdbWriter::Ptr& opentsdbwriter : ConfigType::GetObjectsByType<OpenTsdbWriter>()) {
+	for (const auto& opentsdbwriter : ConfigType::GetObjectsByType<OpenTsdbWriter>()) {
 		nodes.emplace_back(opentsdbwriter->GetName(), new Dictionary({
 			{ "connected", opentsdbwriter->GetConnected() }
 		}));
@@ -200,7 +200,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 		if (config_tmpl_tags) {
 			ObjectLock olock(config_tmpl_tags);
 			
-			for (const Dictionary::Pair& pair : config_tmpl_tags) {
+			for (const auto& pair : config_tmpl_tags) {
 				
 				String missing_macro;
 				Value value = MacroProcessor::ResolveMacros(pair.second, resolvers, cr, &missing_macro);
@@ -309,7 +309,7 @@ void OpenTsdbWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
 	ObjectLock olock(perfdata);
-	for (const Value& val : perfdata) {
+	for (const auto& val : perfdata) {
 		PerfdataValue::Ptr pdv;
 
 		if (val.IsObjectType<PerfdataValue>())
@@ -368,7 +368,7 @@ void OpenTsdbWriter::SendMetric(const Checkable::Ptr& checkable, const String& m
 {
 	String tags_string = "";
 
-	for (const Dictionary::Pair& tag : tags) {
+	for (const auto& tag : tags) {
 		tags_string += " " + tag.first + "=" + Convert::ToString(tag.second);
 	}
 
@@ -492,7 +492,7 @@ void OpenTsdbWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lvalue, c
 	Dictionary::Ptr tags = lvalue()->Get("tags");
 	if (tags) {
 		ObjectLock olock(tags);
-		for (const Dictionary::Pair& pair : tags) {
+		for (const auto& pair : tags) {
 			if (!MacroProcessor::ValidateMacroString(pair.second))
 				BOOST_THROW_EXCEPTION(ValidationError(this, { "host_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second));
 		}
@@ -517,7 +517,7 @@ void OpenTsdbWriter::ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& lvalue
 	Dictionary::Ptr tags = lvalue()->Get("tags");
 	if (tags) {
 		ObjectLock olock(tags);
-		for (const Dictionary::Pair& pair : tags) {
+		for (const auto& pair : tags) {
 			if (!MacroProcessor::ValidateMacroString(pair.second))
 				BOOST_THROW_EXCEPTION(ValidationError(this, { "service_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second));
 		}

--- a/lib/perfdata/perfdatawriter.cpp
+++ b/lib/perfdata/perfdatawriter.cpp
@@ -39,7 +39,7 @@ void PerfdataWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr&)
 {
 	DictionaryData nodes;
 
-	for (const PerfdataWriter::Ptr& perfdatawriter : ConfigType::GetObjectsByType<PerfdataWriter>()) {
+	for (const auto& perfdatawriter : ConfigType::GetObjectsByType<PerfdataWriter>()) {
 		nodes.emplace_back(perfdatawriter->GetName(), 1); //add more stats
 	}
 

--- a/lib/remote/actionshandler.cpp
+++ b/lib/remote/actionshandler.cpp
@@ -82,7 +82,7 @@ bool ActionsHandler::HandleRequest(
 	if (params)
 		verbose = HttpUtility::GetLastParameter(params, "verbose");
 
-	for (const ConfigObject::Ptr& obj : objs) {
+	for (const auto& obj : objs) {
 		try {
 			results.emplace_back(action->Invoke(obj, params));
 		} catch (const std::exception& ex) {
@@ -102,7 +102,7 @@ bool ActionsHandler::HandleRequest(
 	int statusCode = 500;
 	std::set<int> okStatusCodes, nonOkStatusCodes;
 
-	for (const Dictionary::Ptr& res : results) {
+	for (const auto& res : results) {
 		if (!res->Contains("code")) {
 			continue;
 		}

--- a/lib/remote/apilistener-authority.cpp
+++ b/lib/remote/apilistener-authority.cpp
@@ -31,7 +31,7 @@ void ApiListener::UpdateObjectAuthority()
 
 		int num_total = 0;
 
-		for (const Endpoint::Ptr& endpoint : my_zone->GetEndpoints()) {
+		for (const auto& endpoint : my_zone->GetEndpoints()) {
 			num_total++;
 
 			if (endpoint != my_endpoint && !endpoint->GetConnected())
@@ -53,13 +53,13 @@ void ApiListener::UpdateObjectAuthority()
 		);
 	}
 
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 			if (!object->IsActive() || object->GetHAMode() != HARunOnce)
 				continue;
 

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -125,7 +125,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 				<< "Could not create object '" << objName << "':";
 
 			ObjectLock olock(errors);
-			for (const String& error : errors) {
+			for (const auto& error : errors) {
 				Log(LogCritical, "ApiListener", error);
 			}
 
@@ -167,7 +167,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	if (modified_attributes) {
 		ObjectLock olock(modified_attributes);
-		for (const Dictionary::Pair& kv : modified_attributes) {
+		for (const auto& kv : modified_attributes) {
 			/* update all modified attributes
 			 * but do not update the object version yet.
 			 * This triggers cluster events otherwise.
@@ -185,14 +185,14 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 		{
 			ObjectLock xlock(objOriginalAttributes);
-			for (const Dictionary::Pair& kv : objOriginalAttributes) {
+			for (const auto& kv : objOriginalAttributes) {
 				/* original attribute was removed, restore it */
 				if (!newOriginalAttributes->Contains(kv.first))
 					restoreAttrs.push_back(kv.first);
 			}
 		}
 
-		for (const String& key : restoreAttrs) {
+		for (const auto& key : restoreAttrs) {
 			/* do not update the object version yet. */
 			object->RestoreAttribute(key, false);
 		}
@@ -287,7 +287,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 		Log(LogCritical, "ApiListener", "Could not delete object:");
 
 		ObjectLock olock(errors);
-		for (const String& error : errors) {
+		for (const auto& error : errors) {
 			Log(LogCritical, "ApiListener", error);
 		}
 	}
@@ -356,11 +356,11 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 
 	if (original_attributes) {
 		ObjectLock olock(original_attributes);
-		for (const Dictionary::Pair& kv : original_attributes) {
+		for (const auto& kv : original_attributes) {
 			std::vector<String> tokens = kv.first.Split(".");
 
 			Value value = object;
-			for (const String& token : tokens) {
+			for (const auto& token : tokens) {
 				value = VMOps::GetField(value, token);
 			}
 
@@ -453,13 +453,13 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 	Log(LogInformation, "ApiListener")
 		<< "Syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
 
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		auto *dtype = dynamic_cast<ConfigType *>(type.get());
 
 		if (!dtype)
 			continue;
 
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
+		for (const auto& object : dtype->GetObjects()) {
 			/* don't sync objects for non-matching parent-child zones */
 			if (!azone->CanAccessObject(object))
 				continue;

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -28,7 +28,7 @@ std::mutex ApiListener::m_ConfigSyncStageLock;
  */
 void ApiListener::SyncLocalZoneDirs() const
 {
-	for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
+	for (const auto& zone : ConfigType::GetObjectsByType<Zone>()) {
 		try {
 			SyncLocalZoneDir(zone);
 		} catch (const std::exception&) {
@@ -61,13 +61,13 @@ void ApiListener::SyncLocalZoneDir(const Zone::Ptr& zone) const
 	String zoneName = zone->GetName();
 
 	// Load registered zone paths, e.g. '_etc', '_api' and user packages.
-	for (const ZoneFragment& zf : ConfigCompiler::GetZoneDirs(zoneName)) {
+	for (const auto& zf : ConfigCompiler::GetZoneDirs(zoneName)) {
 		ConfigDirInformation newConfigPart = LoadConfigDir(zf.Path);
 
 		// Config files '*.conf'.
 		{
 			ObjectLock olock(newConfigPart.UpdateV1);
-			for (const Dictionary::Pair& kv : newConfigPart.UpdateV1) {
+			for (const auto& kv : newConfigPart.UpdateV1) {
 				String path = "/" + zf.Tag + kv.first;
 
 				newConfigInfo.UpdateV1->Set(path, kv.second);
@@ -78,7 +78,7 @@ void ApiListener::SyncLocalZoneDir(const Zone::Ptr& zone) const
 		// Meta files.
 		{
 			ObjectLock olock(newConfigPart.UpdateV2);
-			for (const Dictionary::Pair& kv : newConfigPart.UpdateV2) {
+			for (const auto& kv : newConfigPart.UpdateV2) {
 				String path = "/" + zf.Tag + kv.first;
 
 				newConfigInfo.UpdateV2->Set(path, kv.second);
@@ -117,7 +117,7 @@ void ApiListener::SyncLocalZoneDir(const Zone::Ptr& zone) const
 	{
 		ObjectLock olock(newConfig);
 
-		for (const Dictionary::Pair& kv : newConfig) {
+		for (const auto& kv : newConfig) {
 			String dst = productionZonesDir + "/" + kv.first;
 
 			Utility::MkDirP(Utility::DirName(dst), 0755);
@@ -195,7 +195,7 @@ void ApiListener::SendConfigUpdate(const JsonRpcConnection::Ptr& aclient)
 
 	String zonesDir = GetApiZonesDir();
 
-	for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
+	for (const auto& zone : ConfigType::GetObjectsByType<Zone>()) {
 		String zoneName = zone->GetName();
 		String zoneDir = zonesDir + zoneName;
 
@@ -372,7 +372,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 
 	ObjectLock olock(updateV1);
 
-	for (const Dictionary::Pair& kv : updateV1) {
+	for (const auto& kv : updateV1) {
 
 		// Check for the configured zones.
 		String zoneName = kv.first;
@@ -460,7 +460,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 			{
 				ObjectLock olock(newConfig);
 
-				for (const Dictionary::Pair &kv : newConfig) {
+				for (const auto&kv : newConfig) {
 
 					// This is super expensive with a string content comparison.
 					if (productionConfig->Get(kv.first) != kv.second) {
@@ -477,7 +477,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 		{
 			ObjectLock olock(newConfig);
 
-			for (const Dictionary::Pair& kv : newConfig) {
+			for (const auto& kv : newConfig) {
 
 				/* Store the relative config file path for later validation and activation.
 				 * IMPORTANT: Store this prior to any filters.
@@ -518,7 +518,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 			// If the update removes a path, delete it on disk and signal a config change.
 			ObjectLock xlock(productionConfig);
 
-			for (const Dictionary::Pair& kv : productionConfig) {
+			for (const auto& kv : productionConfig) {
 				if (!newConfig->Contains(kv.first)) {
 					configChange = true;
 
@@ -617,7 +617,7 @@ void ApiListener::TryActivateZonesStage(const std::vector<String>& relativePaths
 		Utility::MkDirP(apiZonesDir, 0700);
 
 		// Copy all synced configuration files from stage to production.
-		for (const String& path : relativePaths) {
+		for (const auto& path : relativePaths) {
 			if (!Utility::PathExists(apiZonesStageDir + path))
 				continue;
 
@@ -708,7 +708,7 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 	 */
 	{
 		ObjectLock olock(oldChecksums);
-		for (const Dictionary::Pair& kv : oldChecksums) {
+		for (const auto& kv : oldChecksums) {
 			String path = kv.first;
 			String oldChecksum = kv.second;
 
@@ -749,7 +749,7 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 
 	{
 		ObjectLock olock(newChecksums);
-		for (const Dictionary::Pair& kv : newChecksums) {
+		for (const auto& kv : newChecksums) {
 			String path = kv.first;
 			String newChecksum = kv.second;
 

--- a/lib/remote/apiuser.cpp
+++ b/lib/remote/apiuser.cpp
@@ -13,7 +13,7 @@ REGISTER_TYPE(ApiUser);
 
 ApiUser::Ptr ApiUser::GetByClientCN(const String& cn)
 {
-	for (const ApiUser::Ptr& user : ConfigType::GetObjectsByType<ApiUser>()) {
+	for (const auto& user : ConfigType::GetObjectsByType<ApiUser>()) {
 		if (user->GetClientCN() == cn)
 			return user;
 	}

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -140,7 +140,7 @@ String ConfigObjectUtility::CreateObjectConfig(const Type::Ptr& type, const Stri
 		attrs->CopyTo(allAttrs);
 
 		ObjectLock olock(attrs);
-		for (const Dictionary::Pair& kv : attrs) {
+		for (const auto& kv : attrs) {
 			int fid = type->GetFieldId(kv.first.SubStr(0, kv.first.FindFirstOf(".")));
 
 			if (fid < 0)
@@ -222,7 +222,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 
 				Utility::Remove(path);
 
-				for (const boost::exception_ptr& ex : upq.GetExceptions()) {
+				for (const auto& ex : upq.GetExceptions()) {
 					errors->Add(DiagnosticInformation(ex, false));
 
 					if (diagnosticInformation)
@@ -245,7 +245,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 
 				Utility::Remove(path);
 
-				for (const boost::exception_ptr& ex : upq.GetExceptions()) {
+				for (const auto& ex : upq.GetExceptions()) {
 					errors->Add(DiagnosticInformation(ex, false));
 
 					if (diagnosticInformation)
@@ -309,7 +309,7 @@ bool ConfigObjectUtility::DeleteObjectHelper(const ConfigObject::Ptr& object, bo
 		return false;
 	}
 
-	for (const Object::Ptr& pobj : parents) {
+	for (const auto& pobj : parents) {
 		ConfigObject::Ptr parentObj = dynamic_pointer_cast<ConfigObject>(pobj);
 
 		if (!parentObj)

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -65,7 +65,7 @@ void ConfigPackagesHandler::HandleGet(
 	{
 		std::unique_lock<std::mutex> lock(ConfigPackageUtility::GetStaticPackageMutex());
 
-		for (const String& package : packages) {
+		for (const auto& package : packages) {
 			String activeStage;
 
 			try {

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -89,7 +89,7 @@ String ConfigPackageUtility::CreateStage(const String& packageName, const Dictio
 
 	if (files) {
 		ObjectLock olock(files);
-		for (const Dictionary::Pair& kv : files) {
+		for (const auto& kv : files) {
 			if (ContainsDotDot(kv.first)) {
 				foundDotDot = true;
 				break;
@@ -360,7 +360,7 @@ bool ConfigPackageUtility::ContainsDotDot(const String& path)
 {
 	std::vector<String> tokens = path.Split("/\\");
 
-	for (const String& part : tokens) {
+	for (const auto& part : tokens) {
 		if (part == "..")
 			return true;
 	}

--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -33,12 +33,12 @@ static void ScriptFrameCleanupHandler()
 
 	typedef std::pair<String, ApiScriptFrame> KVPair;
 
-	for (const KVPair& kv : l_ApiScriptFrames) {
+	for (const auto& kv : l_ApiScriptFrames) {
 		if (kv.second.Seen < Utility::GetTime() - 1800)
 			cleanup_keys.push_back(kv.first);
 	}
 
-	for (const String& key : cleanup_keys)
+	for (const auto& key : cleanup_keys)
 		l_ApiScriptFrames.erase(key);
 }
 
@@ -230,7 +230,7 @@ static void AddSuggestions(std::vector<String>& matches, const String& word, con
 		Dictionary::Ptr dict = value;
 
 		ObjectLock olock(dict);
-		for (const Dictionary::Pair& kv : dict) {
+		for (const auto& kv : dict) {
 			AddSuggestion(matches, word, prefix + kv.first);
 		}
 	}
@@ -239,7 +239,7 @@ static void AddSuggestions(std::vector<String>& matches, const String& word, con
 		Namespace::Ptr ns = value;
 
 		ObjectLock olock(ns);
-		for (const Namespace::Pair& kv : ns) {
+		for (const auto& kv : ns) {
 			AddSuggestion(matches, word, prefix + kv.first);
 		}
 	}
@@ -259,7 +259,7 @@ static void AddSuggestions(std::vector<String>& matches, const String& word, con
 
 			if (dict) {
 				ObjectLock olock(dict);
-				for (const Dictionary::Pair& kv : dict) {
+				for (const auto& kv : dict) {
 					AddSuggestion(matches, word, prefix + kv.first);
 				}
 			}
@@ -273,20 +273,20 @@ std::vector<String> ConsoleHandler::GetAutocompletionSuggestions(const String& w
 {
 	std::vector<String> matches;
 
-	for (const String& keyword : ConfigWriter::GetKeywords()) {
+	for (const auto& keyword : ConfigWriter::GetKeywords()) {
 		AddSuggestion(matches, word, keyword);
 	}
 
 	{
 		ObjectLock olock(frame.Locals);
-		for (const Dictionary::Pair& kv : frame.Locals) {
+		for (const auto& kv : frame.Locals) {
 			AddSuggestion(matches, word, kv.first);
 		}
 	}
 
 	{
 		ObjectLock olock(ScriptGlobal::GetGlobals());
-		for (const Namespace::Pair& kv : ScriptGlobal::GetGlobals()) {
+		for (const auto& kv : ScriptGlobal::GetGlobals()) {
 			AddSuggestion(matches, word, kv.first);
 		}
 	}

--- a/lib/remote/deleteobjecthandler.cpp
+++ b/lib/remote/deleteobjecthandler.cpp
@@ -70,7 +70,7 @@ bool DeleteObjectHandler::HandleRequest(
 
 	bool success = true;
 
-	for (const ConfigObject::Ptr& obj : objs) {
+	for (const auto& obj : objs) {
 		int code;
 		String status;
 		Array::Ptr errors = new Array();

--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -117,7 +117,7 @@ std::vector<EventQueue::Ptr> EventQueue::GetQueuesForType(const String& type)
 	std::vector<EventQueue::Ptr> availQueues;
 
 	typedef std::pair<String, EventQueue::Ptr> kv_pair;
-	for (const kv_pair& kv : queues) {
+	for (const auto& kv : queues) {
 		if (kv.second->CanProcessEvent(type))
 			availQueues.push_back(kv.second);
 	}

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -73,7 +73,7 @@ bool EventsHandler::HandleRequest(
 
 	{
 		ObjectLock olock(types);
-		for (const String& type : types) {
+		for (const auto& type : types) {
 			FilterUtility::CheckPermission(user, "events/" + type);
 		}
 	}
@@ -89,7 +89,7 @@ bool EventsHandler::HandleRequest(
 
 	{
 		ObjectLock olock(types);
-		for (const String& type : types) {
+		for (const auto& type : types) {
 			auto typeId (l_EventTypes.find(type));
 
 			if (typeId != l_EventTypes.end()) {

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -18,7 +18,7 @@ Type::Ptr FilterUtility::TypeFromPluralName(const String& pluralName)
 	String uname = pluralName;
 	boost::algorithm::to_lower(uname);
 
-	for (const Type::Ptr& type : Type::GetAllTypes()) {
+	for (const auto& type : Type::GetAllTypes()) {
 		String pname = type->GetPluralName();
 		boost::algorithm::to_lower(pname);
 
@@ -35,7 +35,7 @@ void ConfigObjectTargetProvider::FindTargets(const String& type, const std::func
 	auto *ctype = dynamic_cast<ConfigType *>(ptype.get());
 
 	if (ctype) {
-		for (const ConfigObject::Ptr& object : ctype->GetObjects()) {
+		for (const auto& object : ctype->GetObjects()) {
 			addTarget(object);
 		}
 	}
@@ -138,7 +138,7 @@ void FilterUtility::CheckPermission(const ApiUser::Ptr& user, const String& perm
 	Array::Ptr permissions = user->GetPermissions();
 	if (permissions) {
 		ObjectLock olock(permissions);
-		for (const Value& item : permissions) {
+		for (const auto& item : permissions) {
 			String permission;
 			Function::Ptr filter;
 			if (item.IsObjectType<Dictionary>()) {
@@ -194,7 +194,7 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 	Namespace::Ptr permissionFrameNS = new Namespace();
 	ScriptFrame permissionFrame(false, permissionFrameNS);
 
-	for (const String& type : qd.Types) {
+	for (const auto& type : qd.Types) {
 		String attr = type;
 		boost::algorithm::to_lower(attr);
 
@@ -218,7 +218,7 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 			Array::Ptr names = query->Get(attr);
 			if (names) {
 				ObjectLock olock(names);
-				for (const String& name : names) {
+				for (const auto& name : names) {
 					Object::Ptr target = provider->GetTargetByName(type, name);
 
 					if (!FilterUtility::EvaluateFilter(permissionFrame, permissionFilter, target, variableName))
@@ -253,7 +253,7 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 			Dictionary::Ptr filter_vars = query->Get("filter_vars");
 			if (filter_vars) {
 				ObjectLock olock(filter_vars);
-				for (const Dictionary::Pair& kv : filter_vars) {
+				for (const auto& kv : filter_vars) {
 					frameNS->Set(kv.first, kv.second);
 				}
 			}

--- a/lib/remote/httphandler.cpp
+++ b/lib/remote/httphandler.cpp
@@ -19,7 +19,7 @@ void HttpHandler::Register(const Url::Ptr& url, const HttpHandler::Ptr& handler)
 
 	Dictionary::Ptr node = m_UrlTree;
 
-	for (const String& elem : url->GetPath()) {
+	for (const auto& elem : url->GetPath()) {
 		Dictionary::Ptr children = node->Get("children");
 
 		if (!children) {
@@ -66,7 +66,7 @@ void HttpHandler::ProcessRequest(
 
 		if (current_handlers) {
 			ObjectLock olock(current_handlers);
-			for (const HttpHandler::Ptr& current_handler : current_handlers) {
+			for (const auto& current_handler : current_handlers) {
 				handlers.push_back(current_handler);
 			}
 		}
@@ -107,7 +107,7 @@ void HttpHandler::ProcessRequest(
 	 * do exist.
 	 */
 	try {
-		for (const HttpHandler::Ptr& handler : handlers) {
+		for (const auto& handler : handlers) {
 			if (handler->HandleRequest(stream, user, request, url, response, params, yc, server)) {
 				processed = true;
 				break;

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -367,7 +367,7 @@ bool EnsureValidBody(
 
 			ObjectLock olock(permissions);
 
-			for (const Value& permissionInfo : permissions) {
+			for (const auto& permissionInfo : permissions) {
 				String permission;
 
 				if (permissionInfo.IsObjectType<Dictionary>()) {

--- a/lib/remote/infohandler.cpp
+++ b/lib/remote/infohandler.cpp
@@ -43,7 +43,7 @@ bool InfoHandler::HandleRequest(
 
 	if (permissions) {
 		ObjectLock olock(permissions);
-		for (const Value& permission : permissions) {
+		for (const auto& permission : permissions) {
 			String name;
 			bool hasFilter = false;
 			if (permission.IsObjectType<Dictionary>()) {
@@ -82,7 +82,7 @@ bool InfoHandler::HandleRequest(
 		if (!permInfo.empty()) {
 			body += "Your user has the following permissions:</p> <ul>";
 
-			for (const String& perm : permInfo) {
+			for (const auto& perm : permInfo) {
 				body += "<li>" + perm + "</li>";
 			}
 

--- a/lib/remote/modifyobjecthandler.cpp
+++ b/lib/remote/modifyobjecthandler.cpp
@@ -79,7 +79,7 @@ bool ModifyObjectHandler::HandleRequest(
 
 	ArrayData results;
 
-	for (const ConfigObject::Ptr& obj : objs) {
+	for (const auto& obj : objs) {
 		Dictionary::Ptr result1 = new Dictionary();
 
 		result1->Set("type", type->GetName());
@@ -90,7 +90,7 @@ bool ModifyObjectHandler::HandleRequest(
 		try {
 			if (attrs) {
 				ObjectLock olock(attrs);
-				for (const Dictionary::Pair& kv : attrs) {
+				for (const auto& kv : attrs) {
 					key = kv.first;
 					obj->ModifyAttribute(kv.first, kv.second);
 				}

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -22,7 +22,7 @@ Dictionary::Ptr ObjectQueryHandler::SerializeObjectAttrs(const Object::Ptr& obje
 
 	if (isJoin && attrs) {
 		ObjectLock olock(attrs);
-		for (const String& attr : attrs) {
+		for (const auto& attr : attrs) {
 			if (attr == attrPrefix) {
 				allAttrs = true;
 				break;
@@ -39,7 +39,7 @@ Dictionary::Ptr ObjectQueryHandler::SerializeObjectAttrs(const Object::Ptr& obje
 		}
 	} else if (attrs) {
 		ObjectLock olock(attrs);
-		for (const String& attr : attrs) {
+		for (const auto& attr : attrs) {
 			String userAttr;
 
 			if (isJoin) {
@@ -172,7 +172,7 @@ bool ObjectQueryHandler::HandleRequest(
 
 	if (ujoins) {
 		ObjectLock olock(ujoins);
-		for (const String& ujoin : ujoins) {
+		for (const auto& ujoin : ujoins) {
 			userJoinAttrs.insert(ujoin.SubStr(0, ujoin.FindFirstOf(".")));
 		}
 	}
@@ -189,7 +189,7 @@ bool ObjectQueryHandler::HandleRequest(
 		joinAttrs.insert(field.Name);
 	}
 
-	for (const ConfigObject::Ptr& obj : objs) {
+	for (const auto& obj : objs) {
 		DictionaryData result1{
 			{ "name", obj->GetName() },
 			{ "type", obj->GetReflectionType()->GetName() }
@@ -199,12 +199,12 @@ bool ObjectQueryHandler::HandleRequest(
 
 		if (umetas) {
 			ObjectLock olock(umetas);
-			for (const String& meta : umetas) {
+			for (const auto& meta : umetas) {
 				if (meta == "used_by") {
 					Array::Ptr used_by = new Array();
 					metaAttrs.emplace_back("used_by", used_by);
 
-					for (const Object::Ptr& pobj : DependencyGraph::GetParents((obj)))
+					for (const auto& pobj : DependencyGraph::GetParents((obj)))
 					{
 						ConfigObject::Ptr configObj = dynamic_pointer_cast<ConfigObject>(pobj);
 
@@ -236,7 +236,7 @@ bool ObjectQueryHandler::HandleRequest(
 
 		DictionaryData joins;
 
-		for (const String& joinAttr : joinAttrs) {
+		for (const auto& joinAttr : joinAttrs) {
 			Object::Ptr joinedObj;
 			int fid = type->GetFieldId(joinAttr);
 

--- a/lib/remote/statushandler.cpp
+++ b/lib/remote/statushandler.cpp
@@ -24,7 +24,7 @@ public:
 		if (statsFunctions) {
 			ObjectLock olock(statsFunctions);
 
-			for (const Namespace::Pair& kv : statsFunctions)
+			for (const auto& kv : statsFunctions)
 				addTarget(GetTargetByName("Status", kv.first));
 		}
 	}

--- a/lib/remote/templatequeryhandler.cpp
+++ b/lib/remote/templatequeryhandler.cpp
@@ -41,7 +41,7 @@ public:
 	{
 		Type::Ptr ptype = Type::GetByName(type);
 
-		for (const ConfigItem::Ptr& item : ConfigItem::GetItems(ptype)) {
+		for (const auto& item : ConfigItem::GetItems(ptype)) {
 			if (item->IsAbstract())
 				addTarget(GetTargetForTemplate(item));
 		}

--- a/lib/remote/typequeryhandler.cpp
+++ b/lib/remote/typequeryhandler.cpp
@@ -20,7 +20,7 @@ public:
 	void FindTargets(const String& type,
 		const std::function<void (const Value&)>& addTarget) const override
 	{
-		for (const Type::Ptr& target : Type::GetAllTypes()) {
+		for (const auto& target : Type::GetAllTypes()) {
 			addTarget(target);
 		}
 	}
@@ -91,7 +91,7 @@ bool TypeQueryHandler::HandleRequest(
 
 	ArrayData results;
 
-	for (const Type::Ptr& obj : objs) {
+	for (const auto& obj : objs) {
 		Dictionary::Ptr result1 = new Dictionary();
 		results.push_back(result1);
 
@@ -109,7 +109,7 @@ bool TypeQueryHandler::HandleRequest(
 
 		if (prototype) {
 			ObjectLock olock(prototype);
-			for (const Dictionary::Pair& kv : prototype) {
+			for (const auto& kv : prototype) {
 				prototypeKeys->Add(kv.first);
 			}
 		}

--- a/lib/remote/url.cpp
+++ b/lib/remote/url.cpp
@@ -197,7 +197,7 @@ String Url::Format(bool onlyPathAndQuery, bool printCredentials) const
 	if (m_Path.empty())
 		url += "/";
 	else {
-		for (const String& segment : m_Path) {
+		for (const auto& segment : m_Path) {
 			url += "/";
 			url += Utility::EscapeString(segment, ACPATHSEGMENT_ENCODE, false);
 		}
@@ -290,7 +290,7 @@ bool Url::ParsePath(const String& path)
 	boost::char_separator<char> sep("/");
 	boost::tokenizer<boost::char_separator<char> > tokens(pathStr, sep);
 
-	for (const String& token : tokens) {
+	for (const auto& token : tokens) {
 		if (token.IsEmpty())
 			continue;
 
@@ -310,7 +310,7 @@ bool Url::ParseQuery(const String& query)
 	boost::char_separator<char> sep("&");
 	boost::tokenizer<boost::char_separator<char> > tokens(queryStr, sep);
 
-	for (const String& token : tokens) {
+	for (const auto& token : tokens) {
 		size_t pHelper = token.Find("=");
 
 		if (pHelper == 0)

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -34,7 +34,7 @@ public:
 		{
 			Namespace::Ptr globals = ScriptGlobal::GetGlobals();
 			ObjectLock olock(globals);
-			for (const Namespace::Pair& kv : globals) {
+			for (const auto& kv : globals) {
 				addTarget(GetTargetForVar(kv.first, kv.second->Get()));
 			}
 		}
@@ -98,7 +98,7 @@ bool VariableQueryHandler::HandleRequest(
 
 	ArrayData results;
 
-	for (const Dictionary::Ptr& var : objs) {
+	for (const auto& var : objs) {
 		results.emplace_back(new Dictionary({
 			{ "name", var->Get("name") },
 			{ "type", var->Get("type") },

--- a/lib/remote/zone.cpp
+++ b/lib/remote/zone.cpp
@@ -27,7 +27,7 @@ void Zone::OnAllConfigLoaded()
 
 	if (endpoints) {
 		ObjectLock olock(endpoints);
-		for (const String& endpoint : endpoints) {
+		for (const auto& endpoint : endpoints) {
 			Endpoint::Ptr ep = Endpoint::GetByName(endpoint);
 
 			if (ep)
@@ -60,7 +60,7 @@ std::set<Endpoint::Ptr> Zone::GetEndpoints() const
 	if (endpoints) {
 		ObjectLock olock(endpoints);
 
-		for (const String& name : endpoints) {
+		for (const auto& name : endpoints) {
 			Endpoint::Ptr endpoint = Endpoint::GetByName(name);
 
 			if (!endpoint)

--- a/plugins/check_nscp_api.cpp
+++ b/plugins/check_nscp_api.cpp
@@ -93,7 +93,7 @@ static int FormatOutput(const Dictionary::Ptr& result)
 
 	ObjectLock olock(lines);
 
-	for (const Value& vline : lines) {
+	for (const auto& vline : lines) {
 		Dictionary::Ptr line;
 
 		try {
@@ -119,7 +119,7 @@ static int FormatOutput(const Dictionary::Ptr& result)
 
 		ObjectLock olock(perfs);
 
-		for (const Dictionary::Ptr& perf : perfs) {
+		for (const auto& perf : perfs) {
 			ssout << "'" << perf->Get("alias") << "'=";
 
 			Dictionary::Ptr values = perf->Get("float_value");
@@ -483,7 +483,7 @@ int main(int argc, char **argv)
 		endpoint += '/';
 	else {
 		endpoint += '?';
-		for (const String& argument : vm["arguments"].as<std::vector<std::string>>()) {
+		for (const auto& argument : vm["arguments"].as<std::vector<std::string>>()) {
 			String::SizeType pos = argument.FindFirstOf("=");
 			if (pos == String::NPos)
 				endpoint += Utility::EscapeString(argument, ACQUERY_ENCODE, false);

--- a/test/base-array.cpp
+++ b/test/base-array.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(foreach)
 
 	int n = 0;
 
-	for (const Value& item : array) {
+	for (const auto& item : array) {
 		BOOST_CHECK(n != 0 || item == 7);
 		BOOST_CHECK(n != 1 || item == 2);
 		BOOST_CHECK(n != 2 || item == 5);

--- a/test/base-base64.cpp
+++ b/test/base-base64.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(base64)
 
 	// 1024 chars
 
-	for (const String& str : clearText) {
+	for (const auto& str : clearText) {
 		String enc = Base64::Encode(str);
 		String dec = Base64::Decode(enc);
 		BOOST_CHECK(str == dec);

--- a/test/base-dictionary.cpp
+++ b/test/base-dictionary.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(foreach)
 
 	bool seen_test1 = false, seen_test2 = false;
 
-	for (const Dictionary::Pair& kv : dictionary) {
+	for (const auto& kv : dictionary) {
 		BOOST_CHECK(kv.first == "test1" || kv.first == "test2");
 
 		if (kv.first == "test1") {

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(dst)
 	std::vector<TestData> tests;
 
 	// 2021-03-14: 01:59:59 PST (UTC-8) -> 03:00:00 PDT (UTC-7)
-	for (const std::string& day : {"2021-03-14", "sunday", "sunday 2", "sunday -3"}) {
+	for (const auto& day : {"2021-03-14", "sunday", "sunday 2", "sunday -3"}) {
 		// range before DST change
 		tests.push_back(TestData{
 			day, "00:30-01:30",
@@ -465,7 +465,7 @@ BOOST_AUTO_TEST_CASE(dst)
 	}
 
 	// 2021-11-07: 01:59:59 PDT (UTC-7) -> 01:00:00 PST (UTC-8)
-	for (const std::string& day : {"2021-11-07", "sunday", "sunday 1", "sunday -4"}) {
+	for (const auto& day : {"2021-11-07", "sunday", "sunday 1", "sunday -4"}) {
 		// range before DST change
 		tests.push_back(TestData{
 			day, "00:15-00:45",
@@ -604,8 +604,8 @@ BOOST_AUTO_TEST_CASE(dst)
 		return Segment{time_t(segment->Get("begin")), time_t(segment->Get("end"))};
 	};
 
-	for (const TestData& t : tests) {
-		for (const tm& ref : t.during) {
+	for (const auto& t : tests) {
+		for (const auto& ref : t.during) {
 			if (t.expected) {
 				// test data sanity check
 				time_t ref_ts = make_time_t(&ref);
@@ -624,7 +624,7 @@ BOOST_AUTO_TEST_CASE(dst)
 				<< " expected=" << t.expected);
 		}
 
-		for (const tm& ref : t.before) {
+		for (const auto& ref : t.before) {
 			if (t.expected) {
 				// test data sanity check
 				time_t ref_ts = make_time_t(&ref);

--- a/test/remote-configpackageutility.cpp
+++ b/test/remote-configpackageutility.cpp
@@ -12,12 +12,12 @@ BOOST_AUTO_TEST_SUITE(remote_configpackageutility)
 BOOST_AUTO_TEST_CASE(ValidateName)
 {
 	std::vector<std::string> validNames {"foo", "foo-bar", "FooBar", "Foo123", "_Foo-", "123bar"};
-	for (const std::string& n : validNames) {
+	for (const auto& n : validNames) {
 		BOOST_CHECK_MESSAGE(ConfigPackageUtility::ValidatePackageName(n), "'" << n << "' should be valid");
 	}
 
 	std::vector<std::string> invalidNames {"", ".", "..", "foo.bar", "foo/../bar", "foo/bar", "foo:bar"};
-	for (const std::string& n : invalidNames) {
+	for (const auto& n : invalidNames) {
 		BOOST_CHECK_MESSAGE(!ConfigPackageUtility::ValidatePackageName(n), "'" << n << "' should not be valid");
 	}
 }

--- a/tools/mkclass/class_parser.yy
+++ b/tools/mkclass/class_parser.yy
@@ -233,7 +233,7 @@ class: class_attribute_list T_CLASS T_IDENTIFIER inherits_specifier type_base_sp
 
 		$$->Attributes = $1;
 
-		for (const Field& field : *$7) {
+		for (const auto& field : *$7) {
 			if (field.Attributes & FALoadDependency) {
 				$$->LoadDependencies.push_back(field.Name);
 			} else if (field.Attributes & FAActivationPriority) {

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -100,7 +100,7 @@ unsigned long ClassCompiler::SDBM(const std::string& str, size_t len = std::stri
 	unsigned long hash = 0;
 	size_t current = 0;
 
-	for (const char& ch : str) {
+	for (const auto& ch : str) {
 		if (current >= len)
 			break;
 
@@ -271,7 +271,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		jumptable.clear();
 		collisions = 0;
 
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			auto hash = static_cast<int>(SDBM(field.Name, hlen));
 			jumptable[hash].emplace_back(num, field.Name);
 			num++;
@@ -331,7 +331,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << ") {" << std::endl;
 
 		size_t num = 0;
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			std::string ftype = FieldTypeToIcingaName(field, false);
 
 			std::string nameref;
@@ -385,7 +385,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		<< "{" << std::endl
 		<< "\t" << "std::vector<String> deps;" << std::endl;
 
-	for (const std::string& dep : klass.LoadDependencies)
+	for (const auto& dep : klass.LoadDependencies)
 		m_Impl << "\t" << "deps.emplace_back(\"" << dep << "\");" << std::endl;
 
 	m_Impl << "\t" << "return deps;" << std::endl
@@ -421,7 +421,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << ") {" << std::endl;
 
 		int num = 0;
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Impl << "\t\t" << "case " << num << ":" << std::endl
 				<< "\t\t\t" << "ObjectImpl<" << klass.Name << ">::On" << field.GetFriendlyName() << "Changed.connect(callback);" << std::endl
 				<< "\t\t\t" << "break;" << std::endl;
@@ -459,14 +459,14 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 	if (!klass.Parent.empty())
 		m_Impl << "\t" << klass.Parent << "::Validate(types, utils);" << std::endl << std::endl;
 
-	for (const Field& field : klass.Fields) {
+	for (const auto& field : klass.Fields) {
 		m_Impl << "\t" << "if (" << (field.Attributes & (FAEphemeral|FAConfig|FAState)) << " & types)" << std::endl
 				<< "\t\t" << "Validate" << field.GetFriendlyName() << "(Lazy<" << field.Type.GetRealType() << ">([this]() { return Get" << field.GetFriendlyName() << "(); }), utils);" << std::endl;
 	}
 
 	m_Impl << "}" << std::endl << std::endl;
 
-	for (const Field& field : klass.Fields) {
+	for (const auto& field : klass.Fields) {
 		std::string argName, valName;
 
 		if (field.Type.ArrayRank > 0) {
@@ -503,7 +503,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		if (field.Type.ArrayRank > 0) {
 			m_Impl << "\t" << "if (avalue()) {" << std::endl
 				<< "\t\t" << "ObjectLock olock(avalue());" << std::endl
-				<< "\t\t" << "for (const Value& value : avalue()) {" << std::endl;
+				<< "\t\t" << "for (const auto& value : avalue()) {" << std::endl;
 		}
 
 		std::string ftype = FieldTypeToIcingaName(field, true);
@@ -560,7 +560,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 	m_Impl << "ObjectImpl<" << klass.Name << ">::ObjectImpl()" << std::endl
 		<< "{" << std::endl;
 
-	for (const Field& field : klass.Fields) {
+	for (const auto& field : klass.Fields) {
 		if (!field.PureSetAccessor)
 			m_Impl << "\t" << "Set" << field.GetFriendlyName() << "(" << "GetDefault" << field.GetFriendlyName() << "(), true);" << std::endl;
 	}
@@ -596,7 +596,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << ") {" << std::endl;
 
 		size_t num = 0;
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Impl << "\t\t" << "case " << num << ":" << std::endl
 				<< "\t\t\t" << "Set" << field.GetFriendlyName() << "(";
 			
@@ -640,7 +640,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << ") {" << std::endl;
 
 		num = 0;
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Impl << "\t\t" << "case " << num << ":" << std::endl
 				<< "\t\t\t" << "return Get" << field.GetFriendlyName() << "();" << std::endl;
 			num++;
@@ -673,7 +673,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << ") {" << std::endl;
 
 		num = 0;
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Impl << "\t\t" << "case " << num << ":" << std::endl
 				<< "\t\t\t" << "Validate" << field.GetFriendlyName() << "(";
 			
@@ -717,7 +717,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << ") {" << std::endl;
 
 		num = 0;
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Impl << "\t\t" << "case " << num << ":" << std::endl
 				<< "\t\t\t" << "Notify" << field.GetFriendlyName() << "(cookie);" << std::endl
 				<< "\t\t\t" << "break;" << std::endl;
@@ -743,7 +743,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 		bool haveNavigationFields = false;
 
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			if (field.Attributes & FANavigation) {
 				haveNavigationFields = true;
 				break;
@@ -761,7 +761,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			m_Impl << ") {" << std::endl;
 
 			num = 0;
-			for (const Field& field : klass.Fields) {
+			for (const auto& field : klass.Fields) {
 				if (field.Attributes & FANavigation) {
 					m_Impl << "\t\t" << "case " << num << ":" << std::endl
 						<< "\t\t\t" << "return Navigate" << field.GetFriendlyName() << "();" << std::endl;
@@ -782,7 +782,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		m_Impl << "}" << std::endl << std::endl;
 
 		/* getters */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			std::string prot;
 
 			if (field.Attributes & FAGetProtected)
@@ -816,7 +816,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		}
 
 		/* setters */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			std::string prot;
 
 			if (field.Attributes & FASetProtected)
@@ -876,7 +876,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		bool needs_tracking = false;
 
 		/* tracking */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			if (!field.Type.IsName && field.TrackAccessor.empty())
 				continue;
 
@@ -894,7 +894,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				if (field.Type.ArrayRank > 0) {
 					m_Impl << "\t" << "if (oldValue) {" << std::endl
 						<< "\t\t" << "ObjectLock olock(oldValue);" << std::endl
-						<< "\t\t" << "for (const String& ref : oldValue) {" << std::endl
+						<< "\t\t" << "for (const auto& ref : oldValue) {" << std::endl
 						<< "\t\t\t" << "DependencyGraph::RemoveDependency(this, ConfigObject::GetObject";
 
 					/* Ew */
@@ -908,7 +908,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 						<< "\t" << "}" << std::endl
 						<< "\t" << "if (newValue) {" << std::endl
 						<< "\t\t" << "ObjectLock olock(newValue);" << std::endl
-						<< "\t\t" << "for (const String& ref : newValue) {" << std::endl
+						<< "\t\t" << "for (const auto& ref : newValue) {" << std::endl
 						<< "\t\t\t" << "DependencyGraph::AddDependency(this, ConfigObject::GetObject";
 
 					/* Ew */
@@ -948,7 +948,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		}
 
 		/* navigation */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			if ((field.Attributes & FANavigation) == 0)
 				continue;
 
@@ -982,7 +982,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				<< "{" << std::endl
 				<< "\t" << klass.Parent << "::Start(runtimeCreated);" << std::endl << std::endl;
 
-			for (const Field& field : klass.Fields) {
+			for (const auto& field : klass.Fields) {
 				if (!field.Type.IsName && field.TrackAccessor.empty())
 					continue;
 
@@ -994,7 +994,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 				<< "{" << std::endl
 				<< "\t" << klass.Parent << "::Stop(runtimeRemoved);" << std::endl << std::endl;
 
-			for (const Field& field : klass.Fields) {
+			for (const auto& field : klass.Fields) {
 				if (!field.Type.IsName && field.TrackAccessor.empty())
 					continue;
 
@@ -1005,7 +1005,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		}
 
 		/* notify */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			std::string prot;
 
 			if (field.Attributes & FASetProtected)
@@ -1030,7 +1030,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		}
 		
 		/* default */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			std::string realType = field.Type.GetRealType();
 
 			m_Header << "private:" << std::endl
@@ -1048,7 +1048,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		}
 
 		/* validators */
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Header << "protected:" << std::endl
 					<< "\t" << "virtual void Validate" << field.GetFriendlyName() << "(const Lazy<" << field.Type.GetRealType() << ">& lvalue, const ValidationUtils& utils);" << std::endl;
 		}
@@ -1056,7 +1056,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		/* instance variables */
 		m_Header << "private:" << std::endl;
 
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			if (field.Attributes & FANoStorage)
 				continue;
 
@@ -1066,7 +1066,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		/* signal */
 		m_Header << "public:" << std::endl;
 		
-		for (const Field& field : klass.Fields) {
+		for (const auto& field : klass.Fields) {
 			m_Header << "\t" << "static boost::signals2::signal<void (const intrusive_ptr<" << klass.Name << ">&, const Value&)> On" << field.GetFriendlyName() << "Changed;" << std::endl;
 			m_Impl << std::endl << "boost::signals2::signal<void (const intrusive_ptr<" << klass.Name << ">&, const Value&)> ObjectImpl<" << klass.Name << ">::On" << field.GetFriendlyName() << "Changed;" << std::endl << std::endl;
 
@@ -1089,7 +1089,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 	m_Header << "};" << std::endl << std::endl;
 
-	for (const Field& field : klass.Fields) {
+	for (const auto& field : klass.Fields) {
 		m_MissingValidators[std::make_pair(klass.Name, field.GetFriendlyName())] = field;
 	}
 }
@@ -1107,7 +1107,7 @@ void ClassCompiler::CodeGenValidator(const std::string& name, const std::string&
 	if (validatorType == ValidatorField) {
 		bool required = false;
 
-		for (const Rule& rule : rules) {
+		for (const auto& rule : rules) {
 			if ((rule.Attributes & RARequired) && rule.Pattern == field) {
 				required = true;
 				break;
@@ -1135,7 +1135,7 @@ void ClassCompiler::CodeGenValidator(const std::string& name, const std::string&
 	bool type_check = false;
 	int i = 0;
 
-	for (const Rule& rule : rules) {
+	for (const auto& rule : rules) {
 		if (rule.Attributes & RARequired)
 			continue;
 
@@ -1200,7 +1200,7 @@ void ClassCompiler::CodeGenValidator(const std::string& name, const std::string&
 
 					m_Impl << (type_check ? "\t" : "") << "\t\t" << "{" << std::endl
 						<< (type_check ? "\t" : "") << "\t\t\t" << "ObjectLock olock(dict);" << std::endl
-						<< (type_check ? "\t" : "") << "\t\t\t" << "for (const Dictionary::Pair& kv : dict) {" << std::endl
+						<< (type_check ? "\t" : "") << "\t\t\t" << "for (const auto& kv : dict) {" << std::endl
 						<< (type_check ? "\t" : "") << "\t\t\t\t" << "const String& akey = kv.first;" << std::endl
 						<< (type_check ? "\t" : "") << "\t\t\t\t" << "const Value& avalue = kv.second;" << std::endl;
 					indent = true;
@@ -1213,7 +1213,7 @@ void ClassCompiler::CodeGenValidator(const std::string& name, const std::string&
 					m_Impl << (type_check ? "\t" : "") << "\t\t" << "Array::SizeType anum = 0;" << std::endl
 						<< (type_check ? "\t" : "") << "\t\t" << "{" << std::endl
 						<< (type_check ? "\t" : "") << "\t\t\t" << "ObjectLock olock(arr);" << std::endl
-						<< (type_check ? "\t" : "") << "\t\t\t" << "for (const Value& avalue : arr) {" << std::endl
+						<< (type_check ? "\t" : "") << "\t\t\t" << "for (const auto& avalue : arr) {" << std::endl
 						<< (type_check ? "\t" : "") << "\t\t\t\t" << "String akey = Convert::ToString(anum);" << std::endl;
 					indent = true;
 				} else {
@@ -1240,7 +1240,7 @@ void ClassCompiler::CodeGenValidator(const std::string& name, const std::string&
 						<< (type_check ? "\t" : "") << "\t\t" << "}" << std::endl;
 				}
 
-				for (const Rule& srule : rule.Rules) {
+				for (const auto& srule : rule.Rules) {
 					if ((srule.Attributes & RARequired) == 0)
 						continue;
 
@@ -1290,7 +1290,7 @@ void ClassCompiler::CodeGenValidatorSubrules(const std::string& name, const std:
 {
 	int i = 0;
 
-	for (const Rule& rule : rules) {
+	for (const auto& rule : rules) {
 		if (rule.Attributes & RARequired)
 			continue;
 


### PR DESCRIPTION
`git ls-files -z |xargs -0 perl -pi -e 's/\b(for \(const ).+?&/$1auto&/'`

If the types of x and y mismatch (which can't happen with `auto`),
GCC just warns you and constructs a T from y on every iteration:

`../base/dependencygraph.cpp:44:37: warning: loop variable 'kv' of type 'const kv_pair&' {aka 'const std::pair<icinga::Object*, int>&'} binds to a temporary constructed from type 'std::pair<icinga::Object* const, int>' [-Wrange-loop-construct]`