### PR TITLE
Release 2.12.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga2/milestones?state=closed).
 
+## 2.12.9 (2022-06-30)
+
+This release includes some fixes and a performance improvement
+resulting in faster config validation and reload times.
+
+### Bugfixes
+
+* Fix a race-condition involving object attribute updates that could result in a crash. #9394
+* Speed up config validation by avoiding redundant serialization of objects. #9401
+* Windows: Update bundled version OpenSSL. #9414
+
 ## 2.12.8 (2022-04-28)
 
 In the previous version 2.12.7, one bugfix was applied incorrectly. This is fixed by this release.

--- a/ICINGA2_VERSION
+++ b/ICINGA2_VERSION
@@ -1,2 +1,2 @@
-Version: 2.12.8
+Version: 2.12.9
 Revision: 1


### PR DESCRIPTION
Version bump and changelog

## TODO

* [x] Add release date
* [x] Create PRs for the OpenSSL update and add them here (there's a release [announced](https://mta.openssl.org/pipermail/openssl-announce/2022-June/000225.html) for 2022-06-21)