### PR TITLE
GitHub Actions: Use preinstalled dependencies on Windows

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -70,43 +70,26 @@ try {
 	$Env:Path += $ChocoPath
 }
 
-
-choco install -y "visualstudio${VsVersion}community"
-ThrowOnNativeFailure
-
-choco install -y "visualstudio${VsVersion}-workload-netcoretools"
-ThrowOnNativeFailure
-
-choco install -y "visualstudio${VsVersion}-workload-vctools"
-ThrowOnNativeFailure
-
-choco install -y "visualstudio${VsVersion}-workload-manageddesktop"
-ThrowOnNativeFailure
-
-choco install -y "visualstudio${VsVersion}-workload-nativedesktop"
-ThrowOnNativeFailure
-
-choco install -y "visualstudio${VsVersion}-workload-universal"
-ThrowOnNativeFailure
-
-choco install -y "visualstudio${VsVersion}buildtools"
-ThrowOnNativeFailure
-
-
-choco install -y git
-ThrowOnNativeFailure
-
-choco install -y cmake
-ThrowOnNativeFailure
-
-choco install -y winflexbison3
-ThrowOnNativeFailure
-
-choco install -y windows-sdk-8.1
-ThrowOnNativeFailure
-
-choco install -y wixtoolset
-ThrowOnNativeFailure
+# GitHub Actions uses an image that comes with most dependencies preinstalled. Don't install them twice.
+if (-not $Env:GITHUB_ACTIONS) {
+    choco install -y `
+        "visualstudio${VsVersion}community" `
+        "visualstudio${VsVersion}-workload-netcoretools" `
+        "visualstudio${VsVersion}-workload-vctools" `
+        "visualstudio${VsVersion}-workload-manageddesktop" `
+        "visualstudio${VsVersion}-workload-nativedesktop" `
+        "visualstudio${VsVersion}-workload-universal" `
+        "visualstudio${VsVersion}buildtools" `
+        git `
+        cmake `
+        winflexbison3 `
+        windows-sdk-8.1 `
+        wixtoolset
+    ThrowOnNativeFailure
+} else {
+    choco install -y winflexbison3
+    ThrowOnNativeFailure
+}
 
 
 Install-Exe -Url "https://packages.icinga.com/windows/dependencies/boost_$($BoostVersion -join '_')-msvc-${MsvcVersion}-${Env:BITS}.exe" -Dir "C:\local\boost_$($BoostVersion -join '_')-Win${Env:BITS}"

--- a/tools/win32/load-vsenv.ps1
+++ b/tools/win32/load-vsenv.ps1
@@ -29,8 +29,9 @@ if (Test-Path env:BITS) {
 
 # Execute vcvars in cmd and store env
 $vcvars_locations = @(
-  "${VSBASE}\BuildTools\VC\Auxiliary\Build\vcvars${bits}.bat",
+  "${VSBASE}\BuildTools\VC\Auxiliary\Build\vcvars${bits}.bat"
   "${VSBASE}\Community\VC\Auxiliary\Build\vcvars${bits}.bat"
+  "${VSBASE}\Enterprise\VC\Auxiliary\Build\vcvars${bits}.bat"
 )
 
 $vcvars = $null


### PR DESCRIPTION
The Windows image provided by GitHub already includes most of our dependencies, so the installation of all Chocolatey packages except winflexbison3 was redundant. Visual Studio is provided in the Enterprise version instead of Community, so that has to be added to the search path as well.

### Tests

Note: Test below reference a [slightly different](https://github.com/Icinga/icinga2/compare/03758fe2259cce533b7561f026fea5a4488ac970..8e766a6a47b592ec47f9e652b20b55fda6d97ea6) commit than the current state of the PR, but that's only a minor difference in [PowerShell array notatation](https://github.com/Icinga/icinga2/pull/9172#discussion_r782081643), so this will be fine if the checks for the current version pass.

#### GitHub Actions

Still work (as you can see in the checks of this PR). Also greatly improves the build time:

* Current master:
  * 64 bit: 39m 53s total, 29m 28s build tools: https://github.com/Icinga/icinga2/runs/4758940266?check_suite_focus=true
  * 32 bit: 40m 43s total, 30m 57s build tools: https://github.com/Icinga/icinga2/runs/4758940211?check_suite_focus=true
* This PR:
  * 64 bit:  16m 55s total, 5m 53s build tools: https://github.com/Icinga/icinga2/runs/4773291468?check_suite_focus=true
  * 32 bit:  15m 27s total, 5m 38s build tools: https://github.com/Icinga/icinga2/runs/4773291406?check_suite_focus=true

#### Fresh Windows Installation

Adapted version of https://icinga.com/docs/icinga-2/latest/doc/21-development/#tldr still successfully builds icinga2 on a fresh Windows VM (note the different script URL):

```
Enable-WindowsOptionalFeature -FeatureName "NetFx3" -Online
powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-Expression (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/Icinga/icinga2/03758fe2259cce533b7561f026fea5a4488ac970/doc/win-dev.ps1')"

git clone https://github.com/Icinga/icinga2.git
cd .\icinga2\
mkdir build
cd .\build\

& "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
  -DBoost_INCLUDE_DIR=C:\local\boost_1_76_0-Win64 `
  -DBISON_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_bison.exe `
  -DFLEX_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_flex.exe `
  -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF ..

& "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe" .\icinga2.sln
```

I had to run the second command twice as it looks like Microsoft found yet another place where to require a reboot:
<details>

```
Warnings:
 - visualstudio2019buildtools - visualstudio2019buildtools v16.11.8.0 already installed.
 Use --force to reinstall, specify a version to install, or try upgrade.

Packages requiring reboot:
 - dotnetfx (exit code 3010)

The recent package changes indicate a reboot is necessary.
 Please reboot at your earliest convenience.
DEBUG:   88+      >>>> ThrowOnNativeFailure
DEBUG:    7+ function ThrowOnNativeFailure  >>>> {
DEBUG:    8+  if ( >>>> -not $?) {
DEBUG:    9+    >>>> throw 'Native failure'
Native failure
At line:9 char:3
+         throw 'Native failure'
+         ~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Native failure:String) [], RuntimeException
    + FullyQualifiedErrorId : Native failure
```
</details>

But in the end, it still compiles:
```
Done Building Project "C:\Users\Administrator\icinga2\build\icinga2.sln" (default targets).


Build succeeded.

[...]

    243 Warning(s)
    0 Error(s)

Time Elapsed 00:05:28.50
```