### PR TITLE
icinga2.service: depend on icingadb-redis.service if any

### DIFF
--- a/etc/initsystem/icinga2.service.cmake
+++ b/etc/initsystem/icinga2.service.cmake
@@ -1,7 +1,7 @@
 [Unit]
 Description=Icinga host/service/network monitoring system
 Requires=network-online.target
-After=syslog.target network-online.target postgresql.service mariadb.service carbon-cache.service carbon-relay.service
+After=syslog.target network-online.target icingadb-redis.service postgresql.service mariadb.service carbon-cache.service carbon-relay.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
to prevent its shutdown until we've written everything.