### PR TITLE
Checkable#ExecuteEventHandler(): don't outsource event command run twice

### DIFF
--- a/lib/icinga/checkable-event.cpp
+++ b/lib/icinga/checkable-event.cpp
@@ -49,7 +49,7 @@ void Checkable::ExecuteEventHandler(const Dictionary::Ptr& resolvedMacros, bool 
 
 	ec->Execute(this, macros, useResolvedMacros);
 
-	if (endpoint) {
+	if (endpoint && !GetExtension("agent_check")) {
 		Dictionary::Ptr message = new Dictionary();
 		message->Set("jsonrpc", "2.0");
 		message->Set("method", "event::ExecuteCommand");


### PR DESCRIPTION
Backport of #9259