### PR TITLE
IcingaDB: handle null (Empty) for value/set_if/separator in command arguments

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -996,6 +996,7 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 					// Stringify if set.
 					if (values->Get(attr, &value)) {
 						switch (value.GetType()) {
+							case ValueEmpty:
 							case ValueString:
 								break;
 							case ValueObject:


### PR DESCRIPTION
backport of #9371