### PR TITLE
ConfigItem: Fix infinite recursion caused by `ignore_on_error` when …

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -470,7 +470,14 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 				if (item->m_Type != type)
 					return;
 
-				ip.first->Commit(ip.second);
+				if (!item->Commit(ip.second)) {
+					if (item->IsIgnoreOnError()) {
+						item->Unregister();
+					}
+
+					return;
+				}
+
 				committed_items++;
 			});
 


### PR DESCRIPTION
…committing an item

When committing an item with `ignore_on_error` flag set fails, the `Commit()` method only returns `nullptr`
and the current item is not being dropped from `m_Items`. `CommittNewItems()` also doesn't check the return
value of `Commit()` but just continues and tries to commit all items from `m_Items` in recursive call. Since
this corrupt item is never removed from `m_Items`, it ends up in an endless recursion till it finally crashes.

### Test config

```
object Host "dummy-check" ignore_on_error {
    address = "localhost"
}
```

### Before

see https://github.com/Icinga/icinga2/issues/8824#issuecomment-949757451

**And....:**

```
~/Workspace/icinga2 (master ✗) prefix/sbin/icinga2 daemon -C
[2022-06-20 14:38:46 +0200] information/cli: Icinga application loader (version: v2.13.0-312-g452252244; debug)
[2022-06-20 14:38:46 +0200] information/cli: Loading configuration file(s).
[2022-06-20 14:38:46 +0200] information/ConfigItem: Committing config item(s).
[2022-06-20 14:38:46 +0200] information/ApiListener: My API identity: satellite
[1]    74144 segmentation fault  prefix/sbin/icinga2 daemon -C
```

#### Performance 

**Check this out:**

```
[2022-06-20 12:43:44 +0200] information/WorkQueue: #3 (DaemonUtility::LoadConfigFiles) items: 4, rate: 3.13333/s (188/min 324/5min 324/15min); empty in infinite time, your task handler isn't able to keep up
``` 

```
[2022-06-20 10:58:44 +0200] information/cli: Icinga application loader (version: v2.13.0-312-g452252244; debug)
[2022-06-20 10:58:44 +0200] information/cli: Loading configuration file(s).
[2022-06-20 10:58:50 +0200] information/ConfigItem: Committing config item(s).
[2022-06-20 10:58:50 +0200] information/ApiListener: My API identity: satellite
[2022-06-20 10:59:00 +0200] information/WorkQueue: #3 (DaemonUtility::LoadConfigFiles) items: 0, rate: 2.2/s (132/min 132/5min 132/15min);
[2022-06-20 10:59:00 +0200] information/WorkQueue: #4 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2022-06-20 10:59:00 +0200] information/WorkQueue: #5 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2022-06-20 11:00:10 +0200] information/WorkQueue: #3 (DaemonUtility::LoadConfigFiles) items: 4, rate: 3.2/s (192/min 324/5min 324/15min); empty in 10 seconds
[2022-06-20 11:04:00 +0200] information/WorkQueue: #3 (DaemonUtility::LoadConfigFiles) items: 0, rate:  0/s (0/min 1576/5min 1708/15min);
[2022-06-20 11:04:00 +0200] information/WorkQueue: #5 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2022-06-20 11:04:00 +0200] information/WorkQueue: #4 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 50012 Notifications.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 ScheduledDowntime.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 100011 Services.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 ApiListener.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 244 CheckCommands.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 NotificationComponent.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 CheckerComponent.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 FileLogger.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 User.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 2 Endpoints.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 50001 Hosts.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 2 HostGroups.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 IcingaApplication.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 2 NotificationCommands.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 4 Zones.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 3 ServiceGroups.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 3 TimePeriods.
[2022-06-20 11:04:25 +0200] information/ConfigItem: Instantiated 1 UserGroup.
[2022-06-20 11:04:26 +0200] information/ScriptGlobal: Dumping variables to file '/Users/yhabteab/CLionProjects/icinga2/prefix/var/cache/icinga2/icinga2.vars'
[2022-06-20 11:04:26 +0200] information/cli: Finished validating the configuration file(s).
prefix/sbin/icinga2 daemon -C  504.89s user 18.22s system 150% cpu 5:48.26 total
``` 

### After

```
[2022-06-24 10:21:57 +0200] notice/ConfigObject: Ignoring config object 'dummy-check' of type 'Host' due to errors: Error: Validation failed for object 'dummy-check' of type 'Host'; Attribute 'check_command': Attribute must not be empty.
Location: in /Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/zones.d/master/test-config.conf: 27:1-27:41
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/zones.d/master/test-config.conf(25): }
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/zones.d/master/test-config.conf(26): 
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/zones.d/master/test-config.conf(27): object Host "dummy-check" ignore_on_error {
                                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/zones.d/master/test-config.conf(28):   address = "localhost"
/Users/yhabteab/Workspace/icinga2/prefix/etc/icinga2/zones.d/master/test-config.conf(29): }
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 11 Notifications.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 10 Services.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 ApiListener.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 244 CheckCommands.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 FileLogger.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 2 ApiUsers.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 Endpoint.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 CheckerComponent.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 Host.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 IcingaApplication.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 User.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 2 NotificationCommands.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 3 Zones.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 4 TimePeriods.
[2022-06-24 10:21:57 +0200] information/ConfigItem: Instantiated 1 NotificationComponent.
[2022-06-24 10:21:57 +0200] information/ScriptGlobal: Dumping variables to file '/Users/yhabteab/Workspace/icinga2/prefix/var/cache/icinga2/icinga2.vars'
[2022-06-24 10:21:57 +0200] notice/WorkQueue: Stopped WorkQueue threads for 'DaemonUtility::LoadConfigFiles'
[2022-06-24 10:21:57 +0200] information/cli: Finished validating the configuration file(s)
```

#### Performance 

```
 time prefix/sbin/icinga2 daemon -C    
[2022-06-20 10:55:23 +0200] information/cli: Icinga application loader (version: v2.13.0-313-ge8cd42d12; debug)
[2022-06-20 10:55:23 +0200] information/cli: Loading configuration file(s).
[2022-06-20 10:55:29 +0200] information/ConfigItem: Committing config item(s).
[2022-06-20 10:55:29 +0200] information/ApiListener: My API identity: yonass-mbp.fritz.box
[2022-06-20 10:55:39 +0200] information/WorkQueue: #4 (DaemonUtility::LoadConfigFiles) items: 0, rate: 2.33333/s (140/min 140/5min 140/15min);
[2022-06-20 10:55:39 +0200] information/WorkQueue: #5 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2022-06-20 10:55:39 +0200] information/WorkQueue: #6 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 ApiListener.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 244 CheckCommands.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 FileLogger.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 2 ApiUsers.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 Endpoint.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 CheckerComponent.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 50001 Hosts.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 2 HostGroups.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 IcingaApplication.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 User.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 2 NotificationCommands.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 3 Zones.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 3 ServiceGroups.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 4 TimePeriods.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 UserGroup.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 NotificationComponent.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 Downtime.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 50012 Notifications.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 1 ScheduledDowntime.
[2022-06-20 10:58:03 +0200] information/ConfigItem: Instantiated 100011 Services.
[2022-06-20 10:58:03 +0200] information/ScriptGlobal: Dumping variables to file '/Users/yhabteab/Workspace/icinga2/prefix/var/cache/icinga2/icinga2.vars'
[2022-06-20 10:58:03 +0200] information/cli: Finished validating the configuration file(s).
prefix/sbin/icinga2 daemon -C  444.81s user 9.16s system 271% cpu 2:47.24 total
```

fixes #8824