### PR TITLE
Fix data race in `ApplyRule` class

### DIFF
--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -126,12 +126,12 @@ const std::vector<String>& ApplyRule::GetTargetTypes(const String& sourceType)
 
 void ApplyRule::AddMatch()
 {
-	m_HasMatches = true;
+	m_HasMatches.store(true, std::memory_order_relaxed);
 }
 
 bool ApplyRule::HasMatches() const
 {
-	return m_HasMatches;
+	return m_HasMatches.load(std::memory_order_relaxed);
 }
 
 const std::vector<ApplyRule::Ptr>& ApplyRule::GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType)

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -9,6 +9,7 @@
 #include "base/shared-object.hpp"
 #include "base/type.hpp"
 #include <unordered_map>
+#include <atomic>
 
 namespace icinga
 {
@@ -101,7 +102,7 @@ private:
 	bool m_IgnoreOnError;
 	DebugInfo m_DebugInfo;
 	Dictionary::Ptr m_Scope;
-	bool m_HasMatches;
+	std::atomic<bool> m_HasMatches;
 
 	static TypeMap m_Types;
 	static RuleMap m_Rules;


### PR DESCRIPTION
This prevents the `m_HasMatches` property from being altered simultaneously.
This might seem harmless (since this property can only be set to true by any calling thread),
however, from a technical (C++) point of view, this constitutes a data race.

