### PR TITLE
Icinga DB: correct ack comments' is_sticky

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -243,7 +243,7 @@ Dictionary::Ptr ApiActions::AcknowledgeProblem(const ConfigObject::Ptr& object,
 	}
 
 	Comment::AddComment(checkable, CommentAcknowledgement, HttpUtility::GetLastParameter(params, "author"),
-		HttpUtility::GetLastParameter(params, "comment"), persistent, timestamp);
+		HttpUtility::GetLastParameter(params, "comment"), persistent, timestamp, sticky == AcknowledgementSticky);
 	checkable->AcknowledgeProblem(HttpUtility::GetLastParameter(params, "author"),
 		HttpUtility::GetLastParameter(params, "comment"), sticky, notify, persistent, Utility::GetTime(), timestamp);
 

--- a/lib/icinga/comment.cpp
+++ b/lib/icinga/comment.cpp
@@ -131,7 +131,7 @@ int Comment::GetNextCommentID()
 }
 
 String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryType, const String& author,
-	const String& text, bool persistent, double expireTime, const String& id, const MessageOrigin::Ptr& origin)
+	const String& text, bool persistent, double expireTime, bool sticky, const String& id, const MessageOrigin::Ptr& origin)
 {
 	String fullName;
 
@@ -147,6 +147,7 @@ String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryTyp
 	attrs->Set("persistent", persistent);
 	attrs->Set("expire_time", expireTime);
 	attrs->Set("entry_type", entryType);
+	attrs->Set("sticky", sticky);
 	attrs->Set("entry_time", Utility::GetTime());
 
 	Host::Ptr host;

--- a/lib/icinga/comment.hpp
+++ b/lib/icinga/comment.hpp
@@ -35,7 +35,7 @@ public:
 	static int GetNextCommentID();
 
 	static String AddComment(const intrusive_ptr<Checkable>& checkable, CommentType entryType,
-		const String& author, const String& text, bool persistent, double expireTime,
+		const String& author, const String& text, bool persistent, double expireTime, bool sticky = false,
 		const String& id = String(), const MessageOrigin::Ptr& origin = nullptr);
 
 	static void RemoveComment(const String& id, bool removedManually = false, const String& removedBy = "",

--- a/lib/icinga/comment.ti
+++ b/lib/icinga/comment.ti
@@ -66,6 +66,7 @@ class Comment : ConfigObject < CommentNameComposer
 	[config, enum] CommentType entry_type {
 		default {{{ return CommentUser; }}}
 	};
+	[config, no_user_view, no_user_modify] bool sticky;
 	[config, required] String author;
 	[config, required] String text;
 	[config] bool persistent;

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -616,7 +616,7 @@ void ExternalCommandProcessor::AcknowledgeSvcProblem(double, const std::vector<S
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Setting acknowledgement for service '" << service->GetName() << "'" << (notify ? "" : ". Disabled notification");
 
-	Comment::AddComment(service, CommentAcknowledgement, arguments[5], arguments[6], persistent, 0);
+	Comment::AddComment(service, CommentAcknowledgement, arguments[5], arguments[6], persistent, 0, sticky);
 	service->AcknowledgeProblem(arguments[5], arguments[6], sticky ? AcknowledgementSticky : AcknowledgementNormal, notify, persistent);
 }
 
@@ -646,7 +646,7 @@ void ExternalCommandProcessor::AcknowledgeSvcProblemExpire(double, const std::ve
 	Log(LogNotice, "ExternalCommandProcessor")
 		<< "Setting timed acknowledgement for service '" << service->GetName() << "'" << (notify ? "" : ". Disabled notification");
 
-	Comment::AddComment(service, CommentAcknowledgement, arguments[6], arguments[7], persistent, timestamp);
+	Comment::AddComment(service, CommentAcknowledgement, arguments[6], arguments[7], persistent, timestamp, sticky);
 	service->AcknowledgeProblem(arguments[6], arguments[7], sticky ? AcknowledgementSticky : AcknowledgementNormal, notify, persistent, timestamp);
 }
 
@@ -690,7 +690,7 @@ void ExternalCommandProcessor::AcknowledgeHostProblem(double, const std::vector<
 		BOOST_THROW_EXCEPTION(std::invalid_argument("The host '" + arguments[1] + "' is already acknowledged."));
 	}
 
-	Comment::AddComment(host, CommentAcknowledgement, arguments[4], arguments[5], persistent, 0);
+	Comment::AddComment(host, CommentAcknowledgement, arguments[4], arguments[5], persistent, 0, sticky);
 	host->AcknowledgeProblem(arguments[4], arguments[5], sticky ? AcknowledgementSticky : AcknowledgementNormal, notify, persistent);
 }
 
@@ -720,7 +720,7 @@ void ExternalCommandProcessor::AcknowledgeHostProblemExpire(double, const std::v
 		BOOST_THROW_EXCEPTION(std::invalid_argument("The host '" + arguments[1] + "' is already acknowledged."));
 	}
 
-	Comment::AddComment(host, CommentAcknowledgement, arguments[5], arguments[6], persistent, timestamp);
+	Comment::AddComment(host, CommentAcknowledgement, arguments[5], arguments[6], persistent, timestamp, sticky);
 	host->AcknowledgeProblem(arguments[5], arguments[6], sticky ? AcknowledgementSticky : AcknowledgementNormal, notify, persistent, timestamp);
 }
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1380,7 +1380,7 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 		attributes->Set("entry_type", comment->GetEntryType());
 		attributes->Set("entry_time", TimestampToMilliseconds(comment->GetEntryTime()));
 		attributes->Set("is_persistent", comment->GetPersistent());
-		attributes->Set("is_sticky", comment->GetEntryType() == CommentAcknowledgement && comment->GetCheckable()->GetAcknowledgement() == AcknowledgementSticky);
+		attributes->Set("is_sticky", comment->GetSticky());
 
 		Host::Ptr host;
 		Service::Ptr service;
@@ -1985,7 +1985,7 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 		"comment", Utility::ValidateUTF8(comment->GetText()),
 		"entry_type", Convert::ToString(comment->GetEntryType()),
 		"is_persistent", Convert::ToString((unsigned short)comment->GetPersistent()),
-		"is_sticky", Convert::ToString((unsigned short)(comment->GetEntryType() == CommentAcknowledgement && comment->GetCheckable()->GetAcknowledgement() == AcknowledgementSticky)),
+		"is_sticky", Convert::ToString((unsigned short)comment->GetSticky()),
 		"event_id", CalcEventID("comment_add", comment),
 		"event_type", "comment_add"
 	});
@@ -2042,7 +2042,7 @@ void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 		"comment", Utility::ValidateUTF8(comment->GetText()),
 		"entry_type", Convert::ToString(comment->GetEntryType()),
 		"is_persistent", Convert::ToString((unsigned short)comment->GetPersistent()),
-		"is_sticky", Convert::ToString((unsigned short)(comment->GetEntryType() == CommentAcknowledgement && comment->GetCheckable()->GetAcknowledgement() == AcknowledgementSticky)),
+		"is_sticky", Convert::ToString((unsigned short)comment->GetSticky()),
 		"event_id", CalcEventID("comment_remove", comment),
 		"event_type", "comment_remove"
 	});


### PR DESCRIPTION
On ack Icinga first adds a comment, then acks the checkable
    so the ack event has the comment ID.

  But due to the yet missing ack the comment was missing is_sticky.
    That's corrected now.