### PR TITLE
GitHub Actions: pin Windows Server version to 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         bits: [32, 64]
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     env:
       BITS: '${{ matrix.bits }}'


### PR DESCRIPTION
Looks like GitHub has just changed `windows-latest` from `windows-2019` to `windows-2022`. As of writing this https://github.com/actions/virtual-environments#available-environments even still shows 2019 as latest.

Recent job using `windows-latest` running on Server 2022: https://github.com/Icinga/icinga2/runs/5066719665?check_suite_focus=true#step:1:3

Pin it to 2019 for now as otherwise this would also use Visual Studio 2022 which we're not yet using for our release builds.