### PR TITLE
Checkable::RemoveCommentsByType(): also set removal time, not just the actor

### DIFF
--- a/lib/icinga/checkable-comment.cpp
+++ b/lib/icinga/checkable-comment.cpp
@@ -27,12 +27,7 @@ void Checkable::RemoveCommentsByType(int type, const String& removedBy)
 			continue;
 
 		if (comment->GetEntryType() == type) {
-			{
-				ObjectLock oLock (comment);
-				comment->SetRemovedBy(removedBy);
-			}
-
-			Comment::RemoveComment(comment->GetName());
+			Comment::RemoveComment(comment->GetName(), true, removedBy);
 		}
 	}
 }


### PR DESCRIPTION
Before:

1. Acked checkable recovers
2. Icinga clears ack comments w/o setting removal time
3. Icinga DB gets neither removal time, nor expire time
4. Icinga DB falls back to NULL and violates NOT NULL constraint

After:

1. Acked checkable recovers
2. Icinga clears ack comments w/ setting removal time
3. Icinga DB gets removal time

fixes #9272