### PR TITLE
IcingaDB: Add previous_soft_state to host_state and service_state

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2200,6 +2200,7 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 		attrs->Set("severity", host->GetSeverity());
 	}
 
+	attrs->Set("previous_soft_state", GetPreviousState(checkable, service, StateTypeSoft));
 	attrs->Set("previous_hard_state", GetPreviousState(checkable, service, StateTypeHard));
 	attrs->Set("check_attempt", checkable->GetCheckAttempt());
 


### PR DESCRIPTION
fixes #9210
backport of #9213