### PR TITLE
Run only a single job per workflow at a time

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -17,6 +17,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         distro:
           - name: debian

--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -17,6 +17,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         codename:
           - bullseye

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -17,6 +17,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         distro:
           - name: rhel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         bits: [32, 64]
 


### PR DESCRIPTION
Run only a single job per workflow matrix at a time. This limits each run of these workflows to a single active matrix job.

This means, for each PR, merge or release only five jobs run concurrently.

We are limited to 20 runners concurrently. This means four PRs can still lock them up. But at least it prevents a single PR from locking up all resources.

~~At the moment it's only a draft, so feel free to ignore this at the moment. But I'd really like to merge this in the next days/weeks. (If it works as I thought, I'll cancel the runs after creating this PR so I can't tell if it does until all releases are finished)~~