### PR TITLE
Perfdata writers: disconnect handlers from signals in Pause()

### DIFF
--- a/lib/perfdata/elasticsearchwriter.hpp
+++ b/lib/perfdata/elasticsearchwriter.hpp
@@ -31,6 +31,7 @@ protected:
 private:
 	String m_EventPrefix;
 	WorkQueue m_WorkQueue{10000000, 1};
+	boost::signals2::connection m_HandleCheckResults, m_HandleStateChanges, m_HandleNotifications;
 	Timer::Ptr m_FlushTimer;
 	std::vector<String> m_DataBuffer;
 	std::mutex m_DataBufferMutex;

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -36,6 +36,7 @@ private:
 	OptionalTlsStream m_Stream;
 	WorkQueue m_WorkQueue{10000000, 1};
 
+	boost::signals2::connection m_HandleCheckResults, m_HandleNotifications, m_HandleStateChanges;
 	Timer::Ptr m_ReconnectTimer;
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -95,7 +95,8 @@ void GraphiteWriter::Resume()
 	m_ReconnectTimer->Reschedule(0);
 
 	/* Register event handlers. */
-	Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
+	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,
+		const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
 		CheckResultHandler(checkable, cr);
 	});
 }
@@ -105,6 +106,7 @@ void GraphiteWriter::Resume()
  */
 void GraphiteWriter::Pause()
 {
+	m_HandleCheckResults.disconnect();
 	m_ReconnectTimer.reset();
 
 	try {

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -41,6 +41,7 @@ private:
 	std::mutex m_StreamMutex;
 	WorkQueue m_WorkQueue{10000000, 1};
 
+	boost::signals2::connection m_HandleCheckResults;
 	Timer::Ptr m_ReconnectTimer;
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -97,7 +97,8 @@ void InfluxdbCommonWriter::Resume()
 	m_FlushTimer->Reschedule(0);
 
 	/* Register for new metrics. */
-	Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
+	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,
+		const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
 		CheckResultHandler(checkable, cr);
 	});
 }
@@ -105,6 +106,8 @@ void InfluxdbCommonWriter::Resume()
 /* Pause is equivalent to Stop, but with HA capabilities to resume at runtime. */
 void InfluxdbCommonWriter::Pause()
 {
+	m_HandleCheckResults.disconnect();
+
 	/* Force a flush. */
 	Log(LogDebug, GetReflectionType()->GetName())
 		<< "Flushing pending data buffers.";

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -49,6 +49,7 @@ protected:
 	virtual Url::Ptr AssembleUrl() = 0;
 
 private:
+	boost::signals2::connection m_HandleCheckResults;
 	Timer::Ptr m_FlushTimer;
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -81,7 +81,7 @@ void OpenTsdbWriter::Resume()
 	m_ReconnectTimer->Start();
 	m_ReconnectTimer->Reschedule(0);
 
-	Service::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
+	m_HandleCheckResults = Service::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
 		CheckResultHandler(checkable, cr);
 	});
 }
@@ -91,6 +91,7 @@ void OpenTsdbWriter::Resume()
  */
 void OpenTsdbWriter::Pause()
 {
+	m_HandleCheckResults.disconnect();
 	m_ReconnectTimer.reset();
 
 	Log(LogInformation, "OpentsdbWriter")

--- a/lib/perfdata/opentsdbwriter.hpp
+++ b/lib/perfdata/opentsdbwriter.hpp
@@ -37,6 +37,7 @@ protected:
 private:
 	Shared<AsioTcpStream>::Ptr m_Stream;
 
+	boost::signals2::connection m_HandleCheckResults;
 	Timer::Ptr m_ReconnectTimer;
 
 	Dictionary::Ptr m_ServiceConfigTemplate;

--- a/lib/perfdata/perfdatawriter.cpp
+++ b/lib/perfdata/perfdatawriter.cpp
@@ -53,7 +53,8 @@ void PerfdataWriter::Resume()
 	Log(LogInformation, "PerfdataWriter")
 		<< "'" << GetName() << "' resumed.";
 
-	Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
+	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,
+		const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
 		CheckResultHandler(checkable, cr);
 	});
 
@@ -68,6 +69,7 @@ void PerfdataWriter::Resume()
 
 void PerfdataWriter::Pause()
 {
+	m_HandleCheckResults.disconnect();
 	m_RotationTimer.reset();
 
 #ifdef I2_DEBUG

--- a/lib/perfdata/perfdatawriter.hpp
+++ b/lib/perfdata/perfdatawriter.hpp
@@ -34,6 +34,7 @@ protected:
 	void Pause() override;
 
 private:
+	boost::signals2::connection m_HandleCheckResults;
 	Timer::Ptr m_RotationTimer;
 	std::ofstream m_ServiceOutputFile;
 	std::ofstream m_HostOutputFile;


### PR DESCRIPTION
as they would be re-connected in Resume() (HA).

Before they were still connected during pause and connected X+1 times
after X split-brains (the same data was written X+1 times).

Backport of #9321