### PR TITLE
Docs: remove duration from schedule-downtime example

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1393,7 +1393,7 @@ Example for scheduling a downtime for all `ping4` services:
 ```bash
 curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
  -X POST 'https://localhost:5665/v1/actions/schedule-downtime' \
- -d '{ "type": "Service", "filter": "service.name==\"ping4\"", "start_time": 1446388806, "end_time": 1446389806, "duration": 1000, "author": "icingaadmin", "comment": "IPv4 network maintenance", "pretty": true }'
+ -d '{ "type": "Service", "filter": "service.name==\"ping4\"", "start_time": 1446388806, "end_time": 1446389806, "author": "icingaadmin", "comment": "IPv4 network maintenance", "pretty": true }'
 ```
 
 ```json


### PR DESCRIPTION
The API call does not explicitly specify `fixed` so the default of `true` is used. For a fixed downtime, `duration` is ignored so there is no reason for specifying it and it's just confusing ("why do I have to give start/end *and* a duration which should be the difference between start and end anyways?").