### PR TITLE
Replace `EventuallyAtomic` with `AtomicOrLocked` which falls back to a mutex

### DIFF
--- a/lib/base/configobject.ti
+++ b/lib/base/configobject.ti
@@ -59,10 +59,11 @@ abstract class ConfigObject : ConfigObjectBase < ConfigType
 	[config, no_user_modify] String __name (Name);
 	[config, no_user_modify] String "name" (ShortName) {
 		get {{{
-			if (m_ShortName.m_Value.IsEmpty())
+			String shortName = m_ShortName.load();
+			if (shortName.IsEmpty())
 				return GetName();
 			else
-				return m_ShortName.m_Value;
+				return shortName;
 		}}}
 	};
 	[config, no_user_modify] name(Zone) zone (ZoneName);

--- a/lib/icinga/host.ti
+++ b/lib/icinga/host.ti
@@ -21,10 +21,11 @@ class Host : Checkable
 
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 

--- a/lib/icinga/hostgroup.ti
+++ b/lib/icinga/hostgroup.ti
@@ -11,10 +11,11 @@ class HostGroup : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -33,10 +33,11 @@ class Service : Checkable < ServiceNameComposer
 
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetShortName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 	[config, required] name(Host) host_name;

--- a/lib/icinga/servicegroup.ti
+++ b/lib/icinga/servicegroup.ti
@@ -11,10 +11,11 @@ class ServiceGroup : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 

--- a/lib/icinga/timeperiod.ti
+++ b/lib/icinga/timeperiod.ti
@@ -12,10 +12,11 @@ class TimePeriod : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 	[config, signal_with_old_value] Dictionary::Ptr ranges;

--- a/lib/icinga/user.ti
+++ b/lib/icinga/user.ti
@@ -13,10 +13,11 @@ class User : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 	[config, no_user_modify, required, signal_with_old_value] array(name(UserGroup)) groups {

--- a/lib/icinga/usergroup.ti
+++ b/lib/icinga/usergroup.ti
@@ -11,10 +11,11 @@ class UserGroup : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			if (m_DisplayName.m_Value.IsEmpty())
+			String displayName = m_DisplayName.load();
+			if (displayName.IsEmpty())
 				return GetName();
 			else
-				return m_DisplayName.m_Value;
+				return displayName;
 		}}}
 	};
 

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -1060,7 +1060,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			if (field.Attributes & FANoStorage)
 				continue;
 
-			m_Header << "\tEventuallyAtomic<" << field.Type.GetRealType() << ">::type m_" << field.GetFriendlyName() << ";" << std::endl;
+			m_Header << "\tAtomicOrLocked<" << field.Type.GetRealType() << "> m_" << field.GetFriendlyName() << ";" << std::endl;
 		}
 		
 		/* signal */


### PR DESCRIPTION
Apparently there was a reason for making the members of generated classes atomic. However, this was only done for some types, others were still accessed using non-atomic operations. For members of type `T::Ptr` (i.e.  `intrusive_ptr<T>`), this can result in a double free when multiple threads access the same variable and at least one of them writes to the variable.

This commit makes use of `std::atomic<T>` for more `T` (it removes the additional constraint `sizeof(T) <= sizeof(void*)`) and uses a type including a mutex for load and store operations as a fallback.

### Context

There isn't really much to test here, we received a crash dump from which I'm pretty sure what's above is what happened there, but I wasn't able to reproduce it (timing is crucial as two very short operations have to overlap perfectly, so to get a good chance of hitting it, you probably have to run Icinga for a while).

```
Stacktrace:
 0# icinga::Application::SigAbrtHandler(int) in /usr/lib64/icinga2/sbin/icinga2
 1# 0x00007F66DD81D630 in /lib64/libpthread.so.0
 2# gsignal in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# 0x00007F66DD4B8F67 in /lib64/libc.so.6
 5# 0x00007F66DD4C1329 in /lib64/libc.so.6
 6# icinga::ObjectImpl<icinga::CheckResult>::~ObjectImpl() in /usr/lib64/icinga2/sbin/icinga2
 7# icinga::ObjectImpl<icinga::CheckResult>::~ObjectImpl() in /usr/lib64/icinga2/sbin/icinga2
 8# icinga::Dependency::IsAvailable(icinga::DependencyType) const in /usr/lib64/icinga2/sbin/icinga2
 9# icinga::Checkable::IsReachable(icinga::DependencyType, boost::intrusive_ptr<icinga::Dependency>*, int) const in /usr/lib64/icinga2/sbin/icinga2
10# icinga::Checkable::ProcessCheckResult(boost::intrusive_ptr<icinga::CheckResult> const&, boost::intrusive_ptr<icinga::MessageOrigin> const&) in /usr/lib64/icinga2/sbin/icinga2
11# icinga::PluginCheckTask::ProcessFinishedHandler(boost::intrusive_ptr<icinga::Checkable> const&, boost::intrusive_ptr<icinga::CheckResult> const&, icinga::Value const&, icinga::ProcessResult const&) in /usr/lib64/icinga2/sbin/icinga2
12# bool icinga::ThreadPool::Post<std::function<void ()> >(std::function<void ()>, icinga::SchedulerPolicy)::{lambda()#1}::operator()() const in /usr/lib64/icinga2/sbin/icinga2
13# boost::asio::detail::executor_op<boost::asio::detail::work_dispatcher<bool icinga::ThreadPool::Post<std::function<void ()> >(std::function<void ()>, icinga::SchedulerPolicy)::{lambda()#1}>, std::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, std::allocator<void>*, boost::system::error_code const&, unsigned long) in /usr/lib64/icinga2/sbin/icinga2
14# boost::asio::detail::scheduler::run(boost::system::error_code&) in /usr/lib64/icinga2/sbin/icinga2
15# boost::asio::detail::posix_thread::func<boost::asio::thread_pool::thread_function>::run() in /usr/lib64/icinga2/sbin/icinga2
16# boost_asio_detail_posix_thread_function in /usr/lib64/icinga2/sbin/icinga2
17# 0x00007F66DD815EA5 in /lib64/libpthread.so.0
18# clone in /lib64/libc.so.6
```

GDB dump showed more detailed context where `~ObjectImpl` was invoked:

```
#14 icinga::Dependency::IsAvailable (this=0x7f65fc41e4f0, dt=dt@entry=icinga::DependencyState) at ../icinga/dependency.cpp:118
```

Which is this line:

https://github.com/Icinga/icinga2/blob/31c4ba31b860f87ab41b930da720a1cad8bc53dc/lib/icinga/dependency.cpp#L118

### Alternatives

I considered the following alternatives:
* Not using a new mutex but use the mutex within the object for locking (i.e. `ObjectLock`): as that's a `std::recursive_mutex`, you might save some locking operations, however, there's a pretty good chance that this would introduce deadlocks. With a separate mutex, that isn't an issue because no other lock is acquired while it is held (unless you'd deliberately build some types that do that when they are copied).
* Properly locking when accessing member variables: it definitely looks like the `EventuallyAtomic<T>` construction was there for a reason, so doing so would basically require auditing and reworking locking throughout the whole code. Just look at the crash above, this is a simple read operation on a pointer that causes a problem here, all of these would have to be considered, including the deadlock considerations from the previous point. So I'd say this would be infeasible if we would want to get this fixed any time soon.

ref/IP/37271