### PR TITLE
Doc: Windows Dev Environment: correct reboot requirement

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -1772,7 +1772,7 @@ cd .\build\
 ```
 
 Building icinga2.sln via Visual Studio itself seems to require a reboot
-after installing the build tools and building once via command line.
+after installing the build tools.
 
 #### Chocolatey
 


### PR DESCRIPTION
Building icinga2.sln via Visual Studio doesn't require compilation via MSBuild.exe.