### PR TITLE
Icinga DB: on sticky ack refresh ack comments

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2181,6 +2181,15 @@ void IcingaDB::SendAcknowledgementSet(const Checkable::Ptr& checkable, const Str
 	/* Update checkable state as is_acknowledged may have changed. */
 	UpdateState(checkable, StateUpdate::Full);
 
+	if (type == AcknowledgementSticky) {
+		for (auto& comment : checkable->GetComments()) {
+			if (comment->GetEntryType() == CommentAcknowledgement) {
+				// Correct is_sticky to true
+				SendConfigUpdate(comment, true);
+			}
+		}
+	}
+
 	std::vector<String> xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
 		"environment_id", m_EnvironmentId,


### PR DESCRIPTION
On ack Icinga first adds a comment, then acks the checkable
so the ack event has the comment ID.

But due to the yet missing ack the comment is missing is_sticky.
That's corrected now on ack.

fixes #9275
Backport of #9276