### PR TITLE
Disallow empty object names

### DIFF
--- a/lib/base/configobject.ti
+++ b/lib/base/configobject.ti
@@ -57,7 +57,7 @@ private:
 abstract class ConfigObject : ConfigObjectBase < ConfigType
 {
 	[config, no_user_modify] String __name (Name);
-	[config, no_user_modify] String "name" (ShortName) {
+	[config, no_user_modify, required] String "name" (ShortName) {
 		get {{{
 			String shortName = m_ShortName.load();
 			if (shortName.IsEmpty())


### PR DESCRIPTION
This PR sets the `required` flag for object names to prevent objects with `""` or `null` names from being created.

fixes #9097