### PR TITLE
Don't trigger a fixed downtime like a flexible one

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -121,7 +121,7 @@ void Downtime::Start(bool runtimeCreated)
 	 * this downtime now *after* it has been added (important
 	 * for DB IDO, etc.)
 	 */
-	if (!checkable->IsStateOK(checkable->GetStateRaw())) {
+	if (!GetFixed() && !checkable->IsStateOK(checkable->GetStateRaw())) {
 		Log(LogNotice, "Downtime")
 			<< "Checkable '" << checkable->GetName() << "' already in a NOT-OK state."
 			<< " Triggering downtime now.";


### PR DESCRIPTION
When creating a fixed downtime that starts immediately while the checkable is
in a non-OK state, previously the code path for flexible downtimes was used to
trigger this downtime. This is fixed by this commit which resolves two issued:

1. Missing downtime start notification: notifications work differently for
   fixed and flexible downtimes. This resulted in missing downtime start
   notifications under the conditions described above.
2. Incorrect downtime trigger time: this code path would incorrectly assume the
   timestamp of the last checkable as the trigger time which is incorrect for
   fixed downtimes.

Backport of #9131