### PR TITLE
Checkable: send state notifications after suppression if and only if the state differs compared to before the suppression started

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1370,6 +1370,43 @@ Message updates will be dropped when:
 * Checkable does not exist.
 * Origin endpoint's zone is not allowed to access this checkable.
 
+#### event::SetStateBeforeSuppression <a id="technical-concepts-json-rpc-messages-event-setstatebeforesuppression"></a>
+
+> Location: `clusterevents.cpp`
+
+##### Message Body
+
+Key       | Value
+----------|---------------------------------
+jsonrpc   | 2.0
+method    | event::SetStateBeforeSuppression
+params    | Dictionary
+
+##### Params
+
+Key                        | Type   | Description
+---------------------------|--------|-----------------------------------------------
+host                       | String | Host name
+service                    | String | Service name
+state\_before\_suppression | Number | Checkable state before the current suppression
+
+##### Functions
+
+Event Sender: `Checkable::OnStateBeforeSuppressionChanged`
+Event Receiver: `StateBeforeSuppressionChangedAPIHandler`
+
+Used to sync the checkable state from before a notification suppression (for example
+because the checkable is in a downtime) started within the same HA zone.
+
+##### Permissions
+
+The receiver will not process messages from not configured endpoints.
+
+Message updates will be dropped when:
+
+* Checkable does not exist.
+* Origin endpoint is not within the local zone.
+
 #### event::SetSuppressedNotifications <a id="technical-concepts-json-rpc-messages-event-setsupressednotifications"></a>
 
 > Location: `clusterevents.cpp`

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -479,7 +479,12 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 
 	if (send_notification && !is_flapping) {
 		if (!IsPaused()) {
-			if (suppress_notification) {
+			/* If there are still some pending suppressed state notification, keep the suppression until these are
+			 * handled by Checkable::FireSuppressedNotifications().
+			 */
+			bool pending = GetSuppressedNotifications() & (NotificationRecovery|NotificationProblem);
+
+			if (suppress_notification || pending) {
 				suppressed_types |= (recovery ? NotificationRecovery : NotificationProblem);
 			} else {
 				OnNotificationsRequested(this, recovery ? NotificationRecovery : NotificationProblem, cr, "", "", nullptr);
@@ -496,12 +501,21 @@ void Checkable::ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrig
 		int suppressed_types_before (GetSuppressedNotifications());
 		int suppressed_types_after (suppressed_types_before | suppressed_types);
 
-		for (int conflict : {NotificationProblem | NotificationRecovery, NotificationFlappingStart | NotificationFlappingEnd}) {
-			/* E.g. problem and recovery notifications neutralize each other. */
+		const int conflict = NotificationFlappingStart | NotificationFlappingEnd;
+		if ((suppressed_types_after & conflict) == conflict) {
+			/* Flapping start and end cancel out each other. */
+			suppressed_types_after &= ~conflict;
+		}
 
-			if ((suppressed_types_after & conflict) == conflict) {
-				suppressed_types_after &= ~conflict;
-			}
+		const int stateNotifications = NotificationRecovery | NotificationProblem;
+		if (!(suppressed_types_before & stateNotifications) && (suppressed_types & stateNotifications)) {
+			/* A state-related notification is suppressed for the first time, store the previous state. When
+			 * notifications are no longer suppressed, this can be compared with the current state to determine
+			 * if a notification must be sent. This is done differently compared to flapping notifications just above
+			 * as for state notifications, problem and recovery don't always cancel each other. For example,
+			 * WARNING -> OK -> CRITICAL generates both types once, but there should still be a notification.
+			 */
+			SetStateBeforeSuppression(old_stateType == StateTypeHard ? old_state : ServiceOK);
 		}
 
 		if (suppressed_types_after != suppressed_types_before) {

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -103,7 +103,7 @@ void Checkable::Start(bool runtimeCreated)
 	boost::call_once(once, []() {
 		l_CheckablesFireSuppressedNotifications = new Timer();
 		l_CheckablesFireSuppressedNotifications->SetInterval(5);
-		l_CheckablesFireSuppressedNotifications->OnTimerExpired.connect(&Checkable::FireSuppressedNotifications);
+		l_CheckablesFireSuppressedNotifications->OnTimerExpired.connect(&Checkable::FireSuppressedNotificationsTimer);
 		l_CheckablesFireSuppressedNotifications->Start();
 
 		l_CleanDeadlinedExecutions = new Timer();

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -191,6 +191,8 @@ public:
 	bool NotificationReasonSuppressed(NotificationType type);
 	bool IsLikelyToBeCheckedSoon();
 
+	void FireSuppressedNotifications();
+
 	static void IncreasePendingChecks();
 	static void DecreasePendingChecks();
 	static int GetPendingChecks();
@@ -222,7 +224,7 @@ private:
 
 	static void NotifyDowntimeEnd(const Downtime::Ptr& downtime);
 
-	static void FireSuppressedNotifications(const Timer * const&);
+	static void FireSuppressedNotificationsTimer(const Timer * const&);
 	static void CleanDeadlinedExecutions(const Timer * const&);
 
 	/* Comments */

--- a/lib/icinga/checkable.ti
+++ b/lib/icinga/checkable.ti
@@ -175,6 +175,9 @@ abstract class Checkable : CustomVarObject
 	[state, no_user_view, no_user_modify] int suppressed_notifications {
 		default {{{ return 0; }}}
 	};
+	[state, enum, no_user_view, no_user_modify] ServiceState state_before_suppression {
+		default {{{ return ServiceOK; }}}
+	};
 
 	[config, navigation] name(Endpoint) command_endpoint (CommandEndpointRaw) {
 		navigate {{{

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -25,6 +25,7 @@ INITIALIZE_ONCE(&ClusterEvents::StaticInitialize);
 REGISTER_APIFUNCTION(CheckResult, event, &ClusterEvents::CheckResultAPIHandler);
 REGISTER_APIFUNCTION(SetNextCheck, event, &ClusterEvents::NextCheckChangedAPIHandler);
 REGISTER_APIFUNCTION(SetLastCheckStarted, event, &ClusterEvents::LastCheckStartedChangedAPIHandler);
+REGISTER_APIFUNCTION(SetStateBeforeSuppression, event, &ClusterEvents::StateBeforeSuppressionChangedAPIHandler);
 REGISTER_APIFUNCTION(SetSuppressedNotifications, event, &ClusterEvents::SuppressedNotificationsChangedAPIHandler);
 REGISTER_APIFUNCTION(SetSuppressedNotificationTypes, event, &ClusterEvents::SuppressedNotificationTypesChangedAPIHandler);
 REGISTER_APIFUNCTION(SetNextNotification, event, &ClusterEvents::NextNotificationChangedAPIHandler);
@@ -45,6 +46,7 @@ void ClusterEvents::StaticInitialize()
 	Checkable::OnNewCheckResult.connect(&ClusterEvents::CheckResultHandler);
 	Checkable::OnNextCheckChanged.connect(&ClusterEvents::NextCheckChangedHandler);
 	Checkable::OnLastCheckStartedChanged.connect(&ClusterEvents::LastCheckStartedChangedHandler);
+	Checkable::OnStateBeforeSuppressionChanged.connect(&ClusterEvents::StateBeforeSuppressionChangedHandler);
 	Checkable::OnSuppressedNotificationsChanged.connect(&ClusterEvents::SuppressedNotificationsChangedHandler);
 	Notification::OnSuppressedNotificationsChanged.connect(&ClusterEvents::SuppressedNotificationTypesChangedHandler);
 	Notification::OnNextNotificationChanged.connect(&ClusterEvents::NextNotificationChangedHandler);
@@ -302,6 +304,68 @@ Value ClusterEvents::LastCheckStartedChangedAPIHandler(const MessageOrigin::Ptr&
 	}
 
 	checkable->SetLastCheckStarted(params->Get("last_check_started"), false, origin);
+
+	return Empty;
+}
+
+void ClusterEvents::StateBeforeSuppressionChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin)
+{
+	ApiListener::Ptr listener = ApiListener::GetInstance();
+
+	if (!listener)
+		return;
+
+	Host::Ptr host;
+	Service::Ptr service;
+	tie(host, service) = GetHostService(checkable);
+
+	Dictionary::Ptr params = new Dictionary();
+	params->Set("host", host->GetName());
+	if (service)
+		params->Set("service", service->GetShortName());
+	params->Set("state_before_suppression", checkable->GetStateBeforeSuppression());
+
+	Dictionary::Ptr message = new Dictionary();
+	message->Set("jsonrpc", "2.0");
+	message->Set("method", "event::SetStateBeforeSuppression");
+	message->Set("params", params);
+
+	listener->RelayMessage(origin, nullptr, message, true);
+}
+
+Value ClusterEvents::StateBeforeSuppressionChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
+{
+	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
+
+	if (!endpoint) {
+		Log(LogNotice, "ClusterEvents")
+			<< "Discarding 'state before suppression changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
+		return Empty;
+	}
+
+	Host::Ptr host = Host::GetByName(params->Get("host"));
+
+	if (!host)
+		return Empty;
+
+	Checkable::Ptr checkable;
+
+	if (params->Contains("service"))
+		checkable = host->GetServiceByShortName(params->Get("service"));
+	else
+		checkable = host;
+
+	if (!checkable)
+		return Empty;
+
+	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
+		Log(LogNotice, "ClusterEvents")
+			<< "Discarding 'state before suppression changed' message for checkable '" << checkable->GetName()
+			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
+		return Empty;
+	}
+
+	checkable->SetStateBeforeSuppression(ServiceState(int(params->Get("state_before_suppression"))), false, origin);
 
 	return Empty;
 }

--- a/lib/icinga/clusterevents.hpp
+++ b/lib/icinga/clusterevents.hpp
@@ -29,6 +29,9 @@ public:
 	static void LastCheckStartedChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);
 	static Value LastCheckStartedChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
+	static void StateBeforeSuppressionChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);
+	static Value StateBeforeSuppressionChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
+
 	static void SuppressedNotificationsChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);
 	static Value SuppressedNotificationsChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -62,12 +62,13 @@ public:
 	void TriggerDowntime(double triggerTime);
 	void SetRemovalInfo(const String& removedBy, double removeTime, const MessageOrigin::Ptr& origin = nullptr);
 
+	void OnAllConfigLoaded() override;
+
 	static String GetDowntimeIDFromLegacyID(int id);
 
 	static DowntimeChildOptions ChildOptionsFromValue(const Value& options);
 
 protected:
-	void OnAllConfigLoaded() override;
 	void Start(bool runtimeCreated) override;
 	void Stop(bool runtimeRemoved) override;
 

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -25,12 +25,12 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, protected, required, navigation(host)] name(Host) host_name {
+	[config, required, navigation(host)] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, protected, navigation(service)] String service_name {
+	[config, navigation(service)] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/host.hpp
+++ b/lib/icinga/host.hpp
@@ -50,10 +50,11 @@ public:
 
 	bool ResolveMacro(const String& macro, const CheckResult::Ptr& cr, Value *result) const override;
 
+	void OnAllConfigLoaded() override;
+
 protected:
 	void Stop(bool runtimeRemoved) override;
 
-	void OnAllConfigLoaded() override;
 	void CreateChildObjects(const Type::Ptr& childType) override;
 
 private:

--- a/lib/icinga/service.hpp
+++ b/lib/icinga/service.hpp
@@ -44,10 +44,11 @@ public:
 
 	static void EvaluateApplyRules(const Host::Ptr& host);
 
+	void OnAllConfigLoaded() override;
+
 	static boost::signals2::signal<void (const Service::Ptr&, const CheckResult::Ptr&, const MessageOrigin::Ptr&)> OnHostProblemChanged;
 
 protected:
-	void OnAllConfigLoaded() override;
 	void CreateChildObjects(const Type::Ptr& childType) override;
 
 private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,6 +133,7 @@ add_boost_test(base
     icinga_checkresult/service_3attempts
     icinga_checkresult/host_flapping_notification
     icinga_checkresult/service_flapping_notification
+    icinga_checkresult/suppressed_notification
     icinga_dependencies/multi_parent
     icinga_notification/strings
     icinga_notification/state_filter


### PR DESCRIPTION
Backport of  #9207

Also ran my test script from there on this version and looks good:

```
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Sending 'Problem' notification 'github-9207!problm-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Sending 'Recovery' notification 'github-9207!rec-1!dummy-service-notification' for user 'dummy'
```

```
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Sending 'Recovery' notification 'github-9207!rec-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Sending 'Problem' notification 'github-9207!problm-2!dummy-service-notification' for user 'dummy'
```

<details><summary>Full output</summary>

```
[2022-03-09T17:12:20+01:00] Ensure clean initial state
Network cluster_default  Creating
Network cluster_default  Created
Container cluster-master-1-1  Creating
Container cluster-master-2-1  Creating
Container cluster-master-2-1  Created
Container cluster-master-1-1  Created
Container cluster-master-2-1  Starting
Container cluster-master-1-1  Starting
Container cluster-master-2-1  Started
Container cluster-master-1-1  Started
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!none-1' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!none-2' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!rec-1' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!rec-2' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!problm-1' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!problm-2' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-2'."}]}
Container cluster-master-2-1  Stopping
Container cluster-master-2-1  Stopping
Container cluster-master-1-1  Stopping
Container cluster-master-1-1  Stopping
Container cluster-master-2-1  Stopped
Container cluster-master-2-1  Removing
Container cluster-master-2-1  Removed
Container cluster-master-1-1  Stopped
Container cluster-master-1-1  Removing
Container cluster-master-1-1  Removed
Network cluster_default  Removing
Network cluster_default  Removed
[2022-03-09T17:14:31+01:00] Starting master-1
Network cluster_default  Creating
Network cluster_default  Created
Container cluster-master-1-1  Creating
Container cluster-master-1-1  Created
Container cluster-master-1-1  Starting
Container cluster-master-1-1  Started
[2022-03-09T17:15:32+01:00] master-1 version
v2.13.2-73-gccb18a04e
[2022-03-09T17:15:32+01:00] Ensure all services are CRITICAL
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-2'."}]}
[2022-03-09T17:15:38+01:00] Schedule downtimes for all services
{"results":[{"code":200,"legacy_id":13,"name":"github-9207!none-1!ea4097d4-6d0d-43da-bc27-0197bb315f21","status":"Successfully scheduled downtime 'github-9207!none-1!ea4097d4-6d0d-43da-bc27-0197bb315f21' for object 'github-9207!none-1'."}]}
{"results":[{"code":200,"legacy_id":14,"name":"github-9207!none-2!ad18bade-2551-4895-a5c7-eb97c0f09b08","status":"Successfully scheduled downtime 'github-9207!none-2!ad18bade-2551-4895-a5c7-eb97c0f09b08' for object 'github-9207!none-2'."}]}
{"results":[{"code":200,"legacy_id":15,"name":"github-9207!rec-1!6e85f88c-abdf-433f-88e8-67855e92f8dd","status":"Successfully scheduled downtime 'github-9207!rec-1!6e85f88c-abdf-433f-88e8-67855e92f8dd' for object 'github-9207!rec-1'."}]}
{"results":[{"code":200,"legacy_id":16,"name":"github-9207!rec-2!a40baac8-eeab-48c6-8c29-1ae7a7f715ad","status":"Successfully scheduled downtime 'github-9207!rec-2!a40baac8-eeab-48c6-8c29-1ae7a7f715ad' for object 'github-9207!rec-2'."}]}
{"results":[{"code":200,"legacy_id":17,"name":"github-9207!problm-1!1976c770-e9f2-44c7-ab46-c070c4a848aa","status":"Successfully scheduled downtime 'github-9207!problm-1!1976c770-e9f2-44c7-ab46-c070c4a848aa' for object 'github-9207!problm-1'."}]}
{"results":[{"code":200,"legacy_id":18,"name":"github-9207!problm-2!a8c2a018-dbd6-4fac-9c89-398066df933f","status":"Successfully scheduled downtime 'github-9207!problm-2!a8c2a018-dbd6-4fac-9c89-398066df933f' for object 'github-9207!problm-2'."}]}
[2022-03-09T17:15:44+01:00] Make all services WARNING
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-2'."}]}
[2022-03-09T17:15:50+01:00] Bring services *-1 into final states
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-1'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-1'."}]}
[2022-03-09T17:15:56+01:00] Cancel downtimes for services *-1
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!none-1' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!rec-1' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!problm-1' and 0 child downtimes."}]}
[2022-03-09T17:16:56+01:00] Notification logs from master-1
cluster-master-1-1  | [2022-03-09 17:15:38 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!none-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:38 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!none-1!dummy-service-notification' for checkable 'github-9207!none-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!none-2!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!none-2!dummy-service-notification' for checkable 'github-9207!none-2' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!rec-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!rec-1!dummy-service-notification' for checkable 'github-9207!rec-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!rec-2!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!rec-2!dummy-service-notification' for checkable 'github-9207!rec-2' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!problm-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!problm-1!dummy-service-notification' for checkable 'github-9207!problm-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!problm-2!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:39 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!problm-2!dummy-service-notification' for checkable 'github-9207!problm-2' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:56 +0100] information/Notification: Sending 'DowntimeEnd' notification 'github-9207!none-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:56 +0100] information/Notification: Completed sending 'DowntimeEnd' notification 'github-9207!none-1!dummy-service-notification' for checkable 'github-9207!none-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:56 +0100] information/Notification: Sending 'DowntimeEnd' notification 'github-9207!rec-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:56 +0100] information/Notification: Completed sending 'DowntimeEnd' notification 'github-9207!rec-1!dummy-service-notification' for checkable 'github-9207!rec-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:56 +0100] information/Notification: Sending 'DowntimeEnd' notification 'github-9207!problm-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:56 +0100] information/Notification: Completed sending 'DowntimeEnd' notification 'github-9207!problm-1!dummy-service-notification' for checkable 'github-9207!problm-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Sending 'Problem' notification 'github-9207!problm-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Sending 'Recovery' notification 'github-9207!rec-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Completed sending 'Problem' notification 'github-9207!problm-1!dummy-service-notification' for checkable 'github-9207!problm-1' and user 'dummy' using command 'dummy'.
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Completed sending 'Recovery' notification 'github-9207!rec-1!dummy-service-notification' for checkable 'github-9207!rec-1' and user 'dummy' using command 'dummy'.
[2022-03-09T17:16:56+01:00] Notification logs from master-1 (filtered)
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Sending 'Problem' notification 'github-9207!problm-1!dummy-service-notification' for user 'dummy'
cluster-master-1-1  | [2022-03-09 17:15:59 +0100] information/Notification: Sending 'Recovery' notification 'github-9207!rec-1!dummy-service-notification' for user 'dummy'
[2022-03-09T17:16:56+01:00] Starting master-2
Container cluster-master-2-1  Creating
Container cluster-master-2-1  Created
Container cluster-master-2-1  Starting
Container cluster-master-2-1  Started
[2022-03-09T17:17:57+01:00] master-2 version
v2.13.2-73-gccb18a04e
[2022-03-09T17:17:57+01:00] Stopping master-1
Container cluster-master-1-1  Stopping
Container cluster-master-1-1  Stopped
[2022-03-09T17:19:00+01:00] Bring services *-2 into final states
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!none-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!rec-2'."}]}
{"results":[{"code":200,"status":"Successfully processed check result for object 'github-9207!problm-2'."}]}
[2022-03-09T17:19:05+01:00] Cancel downtimes for services *-2
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!none-2' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!rec-2' and 0 child downtimes."}]}
{"results":[{"code":200,"status":"Successfully removed all downtimes for object 'github-9207!problm-2' and 0 child downtimes."}]}
[2022-03-09T17:20:06+01:00] Notification logs from master-2
cluster-master-2-1  | [2022-03-09 17:17:02 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!none-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:17:02 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!none-2!dummy-service-notification' for checkable 'github-9207!none-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:17:02 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!rec-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:17:02 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!rec-2!dummy-service-notification' for checkable 'github-9207!rec-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:17:02 +0100] information/Notification: Sending 'DowntimeStart' notification 'github-9207!problm-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:17:02 +0100] information/Notification: Completed sending 'DowntimeStart' notification 'github-9207!problm-2!dummy-service-notification' for checkable 'github-9207!problm-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:19:06 +0100] information/Notification: Sending 'DowntimeEnd' notification 'github-9207!none-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:06 +0100] information/Notification: Completed sending 'DowntimeEnd' notification 'github-9207!none-2!dummy-service-notification' for checkable 'github-9207!none-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:19:06 +0100] information/Notification: Sending 'DowntimeEnd' notification 'github-9207!rec-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:06 +0100] information/Notification: Completed sending 'DowntimeEnd' notification 'github-9207!rec-2!dummy-service-notification' for checkable 'github-9207!rec-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:19:06 +0100] information/Notification: Sending 'DowntimeEnd' notification 'github-9207!problm-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:06 +0100] information/Notification: Completed sending 'DowntimeEnd' notification 'github-9207!problm-2!dummy-service-notification' for checkable 'github-9207!problm-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Sending 'Recovery' notification 'github-9207!rec-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Sending 'Problem' notification 'github-9207!problm-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Completed sending 'Recovery' notification 'github-9207!rec-2!dummy-service-notification' for checkable 'github-9207!rec-2' and user 'dummy' using command 'dummy'.
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Completed sending 'Problem' notification 'github-9207!problm-2!dummy-service-notification' for checkable 'github-9207!problm-2' and user 'dummy' using command 'dummy'.
[2022-03-09T17:20:06+01:00] Notification logs from master-2 (filtered)
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Sending 'Recovery' notification 'github-9207!rec-2!dummy-service-notification' for user 'dummy'
cluster-master-2-1  | [2022-03-09 17:19:09 +0100] information/Notification: Sending 'Problem' notification 'github-9207!problm-2!dummy-service-notification' for user 'dummy'
Container cluster-master-2-1  Stopping
Container cluster-master-2-1  Stopping
Container cluster-master-1-1  Stopping
Container cluster-master-1-1  Stopping
Container cluster-master-1-1  Stopped
Container cluster-master-1-1  Removing
Container cluster-master-1-1  Removed
Container cluster-master-2-1  Stopped
Container cluster-master-2-1  Removing
Container cluster-master-2-1  Removed
Network cluster_default  Removing
Network cluster_default  Removed
```
</details>

So if the unit tests are happy, I'm also happy.