### PR TITLE
GHA: drop CentOS 8

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         distro:
           - name: centos
-            release: 8
-          - name: centos
             release: 7
           - name: fedora
             release: 35


### PR DESCRIPTION
backport of #9201