### PR TITLE
IcingaDB#SendRemovedComment(): ignore ack comments like #SendAddedComment()

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2022,7 +2022,7 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 
 void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 {
-	if (!GetActive()) {
+	if (comment->GetEntryType() != CommentUser || !GetActive()) {
 		return;
 	}
 


### PR DESCRIPTION
Icinga DB doesn't expect comment history for ack comments.

Before:

1. Acked checkable recovers
2. Icinga clears ack comments w/o setting removal time
3. Icinga DB gets neither removal time, nor expire time
4. Icinga DB falls back to NULL and violates NOT NULL constraint