### PR TITLE
Logger: don't render log messages which will be disposed anyway

### DIFF
--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -3,6 +3,7 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
+#include "base/atomic.hpp"
 #include "base/i2-base.hpp"
 #include "base/logger-ti.hpp"
 #include <set>
@@ -22,7 +23,8 @@ enum LogSeverity
 	LogNotice,
 	LogInformation,
 	LogWarning,
-	LogCritical
+	LogCritical,
+	LogNothing
 };
 
 /**
@@ -76,6 +78,12 @@ public:
 	static void SetConsoleLogSeverity(LogSeverity logSeverity);
 	static LogSeverity GetConsoleLogSeverity();
 
+	static inline
+	LogSeverity GetMinLogSeverity()
+	{
+		return m_MinLogSeverity.load();
+	}
+
 	void ValidateSeverity(const Lazy<String>& lvalue, const ValidationUtils& utils) final;
 
 protected:
@@ -83,12 +91,15 @@ protected:
 	void Stop(bool runtimeRemoved) override;
 
 private:
+	static void UpdateMinLogSeverity();
+
 	static std::mutex m_Mutex;
 	static std::set<Logger::Ptr> m_Loggers;
 	static bool m_ConsoleLogEnabled;
 	static std::atomic<bool> m_EarlyLoggingEnabled;
 	static bool m_TimestampEnabled;
 	static LogSeverity m_ConsoleLogSeverity;
+	static Atomic<LogSeverity> m_MinLogSeverity;
 };
 
 class Log
@@ -116,6 +127,7 @@ private:
 	LogSeverity m_Severity;
 	String m_Facility;
 	std::ostringstream m_Buffer;
+	bool m_IsNoOp;
 };
 
 extern template Log& Log::operator<<(const Value&);


### PR DESCRIPTION
by caching the total minimum log severity of all loggers in a "global variable" and whether a message's severity is large enough for any of the loggers in a per-message no-op flag.

closes #9504