### PR TITLE
Windows packaging repo no longer requires update for newer dependencies

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -94,7 +94,6 @@ Fix incompatibilities if any.
 
 * https://git.icinga.com/infra/ansible-windows-build
   (don't forget to provision!)
-* https://git.icinga.com/packaging/windows-icinga2
 * [doc/21-development.md](doc/21-development.md)
 * [doc/win-dev.ps1](doc/win-dev.ps1)
   (also affects CI/CD)


### PR DESCRIPTION
Since commit https://git.icinga.com/packaging/windows-icinga2/-/commit/07b16da2500bcd69bad9c6d0b2b7af4f968fc47e in the windows-icinga2 packaging repo, the versions of build dependencies are controlled from this repo (icinga2). So the other repo no longer needs to be updated for newer dependencies.