### PR TITLE
Revert "Service#GetSeverity(): behave as the respective IDO query of Icinga Web"

### DIFF
--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -137,7 +137,7 @@ int Service::GetSeverity() const
 
 		Host::Ptr host = GetHost();
 		ObjectLock hlock (host);
-		if (host->GetState() != HostUp) {
+		if (host->GetState() != HostUp || !host->IsReachable()) {
 			severity += 1024;
 		} else {
 			if (IsAcknowledged())


### PR DESCRIPTION
Reverts Icinga/icinga2#9245

The severity is only used for Icinga DB within the Icinga 2 code base. This change was only done as a prerequisite of https://github.com/Icinga/icinga2/pull/9154 which is for Icinga DB. Therefore, there is no reason for changing this value within the 2.12 branch.