### PR TITLE
RHEL8 doesn't have a rhel-8-server-optional-rpms repo

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -141,7 +141,6 @@ repository before installing the [EPEL rpm package](https://fedoraproject.org/wi
 ```bash
 ARCH=$( /bin/arch )
 
-subscription-manager repos --enable rhel-8-server-optional-rpms
 subscription-manager repos --enable "codeready-builder-for-rhel-8-${ARCH}-rpms"
 
 dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm


### PR DESCRIPTION
Remove rhel-8-server-optional-rpms from documentation because it doesn't exist in RHEL8
see Issue#9380