### PR TITLE
Worker process doesn't let parallel API package stage updates to complete when terminated

### DIFF
--- a/lib/base/defer.hpp
+++ b/lib/base/defer.hpp
@@ -30,11 +30,19 @@ public:
 	inline
 	~Defer()
 	{
-		try {
-			m_Func();
-		} catch (...) {
-			// https://stackoverflow.com/questions/130117/throwing-exceptions-out-of-a-destructor
+		if (m_Func) {
+			try {
+				m_Func();
+			} catch (...) {
+				// https://stackoverflow.com/questions/130117/throwing-exceptions-out-of-a-destructor
+			}
 		}
+	}
+
+	inline
+	void Cancel()
+	{
+		m_Func = nullptr;
 	}
 
 private:

--- a/lib/remote/configpackageutility.hpp
+++ b/lib/remote/configpackageutility.hpp
@@ -8,6 +8,8 @@
 #include "base/dictionary.hpp"
 #include "base/process.hpp"
 #include "base/string.hpp"
+#include "base/defer.hpp"
+#include "base/shared.hpp"
 #include <vector>
 
 namespace icinga
@@ -37,7 +39,8 @@ public:
 	static void SetActiveStage(const String& packageName, const String& stageName);
 	static void SetActiveStageToFile(const String& packageName, const String& stageName);
 	static void ActivateStage(const String& packageName, const String& stageName);
-	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool activate, bool reload);
+	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool activate, bool reload,
+		const Shared<Defer>::Ptr& resetPackageUpdates);
 
 	static std::vector<std::pair<String, bool> > GetFiles(const String& packageName, const String& stageName);
 
@@ -59,7 +62,8 @@ private:
 	static void WritePackageConfig(const String& packageName);
 	static void WriteStageConfig(const String& packageName, const String& stageName);
 
-	static void TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName, bool activate, bool reload);
+	static void TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName, bool activate,
+		bool reload, const Shared<Defer>::Ptr& resetPackageUpdates);
 
 	static bool ValidateFreshName(const String& name);
 };

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -5,11 +5,14 @@
 #include "remote/httputility.hpp"
 #include "remote/filterutility.hpp"
 #include "base/application.hpp"
+#include "base/defer.hpp"
 #include "base/exception.hpp"
 
 using namespace icinga;
 
 REGISTER_URLHANDLER("/v1/config/stages", ConfigStagesHandler);
+
+std::atomic<bool> ConfigStagesHandler::m_RunningPackageUpdates (false);
 
 bool ConfigStagesHandler::HandleRequest(
 	AsioTlsStream& stream,
@@ -128,12 +131,19 @@ void ConfigStagesHandler::HandlePost(
 		if (reload && !activate)
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Parameter 'reload' must be false when 'activate' is false."));
 
+		if (m_RunningPackageUpdates.exchange(true)) {
+			return HttpUtility::SendJsonError(response, params, 423,
+				"Conflicting request, there is already an ongoing package update in progress. Please try it again later.");
+		}
+
+		auto resetPackageUpdates (Shared<Defer>::Make([]() { ConfigStagesHandler::m_RunningPackageUpdates.store(false); }));
+
 		std::unique_lock<std::mutex> lock(ConfigPackageUtility::GetStaticPackageMutex());
 
 		stageName = ConfigPackageUtility::CreateStage(packageName, files);
 
 		/* validate the config. on success, activate stage and reload */
-		ConfigPackageUtility::AsyncTryActivateStage(packageName, stageName, activate, reload);
+		ConfigPackageUtility::AsyncTryActivateStage(packageName, stageName, activate, reload, resetPackageUpdates);
 	} catch (const std::exception& ex) {
 		return HttpUtility::SendJsonError(response, params, 500,
 			"Stage creation failed.",

--- a/lib/remote/configstageshandler.hpp
+++ b/lib/remote/configstageshandler.hpp
@@ -4,6 +4,7 @@
 #define CONFIGSTAGESHANDLER_H
 
 #include "remote/httphandler.hpp"
+#include <atomic>
 
 namespace icinga
 {
@@ -47,6 +48,7 @@ private:
 		const Dictionary::Ptr& params
 	);
 
+	static std::atomic<bool> m_RunningPackageUpdates;
 };
 
 }


### PR DESCRIPTION
When the second request isn't finished processing till the new worker process is started and its configs are validated, the old worker is terminated immediately after the new worker becomes ready. When the worker process is terminated, all the worker threads of the `Process` class that are responsible for processing such requests are also destroyed. Thus, the second API request remains incomplete and produces a package stage without `startup` logs and `status` file.

**Changes:**

**Concurrent package updates are strictly prohibited.**

## To Reproduce

- First create two different config packages
  - `curl -k -s -S -i -u root:icinga -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/config/packages/cmdb?pretty=1'`
  - `curl -k -s -S -i -u root:icinga -H 'Accept: application/json'  -X POST 'https://localhost:5665/v1/config/packages/test?pretty=1'`
- Next just update these packages asynchronously. You need also to specify different configuration each time so that the reload signal can be triggered internally. You also need to post the requests in a bit order (not strictly simultaneous) so that you can reproduce the issue.

```bash
curl -k -s -S -i -u root:icinga -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/config/stages/cmdb'  -d '{ "files": { "conf.d/test.conf": "object Host \"cmdb-host\" { check_command = \"dummy\" }" }, "pretty": true }'
curl -k -s -S -i -u root:icinga -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/config/stages/test'  -d '{ "files": { "conf.d/test.conf": "object Host \"test-host\" { check_command = \"dummy\" }" }, "pretty": true }'
```

fixes #7898