### PR TITLE
Fix mixed up arguments for AddDowntime/RemoveDowntime in 2.12.x

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -457,7 +457,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 						<< "Creating downtime for service " << childService->GetName() << " on child host " << childHost->GetName();
 
 					Downtime::Ptr serviceDowntime = Downtime::AddDowntime(childService, author, comment, startTime, endTime,
-						fixed, triggerName, duration, String(), String(), childDowntimeName);
+						fixed, triggerName, duration);
 					String serviceDowntimeName = serviceDowntime->GetName();
 
 					childServiceDowntimes.push_back(new Dictionary({

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -323,7 +323,7 @@ void ScheduledDowntime::RemoveObsoleteDowntimes()
 			auto configOwnerHash (downtime->GetConfigOwnerHash());
 
 			if (!configOwnerHash.IsEmpty() && configOwnerHash != downtimeOptionsHash)
-				Downtime::RemoveDowntime(downtime->GetName(), false, true);
+				Downtime::RemoveDowntime(downtime->GetName(), true);
 		}
 	}
 }


### PR DESCRIPTION
PRs #8879 and #9184 backported calls to these functions without properly considering the different signatures on the support/2.12 branch. This PR fixes the affected calls, for more details (i.e. functions signature used and arguments with different versions side by side), please take a look at the individual commit messages.

fixes #9345

## Test

Repeating the test from #8990 on this branch.

### Before
```console
$ curl -iskSu root:icinga -H 'Accept: application/json' -X POST "https://127.0.0.1:5665/v1/actions/schedule-downtime" -d '{"type":"Host", "filter":"host.name == \"github-8989-parent\"", "start_time":'$(date +%s)', "end_time":'$(date -d +5min +%s)', "author":"icingaadmin", "comment":"42", "pretty":true, "all_services":1, "child_options":"DowntimeTriggeredChildren"}'
HTTP/1.1 500 Internal Server Error
Server: Icinga/v2.12.7
Content-Type: application/json
Content-Length: 161

{
    "results": [
        {
            "code": 500.0,
            "status": "Action execution failed: 'Error: Could not create downtime.\n'."
        }
    ]
}
```

### After
```console
$ curl -iskSu root:icinga -H 'Accept: application/json' -X POST "https://127.0.0.1:5665/v1/actions/schedule-downtime" -d '{"type":"Host", "filter":"host.name == \"github-8989-parent\"", "start_time":'$(date +%s)', "end_time":'$(date -d +5min +%s)', "author":"icingaadmin", "comment":"42", "pretty":true, "all_services":1, "child_options":"DowntimeTriggeredChildren"}'
HTTP/1.1 200 OK
Server: Icinga/v2.12.7-2-gd281107f3
Content-Type: application/json
Content-Length: 1632

{
    "results": [
        {
            "child_downtimes": [
                {
                    "legacy_id": 19.0,
                    "name": "github-8989-child2!github-8989-service1!f37aea45-4872-44b0-a3aa-35a9f6515849"
                },
                {
                    "legacy_id": 20.0,
                    "name": "github-8989-child1!96fe9bd5-0064-45b4-a5fb-a4d3557c3a25",
                    "service_downtimes": [
                        {
                            "legacy_id": 21.0,
                            "name": "github-8989-child1!github-8989-service1!1dc4c4d5-a7e6-4e82-90de-8c9fdef8cc12"
                        },
                        {
                            "legacy_id": 22.0,
                            "name": "github-8989-child1!github-8989-service2!10a7ce55-bc57-4e7f-9173-a4b21ba82ea7"
                        }
                    ]
                }
            ],
            "code": 200.0,
            "legacy_id": 16.0,
            "name": "github-8989-parent!627a4bab-579b-4575-8396-edd6452bbe8b",
            "service_downtimes": [
                {
                    "legacy_id": 17.0,
                    "name": "github-8989-parent!github-8989-service1!839f8a65-36af-454c-a8dd-6eb8ab2892d1"
                },
                {
                    "legacy_id": 18.0,
                    "name": "github-8989-parent!github-8989-service2!c8360881-e361-44e4-a533-1ab3dc3fa839"
                }
            ],
            "status": "Successfully scheduled downtime 'github-8989-parent!627a4bab-579b-4575-8396-edd6452bbe8b' for object 'github-8989-parent'."
        }
    ]
}
```