### PR TITLE
IcingaDB::SendCustomVarsChanged(): don't delete custom vars of not synced types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ improves logging and updates a bundled library.
 
 * Ensure not to write an incomplete (i.e. corrupt) state file. #9467
 * ITL: Render vars.apt\_upgrade=true as --upgrade, not --upgrade=true. #9458
+* Icinga DB: Don't surprise (and crash) the Go daemon with config types it doesn't know. #9480
 * Icinga DB: Add missing Redis SELinux policy. #9473
 * Windows: Don't spam the event log with non-error startup messages. #9457
 * Windows: Update bundled version of OpenSSL. #9460

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -44,6 +44,8 @@ using namespace icinga;
 
 using Prio = RedisConnection::QueryPriority;
 
+std::unordered_set<Type*> IcingaDB::m_IndexedTypes;
+
 INITIALIZE_ONCE(&IcingaDB::ConfigStaticInitialize);
 
 std::vector<Type::Ptr> IcingaDB::GetTypes()
@@ -74,6 +76,10 @@ std::vector<Type::Ptr> IcingaDB::GetTypes()
 
 void IcingaDB::ConfigStaticInitialize()
 {
+	for (auto& type : GetTypes()) {
+		m_IndexedTypes.emplace(type.get());
+	}
+
 	/* triggered in ProcessCheckResult(), requires UpdateNextCheck() to be called before */
 	Checkable::OnStateChange.connect([](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type, const MessageOrigin::Ptr&) {
 		IcingaDB::StateChangeHandler(checkable, cr, type);
@@ -2511,6 +2517,10 @@ void IcingaDB::SendCommandArgumentsChanged(const ConfigObject::Ptr& command, con
 }
 
 void IcingaDB::SendCustomVarsChanged(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues) {
+	if (m_IndexedTypes.find(object->GetReflectionType().get()) == m_IndexedTypes.end()) {
+		return;
+	}
+
 	if (!m_Rcon || !m_Rcon->IsConnected() || oldValues == newValues) {
 		return;
 	}

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2725,6 +2725,10 @@ void IcingaDB::VersionChangedHandler(const ConfigObject::Ptr& object)
 {
 	Type::Ptr type = object->GetReflectionType();
 
+	if (m_IndexedTypes.find(type.get()) == m_IndexedTypes.end()) {
+		return;
+	}
+
 	if (object->IsActive()) {
 		// Create or update the object config
 		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace icinga
@@ -232,6 +233,8 @@ private:
 	// initialization, the value is read-only and can be accessed without further synchronization.
 	static String m_EnvironmentId;
 	static std::mutex m_EnvironmentIdInitMutex;
+
+	static std::unordered_set<Type*> m_IndexedTypes;
 };
 }
 


### PR DESCRIPTION
Backport of #9479