### PR TITLE
IcingaDB: Raise history bulker threshold to `1s`

### DIFF
--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -208,7 +208,7 @@ private:
 	WorkQueue m_WorkQueue{0, 1, LogNotice};
 
 	std::future<void> m_HistoryThread;
-	Bulker<RedisConnection::Query> m_HistoryBulker {4096, std::chrono::milliseconds(250)};
+	Bulker<RedisConnection::Query> m_HistoryBulker {4096, std::chrono::seconds(1)};
 
 	String m_PrefixConfigObject;
 	String m_PrefixConfigCheckSum;


### PR DESCRIPTION
At the moment, the history bulker threshold is set to 250 milliseconds. However, since we are already using a separate thread for it, it would be sufficient to have 1 second as a deadline and checking whether there are any histories that need to be performed.