### PR TITLE
IDO: fix incorrect contacts in notification history with multiple IDO instances on a single node

### DIFF
--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -45,8 +45,19 @@ void DbConnection::Start(bool runtimeCreated)
 	Log(LogInformation, "DbConnection")
 		<< "'" << GetName() << "' started.";
 
-	DbObject::OnQuery.connect([this](const DbQuery& query) { ExecuteQuery(query); });
-	DbObject::OnMultipleQueries.connect([this](const std::vector<DbQuery>& multiQueries) { ExecuteMultipleQueries(multiQueries); });
+	auto onQuery = [this](const DbQuery& query) { ExecuteQuery(query); };
+	DbObject::OnQuery.connect(onQuery);
+
+	auto onMultipleQueries = [this](const std::vector<DbQuery>& multiQueries) { ExecuteMultipleQueries(multiQueries); };
+	DbObject::OnMultipleQueries.connect(onMultipleQueries);
+
+	DbObject::QueryCallbacks queryCallbacks;
+	queryCallbacks.Query = onQuery;
+	queryCallbacks.MultipleQueries = onMultipleQueries;
+
+	DbObject::OnMakeQueries.connect([queryCallbacks](const std::function<void (const DbObject::QueryCallbacks&)>& queryFunc) {
+		queryFunc(queryCallbacks);
+	});
 }
 
 void DbConnection::Stop(bool runtimeRemoved)

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -837,72 +837,79 @@ void DbEvents::AddAcknowledgementInternal(const Checkable::Ptr& checkable, Ackno
 void DbEvents::AddNotificationHistory(const Notification::Ptr& notification, const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, NotificationType type,
 	const CheckResult::Ptr& cr, const String& author, const String& text)
 {
-	/* start and end happen at the same time */
-	std::pair<unsigned long, unsigned long> timeBag = ConvertTimestamp(Utility::GetTime());
+	/* NotificationInsertID has to be tracked per IDO instance, therefore the OnQuery and OnMultipleQueries signals
+	 * cannot be called directly as all IDO instances would insert rows with the same ID which is (most likely) only
+	 * correct in one database. Instead, pass a lambda which generates the queries with new DbValue for
+	 * NotificationInsertID each IDO instance.
+	 */
+	DbObject::OnMakeQueries([&checkable, &users, &type, &cr](const DbObject::QueryCallbacks& callbacks) {
+		/* start and end happen at the same time */
+		std::pair<unsigned long, unsigned long> timeBag = ConvertTimestamp(Utility::GetTime());
 
-	DbQuery query1;
-	query1.Table = "notifications";
-	query1.Type = DbQueryInsert;
-	query1.Category = DbCatNotification;
-	query1.NotificationInsertID = new DbValue(DbValueObjectInsertID, -1);
+		DbQuery query1;
+		query1.Table = "notifications";
+		query1.Type = DbQueryInsert;
+		query1.Category = DbCatNotification;
+		query1.NotificationInsertID = new DbValue(DbValueObjectInsertID, -1);
 
-	Host::Ptr host;
-	Service::Ptr service;
-	tie(host, service) = GetHostService(checkable);
+		Host::Ptr host;
+		Service::Ptr service;
+		tie(host, service) = GetHostService(checkable);
 
-	Dictionary::Ptr fields1 = new Dictionary();
-	fields1->Set("notification_type", 1); /* service */
-	fields1->Set("notification_reason", MapNotificationReasonType(type));
-	fields1->Set("object_id", checkable);
-	fields1->Set("start_time", DbValue::FromTimestamp(timeBag.first));
-	fields1->Set("start_time_usec", timeBag.second);
-	fields1->Set("end_time", DbValue::FromTimestamp(timeBag.first));
-	fields1->Set("end_time_usec", timeBag.second);
+		Dictionary::Ptr fields1 = new Dictionary();
+		fields1->Set("notification_type", 1); /* service */
+		fields1->Set("notification_reason", MapNotificationReasonType(type));
+		fields1->Set("object_id", checkable);
+		fields1->Set("start_time", DbValue::FromTimestamp(timeBag.first));
+		fields1->Set("start_time_usec", timeBag.second);
+		fields1->Set("end_time", DbValue::FromTimestamp(timeBag.first));
+		fields1->Set("end_time_usec", timeBag.second);
 
-	if (service)
-		fields1->Set("state", service->GetState());
-	else
-		fields1->Set("state", GetHostState(host));
+		if (service)
+			fields1->Set("state", service->GetState());
+		else
+			fields1->Set("state", GetHostState(host));
 
-	if (cr) {
-		fields1->Set("output", CompatUtility::GetCheckResultOutput(cr));
-		fields1->Set("long_output", CompatUtility::GetCheckResultLongOutput(cr));
-	}
+		if (cr) {
+			fields1->Set("output", CompatUtility::GetCheckResultOutput(cr));
+			fields1->Set("long_output", CompatUtility::GetCheckResultLongOutput(cr));
+		}
 
-	fields1->Set("escalated", 0);
-	fields1->Set("contacts_notified", static_cast<long>(users.size()));
-	fields1->Set("instance_id", 0); /* DbConnection class fills in real ID */
+		fields1->Set("escalated", 0);
+		fields1->Set("contacts_notified", static_cast<long>(users.size()));
+		fields1->Set("instance_id", 0); /* DbConnection class fills in real ID */
 
-	Endpoint::Ptr endpoint = Endpoint::GetByName(IcingaApplication::GetInstance()->GetNodeName());
+		Endpoint::Ptr endpoint = Endpoint::GetByName(IcingaApplication::GetInstance()->GetNodeName());
 
-	if (endpoint)
-		fields1->Set("endpoint_object_id", endpoint);
+		if (endpoint)
+			fields1->Set("endpoint_object_id", endpoint);
 
-	query1.Fields = fields1;
-	DbObject::OnQuery(query1);
+		query1.Fields = fields1;
+		callbacks.Query(query1);
 
-	std::vector<DbQuery> queries;
+		std::vector<DbQuery> queries;
 
-	for (const User::Ptr& user : users) {
-		DbQuery query2;
-		query2.Table = "contactnotifications";
-		query2.Type = DbQueryInsert;
-		query2.Category = DbCatNotification;
+		for (const User::Ptr& user : users) {
+			DbQuery query2;
+			query2.Table = "contactnotifications";
+			query2.Type = DbQueryInsert;
+			query2.Category = DbCatNotification;
 
-		query2.Fields = new Dictionary({
-			{ "contact_object_id", user },
-			{ "start_time", DbValue::FromTimestamp(timeBag.first) },
-			{ "start_time_usec", timeBag.second },
-			{ "end_time", DbValue::FromTimestamp(timeBag.first) },
-			{ "end_time_usec", timeBag.second },
-			{ "notification_id", query1.NotificationInsertID },
-			{ "instance_id", 0 } /* DbConnection class fills in real ID */
-		});
+			query2.Fields = new Dictionary({
+				{ "contact_object_id", user },
+				{ "start_time", DbValue::FromTimestamp(timeBag.first) },
+				{ "start_time_usec", timeBag.second },
+				{ "end_time", DbValue::FromTimestamp(timeBag.first) },
+				{ "end_time_usec", timeBag.second },
+				{ "notification_id", query1.NotificationInsertID },
+				{ "instance_id", 0 } /* DbConnection class fills in real ID */
+			});
 
-		queries.emplace_back(std::move(query2));
-	}
+			queries.emplace_back(std::move(query2));
+		}
 
-	DbObject::OnMultipleQueries(queries);
+		callbacks.MultipleQueries(queries);
+	});
 }
 
 /* statehistory */

--- a/lib/db_ido/dbobject.cpp
+++ b/lib/db_ido/dbobject.cpp
@@ -25,6 +25,7 @@ using namespace icinga;
 
 boost::signals2::signal<void (const DbQuery&)> DbObject::OnQuery;
 boost::signals2::signal<void (const std::vector<DbQuery>&)> DbObject::OnMultipleQueries;
+boost::signals2::signal<void (const std::function<void (const DbObject::QueryCallbacks&)>&)> DbObject::OnMakeQueries;
 
 INITIALIZE_ONCE(&DbObject::StaticInitialize);
 

--- a/lib/db_ido/dbobject.hpp
+++ b/lib/db_ido/dbobject.hpp
@@ -61,8 +61,14 @@ public:
 
 	static DbObject::Ptr GetOrCreateByObject(const ConfigObject::Ptr& object);
 
+	struct QueryCallbacks {
+		std::function<void(const DbQuery&)> Query;
+		std::function<void(const std::vector<DbQuery>&)> MultipleQueries;
+	};
+
 	static boost::signals2::signal<void (const DbQuery&)> OnQuery;
 	static boost::signals2::signal<void (const std::vector<DbQuery>&)> OnMultipleQueries;
+	static boost::signals2::signal<void (const std::function<void (const QueryCallbacks&)>&)> OnMakeQueries;
 
 	void SendConfigUpdateHeavy(const Dictionary::Ptr& configFields);
 	void SendConfigUpdateLight();


### PR DESCRIPTION
When there are multiple active IDO instances on the same node, without this PR all of them would share a single `DbValue` object for the `notification_id` column of the `icinga_contactnotifications` table. This resulted in the issue that one database references the `notification_id` in another database.

This PR fixes this by using a separate `DbValue` value for each IDO instance. This needs a new signal as the existing `OnQuery` and `OnMultipleQueries` signals perform the same queries on all IDO instances, but different queries are needed
here per instance (they only differ in the referenced `DbValue`). Therefore, a new signal `OnMakeQueries` is added that takes a `std::function` which is called once per IDO instance and can access callbacks to perform one or multiple queries only on this specific IDO instance.

## Test

* Start an icinga2 node with two active IDO connections (for example non-HA zone with `ido-mysql` and `ido-pgsql` enabled)
* Generate a notification
* Select the notification history including contacts from both databases or look at it in Web

### Before
```console
$ curl -iksSu root:icinga -H'Accept: application/json' -XPOST 'https://localhost:5665/v1/actions/send-custom-notification' -d '{"type": "Service", "service": "master-1!icinga-health", "author": "test", "comment": "test"}'
HTTP/1.1 200 OK
Server: Icinga/v2.13.0-197-g8016b013a
Content-Type: application/json
Content-Length: 112

{"results":[{"code":200,"status":"Successfully sent custom notification for object 'master-1!icinga-health'."}]}
```

Note how 17312 is used for `notification_id` in both IDO instances:
```
[2022-02-10 17:06:08 +0100] debug/IdoPgsqlConnection: Query: INSERT INTO icinga_contactnotifications (contact_object_id, end_time, end_time_usec, instance_id, notification_id, start_time, start_time_usec) VALUES (288, TO_TIMESTAMP(1644509168) AT TIME ZONE 'UTC', '681332', 1, 17312, TO_TIMESTAMP(1644509168) AT TIME ZONE 'UTC', '681332')
[2022-02-10 17:06:09 +0100] debug/IdoMysqlConnection: Query: INSERT INTO icinga_contactnotifications (contact_object_id, end_time, end_time_usec, instance_id, notification_id, start_time, start_time_usec) VALUES (55575, FROM_UNIXTIME(1644509168), '681332', 1, 17312, FROM_UNIXTIME(1644509168), '681332')
```

History entry in PostgreSQL is fine:
```
icingaido=# SELECT
  o.name1 AS host,
  o.name2 AS service,
  n.notification_id,
  n.start_time AS time,
  n.notification_type AS type,
  n.notification_reason AS reason,
  n.state,
  n.output,
  n.contacts_notified,
  cn.contact_object_id,
  co.name1 AS contact,
  co.is_active
FROM icinga_objects o
LEFT JOIN icinga_notifications n ON n.object_id = o.object_id
LEFT JOIN icinga_contactnotifications cn ON cn.notification_id = n.notification_id
LEFT JOIN icinga_objects co ON co.object_id = cn.contact_object_id
WHERE o.objecttype_id = 2
  AND o.name1 = 'master-1'
  AND o.name2 = 'icinga-health'
ORDER BY n.start_time DESC, n.notification_id, co.name1
LIMIT 1;
-[ RECORD 1 ]-----+--------------------------------------------------------------------------------------
host              | master-1
service           | icinga-health
notification_id   | 17312
time              | 2022-02-10 16:06:08
type              | 1
reason            | 8
state             | 0
output            | Icinga 2 has been running for 1 minute and 9 seconds. Version: v2.13.0-197-g8016b013a
contacts_notified | 1
contact_object_id | 288
contact           | dummy
is_active         | 1
```

But it's not correctly referenced in MySQL (see NULL columns at the end):
```
MariaDB [icingaido]> SELECT
    ->   o.name1 AS host,
    ->   o.name2 AS service,
    ->   n.notification_id,
    ->   n.start_time AS time,
    ->   n.notification_type AS type,
    ->   n.notification_reason AS reason,
    ->   n.state,
    ->   n.output,
    ->   n.contacts_notified,
    ->   cn.contact_object_id,
    ->   co.name1 AS contact,
    ->   co.is_active
    -> FROM icinga_objects o
    -> LEFT JOIN icinga_notifications n ON n.object_id = o.object_id
    -> LEFT JOIN icinga_contactnotifications cn ON cn.notification_id = n.notification_id
    -> LEFT JOIN icinga_objects co ON co.object_id = cn.contact_object_id
    -> WHERE o.objecttype_id = 2
    ->   AND o.name1 = 'master-1'
    ->   AND o.name2 = 'icinga-health'
    -> ORDER BY n.start_time DESC, n.notification_id, co.name1
    -> LIMIT 1 \G
*************************** 1. row ***************************
             host: master-1
          service: icinga-health
  notification_id: 268205
             time: 2022-02-10 16:06:08
             type: 1
           reason: 8
            state: 0
           output: Icinga 2 has been running for 1 minute and 9 seconds. Version: v2.13.0-197-g8016b013a
contacts_notified: 1
contact_object_id: NULL
          contact: NULL
        is_active: NULL
1 row in set (0.003 sec)
```

### After

```console
$ curl -iksSu root:icinga -H'Accept: application/json' -XPOST 'https://localhost:5665/v1/actions/send-custom-notification' -d '{"type": "Service", "service": "master-1!icinga-health", "author": "test", "comment": "test"}'
HTTP/1.1 200 OK
Server: Icinga/v2.13.0-198-g7c9d0fff0
Content-Type: application/json
Content-Length: 112

{"results":[{"code":200,"status":"Successfully sent custom notification for object 'master-1!icinga-health'."}]}
```

Now, both instances use different IDs (17375 and 268268):
```
cluster-master-1-1  | [2022-02-10 17:20:38 +0100] debug/IdoPgsqlConnection: Query: INSERT INTO icinga_contactnotifications (contact_object_id, end_time, end_time_usec, instance_id, notification_id, start_time, start_time_usec) VALUES (288, TO_TIMESTAMP(1644510038) AT TIME ZONE 'UTC', '197875', 1, 17375, TO_TIMESTAMP(1644510038) AT TIME ZONE 'UTC', '197875')
cluster-master-1-1  | [2022-02-10 17:20:39 +0100] debug/IdoMysqlConnection: Query: INSERT INTO icinga_contactnotifications (contact_object_id, end_time, end_time_usec, instance_id, notification_id, start_time, start_time_usec) VALUES (55575, FROM_UNIXTIME(1644510038), '198132', 1, 268268, FROM_UNIXTIME(1644510038), '198132')
```

History from PostgreSQL is still fine:
```
icingaido=# SELECT
  o.name1 AS host,
  o.name2 AS service,
  n.notification_id,
  n.start_time AS time,
  n.notification_type AS type,
  n.notification_reason AS reason,
  n.state,
  n.output,
  n.contacts_notified,
  cn.contact_object_id,
  co.name1 AS contact,
  co.is_active
FROM icinga_objects o
LEFT JOIN icinga_notifications n ON n.object_id = o.object_id
LEFT JOIN icinga_contactnotifications cn ON cn.notification_id = n.notification_id
LEFT JOIN icinga_objects co ON co.object_id = cn.contact_object_id
WHERE o.objecttype_id = 2
  AND o.name1 = 'master-1'
  AND o.name2 = 'icinga-health'
ORDER BY n.start_time DESC, n.notification_id, co.name1
LIMIT 1;
-[ RECORD 1 ]-----+--------------------------------------------------------------------------
host              | master-1
service           | icinga-health
notification_id   | 17375
time              | 2022-02-10 16:20:38
type              | 1
reason            | 8
state             | 0
output            | Icinga 2 has been running for 40 seconds. Version: v2.13.0-198-g7c9d0fff0
contacts_notified | 1
contact_object_id | 288
contact           | dummy
is_active         | 1
```

But now MySQL contains the correct relation in `icinga_contactnotifications` and the same query returns them:
```
MariaDB [icingaido]> SELECT
    ->   o.name1 AS host,
    ->   o.name2 AS service,
    ->   n.notification_id,
    ->   n.start_time AS time,
    ->   n.notification_type AS type,
    ->   n.notification_reason AS reason,
    ->   n.state,
    ->   n.output,
    ->   n.contacts_notified,
    ->   cn.contact_object_id,
    ->   co.name1 AS contact,
    ->   co.is_active
    -> FROM icinga_objects o
    -> LEFT JOIN icinga_notifications n ON n.object_id = o.object_id
    -> LEFT JOIN icinga_contactnotifications cn ON cn.notification_id = n.notification_id
    -> LEFT JOIN icinga_objects co ON co.object_id = cn.contact_object_id
    -> WHERE o.objecttype_id = 2
    ->   AND o.name1 = 'master-1'
    ->   AND o.name2 = 'icinga-health'
    -> ORDER BY n.start_time DESC, n.notification_id, co.name1
    -> LIMIT 1 \G
*************************** 1. row ***************************
             host: master-1
          service: icinga-health
  notification_id: 268268
             time: 2022-02-10 16:20:38
             type: 1
           reason: 8
            state: 0
           output: Icinga 2 has been running for 40 seconds. Version: v2.13.0-198-g7c9d0fff0
contacts_notified: 1
contact_object_id: 55575
          contact: dummy
        is_active: 1
1 row in set (0.001 sec)
```

ref/IP/37979