### PR TITLE
Take host state into account when sending suppressed notifications

### DIFF
--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -155,6 +155,17 @@ void Checkable::FireSuppressedNotifications()
 			}
 
 			auto threshold (cr->GetExecutionStart());
+			Host::Ptr host;
+			Service::Ptr service;
+			tie(host, service) = GetHostService(this);
+
+			if (service) {
+				ObjectLock oLock (host);
+
+				if (!host->GetProblem() && host->GetLastStateChange() >= threshold) {
+					return true;
+				}
+			}
 
 			for (auto& dep : GetDependencies()) {
 				auto parent (dep->GetParent());


### PR DESCRIPTION
`Checkable::FireSuppressedNotifications()` compares the time of the current checkable with the last recovery time of parents to avoid notification right after a parent recovered and before the current checkable was checked.

This commit makes this check also include to host if the checkable is a service.  This makes the behavior consistent with the documentation that states there is an implicit dependency on the host (which isn't realized as implicitly generating a Dependency object unfortunately).

ref/IP/38985
ref/NC/747622

## Tests

Config snippet (needs standard notification apply rules):
```
object Host "ip-38985" {
        check_command = "dummy"
        check_interval = 5s
        retry_interval = 5s
        vars.dummy_state = {{ if (get_time() % 120 < 60) { 0 } else { 2 } }}
}

for (i in range(100)) {
        object Service i {
                host_name = "ip-38985"
                check_command = "dummy"
                check_interval = 7s
                retry_interval = 7s
                vars.dummy_state = {{ if (get_time() % 120 < 60) { 0 } else { 2 } }}
        }
}
```

### Before

Every 2 minute cycle looks something like this: first, the host receives a problem notification, then a recovery notification and after that, a bunch of random services receive a suppressed notification (not visible in the logs that it's a suppressed one, but the hard state is reached for all services well before the host recovers) and a recovery notification shortly after.

```
[2022-04-19 15:57:13 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 15:58:03 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!15!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!63!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!82!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!72!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!30!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!84!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!29!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!71!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!21!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!4!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!7!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!63!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!84!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!72!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!30!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!82!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:05 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!15!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:06 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!7!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:06 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!29!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:06 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!71!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:06 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!21!dummy-service-notification' for user 'dummy'
[2022-04-19 15:58:06 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!4!dummy-service-notification' for user 'dummy'
```

### After

Even when letting this run for a a longer time, only the host receives notifications:

```
[2022-04-19 16:23:11 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:24:01 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:25:11 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:26:01 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:27:11 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:28:01 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:29:11 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:30:01 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:31:11 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:32:01 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:33:11 +0200] information/Notification: Sending 'Problem' notification 'ip-38985!dummy-host-notification' for user 'dummy'
[2022-04-19 16:34:01 +0200] information/Notification: Sending 'Recovery' notification 'ip-38985!dummy-host-notification' for user 'dummy'
```