### PR TITLE
Return correct status codes in process-check-result API

### DIFF
--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -111,7 +111,14 @@ public:
 
 	void ExecuteRemoteCheck(const Dictionary::Ptr& resolvedMacros = nullptr);
 	void ExecuteCheck();
-	void ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrigin::Ptr& origin = nullptr);
+	enum class ProcessingResult
+	{
+		Ok,
+		NoCheckResult,
+		CheckableInactive,
+		NewerCheckResultPresent,
+	};
+	ProcessingResult ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrigin::Ptr& origin = nullptr);
 
 	Endpoint::Ptr GetCommandEndpoint() const;
 


### PR DESCRIPTION
Hi all!

This PR addresses the issue https://github.com/Icinga/icinga2/issues/9353.

fixes #9353

In the implementation we modified the `ProcessCheckResult` function in order to return an enum that describes the actual result of the function. In the `ApiActions::ProcessCheckResult` function we check the returned enum and create a result with an appropriate code and status message.
Please let us know if you think other status codes can be more appropriate.

Below you find some curl request with which we can test the changes, in particular to check that the API returns an appropriate reply when we send a process-check-result with an older timestamp with respect to the last check result of the host. 


### Tests
Initial process-check-result:

`curl -v -k -u root:<pwd> 'https://localhost:5665/v1/actions/process-check-result' -H 'accept: application/json' -XPOST -d '{"type": "Host", "host": "my-host", "exit_status": 1, "plugin_output": "initial pcr", "execution_start": "1650553018.000000", "execution_end": "1650553018.000000"}'`
should return
`{"results":[{"code":200.0,"status":"Successfully processed check result for object 'my-host'."}]}`

Process-check-result with older `execution_start:`

`curl -v -k -u root:<pwd> 'https://localhost:5665/v1/actions/process-check-result' -H 'accept: application/json' -XPOST -d '{"type": "Host", "host": "my-host", "exit_status": 1, "plugin_output": "pcr with older timestamp", "execution_start": "1650553017.000000", "execution_end": "1650553017.000000"}'`
should return:
`{"results":[{"code":409.0,"status":"Newer check result already present. Check result for 'my-host' was discarded."}]}`


Process-check-result with newer `execution_start`:

`curl -v -k -u root:<pwd> 'https://localhost:5665/v1/actions/process-check-result' -H 'accept: application/json' -XPOST -d '{"type": "Host", "host": "my-host", "exit_status": 1, "plugin_output": "pcr with newer timestamp", "execution_start": "1650553019.000000", "execution_end": "1650553019.000000"}'`
should return:
`{"results":[{"code":200.0,"status":"Successfully processed check result for object 'my-host'."}]}`