### PR TITLE
IcingaDB::SendCustomVarsChanged(): don't delete custom vars of not synced types

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -44,6 +44,8 @@ using namespace icinga;
 
 using Prio = RedisConnection::QueryPriority;
 
+std::unordered_set<Type*> IcingaDB::m_IndexedTypes;
+
 INITIALIZE_ONCE(&IcingaDB::ConfigStaticInitialize);
 
 std::vector<Type::Ptr> IcingaDB::GetTypes()
@@ -74,6 +76,10 @@ std::vector<Type::Ptr> IcingaDB::GetTypes()
 
 void IcingaDB::ConfigStaticInitialize()
 {
+	for (auto& type : GetTypes()) {
+		m_IndexedTypes.emplace(type.get());
+	}
+
 	/* triggered in ProcessCheckResult(), requires UpdateNextCheck() to be called before */
 	Checkable::OnStateChange.connect([](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type, const MessageOrigin::Ptr&) {
 		IcingaDB::StateChangeHandler(checkable, cr, type);
@@ -2511,6 +2517,10 @@ void IcingaDB::SendCommandArgumentsChanged(const ConfigObject::Ptr& command, con
 }
 
 void IcingaDB::SendCustomVarsChanged(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues) {
+	if (m_IndexedTypes.find(object->GetReflectionType().get()) == m_IndexedTypes.end()) {
+		return;
+	}
+
 	if (!m_Rcon || !m_Rcon->IsConnected() || oldValues == newValues) {
 		return;
 	}

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2725,6 +2725,10 @@ void IcingaDB::VersionChangedHandler(const ConfigObject::Ptr& object)
 {
 	Type::Ptr type = object->GetReflectionType();
 
+	if (m_IndexedTypes.find(type.get()) == m_IndexedTypes.end()) {
+		return;
+	}
+
 	if (object->IsActive()) {
 		// Create or update the object config
 		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace icinga
@@ -232,6 +233,8 @@ private:
 	// initialization, the value is read-only and can be accessed without further synchronization.
 	static String m_EnvironmentId;
 	static std::mutex m_EnvironmentIdInitMutex;
+
+	static std::unordered_set<Type*> m_IndexedTypes;
 };
 }
 


### PR DESCRIPTION
not to surprise (and crash) the Icinga DB daemon with unknown types.

fixes #9478

## Before

A such request

```
curl -ksSu root:123456 -H 'Accept: application/json' -X POST -d '{"attrs":{"vars.lollcat":"mewww"}}' https://127.0.0.1:5665/v1/objects/dependencies/'alexandersmbp2.int.netways.de!disk!p5d';echo
```

crashes Icinga DB immediately. (`pkg/icingadb/runtime_updates.go:262`)

## After

The message causing the crash isn't even written to Redis:

```
redis.XMessage{ID:"1660122773801-0", Values:map[string]interface {}{"id":"2943ebbf60473950c9a9ea41c4a08069d9e0e461", "redis_key":"icinga:dependency:customvar", "runtime_type":"delete"}}
```

Btw. _known_ types still work:

```
1660124916.091013 [0 127.0.0.1:58106] "XADD" "icinga:runtime" "MAXLEN" "~" "1000000" "*" "redis_key" "icinga:host:customvar" "id" "54b8c2d8074568bc08baac05362f66e884193021" "runtime_type" "delete"
```