### PR TITLE
Windows: only include critical messages in early log messages

### DIFF
--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -256,7 +256,7 @@ Log::~Log()
 	}
 
 #ifdef _WIN32
-	if (Logger::IsEarlyLoggingEnabled() && entry.Severity >= Logger::GetConsoleLogSeverity()) {
+	if (Logger::IsEarlyLoggingEnabled() && entry.Severity >= LogCritical) {
 		WindowsEventLogLogger::WriteToWindowsEventLog(entry);
 	}
 #endif /* _WIN32 */


### PR DESCRIPTION
The point of logging to the Windows Event Log was to catch errors that happen before the full logging configuration has been loaded and enabled (see #5399). Messages like the number of loaded objects per type just cause noise in the log and provide little benefit. Therefore raise the required log level at this stage.

Note that this commit removes the (never documented) ability to use the `-x` flag to change the level. But doing so would require patching the command line of the service in the registry anyways.

## Test

### Before

All early startup messages are logged to the Windows Event Log, for example the message containing the version, see the screenshot in #8710 for example.

### After

With this PR, the event log now looks like this:
![20220718_11h39m37s_grim](https://user-images.githubusercontent.com/18552/179485221-bb3b94e1-1dfc-4ada-80fb-44dd1549f24a.png)

### Sequence of Events and Log Messages

In chronological order (the screenshot above shows them in reverse-chronological order):

* Install Icinga 2 MSI on a clean system.
* `Beginning a Windows Installer transaction: C:\Users\Administrator\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\TempState\Downloads\Icinga2-snapshot-feature-windows-early-log-severity-x86_64 (1).msi. Client Process Id: 9020.`
* `Ending a Windows Installer transaction: C:\Users\Administrator\AppData\Local\Packages\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\TempState\Downloads\Icinga2-snapshot-feature-windows-early-log-severity-x86_64 (1).msi. Client Process Id: 9020.`
* `information/NotificationComponent: 'notification' started.`
* `information/CheckerComponent: 'checker' started.`
* `information/ConfigItem: Activated all objects.`
* `Product: Icinga 2 -- Installation completed successfully.`
* `Windows Installer installed the product. Product Name: Icinga 2. Product Version: 2.13.0.378. Product Language: 1033. Manufacturer: Icinga GmbH. Installation success or error status: 0.`
* `information/ConfigObjectUtility: Created and activated object 'DESKTOP-ATHPKE9!load!24da445e-8c43-4bc4-9b52-c6bd9e56a08e' of type 'Downtime'.`
* `information/Downtime: Added downtime 'DESKTOP-ATHPKE9!load!24da445e-8c43-4bc4-9b52-c6bd9e56a08e' between '2022-07-19 02:00:00' and '2022-07-19 03:00:00', author: 'icingaadmin', fixed`
* Manually restart the Icinga 2 service.
* `information/NotificationComponent: 'notification' started.`
* `information/CheckerComponent: 'checker' started.`
* `information/ConfigItem: Activated all objects.`
* Introduce an error in the configuration and restart the service again.
* ```critical/config: Error: Error while evaluating expression: Tried to access undefined script variable 'invalid'
  Location: in C:\ProgramData\icinga2\etc\icinga2/conf.d/hosts.conf: 44:1-44:7
  C:\ProgramData\icinga2\etc\icinga2/conf.d/hosts.conf(42): }
  C:\ProgramData\icinga2\etc\icinga2/conf.d/hosts.conf(43): 
  C:\ProgramData\icinga2\etc\icinga2/conf.d/hosts.conf(44): invalid
                                                            ^^^^^^^
  ```
* `critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.`

Note that the messages of severity `information` are just those generated after the full `WindowsEventLogLogger` configuration was loaded, which defaults to level information and therefore can be controlled by the user as expected:
https://github.com/Icinga/icinga2/blob/32c7f7730db154ba0dff5856a8985d125791c73e/etc/icinga2/features-available/windowseventlog.conf#L5-L7

refs #8996