### PR TITLE
Application::Exit(): don't exit(), but _exit(), even in debug build mode

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -112,11 +112,7 @@ void Application::Exit(int rc)
 	}
 
 	UninitializeBase();
-#ifdef I2_DEBUG
-	exit(rc);
-#else /* I2_DEBUG */
 	_exit(rc); // Yay, our static destructors are pretty much beyond repair at this point.
-#endif /* I2_DEBUG */
 }
 
 void Application::InitializeBase()


### PR DESCRIPTION
Case:

1. icinga2 api setup
2. icinga2 daemon -C -x debug

Before: Second commands crashes at exit.
After: No crash.

As the comment between the removed lines clearly says:
Our destructors haven't been built for static data.

This is build type independent.

fixes #9249
closes #9495