### PR TITLE
Let new cluster certificates expire after 397 days, not 15 years

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -623,7 +623,7 @@ std::shared_ptr<X509> CreateCert(EVP_PKEY *pubkey, X509_NAME *subject, X509_NAME
 	X509 *cert = X509_new();
 	X509_set_version(cert, 2);
 	X509_gmtime_adj(X509_get_notBefore(cert), 0);
-	X509_gmtime_adj(X509_get_notAfter(cert), 365 * 24 * 60 * 60 * 15);
+	X509_gmtime_adj(X509_get_notAfter(cert), 397 * 24 * 60 * 60);
 	X509_set_pubkey(cert, pubkey);
 
 	X509_set_subject_name(cert, subject);


### PR DESCRIPTION
https://cabforum.org/wp-content/uploads/CA-Browser-Forum-BR-1.7.3.pdf, section 6.3.2:

"Subscriber Certificates issued on or after 1 September 2020 SHOULD NOT have a Validity Period greater than 397 days and MUST NOT have a Validity Period greater than 398 days."

fixes #8490
closes #8563