### PR TITLE
Doc: SUSE: install monitoring-plugins-all

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -433,7 +433,7 @@ as part of the [server:monitoring repository](https://build.opensuse.org/project
 Please make sure to enable this repository beforehand.
 
 ```bash
-zypper install monitoring-plugins-all
+zypper install --recommends monitoring-plugins-all
 ```
 <!-- {% endif %} -->
 

--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -433,7 +433,7 @@ as part of the [server:monitoring repository](https://build.opensuse.org/project
 Please make sure to enable this repository beforehand.
 
 ```bash
-zypper install monitoring-plugins
+zypper install monitoring-plugins-all
 ```
 <!-- {% endif %} -->
 


### PR DESCRIPTION
not just monitoring-plugins, as in the other distros.

Read also https://github.com/Icinga/icinga2/pull/9151#issuecomment-1051034393 .

closes #9151