### PR TITLE
Add the Option to disable RetryWrites to CheckCommand of mongodb

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2564,6 +2564,7 @@ mongodb_replcheck                | **Optional.** If set to true, will enable the
 mongodb_querytype                | **Optional.** The query type to check [query\|insert\|update\|delete\|getmore\|command] from queries_per_second.
 mongodb_collection               | **Optional.** Specify the collection to check.
 mongodb_sampletime               | **Optional.** Time used to sample number of pages faults.
+mongodb_disableretrywrites       | **Optional.** If set to true, will disable Retry Writes, to allow counting the QPS.
 
 #### elasticsearch <a id="plugin-contrib-command-elasticsearch"></a>
 

--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -696,6 +696,10 @@ object CheckCommand "mongodb" {
 			value = "$mongodb_warning$"
 			description = "The warning threshold we want to set"
 		}
+		"--disable_retry_writes" = {
+			set_if = "$mongodb_disableretrywrites$"
+			description = "Disable Retry Writes"
+		}
 	}
 
 	vars.mongodb_host = {{


### PR DESCRIPTION
This adds the Option to disable Retry Writes to the CheckCommand definition for mongodb.
This fixes a Problem in check_mongodb.py with newer MongoDB-Versions.
https://github.com/mzupan/nagios-plugin-mongodb/commit/0377f5de7cb65681ceae220c11e91eb4a8681f6b