### PR TITLE
Add nrpe v3 parameter in ITL

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -2321,6 +2321,10 @@ object CheckCommand "nrpe" {
 			set_if = "$nrpe_version_2$"
 			description = "Use this if you want to connect to NRPE v2"
 		}
+		"-3" = {
+			set_if = "$nrpe_version_3$"
+			description = "Use this if you want to use NRPE v3 (with increased payload size)"
+		}
 		"-P" = {
 			value = "$nrpe_payload_size$"
 			description = "Specify non-default payload size for NSClient++"


### PR DESCRIPTION
This adds the `-3` parameter to the nrpe check command. 
This parameter allows to transmit much more data through NRPE than NRPEv2.

From the check_nrpe 4.x help output:

```
 -3, --v3-packets-only        Only use version 3 packets, not version 4
```
