### PR TITLE
Update 03-monitoring-basics.md

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -1572,12 +1572,18 @@ send notifications to all group members.
 > Only users who have been notified of a problem before  (`Warning`, `Critical`, `Unknown`
 states for services, `Down` for hosts) will receive `Recovery` notifications.
 
-Icinga 2 v2.10 allows you to configure `Acknowledgement` and/or `Recovery`
+Icinga 2 v2.10 allows you to configure a `User` object with `Acknowledgement` and/or `Recovery`
 without a `Problem` notification. These notifications will be sent without
 any problem notifications beforehand, and can be used for e.g. ticket systems.
 
 ```
+object User "ticketadmin" {
+  display_name = "Ticket Admin"
+  enable_notifications = true
+  states = [ OK, Warning, Critical ]
   types = [ Acknowledgement, Recovery ]
+  email = "ticket@localhost"
+}
 ```
 
 ### Notifications: Users from Host/Service <a id="alert-notifications-users-host-service"></a>


### PR DESCRIPTION
Fix misleading statement:

```
  types = [ Acknowledgement, Recovery ]
```
right after a Notification config block will not help as this will only work on a `User` object.