### PR TITLE
Fix a crash when the worker threads log on shutdown

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -16,6 +16,7 @@
 #include "base/scriptglobal.hpp"
 #include "base/context.hpp"
 #include "base/console.hpp"
+#include "base/consolelogger.hpp"
 #include "base/process.hpp"
 #include "config.h"
 #include <boost/program_options.hpp>
@@ -294,8 +295,10 @@ static int Main()
 	if (!autocomplete)
 		Application::SetResourceLimits();
 
-	LogSeverity logLevel = Logger::GetConsoleLogSeverity();
-	Logger::SetConsoleLogSeverity(LogWarning);
+	auto console = ConsoleLogger::GetInstance();
+
+	LogSeverity logLevel = console->GetLogSeverity();
+	console->SetLogSeverity(LogWarning);
 
 	po::options_description visibleDesc("Global options");
 
@@ -466,12 +469,12 @@ static int Main()
 	}
 
 	if (!autocomplete) {
-		Logger::SetConsoleLogSeverity(logLevel);
+		console->SetLogSeverity(logLevel);
 
 		if (vm.count("log-level")) {
 			String severity = vm["log-level"].as<std::string>();
 
-			LogSeverity logLevel = LogInformation;
+			logLevel = LogInformation;
 			try {
 				logLevel = Logger::StringToSeverity(severity);
 			} catch (std::exception&) {
@@ -480,7 +483,7 @@ static int Main()
 				return EXIT_FAILURE;
 			}
 
-			Logger::SetConsoleLogSeverity(logLevel);
+			console->SetLogSeverity(logLevel);
 		}
 
 		if (!command || vm.count("help") || vm.count("version")) {

--- a/lib/base/CMakeLists.txt
+++ b/lib/base/CMakeLists.txt
@@ -26,6 +26,7 @@ set(base_SOURCES
   configuration.cpp configuration.hpp configuration-ti.hpp
   configwriter.cpp configwriter.hpp
   console.cpp console.hpp
+  consolelogger.cpp consolelogger.hpp
   context.cpp context.hpp
   convert.cpp convert.hpp
   datetime.cpp datetime.hpp datetime-ti.hpp datetime-script.cpp

--- a/lib/base/consolelogger.cpp
+++ b/lib/base/consolelogger.cpp
@@ -1,0 +1,62 @@
+/* Icinga 2 | (c) 2022 Icinga GmbH | GPLv2+ */
+
+#include "base/consolelogger.hpp"
+
+using namespace icinga;
+
+LazyInit<boost::intrusive_ptr<ConsoleLogger>> ConsoleLogger::m_Instance ([]() {
+	return boost::intrusive_ptr<ConsoleLogger>(new ConsoleLogger());
+});
+
+ConsoleLogger::ConsoleLogger() : m_IsEnabled(true), m_LogSeverity(LogInformation)
+{ }
+
+/**
+ * Get the instance of this console logger
+ *
+ * @return ConsoleLogger
+ */
+const boost::intrusive_ptr<ConsoleLogger>& ConsoleLogger::GetInstance()
+{
+	return m_Instance.Get();
+}
+
+void ConsoleLogger::Disable()
+{
+	m_IsEnabled = false;
+}
+
+void ConsoleLogger::Enable()
+{
+	m_IsEnabled = true;
+}
+
+bool ConsoleLogger::IsEnabled() const
+{
+	return m_IsEnabled;
+}
+
+void ConsoleLogger::SetLogSeverity(LogSeverity logSeverity)
+{
+	m_LogSeverity = logSeverity;
+}
+
+LogSeverity ConsoleLogger::GetLogSeverity()
+{
+	return m_LogSeverity;
+}
+
+/**
+ * This just wraps parent class method and binds the passed stream if not already set
+ *
+ * @param stream The stream to be used for logging the given log entry
+ * @param entry  The actual log entry to be logged
+ */
+void ConsoleLogger::ProcessLogEntry(std::ostream& stream, const LogEntry& entry)
+{
+	if (m_Stream != &stream) {
+		BindStream(&stream, false);
+	}
+
+	StreamLogger::ProcessLogEntry(entry);
+}

--- a/lib/base/consolelogger.hpp
+++ b/lib/base/consolelogger.hpp
@@ -1,0 +1,48 @@
+/* Icinga 2 | (c) 2022 Icinga GmbH | GPLv2+ */
+
+#ifndef CONSOLELOGGER_H
+#define CONSOLELOGGER_H
+
+#include "base/i2-base.hpp"
+#include "base/lazy-init.hpp"
+#include "base/logger.hpp"
+#include "base/streamlogger.hpp"
+#include <boost/intrusive_ptr.hpp>
+
+namespace icinga {
+
+/**
+ * A logger that logs to an ostream.
+ *
+ * This can be used to log entries to all kind of Consoles. This isn't a real config
+ * object, it just extends the stream logger to offload console logging from the Logger
+ * base class.
+ *
+ * @ingroup base
+ */
+class ConsoleLogger final : public StreamLogger
+{
+public:
+	static const boost::intrusive_ptr<ConsoleLogger>& GetInstance();
+
+	void Disable();
+	void Enable();
+	bool IsEnabled() const;
+
+	void SetLogSeverity(LogSeverity logSeverity);
+	LogSeverity GetLogSeverity();
+
+	void ProcessLogEntry(std::ostream& stream, const LogEntry& entry);
+
+private:
+	ConsoleLogger();
+
+	static LazyInit<boost::intrusive_ptr<ConsoleLogger>> m_Instance;
+
+	LogSeverity m_LogSeverity;
+	bool m_IsEnabled;
+};
+
+}
+
+#endif /* CONSOLELOGGER_H */

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -64,17 +64,11 @@ public:
 
 	static std::set<Logger::Ptr> GetLoggers();
 
-	static void DisableConsoleLog();
-	static void EnableConsoleLog();
-	static bool IsConsoleLogEnabled();
 	static void DisableEarlyLogging();
 	static bool IsEarlyLoggingEnabled();
 	static void DisableTimestamp();
 	static void EnableTimestamp();
 	static bool IsTimestampEnabled();
-
-	static void SetConsoleLogSeverity(LogSeverity logSeverity);
-	static LogSeverity GetConsoleLogSeverity();
 
 	void ValidateSeverity(const Lazy<String>& lvalue, const ValidationUtils& utils) final;
 
@@ -85,10 +79,8 @@ protected:
 private:
 	static std::mutex m_Mutex;
 	static std::set<Logger::Ptr> m_Loggers;
-	static bool m_ConsoleLogEnabled;
 	static std::atomic<bool> m_EarlyLoggingEnabled;
 	static bool m_TimestampEnabled;
-	static LogSeverity m_ConsoleLogSeverity;
 };
 
 class Log

--- a/lib/base/streamlogger.hpp
+++ b/lib/base/streamlogger.hpp
@@ -26,15 +26,14 @@ public:
 
 	void BindStream(std::ostream *stream, bool ownsStream);
 
-	static void ProcessLogEntry(std::ostream& stream, const LogEntry& entry);
-
 protected:
 	void ProcessLogEntry(const LogEntry& entry) final;
 	void Flush() final;
 
-private:
-	static std::mutex m_Mutex;
+protected:
 	std::ostream *m_Stream{nullptr};
+
+private:
 	bool m_OwnsStream{false};
 
 	Timer::Ptr m_FlushLogTimer;

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -19,6 +19,7 @@
 #include "base/scriptglobal.hpp"
 #include "base/context.hpp"
 #include "config.h"
+#include "base/consolelogger.hpp"
 #include <cstdint>
 #include <cstring>
 #include <boost/program_options.hpp>
@@ -267,7 +268,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 
 		if (closeConsoleLog) {
 			CloseStdIO(stderrFile);
-			Logger::DisableConsoleLog();
+			ConsoleLogger::GetInstance()->Disable();
 		}
 
 		while (!l_AllowedToWork.load()) {
@@ -711,7 +712,7 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 			errorLog = vm["errorlog"].as<std::string>();
 
 		CloseStdIO(errorLog);
-		Logger::DisableConsoleLog();
+		ConsoleLogger::GetInstance()->Disable();
 	}
 
 #ifdef _WIN32
@@ -761,7 +762,7 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 		Log(LogInformation, "cli", "Closing console log.");
 
 		CloseStdIO(errorLog);
-		Logger::DisableConsoleLog();
+		ConsoleLogger::GetInstance()->Disable();
 	}
 
 	// Immediately allow the first (non-reload) worker to continue working beyond config validation

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -8,6 +8,7 @@
 #include "remote/pkiutility.hpp"
 #include "base/logger.hpp"
 #include "base/console.hpp"
+#include "base/consolelogger.hpp"
 #include "base/application.hpp"
 #include "base/tlsutility.hpp"
 #include "base/scriptglobal.hpp"
@@ -61,7 +62,7 @@ int NodeWizardCommand::Run(const boost::program_options::variables_map& vm,
 	const std::vector<std::string>& ap) const
 {
 	if (!vm.count("verbose"))
-		Logger::SetConsoleLogSeverity(LogCritical);
+		ConsoleLogger::GetInstance()->SetLogSeverity(LogCritical);
 
 	/*
 	 * The wizard will get all information from the user,

--- a/plugins/check_nscp_api.cpp
+++ b/plugins/check_nscp_api.cpp
@@ -5,6 +5,7 @@
 // ensure to include base first
 #include "base/i2-base.hpp"
 #include "base/application.hpp"
+#include "base/consolelogger.hpp"
 #include "base/json.hpp"
 #include "base/string.hpp"
 #include "base/logger.hpp"
@@ -471,11 +472,13 @@ int main(int argc, char **argv)
 
 	l_Debug = vm.count("debug") > 0;
 
+	auto console = ConsoleLogger::GetInstance();
+
 	// Initialize logger
 	if (l_Debug)
-		Logger::SetConsoleLogSeverity(LogDebug);
+		console->SetLogSeverity(LogDebug);
 	else
-		Logger::SetConsoleLogSeverity(LogWarning);
+		console->SetLogSeverity(LogWarning);
 
 	// Create the URL string and escape certain characters since Url() follows RFC 3986
 	String endpoint = "/query/" + vm["query"].as<std::string>();


### PR DESCRIPTION
This fixes the problem described in the referenced issue, as it now just hold a lock on itself instead
of static mutex when logging to a console. It's the case that when starting a process, e.g. to validate
Icinga2 configs, and calling `exit(3)` after validation succeeds, then the static `ProcessEntry()` method
from `StreamLogger` class is used to process the entries. See `Logger::~Logger()` for details. However, the
problem here is that after the process has entered to exit(3), work queue threads still log something, and
of course a `static mutex` from the stream logger class is used to ensure `std::cout` thread-safety. But this
static mutex may already have been destroyed. And since we don't have a handler for this use
case (to lock a dead mutex), it will directly call `std::terminate()`, as it immediately raises a system error.
Our unhandled exception handler of course tries to generate statcktrace from this situation but, for some reason
(could be due to the same reasone as above) the static variables in `exception.cpp` such as `l_lastExceptionObj`
etc.. aren't set, which in turn causes a segfault in `RethrowUncaughtException()`.

fixes #9249 