### PR TITLE
ApplyRule::GetTargetType(): return by ref not to malloc() unnecessarily

### DIFF
--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -16,11 +16,6 @@ ApplyRule::ApplyRule(String targetType, String name, Expression::Ptr expression,
 	m_FVVar(std::move(fvvar)), m_FTerm(std::move(fterm)), m_IgnoreOnError(ignoreOnError), m_DebugInfo(std::move(di)), m_Scope(std::move(scope)), m_HasMatches(false)
 { }
 
-String ApplyRule::GetTargetType() const
-{
-	return m_TargetType;
-}
-
 String ApplyRule::GetName() const
 {
 	return m_Name;

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -19,7 +19,11 @@ public:
 	typedef std::map<String, std::vector<String> > TypeMap;
 	typedef std::map<String, std::vector<ApplyRule> > RuleMap;
 
-	String GetTargetType() const;
+	const String& GetTargetType() const
+	{
+		return m_TargetType;
+	}
+
 	String GetName() const;
 	Expression::Ptr GetExpression() const;
 	Expression::Ptr GetFilter() const;


### PR DESCRIPTION
ref/IP/42584