### PR TITLE
Service#GetSeverity(): behave as the respective IDO query of Icinga Web

### DIFF
--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -137,7 +137,7 @@ int Service::GetSeverity() const
 
 		Host::Ptr host = GetHost();
 		ObjectLock hlock (host);
-		if (host->GetState() != HostUp || !host->IsReachable()) {
+		if (host->GetState() != HostUp) {
 			severity += 1024;
 		} else {
 			if (IsAcknowledged())


### PR DESCRIPTION
Backport of #9196