### PR TITLE
ITL: apt: allow user to choose between --[dist-]upgrade and --[dist-]upgrade=OPTS

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -219,8 +219,10 @@ Custom variables passed as [command parameters](03-monitoring-basics.md#command-
 Name                    | Description
 ------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 apt_extra_opts          | **Optional.** Read options from an ini file.
-apt_upgrade             | **Optional.** [Default] Perform an upgrade. If an optional OPTS argument is provided, apt-get will be run with these command line options instead of the default.
-apt_dist_upgrade        | **Optional.** Perform a dist-upgrade instead of normal upgrade. Like with -U OPTS can be provided to override the default options.
+apt_upgrade             | **Optional.** [Default] Perform an upgrade. apt-get will be run with the default command line options.
+apt_upgrade_opts        | **Optional.** Perform an upgrade. apt-get will be run with the provided command line options instead of the default.
+apt_dist_upgrade        | **Optional.** Perform a dist-upgrade instead of normal upgrade. apt-get will be run with the default command line options.
+apt_dist_upgrade_opts   | **Optional.** Perform a dist-upgrade instead of normal upgrade. apt-get will be run with the provided command line options instead of the default.
 apt_include             | **Optional.** Include only packages matching REGEXP. Can be specified multiple times the values will be combined together.
 apt_exclude             | **Optional.** Exclude packages matching REGEXP from the list of packages that would otherwise be included. Can be specified multiple times.
 apt_critical            | **Optional.** If the full package information of any of the upgradable packages match this REGEXP, the plugin will return CRITICAL status. Can be specified multiple times.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1924,14 +1924,24 @@ object CheckCommand "apt" {
 			description = "Read options from an ini file."
 		}
 		"--upgrade" = {
-			value = "$apt_upgrade$"
+			set_if = "$apt_upgrade$"
+			description = "[Default] Perform an upgrade."
+		}
+		"--upgrade=OPTS" = {
+			key = "--upgrade"
 			separator = "="
-			description = "[Default] Perform an upgrade. If an optional OPTS argument is provided, apt-get will be run with these command line options instead of the default."
+			value = "$apt_upgrade_opts$"
+			description = "Perform an upgrade. apt-get will be run with the provided command line options instead of the default."
 		}
 		"--dist-upgrade" = {
-			value = "$apt_dist_upgrade$"
+			set_if = "$apt_dist_upgrade$"
+			description = "Perform a dist-upgrade instead of normal upgrade."
+		}
+		"--dist-upgrade=OPTS" = {
+			key = "--dist-upgrade"
 			separator = "="
-			description = "Perform a dist-upgrade instead of normal upgrade. Like with -U OPTS can be provided to override the default options."
+			value = "$apt_dist_upgrade_opts$"
+			description = "Perform a dist-upgrade instead of normal upgrade. apt-get will be run with the provided command line options instead of the default."
 		}
 		"--include" = {
 			value = "$apt_include$"


### PR DESCRIPTION
By introducing separate custom vars for them.

Previously apt_[dist_]upgrade=true became --[dist-]upgrade=true,
now it's just --[dist-]upgrade.

closes #9447