### PR TITLE
ClassCompiler: Validate field types -> Icinga type names correctly

### DIFF
--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -151,9 +151,6 @@ static std::string FieldTypeToIcingaName(const Field& field, bool inner)
 	if (field.Attributes & FAEnum)
 		return "Number";
 
-	if (ftype == "bool" || ftype == "int" || ftype == "double")
-		return "Number";
-
 	if (ftype == "int" || ftype == "double")
 		return "Number";
 	else if (ftype == "bool")


### PR DESCRIPTION
When the classcompiler is validating/transforming field types -> Icinga type names, it is currently returning
Icinga `Number` type for field type of `bool`, which is actually wrong. This PR ensures to always transform
into the correct Icinga type names.