### PR TITLE
Some documentation fixes

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -565,7 +565,7 @@ created by the API.
 ### Querying Objects <a id="icinga2-api-config-objects-query"></a>
 
 You can request information about configuration objects by sending
-a `GET` query to the `/v1/objects/<type>` URL endpoint. `<type` has
+a `GET` query to the `/v1/objects/<type>` URL endpoint. `<type>` has
 to be replaced with the plural name of the object type you are interested
 in:
 

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1376,6 +1376,7 @@ Send a `POST` request to the URL endpoint `/v1/actions/schedule-downtime`.
 
   Parameter     | Type      | Description
   --------------|-----------|--------------
+  type          | String    | **Required.** Downtime type. Either `Host`, or `Service`.
   author        | String    | **Required.** Name of the author.
   comment       | String    | **Required.** Comment text.
   start\_time   | Timestamp | **Required.** Timestamp marking the beginning of the downtime.
@@ -1386,7 +1387,7 @@ Send a `POST` request to the URL endpoint `/v1/actions/schedule-downtime`.
   trigger\_name | String    | **Optional.** Sets the trigger for a triggered downtime. See [downtimes](08-advanced-topics.md#downtimes) for more information on triggered downtimes.
   child\_options| String    | **Optional.** Schedule child downtimes. `DowntimeNoChildren` does not do anything, `DowntimeTriggeredChildren` schedules child downtimes triggered by this downtime, `DowntimeNonTriggeredChildren` schedules non-triggered downtimes. Defaults to `DowntimeNoChildren`.
 
-In addition to these parameters a [filter](12-icinga2-api.md#icinga2-api-filters) must be provided. The valid types for this action are `Host` and `Service`.
+In addition to these parameters a [filter](12-icinga2-api.md#icinga2-api-filters) must be provided.
 
 Example for scheduling a downtime for all `ping4` services:
 


### PR DESCRIPTION
The 1st commit adds a `>`.

The 2nd commit is about adding the `type` parameter as a row to the table.

I think the parameter should be mentioned in the table, as it is an essential parameter. I was dealing with scheduling downtimes, so I stumbled upon this. 

Having a deeper look into the documentation, I've seen in almost every section the `type` parameter is not mentioned _in_ the table, but below the table.
Please let me know if I should move the `type` parameter to the table for other sections, too. It would be consistent across the whole document then. (I would create a 3rd commit then.)
If the `type` parameter is mentioned below the table intentionally, then I suggest to drop the 2nd commit and only apply the 1st commit of this PR.

Regards,
Bernd