### PR TITLE
[ITL] Added some ignore options for check_ssl_cert

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5788,12 +5788,12 @@ ssl_cert_ssl_version          | **Optional.** Force specific SSL version out of 
 ssl_cert_disable_ssl_versions | **Optional.** Disable specific SSL versions out of {ssl2,ssl3,tls1,tls1_1,tls1_2}. Multiple versions can be given as array.
 ssl_cert_cipher               | **Optional.** Cipher selection: force {ecdsa,rsa} authentication.
 ssl_cert_ignore_expiration    | **Optional.** Ignore expiration date.
+ssl_cert_ignore_host_cn       | **Optional.** Do not complain if the CN does not match.
 ssl_cert_ignore_ocsp          | **Optional.** Do not check revocation with OCSP.
-ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot be checked
-ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking
+ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot be checked.
+ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking.
 ssl_cert_ignore_sct           | **Optional.** Do not check for signed certificate timestamps.
 ssl_cert_ignore_tls_renegotiation  | **Optional.** Do not check for renegotiation.
-ssl_cert_ignore_host_cn       | **Optional.** Do not complain if the CN does not match
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5789,8 +5789,11 @@ ssl_cert_disable_ssl_versions | **Optional.** Disable specific SSL versions out 
 ssl_cert_cipher               | **Optional.** Cipher selection: force {ecdsa,rsa} authentication.
 ssl_cert_ignore_expiration    | **Optional.** Ignore expiration date.
 ssl_cert_ignore_ocsp          | **Optional.** Do not check revocation with OCSP.
+ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot be checked
+ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking
 ssl_cert_ignore_sct           | **Optional.** Do not check for signed certificate timestamps.
 ssl_cert_ignore_tls_renegotiation  | **Optional.** Do not check for renegotiation.
+ssl_cert_ignore_host_cn       | **Optional.** Do not complain if the CN does not match
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -554,9 +554,21 @@ object CheckCommand "ssl_cert" {
 			set_if = "$ssl_cert_ignore_expiration$"
 			description = "Ignore expiration date"
 		}
+		"--ignore-host-cn" = {
+			set_if = "$ssl_cert_ignore_host_cn$"
+			description = "Do not complain if the CN does not match"
+		}
 		"--ignore-ocsp" = {
 			set_if = "$ssl_cert_ignore_ocsp$"
 			description = "Do not check revocation with OCSP"
+		}
+		"--ignore-ocsp-errors" = {
+			set_if = "$ssl_cert_ignore_ocsp_errors$"
+			description = "Continue if the OCSP status cannot be checked"
+		}
+		"--ignore-ocsp-timeout" = {
+			set_if = "$ssl_cert_ignore_ocsp_timeout$"
+			description = "Ignore OCSP result when timeout occurs while checking"
 		}
 		"--ignore-sct" = {
 			set_if = "$ssl_cert_ignore_sct$"


### PR DESCRIPTION
* ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot be checked
* ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking
* ssl_cert_ignore_host_cn       | **Optional.** Do not complain if the CN does not match