### PR TITLE
GitHub Actions: Build Raspbian on Ubuntu 22.04

### DIFF
--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -18,7 +18,7 @@ jobs:
           - buster
           - bullseye
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # revert back to ubuntu-latest once that is 22.04 or later
 
     steps:
       - name: Cancel previous jobs for the same PR
@@ -34,10 +34,6 @@ jobs:
       - name: qemu-user-static
         run: |
           set -exo pipefail
-          . /etc/os-release
-          if [ "$VERSION_ID" = 20.04 ]; then
-            sudo perl -pi -e s/focal/impish/g /etc/apt/sources.list
-          fi
           sudo apt-get update
           DEBIAN_FRONTEND=noninteractive sudo apt-get install -y qemu-user-static
 


### PR DESCRIPTION
Raspbian builds were running on Ubuntu 20.04 but with qemu-user-static from Ubuntu 21.10 (impish) due to need for newer features. However, the impish package repos are no longer available as that version reached its EOL. ubuntu-latest still refers to 20.04 on GitHub Actions but 22.04 is already available when explicitly specified. This commit switches the build over to that version and removes the workaround.

Example of a failed build due to the repository being gone: https://github.com/Icinga/icinga2/runs/7498293352