### PR TITLE
ITL: apt: render vars.apt_[dist_]upgrade=true as --[dist-]upgrade, not --[dist-]upgrade=true

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1919,19 +1919,42 @@ object CheckCommand "apt" {
 	command = [ PluginDir + "/check_apt" ]
 
 	arguments = {
-		"--extra-opts" = {
-			value = "$apt_extra_opts$"
-			description = "Read options from an ini file."
-		}
+		// apt-get takes only options starting with "-" (like "-sqq") before
+		// the upgrade command, so passing e.g. "foobar" as "--upgrade=foobar"
+		// makes no sense. This allows to easily decide between "-x=-y"
+		// (strings starting with "-") and "-x" (everything else).
 		"--upgrade" = {
-			value = "$apt_upgrade$"
-			separator = "="
+			set_if = {{
+				var v = macro("$apt_upgrade$")
+				return match("-*", string(v).trim()) ? false : v
+			}}
 			description = "[Default] Perform an upgrade. If an optional OPTS argument is provided, apt-get will be run with these command line options instead of the default."
 		}
 		"--dist-upgrade" = {
-			value = "$apt_dist_upgrade$"
-			separator = "="
+			set_if = {{
+				var v = macro("$apt_dist_upgrade$")
+				return match("-*", string(v).trim()) ? false : v
+			}}
 			description = "Perform a dist-upgrade instead of normal upgrade. Like with -U OPTS can be provided to override the default options."
+		}
+		"--upgrade=OPTS" = {
+			set_if = {{ match("-*", string(macro("$apt_upgrade$")).trim()) }}
+			key = "--upgrade"
+			separator = "="
+			value = "$apt_upgrade$"
+			description = "[Default] Perform an upgrade. If an optional OPTS argument is provided, apt-get will be run with these command line options instead of the default."
+		}
+		"--dist-upgrade=OPTS" = {
+			set_if = {{ match("-*", string(macro("$apt_dist_upgrade$")).trim()) }}
+			key = "--dist-upgrade"
+			separator = "="
+			value = "$apt_dist_upgrade$"
+			description = "Perform a dist-upgrade instead of normal upgrade. Like with -U OPTS can be provided to override the default options."
+		}
+
+		"--extra-opts" = {
+			value = "$apt_extra_opts$"
+			description = "Read options from an ini file."
 		}
 		"--include" = {
 			value = "$apt_include$"


### PR DESCRIPTION
but preserve vars.apt_[dist_]upgrade=-s as --[dist-]upgrade=-s.

Backport of #9447