### PR TITLE
IDO MySQL: explicitly use latin1

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -262,6 +262,8 @@ void IdoMysqlConnection::Reconnect()
 		BOOST_THROW_EXCEPTION(std::bad_alloc());
 	}
 
+	m_Mysql->options(&m_Connection, MYSQL_SET_CHARSET_NAME, "latin1");
+
 	if (enableSsl)
 		m_Mysql->ssl_set(&m_Connection, sslKey, sslCert, sslCa, sslCaPath, sslCipher);
 

--- a/lib/mysql_shim/mysqlinterface.cpp
+++ b/lib/mysql_shim/mysqlinterface.cpp
@@ -92,6 +92,11 @@ struct MysqlInterfaceImpl final : public MysqlInterface
 		return mysql_real_escape_string(mysql, to, from, length);
 	}
 
+	int options(MYSQL *mysql, mysql_option option, const void *arg) const override
+	{
+		return mysql_options(mysql, option, arg);
+	}
+
 	bool ssl_set(MYSQL *mysql, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher) const override
 	{
 		return mysql_ssl_set(mysql, key, cert, ca, capath, cipher);

--- a/lib/mysql_shim/mysqlinterface.hpp
+++ b/lib/mysql_shim/mysqlinterface.hpp
@@ -35,6 +35,7 @@ struct MysqlInterface
 	virtual MYSQL *real_connect(MYSQL *mysql, const char *host, const char *user, const char *passwd,
 		const char *db, unsigned int port, const char *unix_socket, unsigned long clientflag) const = 0;
 	virtual unsigned long real_escape_string(MYSQL *mysql, char *to, const char *from, unsigned long length) const = 0;
+	virtual int options(MYSQL *mysql, mysql_option option, const void *arg) const = 0;
 	virtual bool ssl_set(MYSQL *mysql, const char *key, const char *cert, const char *ca, const char *capath, const char *cipher) const = 0;
 	virtual MYSQL_RES *store_result(MYSQL *mysql) const = 0;
 	virtual unsigned int thread_safe() const = 0;


### PR DESCRIPTION
for the case the MySQL client lib is compiled with another default
not to turn Unicode chars into ??.