### PR TITLE
Prevent deadlock in ProcessCheckResult

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -239,20 +239,6 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		}
 	}
 
-	if (recovery) {
-		for (auto& child : children) {
-			if (child->GetProblem() && child->GetEnableActiveChecks()) {
-				auto nextCheck (now + Utility::Random() % 60);
-
-				ObjectLock oLock (child);
-
-				if (nextCheck < child->GetNextCheck()) {
-					child->SetNextCheck(nextCheck);
-				}
-			}
-		}
-	}
-
 	if (!reachable)
 		SetLastStateUnreachable(cr->GetExecutionEnd());
 
@@ -279,20 +265,6 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		if (GetAcknowledgement() == AcknowledgementNormal ||
 			(GetAcknowledgement() == AcknowledgementSticky && IsStateOK(new_state))) {
 			ClearAcknowledgement("");
-		}
-
-		/* reschedule direct parents */
-		for (const Checkable::Ptr& parent : GetParents()) {
-			if (parent.get() == this)
-				continue;
-
-			if (!parent->GetEnableActiveChecks())
-				continue;
-
-			if (parent->GetNextCheck() >= now + parent->GetRetryInterval()) {
-				ObjectLock olock(parent);
-				parent->SetNextCheck(now);
-			}
 		}
 	}
 
@@ -414,6 +386,36 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		<< " threshold high: " << GetFlappingThresholdHigh()
 		<< "% current: " << GetFlappingCurrent() << "%.";
 #endif /* I2_DEBUG */
+
+	if (recovery) {
+		for (auto& child : children) {
+			if (child->GetProblem() && child->GetEnableActiveChecks()) {
+				auto nextCheck (now + Utility::Random() % 60);
+
+				ObjectLock oLock (child);
+
+				if (nextCheck < child->GetNextCheck()) {
+					child->SetNextCheck(nextCheck);
+				}
+			}
+		}
+	}
+
+	if (stateChange) {
+		/* reschedule direct parents */
+		for (const Checkable::Ptr& parent : GetParents()) {
+			if (parent.get() == this)
+				continue;
+
+			if (!parent->GetEnableActiveChecks())
+				continue;
+
+			if (parent->GetNextCheck() >= now + parent->GetRetryInterval()) {
+				ObjectLock olock(parent);
+				parent->SetNextCheck(now);
+			}
+		}
+	}
 
 	OnNewCheckResult(this, cr, origin);
 


### PR DESCRIPTION
Without this commit, children and parents of a checkable were rescheduled on a state change while holding the lock for the current checkable. If both ends of a dependency are checked at the same time and both change state, they could end
up in a deadlock waiting for each other.

This commit fixes this problem by changing the code so that other checkables are rescheduled only after releasing the lock for the current checkable.

## Test

Config snippet:
```
object Host "ip-37271" {
        check_command = "dummy"
}

apply Service for (n in ["parent", "child"]) {
        enable_notifications = false
        check_command = "dummy"
        check_interval = 60
        retry_interval = 10
        max_check_attempts = 1
        assign where host.name == "ip-37271"
}

object Dependency "ip-37271" {
        parent_host_name = "ip-37271"
        parent_service_name = "parent"
        child_host_name = "ip-37271"
        child_service_name = "child"
}
```

And then run the following two loops in parallel:

```shell
while :; do for state in 0 2; do date -Ins; curl -ksSu root:icinga -H'Accept: application/json' -XPOST 'https://localhost:5665/v1/actions/process-check-result' -d '{"type": "Service", "service": "ip-37271!parent", "exit_status": '$state', "plugin_output": "API-submitted", "pretty": true}'; done; done
```

```shell
while :; do for state in 0 2; do date -Ins; curl -ksSu root:icinga -H'Accept: application/json' -XPOST 'https://localhost:5665/v1/actions/process-check-result' -d '{"type": "Service", "service": "ip-37271!child", "exit_status": '$state', "plugin_output": "API-submitted", "pretty": true}'; done; done
```

### Before

After just a few seconds, both loops will block. Secondary effects like `https://127.0.0.1:5665/v1/status` no longer returning a response can also be observed (locks all checkables internally).

### After

The same loop is running just fine for minutes without ever blocking.

ref/IP/37271