### PR TITLE
Windows: explicitly flush state file

### DIFF
--- a/lib/base/exception.hpp
+++ b/lib/base/exception.hpp
@@ -127,7 +127,12 @@ private:
 };
 
 #ifdef _WIN32
-class win32_error : virtual public std::exception, virtual public boost::exception { };
+class win32_error : virtual public std::exception, virtual public boost::exception {
+public:
+	const char *what() const noexcept;
+};
+
+std::string to_string(const win32_error& e);
 
 struct errinfo_win32_error_;
 typedef boost::error_info<struct errinfo_win32_error_, int> errinfo_win32_error;


### PR DESCRIPTION
Work in progress for testing if using a second handle for the same file is good enough for flushing previous writes to that file done using another handle (i.e. does it flush everything pending on that handle or that file). If not, we have to replace the `std::fstream` with something else that allows control over the underlying file handle.

Also includes another commit to actually get more useful errors if something goes wrong.

refs #8840