### PR TITLE
GitHub Actions: pin Windows Server version to 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         bits: [32, 64]
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     env:
       BITS: '${{ matrix.bits }}'


### PR DESCRIPTION
backport of #9208