### PR TITLE
IcingaDB#SendSentNotification(): make stream deterministic via CheckResult#previous_hard_state

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -326,6 +326,8 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		SetLastSoftStatesRaw(GetLastSoftStatesRaw() / 100u + new_state * 100u);
 	}
 
+	cr->SetPreviousHardState(ServiceState(GetLastHardStatesRaw() % 100u));
+
 	if (!IsStateOK(new_state))
 		TriggerDowntimes(cr->GetExecutionEnd());
 

--- a/lib/icinga/checkresult.ti
+++ b/lib/icinga/checkresult.ti
@@ -53,6 +53,7 @@ class CheckResult
 	[state] int exit_status;
 
 	[state, enum] ServiceState "state";
+	[state, enum] ServiceState previous_hard_state;
 	[state] String output;
 	[state] Array::Ptr performance_data;
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1732,7 +1732,7 @@ void IcingaDB::SendSentNotification(
 		"host_id", GetObjectIdentifier(host),
 		"type", Convert::ToString(type),
 		"state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetState()) : Convert::ToLong(Host::CalculateState(cr->GetState())) : 99),
-		"previous_hard_state", Convert::ToString(GetPreviousState(checkable, service, StateTypeHard)),
+		"previous_hard_state", Convert::ToString(cr ? Convert::ToLong(service ? cr->GetPreviousHardState() : Host::CalculateState(cr->GetPreviousHardState())) : 99),
 		"author", Utility::ValidateUTF8(author),
 		"text", Utility::ValidateUTF8(finalText),
 		"users_notified", Convert::ToString(usersAmount),


### PR DESCRIPTION
Now it gets everything from one source, the CheckResult.

fixes #9132