### PR TITLE
Don't allow to change object navigation fields at runtime

### DIFF
--- a/lib/icinga/comment.ti
+++ b/lib/icinga/comment.ti
@@ -34,12 +34,12 @@ class Comment : ConfigObject < CommentNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, protected, required, navigation(host)] name(Host) host_name {
+	[config, no_user_modify, protected, required, navigation(host)] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, protected, navigation(service)] String service_name {
+	[config, no_user_modify, protected, navigation(service)] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -23,13 +23,13 @@ class Dependency : CustomVarObject < DependencyNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, required, navigation(child_host)] name(Host) child_host_name {
+	[config, no_user_modify, required, navigation(child_host)] name(Host) child_host_name {
 		navigate {{{
 			return Host::GetByName(GetChildHostName());
 		}}}
 	};
 
-	[config, navigation(child_service)] String child_service_name {
+	[config, no_user_modify, navigation(child_service)] String child_service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetChildHostName(), oldValue);
@@ -50,13 +50,13 @@ class Dependency : CustomVarObject < DependencyNameComposer
 		}}}
 	};
 
-	[config, required, navigation(parent_host)] name(Host) parent_host_name {
+	[config, no_user_modify, required, navigation(parent_host)] name(Host) parent_host_name {
 		navigate {{{
 			return Host::GetByName(GetParentHostName());
 		}}}
 	};
 
-	[config, navigation(parent_service)] String parent_service_name {
+	[config, no_user_modify, navigation(parent_service)] String parent_service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetParentHostName(), oldValue);

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -25,12 +25,12 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, required, navigation(host)] name(Host) host_name {
+	[config, no_user_modify, required, navigation(host)] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, navigation(service)] String service_name {
+	[config, no_user_modify, navigation(service)] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -43,12 +43,12 @@ class Notification : CustomVarObject < NotificationNameComposer
 	[no_user_view, no_user_modify] int type_filter_real (TypeFilter);
 	[config] array(Value) states;
 	[no_user_view, no_user_modify] int state_filter_real (StateFilter);
-	[config, protected, required, navigation(host)] name(Host) host_name {
+	[config, no_user_modify, protected, required, navigation(host)] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, protected, navigation(service)] String service_name {
+	[config, protected, no_user_modify, navigation(service)] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/scheduleddowntime.ti
+++ b/lib/icinga/scheduleddowntime.ti
@@ -26,12 +26,12 @@ class ScheduledDowntime : CustomVarObject < ScheduledDowntimeNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, protected, required, navigation(host)] name(Host) host_name {
+	[config, protected, no_user_modify, required, navigation(host)] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, protected, navigation(service)] String service_name {
+	[config, protected, no_user_modify, navigation(service)] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -40,7 +40,7 @@ class Service : Checkable < ServiceNameComposer
 				return displayName;
 		}}}
 	};
-	[config, required] name(Host) host_name;
+	[config, no_user_modify, required] name(Host) host_name;
 	[no_storage, navigation] Host::Ptr host {
 		get;
 		navigate {{{

--- a/lib/remote/zone.ti
+++ b/lib/remote/zone.ti
@@ -9,7 +9,7 @@ namespace icinga
 
 class Zone : ConfigObject
 {
-	[config, navigation] name(Zone) parent (ParentRaw) {
+	[config, no_user_modify, navigation] name(Zone) parent (ParentRaw) {
 		navigate {{{
 			return Zone::GetByName(GetParentRaw());
 		}}}


### PR DESCRIPTION
These changes prevent object navigation fields from being modified via the API. However, not all navigation fields are affected, only those that are also included in the object name. For example, `hostname!servicename`, in this example, after creating a service object, the `host_name` attribute cannot be updated at runtime or things will get messed up.

`Zone.parent` and `Dependency.parent_*_name` are special. Because they do not occur in object names, but they are dangerous if we allow to change them via API. For example, if we would update the dependency `parent_service_name`, you would see that the name has been updated, but not the actual dependency graph. Because it would still point to the `parent_service_name` specified in the config file, and that would somehow leave everything in a broken state. And also with` Zone.parent`, the cluster communication/message routing, , would put it in a weird state.

### Before

see #9262

### After

```bash
curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
 -d "$(jo -p pretty=true type=Service service='dummy-host!hs' author=icingaadmin comment="Test test" fixed=true start_time=$(date -v+0H +%s) end_time=$(date -v+1H +%s))"
```

```bash
curl -iskSu root:icinga -H 'Accept: application/json' 'https://localhost:5665/v1/objects/downtimes/dummy-host!hs!c6ce53c0-2fa2-4b33-8ee0-54a05a5c0261?pretty=1' -d '{"attrs":{"host_name":"another"}}'

....
{
    "results": [
        {
            "code": 500,
            "name": "dummy-host!hs!c6ce53c0-2fa2-4b33-8ee0-54a05a5c0261",
            "status": "Attribute 'host_name' could not be set: Error: Attribute cannot be modified.\n",
            "type": "Downtime"
        }
    ]
}
```

```bash
curl -iskSu root:icinga -H 'Accept: application/json' 'https://localhost:5665/v1/objects/downtimes/dummy-host!hs!c6ce53c0-2fa2-4b33-8ee0-54a05a5c0261?pretty=1' -d '{"attrs":{"service_name":"another"}}'

....
{
    "results": [
        {
            "code": 500,
            "name": "dummy-host!hs!c6ce53c0-2fa2-4b33-8ee0-54a05a5c0261",
            "status": "Attribute 'service_name' could not be set: Error: Attribute cannot be modified.\n",
            "type": "Downtime"
        }
    ]
}
```

fixes #9262