### PR TITLE
Windows: only include critical messages in early log messages

### DIFF
--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -256,7 +256,7 @@ Log::~Log()
 	}
 
 #ifdef _WIN32
-	if (Logger::IsEarlyLoggingEnabled() && entry.Severity >= Logger::GetConsoleLogSeverity()) {
+	if (Logger::IsEarlyLoggingEnabled() && entry.Severity >= LogCritical) {
 		WindowsEventLogLogger::WriteToWindowsEventLog(entry);
 	}
 #endif /* _WIN32 */


### PR DESCRIPTION
The point of logging to the Windows Event Log was to catch errors that happen
before the full logging configuration has been loaded and enabled. Messages
like the number of loaded objects per type just cause noise in the log and
provide little benefit. Therefore raise the required log level at this stage.

Note that this commit removes the (never documented) ability to use the -x flag
to change the level. But doing so would require patching the command line of
the service in the registry anyways.

Backport of #9441