### PR TITLE
StartUnixWorker(): watch forked child via waitpid(), not SIGCHLD handler

### DIFF
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -338,7 +338,6 @@ static const sigset_t l_UnixWorkerSignals = ([]() -> sigset_t {
 	sigset_t s;
 
 	(void)sigemptyset(&s);
-	(void)sigaddset(&s, SIGCHLD);
 	(void)sigaddset(&s, SIGUSR1);
 	(void)sigaddset(&s, SIGUSR2);
 	(void)sigaddset(&s, SIGINT);
@@ -475,7 +474,7 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 	}
 
 	/* Block the signal handlers we'd like to change in the child process until we changed them.
-	 * Block SIGUSR2 and SIGCHLD handlers until we've set l_CurrentlyStartingUnixWorkerPid.
+	 * Block SIGUSR2 handler until we've set l_CurrentlyStartingUnixWorkerPid.
 	 */
 	(void)sigprocmask(SIG_BLOCK, &l_UnixWorkerSignals, nullptr);
 
@@ -505,7 +504,6 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 
 					sa.sa_handler = SIG_DFL;
 
-					(void)sigaction(SIGCHLD, &sa, nullptr);
 					(void)sigaction(SIGUSR1, &sa, nullptr);
 					(void)sigaction(SIGHUP, &sa, nullptr);
 				}
@@ -719,7 +717,6 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
 		sa.sa_sigaction = &UmbrellaSignalHandler;
 		sa.sa_flags = SA_NOCLDSTOP | SA_RESTART | SA_SIGINFO;
 
-		(void)sigaction(SIGCHLD, &sa, nullptr);
 		(void)sigaction(SIGUSR1, &sa, nullptr);
 		(void)sigaction(SIGUSR2, &sa, nullptr);
 		(void)sigaction(SIGINT, &sa, nullptr);

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -330,8 +330,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 enum class UnixWorkerState : uint_fast8_t
 {
 	Pending,
-	LoadedConfig,
-	Failed
+	LoadedConfig
 };
 
 // The signals to block temporarily in StartUnixWorker().


### PR DESCRIPTION
## Before

On SIGCHLD from the forked worker the umbrella process sets a failure flag.
StartUnixWorker() recognises that and does waitpid(), failure message, etc..
On OpenBSD we can't tell the signal source, so we always set the failure flag.
That's not how our IPC shall work, that breaks the IPC sooner or later.

## After

No SIGCHLD handling and no failure flag setting.
Instead StartUnixWorker()'s wait loop uses waitpid(x,y,WNOHANG)
to avoid false positives while watching the forked worker.

fixes #9481