### PR TITLE
IDO: fix incorrect contacts in notification history with multiple IDO instances on a single node

### DIFF
--- a/lib/db_ido/dbobject.cpp
+++ b/lib/db_ido/dbobject.cpp
@@ -25,6 +25,7 @@ using namespace icinga;
 
 boost::signals2::signal<void (const DbQuery&)> DbObject::OnQuery;
 boost::signals2::signal<void (const std::vector<DbQuery>&)> DbObject::OnMultipleQueries;
+boost::signals2::signal<void (const std::function<void (const DbObject::QueryCallbacks&)>&)> DbObject::OnMakeQueries;
 
 INITIALIZE_ONCE(&DbObject::StaticInitialize);
 

--- a/lib/db_ido/dbobject.hpp
+++ b/lib/db_ido/dbobject.hpp
@@ -61,8 +61,14 @@ public:
 
 	static DbObject::Ptr GetOrCreateByObject(const ConfigObject::Ptr& object);
 
+	struct QueryCallbacks {
+		std::function<void(const DbQuery&)> Query;
+		std::function<void(const std::vector<DbQuery>&)> MultipleQueries;
+	};
+
 	static boost::signals2::signal<void (const DbQuery&)> OnQuery;
 	static boost::signals2::signal<void (const std::vector<DbQuery>&)> OnMultipleQueries;
+	static boost::signals2::signal<void (const std::function<void (const QueryCallbacks&)>&)> OnMakeQueries;
 
 	void SendConfigUpdateHeavy(const Dictionary::Ptr& configFields);
 	void SendConfigUpdateLight();


### PR DESCRIPTION
Backport of #9212