### PR TITLE
Icinga DB: make error message more helpful if API isn't set up

### DIFF
--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -292,7 +292,14 @@ void IcingaDB::InitEnvironmentId()
 				}
 			}
 		} else {
-			std::shared_ptr<X509> cert = GetX509Certificate(ApiListener::GetDefaultCaPath());
+			String caPath = ApiListener::GetDefaultCaPath();
+
+			if (!Utility::PathExists(caPath)) {
+				throw std::runtime_error("Cannot find the CA certificate at '" + caPath + "'. "
+					"Please ensure the ApiListener is enabled first using 'icinga2 api setup'.");
+			}
+
+			std::shared_ptr<X509> cert = GetX509Certificate(caPath);
 
 			unsigned int n;
 			unsigned char digest[EVP_MAX_MD_SIZE];


### PR DESCRIPTION
Icinga DB depends on the ApiListener for generating the environment ID based on the CA certificate. If there is no certificate, give a more helpful message including a hint how to fix the error.

### Before
```
[2022-06-17 12:47:15 +0000] critical/SSL: Error on bio X509 AUX reading pem file '/var/lib/icinga2/certs//ca.crt': 33558530, "error:02001002:system library:fopen:No such file or directory"
[2022-06-17 12:47:15 +0000] critical/config: Error: Validation failed for object 'icingadb' of type 'IcingaDB': Validation failed: std::exception
Location: in /icinga2.conf: 1:0-1:25
/icinga2.conf(1): object IcingaDB "icingadb" {}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
/icinga2.conf(2): 
[2022-06-17 12:47:15 +0000] critical/config: 1 error
[2022-06-17 12:47:15 +0000] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

### After
```
[2022-06-20 13:05:37 +0000] critical/config: Error: Validation failed for object 'icingadb' of type 'IcingaDB': Validation failed: Cannot find the CA certificate at '/var/lib/icinga2/certs//ca.crt'. Please ensure the ApiListener is enabled first using 'icinga2 api setup'.
Location: in /icinga2.conf: 1:0-1:25
/icinga2.conf(1): object IcingaDB "icingadb" {}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
/icinga2.conf(2): 
[2022-06-20 13:05:37 +0000] critical/config: 1 error
[2022-06-20 13:05:37 +0000] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```