### PR TITLE
Separately handle apply rules targetting only specific parent objects

### DIFF
--- a/lib/base/string.cpp
+++ b/lib/base/string.cpp
@@ -461,3 +461,8 @@ String::ConstIterator icinga::range_end(const String& x)
 {
 	return x.End();
 }
+
+std::size_t std::hash<String>::operator()(const String& s) const noexcept
+{
+	return std::hash<std::string>{}(s.GetData());
+}

--- a/lib/base/string.hpp
+++ b/lib/base/string.hpp
@@ -7,6 +7,7 @@
 #include "base/object.hpp"
 #include <boost/range/iterator.hpp>
 #include <boost/utility/string_view.hpp>
+#include <functional>
 #include <string>
 #include <iosfwd>
 
@@ -177,6 +178,12 @@ String::Iterator range_end(String& x);
 String::ConstIterator range_end(const String& x);
 
 }
+
+template<>
+struct std::hash<icinga::String>
+{
+	std::size_t operator()(const icinga::String& s) const noexcept;
+};
 
 extern template class std::vector<icinga::String>;
 

--- a/lib/config/CMakeLists.txt
+++ b/lib/config/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set(config_SOURCES
   i2-config.hpp
   activationcontext.cpp activationcontext.hpp
-  applyrule.cpp applyrule.hpp
+  applyrule.cpp applyrule-targeted.cpp applyrule.hpp
   configcompiler.cpp configcompiler.hpp
   configcompilercontext.cpp configcompilercontext.hpp
   configfragment.hpp

--- a/lib/config/applyrule-targeted.cpp
+++ b/lib/config/applyrule-targeted.cpp
@@ -11,7 +11,7 @@ using namespace icinga;
 /**
  * @returns All ApplyRules targeting only specific parent objects including the given host. (See AddTargetedRule().)
  */
-const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::Ptr& sourceType, const String& host)
+const std::set<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::Ptr& sourceType, const String& host)
 {
 	auto perSourceType (m_Rules.find(sourceType.get()));
 
@@ -23,14 +23,14 @@ const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::P
 		}
 	}
 
-	static const std::vector<ApplyRule::Ptr> noRules;
+	static const std::set<ApplyRule::Ptr> noRules;
 	return noRules;
 }
 
 /**
  * @returns All ApplyRules targeting only specific parent objects including the given service. (See AddTargetedRule().)
  */
-const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service)
+const std::set<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service)
 {
 	auto perSourceType (m_Rules.find(sourceType.get()));
 
@@ -46,7 +46,7 @@ const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type
 		}
 	}
 
-	static const std::vector<ApplyRule::Ptr> noRules;
+	static const std::set<ApplyRule::Ptr> noRules;
 	return noRules;
 }
 
@@ -67,7 +67,7 @@ bool ApplyRule::AddTargetedRule(const ApplyRule::Ptr& rule, const String& target
 
 		if (GetTargetHosts(rule->m_Filter.get(), hosts)) {
 			for (auto host : hosts) {
-				rules.Targeted[*host].ForHost.emplace_back(rule);
+				rules.Targeted[*host].ForHost.emplace(rule);
 			}
 
 			return true;
@@ -77,7 +77,7 @@ bool ApplyRule::AddTargetedRule(const ApplyRule::Ptr& rule, const String& target
 
 		if (GetTargetServices(rule->m_Filter.get(), services)) {
 			for (auto service : services) {
-				rules.Targeted[*service.first].ForServices[*service.second].emplace_back(rule);
+				rules.Targeted[*service.first].ForServices[*service.second].emplace(rule);
 			}
 
 			return true;

--- a/lib/config/applyrule-targeted.cpp
+++ b/lib/config/applyrule-targeted.cpp
@@ -11,19 +11,15 @@ using namespace icinga;
 /**
  * @returns All ApplyRules targeting only specific parent objects including the given host. (See AddTargetedRule().)
  */
-const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host)
+const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::Ptr& sourceType, const String& host)
 {
 	auto perSourceType (m_Rules.find(sourceType.get()));
 
 	if (perSourceType != m_Rules.end()) {
-		auto perTargetType (perSourceType->second.find(targetType.get()));
+		auto perHost (perSourceType->second.Targeted.find(host));
 
-		if (perTargetType != perSourceType->second.end()) {
-			auto perHost (perTargetType->second.Targeted.find(host));
-
-			if (perHost != perTargetType->second.Targeted.end()) {
-				return perHost->second.ForHost;
-			}
+		if (perHost != perSourceType->second.Targeted.end()) {
+			return perHost->second.ForHost;
 		}
 	}
 
@@ -34,22 +30,18 @@ const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::P
 /**
  * @returns All ApplyRules targeting only specific parent objects including the given service. (See AddTargetedRule().)
  */
-const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host, const String& service)
+const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service)
 {
 	auto perSourceType (m_Rules.find(sourceType.get()));
 
 	if (perSourceType != m_Rules.end()) {
-		auto perTargetType (perSourceType->second.find(targetType.get()));
+		auto perHost (perSourceType->second.Targeted.find(host));
 
-		if (perTargetType != perSourceType->second.end()) {
-			auto perHost (perTargetType->second.Targeted.find(host));
+		if (perHost != perSourceType->second.Targeted.end()) {
+			auto perService (perHost->second.ForServices.find(service));
 
-			if (perHost != perTargetType->second.Targeted.end()) {
-				auto perService (perHost->second.ForServices.find(service));
-
-				if (perService != perHost->second.ForServices.end()) {
-					return perService->second;
-				}
+			if (perService != perHost->second.ForServices.end()) {
+				return perService->second;
 			}
 		}
 	}
@@ -68,7 +60,7 @@ const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type
  *
  * @returns Whether the rule has been added to the "index".
  */
-bool ApplyRule::AddTargetedRule(const ApplyRule::Ptr& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules)
+bool ApplyRule::AddTargetedRule(const ApplyRule::Ptr& rule, const String& targetType, ApplyRule::PerSourceType& rules)
 {
 	if (targetType == "Host") {
 		std::vector<const String *> hosts;

--- a/lib/config/applyrule-targeted.cpp
+++ b/lib/config/applyrule-targeted.cpp
@@ -68,16 +68,14 @@ const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type
  *
  * @returns Whether the rule has been added to the "index".
  */
-bool ApplyRule::AddTargetedRule(ApplyRule& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules)
+bool ApplyRule::AddTargetedRule(const ApplyRule::Ptr& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules)
 {
 	if (targetType == "Host") {
 		std::vector<const String *> hosts;
 
-		if (GetTargetHosts(rule.m_Filter.get(), hosts)) {
-			ApplyRule::Ptr sharedRule = new ApplyRule(std::move(rule));
-
+		if (GetTargetHosts(rule->m_Filter.get(), hosts)) {
 			for (auto host : hosts) {
-				rules.Targeted[*host].ForHost.emplace_back(sharedRule);
+				rules.Targeted[*host].ForHost.emplace_back(rule);
 			}
 
 			return true;
@@ -85,11 +83,9 @@ bool ApplyRule::AddTargetedRule(ApplyRule& rule, const String& sourceType, const
 	} else if (targetType == "Service") {
 		std::vector<std::pair<const String *, const String *>> services;
 
-		if (GetTargetServices(rule.m_Filter.get(), services)) {
-			ApplyRule::Ptr sharedRule = new ApplyRule(std::move(rule));
-
+		if (GetTargetServices(rule->m_Filter.get(), services)) {
 			for (auto service : services) {
-				rules.Targeted[*service.first].ForServices[*service.second].emplace_back(sharedRule);
+				rules.Targeted[*service.first].ForServices[*service.second].emplace_back(rule);
 			}
 
 			return true;

--- a/lib/config/applyrule-targeted.cpp
+++ b/lib/config/applyrule-targeted.cpp
@@ -1,0 +1,266 @@
+/* Icinga 2 | (c) 2022 Icinga GmbH | GPLv2+ */
+
+#include "base/string.hpp"
+#include "config/applyrule.hpp"
+#include "config/expression.hpp"
+#include <utility>
+#include <vector>
+
+using namespace icinga;
+
+/**
+ * @returns All ApplyRules targeting only specific parent objects including the given host. (See AddTargetedRule().)
+ */
+const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedHostRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host)
+{
+	auto perSourceType (m_Rules.find(sourceType.get()));
+
+	if (perSourceType != m_Rules.end()) {
+		auto perTargetType (perSourceType->second.find(targetType.get()));
+
+		if (perTargetType != perSourceType->second.end()) {
+			auto perHost (perTargetType->second.Targeted.find(host));
+
+			if (perHost != perTargetType->second.Targeted.end()) {
+				return perHost->second.ForHost;
+			}
+		}
+	}
+
+	static const std::vector<ApplyRule::Ptr> noRules;
+	return noRules;
+}
+
+/**
+ * @returns All ApplyRules targeting only specific parent objects including the given service. (See AddTargetedRule().)
+ */
+const std::vector<ApplyRule::Ptr>& ApplyRule::GetTargetedServiceRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host, const String& service)
+{
+	auto perSourceType (m_Rules.find(sourceType.get()));
+
+	if (perSourceType != m_Rules.end()) {
+		auto perTargetType (perSourceType->second.find(targetType.get()));
+
+		if (perTargetType != perSourceType->second.end()) {
+			auto perHost (perTargetType->second.Targeted.find(host));
+
+			if (perHost != perTargetType->second.Targeted.end()) {
+				auto perService (perHost->second.ForServices.find(service));
+
+				if (perService != perHost->second.ForServices.end()) {
+					return perService->second;
+				}
+			}
+		}
+	}
+
+	static const std::vector<ApplyRule::Ptr> noRules;
+	return noRules;
+}
+
+/**
+ * If the given ApplyRule targets only specific parent objects, add it to the respective "index".
+ *
+ * - The above means for apply T "N" to Host: assign where host.name == "H" [ || host.name == "h" ... ]
+ * - For apply T "N" to Service it means: assign where host.name == "H" && service.name == "S" [ || host.name == "h" && service.name == "s" ... ]
+ *
+ * The order of operands of || && == doesn't matter.
+ *
+ * @returns Whether the rule has been added to the "index".
+ */
+bool ApplyRule::AddTargetedRule(ApplyRule& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules)
+{
+	if (targetType == "Host") {
+		std::vector<const String *> hosts;
+
+		if (GetTargetHosts(rule.m_Filter.get(), hosts)) {
+			ApplyRule::Ptr sharedRule = new ApplyRule(std::move(rule));
+
+			for (auto host : hosts) {
+				rules.Targeted[*host].ForHost.emplace_back(sharedRule);
+			}
+
+			return true;
+		}
+	} else if (targetType == "Service") {
+		std::vector<std::pair<const String *, const String *>> services;
+
+		if (GetTargetServices(rule.m_Filter.get(), services)) {
+			ApplyRule::Ptr sharedRule = new ApplyRule(std::move(rule));
+
+			for (auto service : services) {
+				rules.Targeted[*service.first].ForServices[*service.second].emplace_back(sharedRule);
+			}
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * If the given assign filter is like the following, extract the host names ("H", "h", ...) into the vector:
+ *
+ * host.name == "H" [ || host.name == "h" ... ]
+ *
+ * The order of operands of || == doesn't matter.
+ *
+ * @returns Whether the given assign filter is like above.
+ */
+bool ApplyRule::GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts)
+{
+	auto lor (dynamic_cast<LogicalOrExpression*>(assignFilter));
+
+	if (lor) {
+		return GetTargetHosts(lor->GetOperand1().get(), hosts)
+			&& GetTargetHosts(lor->GetOperand2().get(), hosts);
+	}
+
+	auto name (GetComparedName(assignFilter, "host"));
+
+	if (name) {
+		hosts.emplace_back(name);
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * If the given assign filter is like the following, extract the host+service names ("H"+"S", "h"+"s", ...) into the vector:
+ *
+ * host.name == "H" && service.name == "S" [ || host.name == "h" && service.name == "s" ... ]
+ *
+ * The order of operands of || && == doesn't matter.
+ *
+ * @returns Whether the given assign filter is like above.
+ */
+bool ApplyRule::GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services)
+{
+	auto lor (dynamic_cast<LogicalOrExpression*>(assignFilter));
+
+	if (lor) {
+		return GetTargetServices(lor->GetOperand1().get(), services)
+			&& GetTargetServices(lor->GetOperand2().get(), services);
+	}
+
+	auto service (GetTargetService(assignFilter));
+
+	if (service.first) {
+		services.emplace_back(service);
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * If the given filter is like the following, extract the host+service names ("H"+"S"):
+ *
+ * host.name == "H" && service.name == "S"
+ *
+ * The order of operands of && == doesn't matter.
+ *
+ * @returns {host, service} on success and {nullptr, nullptr} on failure.
+ */
+std::pair<const String *, const String *> ApplyRule::GetTargetService(Expression* assignFilter)
+{
+	auto land (dynamic_cast<LogicalAndExpression*>(assignFilter));
+
+	if (!land) {
+		return {nullptr, nullptr};
+	}
+
+	auto op1 (land->GetOperand1().get());
+	auto op2 (land->GetOperand2().get());
+	auto host (GetComparedName(op1, "host"));
+
+	if (!host) {
+		std::swap(op1, op2);
+		host = GetComparedName(op1, "host");
+	}
+
+	if (host) {
+		auto service (GetComparedName(op2, "service"));
+
+		if (service) {
+			return {host, service};
+		}
+	}
+
+	return {nullptr, nullptr};
+}
+
+/**
+ * If the given filter is like the following, extract the object name ("N"):
+ *
+ * $lcType$.name == "N"
+ *
+ * The order of operands of == doesn't matter.
+ *
+ * @returns The object name on success and nullptr on failure.
+ */
+const String * ApplyRule::GetComparedName(Expression* assignFilter, const char * lcType)
+{
+	auto eq (dynamic_cast<EqualExpression*>(assignFilter));
+
+	if (!eq) {
+		return nullptr;
+	}
+
+	auto op1 (eq->GetOperand1().get());
+	auto op2 (eq->GetOperand2().get());
+
+	if (IsNameIndexer(op1, lcType)) {
+		return GetLiteralStringValue(op2);
+	}
+
+	if (IsNameIndexer(op2, lcType)) {
+		return GetLiteralStringValue(op1);
+	}
+
+	return nullptr;
+}
+
+/**
+ * @returns Whether the given expression is like $lcType$.name.
+ */
+bool ApplyRule::IsNameIndexer(Expression* exp, const char * lcType)
+{
+	auto ixr (dynamic_cast<IndexerExpression*>(exp));
+
+	if (!ixr) {
+		return false;
+	}
+
+	auto var (dynamic_cast<VariableExpression*>(ixr->GetOperand1().get()));
+
+	if (!var || var->GetVariable() != lcType) {
+		return false;
+	}
+
+	auto val (GetLiteralStringValue(ixr->GetOperand2().get()));
+
+	return val && *val == "name";
+}
+
+/**
+ * @returns If the given expression is a string literal, the string. nullptr on failure.
+ */
+const String * ApplyRule::GetLiteralStringValue(Expression* exp)
+{
+	auto lit (dynamic_cast<LiteralExpression*>(exp));
+
+	if (!lit) {
+		return nullptr;
+	}
+
+	auto& val (lit->GetValue());
+
+	if (!val.IsString()) {
+		return nullptr;
+	}
+
+	return &val.Get<String>();
+}

--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -3,6 +3,7 @@
 #include "config/applyrule.hpp"
 #include "base/logger.hpp"
 #include <set>
+#include <unordered_set>
 
 using namespace icinga;
 
@@ -80,9 +81,12 @@ void ApplyRule::AddRule(const String& sourceType, const String& targetType, cons
 		}
 	}
 
-	m_Rules[Type::GetByName(sourceType).get()][Type::GetByName(*actualTargetType).get()].emplace_back(ApplyRule(
-		name, expression, filter, package, fkvar, fvvar, fterm, ignoreOnError, di, scope
-	));
+	ApplyRule rule (name, expression, filter, package, fkvar, fvvar, fterm, ignoreOnError, di, scope);
+	auto& rules (m_Rules[Type::GetByName(sourceType).get()][Type::GetByName(*actualTargetType).get()]);
+
+	if (!AddTargetedRule(rule, sourceType, *actualTargetType, rules)) {
+		rules.Regular.emplace_back(std::move(rule));
+	}
 }
 
 bool ApplyRule::EvaluateFilter(ScriptFrame& frame) const
@@ -148,7 +152,7 @@ std::vector<ApplyRule>& ApplyRule::GetRules(const Type::Ptr& sourceType, const T
 		auto perTargetType (perSourceType->second.find(targetType.get()));
 
 		if (perTargetType != perSourceType->second.end()) {
-			return perTargetType->second;
+			return perTargetType->second.Regular;
 		}
 	}
 
@@ -160,13 +164,36 @@ void ApplyRule::CheckMatches(bool silent)
 {
 	for (auto& perSourceType : m_Rules) {
 		for (auto& perTargetType : perSourceType.second) {
-			for (auto& rule : perTargetType.second) {
-				if (!rule.HasMatches() && !silent) {
-					Log(LogWarning, "ApplyRule")
-						<< "Apply rule '" << rule.GetName() << "' (" << rule.GetDebugInfo() << ") for type '"
-						<< perSourceType.first->GetName() << "' does not match anywhere!";
+			for (auto& rule : perTargetType.second.Regular) {
+				CheckMatches(rule, perSourceType.first, silent);
+			}
+
+			std::unordered_set<ApplyRule*> targeted;
+
+			for (auto& perHost : perTargetType.second.Targeted) {
+				for (auto& rule : perHost.second.ForHost) {
+					targeted.emplace(rule.get());
+				}
+
+				for (auto& perService : perHost.second.ForServices) {
+					for (auto& rule : perService.second) {
+						targeted.emplace(rule.get());
+					}
 				}
 			}
+
+			for (auto rule : targeted) {
+				CheckMatches(*rule, perSourceType.first, silent);
+			}
 		}
+	}
+}
+
+void ApplyRule::CheckMatches(const ApplyRule& rule, Type* sourceType, bool silent)
+{
+	if (!rule.HasMatches() && !silent) {
+		Log(LogWarning, "ApplyRule")
+			<< "Apply rule '" << rule.GetName() << "' (" << rule.GetDebugInfo() << ") for type '"
+			<< sourceType->GetName() << "' does not match anywhere!";
 	}
 }

--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -81,7 +81,7 @@ void ApplyRule::AddRule(const String& sourceType, const String& targetType, cons
 		}
 	}
 
-	ApplyRule rule (name, expression, filter, package, fkvar, fvvar, fterm, ignoreOnError, di, scope);
+	ApplyRule::Ptr rule = new ApplyRule(name, expression, filter, package, fkvar, fvvar, fterm, ignoreOnError, di, scope);
 	auto& rules (m_Rules[Type::GetByName(sourceType).get()][Type::GetByName(*actualTargetType).get()]);
 
 	if (!AddTargetedRule(rule, sourceType, *actualTargetType, rules)) {
@@ -144,7 +144,7 @@ bool ApplyRule::HasMatches() const
 	return m_HasMatches;
 }
 
-std::vector<ApplyRule>& ApplyRule::GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType)
+const std::vector<ApplyRule::Ptr>& ApplyRule::GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType)
 {
 	auto perSourceType (m_Rules.find(sourceType.get()));
 
@@ -156,7 +156,7 @@ std::vector<ApplyRule>& ApplyRule::GetRules(const Type::Ptr& sourceType, const T
 		}
 	}
 
-	static std::vector<ApplyRule> noRules;
+	static const std::vector<ApplyRule::Ptr> noRules;
 	return noRules;
 }
 
@@ -183,17 +183,17 @@ void ApplyRule::CheckMatches(bool silent)
 			}
 
 			for (auto rule : targeted) {
-				CheckMatches(*rule, perSourceType.first, silent);
+				CheckMatches(rule, perSourceType.first, silent);
 			}
 		}
 	}
 }
 
-void ApplyRule::CheckMatches(const ApplyRule& rule, Type* sourceType, bool silent)
+void ApplyRule::CheckMatches(const ApplyRule::Ptr& rule, Type* sourceType, bool silent)
 {
-	if (!rule.HasMatches() && !silent) {
+	if (!rule->HasMatches() && !silent) {
 		Log(LogWarning, "ApplyRule")
-			<< "Apply rule '" << rule.GetName() << "' (" << rule.GetDebugInfo() << ") for type '"
+			<< "Apply rule '" << rule->GetName() << "' (" << rule->GetDebugInfo() << ") for type '"
 			<< sourceType->GetName() << "' does not match anywhere!";
 	}
 }

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -23,8 +23,8 @@ public:
 
 	struct PerHost
 	{
-		std::vector<ApplyRule::Ptr> ForHost;
-		std::unordered_map<String /* service */, std::vector<ApplyRule::Ptr>> ForServices;
+		std::set<ApplyRule::Ptr> ForHost;
+		std::unordered_map<String /* service */, std::set<ApplyRule::Ptr>> ForServices;
 	};
 
 	struct PerSourceType
@@ -36,13 +36,13 @@ public:
 	/*
 	 * m_Rules[T::TypeInstance.get()].Targeted["H"].ForHost
 	 * contains all apply rules like apply T "x" to Host { ... }
-	 * which target only specific hosts incl. "H", e. g. via
+	 * which target only specific hosts incl. "H", e.g. via
 	 * assign where host.name == "H" || host.name == "h".
 	 *
 	 * m_Rules[T::TypeInstance.get()].Targeted["H"].ForServices["S"]
 	 * contains all apply rules like apply T "x" to Service { ... }
-	 * which target only specific services on specific hosts incl. "H!S",
-	 * e. g. via assign where host.name == "H" && service.name == "S".
+	 * which target only specific services on specific hosts,
+	 * e.g. via assign where host.name == "H" && service.name == "S".
 	 *
 	 * m_Rules[T::TypeInstance.get()].Regular[C::TypeInstance.get()]
 	 * contains all other apply rules like apply T "x" to C { ... }.
@@ -70,8 +70,8 @@ public:
 		const Expression::Ptr& filter, const String& package, const String& fkvar, const String& fvvar, const Expression::Ptr& fterm,
 		bool ignoreOnError, const DebugInfo& di, const Dictionary::Ptr& scope);
 	static const std::vector<ApplyRule::Ptr>& GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType);
-	static const std::vector<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const String& host);
-	static const std::vector<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service);
+	static const std::set<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const String& host);
+	static const std::set<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service);
 
 	static void RegisterType(const String& sourceType, const std::vector<String>& targetTypes);
 	static bool IsValidSourceType(const String& sourceType);

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -27,27 +27,27 @@ public:
 		std::unordered_map<String /* service */, std::vector<ApplyRule::Ptr>> ForServices;
 	};
 
-	struct PerTypes
+	struct PerSourceType
 	{
-		std::vector<ApplyRule::Ptr> Regular;
+		std::unordered_map<Type* /* target type */, std::vector<ApplyRule::Ptr>> Regular;
 		std::unordered_map<String /* host */, PerHost> Targeted;
 	};
 
 	/*
-	 * m_Rules[T::TypeInstance.get()][Host::TypeInstance.get()].Targeted["H"].ForHost
+	 * m_Rules[T::TypeInstance.get()].Targeted["H"].ForHost
 	 * contains all apply rules like apply T "x" to Host { ... }
 	 * which target only specific hosts incl. "H", e. g. via
 	 * assign where host.name == "H" || host.name == "h".
 	 *
-	 * m_Rules[T::TypeInstance.get()][Service::TypeInstance.get()].Targeted["H"].ForServices["S"]
+	 * m_Rules[T::TypeInstance.get()].Targeted["H"].ForServices["S"]
 	 * contains all apply rules like apply T "x" to Service { ... }
 	 * which target only specific services on specific hosts incl. "H!S",
 	 * e. g. via assign where host.name == "H" && service.name == "S".
 	 *
-	 * m_Rules[T::TypeInstance.get()][C::TypeInstance.get()].Regular
+	 * m_Rules[T::TypeInstance.get()].Regular[C::TypeInstance.get()]
 	 * contains all other apply rules like apply T "x" to C { ... }.
 	 */
-	typedef std::unordered_map<Type* /* source type */, std::unordered_map<Type* /* target type */, PerTypes>> RuleMap;
+	typedef std::unordered_map<Type* /* source type */, PerSourceType> RuleMap;
 
 	typedef std::map<String, std::vector<String> > TypeMap;
 
@@ -70,8 +70,8 @@ public:
 		const Expression::Ptr& filter, const String& package, const String& fkvar, const String& fvvar, const Expression::Ptr& fterm,
 		bool ignoreOnError, const DebugInfo& di, const Dictionary::Ptr& scope);
 	static const std::vector<ApplyRule::Ptr>& GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType);
-	static const std::vector<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host);
-	static const std::vector<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host, const String& service);
+	static const std::vector<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const String& host);
+	static const std::vector<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service);
 
 	static void RegisterType(const String& sourceType, const std::vector<String>& targetTypes);
 	static bool IsValidSourceType(const String& sourceType);
@@ -97,7 +97,7 @@ private:
 	static TypeMap m_Types;
 	static RuleMap m_Rules;
 
-	static bool AddTargetedRule(const ApplyRule::Ptr& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules);
+	static bool AddTargetedRule(const ApplyRule::Ptr& rule, const String& targetType, PerSourceType& rules);
 	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts);
 	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services);
 	static std::pair<const String *, const String *> GetTargetService(Expression* assignFilter);

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -6,6 +6,7 @@
 #include "config/i2-config.hpp"
 #include "config/expression.hpp"
 #include "base/debuginfo.hpp"
+#include "base/shared-object.hpp"
 #include "base/type.hpp"
 #include <unordered_map>
 
@@ -15,9 +16,11 @@ namespace icinga
 /**
  * @ingroup config
  */
-class ApplyRule
+class ApplyRule : public SharedObject
 {
 public:
+	DECLARE_PTR_TYPEDEFS(ApplyRule);
+
 	typedef std::map<String, std::vector<String> > TypeMap;
 	typedef std::unordered_map<Type*, std::unordered_map<Type*, std::vector<ApplyRule>>> RuleMap;
 

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -29,7 +29,7 @@ public:
 
 	struct PerTypes
 	{
-		std::vector<ApplyRule> Regular;
+		std::vector<ApplyRule::Ptr> Regular;
 		std::unordered_map<String /* host */, PerHost> Targeted;
 	};
 
@@ -69,7 +69,7 @@ public:
 	static void AddRule(const String& sourceType, const String& targetType, const String& name, const Expression::Ptr& expression,
 		const Expression::Ptr& filter, const String& package, const String& fkvar, const String& fvvar, const Expression::Ptr& fterm,
 		bool ignoreOnError, const DebugInfo& di, const Dictionary::Ptr& scope);
-	static std::vector<ApplyRule>& GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType);
+	static const std::vector<ApplyRule::Ptr>& GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType);
 	static const std::vector<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host);
 	static const std::vector<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const Type::Ptr& targetType, const String& host, const String& service);
 
@@ -79,7 +79,7 @@ public:
 	static const std::vector<String>& GetTargetTypes(const String& sourceType);
 
 	static void CheckMatches(bool silent);
-	static void CheckMatches(const ApplyRule& rule, Type* sourceType, bool silent);
+	static void CheckMatches(const ApplyRule::Ptr& rule, Type* sourceType, bool silent);
 
 private:
 	String m_Name;
@@ -97,7 +97,7 @@ private:
 	static TypeMap m_Types;
 	static RuleMap m_Rules;
 
-	static bool AddTargetedRule(ApplyRule& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules);
+	static bool AddTargetedRule(const ApplyRule::Ptr& rule, const String& sourceType, const String& targetType, ApplyRule::PerTypes& rules);
 	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts);
 	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services);
 	static std::pair<const String *, const String *> GetTargetService(Expression* assignFilter);

--- a/lib/config/expression.hpp
+++ b/lib/config/expression.hpp
@@ -283,6 +283,16 @@ public:
 		: DebuggableExpression(debugInfo), m_Operand1(std::move(operand1)), m_Operand2(std::move(operand2))
 	{ }
 
+	inline const std::unique_ptr<Expression>& GetOperand1() const noexcept
+	{
+		return m_Operand1;
+	}
+
+	inline const std::unique_ptr<Expression>& GetOperand2() const noexcept
+	{
+		return m_Operand2;
+	}
+
 protected:
 	std::unique_ptr<Expression> m_Operand1;
 	std::unique_ptr<Expression> m_Operand2;

--- a/lib/config/expression.hpp
+++ b/lib/config/expression.hpp
@@ -303,7 +303,7 @@ class VariableExpression final : public DebuggableExpression
 public:
 	VariableExpression(String variable, std::vector<Expression::Ptr> imports, const DebugInfo& debugInfo = DebugInfo());
 
-	String GetVariable() const
+	inline const String& GetVariable() const
 	{
 		return m_Variable;
 	}

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -140,6 +140,11 @@ void Dependency::EvaluateApplyRules(const Host::Ptr& host)
 		if (EvaluateApplyRule(host, rule))
 			rule.AddMatch();
 	}
+
+	for (auto& rule : ApplyRule::GetTargetedHostRules(Dependency::TypeInstance, Host::TypeInstance, host->GetName())) {
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
+	}
 }
 
 void Dependency::EvaluateApplyRules(const Service::Ptr& service)
@@ -149,5 +154,10 @@ void Dependency::EvaluateApplyRules(const Service::Ptr& service)
 	for (auto& rule : ApplyRule::GetRules(Dependency::TypeInstance, Service::TypeInstance)) {
 		if (EvaluateApplyRule(service, rule))
 			rule.AddMatch();
+	}
+
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(Dependency::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+		if (EvaluateApplyRule(service, *rule))
+			rule->AddMatch();
 	}
 }

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -141,7 +141,7 @@ void Dependency::EvaluateApplyRules(const Host::Ptr& host)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedHostRules(Dependency::TypeInstance, Host::TypeInstance, host->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedHostRules(Dependency::TypeInstance, host->GetName())) {
 		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}
@@ -156,7 +156,7 @@ void Dependency::EvaluateApplyRules(const Service::Ptr& service)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedServiceRules(Dependency::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(Dependency::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
 		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -156,7 +156,7 @@ void Dependency::EvaluateApplyRules(const Service::Ptr& service)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedServiceRules(Dependency::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(Dependency::TypeInstance, service->GetHost()->GetName(), service->GetShortName())) {
 		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -137,8 +137,8 @@ void Dependency::EvaluateApplyRules(const Host::Ptr& host)
 	CONTEXT("Evaluating 'apply' rules for host '" + host->GetName() + "'");
 
 	for (auto& rule : ApplyRule::GetRules(Dependency::TypeInstance, Host::TypeInstance)) {
-		if (EvaluateApplyRule(host, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(Dependency::TypeInstance, Host::TypeInstance, host->GetName())) {
@@ -152,8 +152,8 @@ void Dependency::EvaluateApplyRules(const Service::Ptr& service)
 	CONTEXT("Evaluating 'apply' rules for service '" + service->GetName() + "'");
 
 	for (auto& rule : ApplyRule::GetRules(Dependency::TypeInstance, Service::TypeInstance)) {
-		if (EvaluateApplyRule(service, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(service, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedServiceRules(Dependency::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -50,8 +50,8 @@ private:
 	Checkable::Ptr m_Parent;
 	Checkable::Ptr m_Child;
 
-	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule);
-	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule);
+	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
+	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter = false);
 };
 
 }

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -156,7 +156,7 @@ void Notification::EvaluateApplyRules(const Service::Ptr& service)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, service->GetHost()->GetName(), service->GetShortName())) {
 		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -140,6 +140,11 @@ void Notification::EvaluateApplyRules(const Host::Ptr& host)
 		if (EvaluateApplyRule(host, rule))
 			rule.AddMatch();
 	}
+
+	for (auto& rule : ApplyRule::GetTargetedHostRules(Notification::TypeInstance, Host::TypeInstance, host->GetName())) {
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
+	}
 }
 
 void Notification::EvaluateApplyRules(const Service::Ptr& service)
@@ -149,5 +154,10 @@ void Notification::EvaluateApplyRules(const Service::Ptr& service)
 	for (auto& rule : ApplyRule::GetRules(Notification::TypeInstance, Service::TypeInstance)) {
 		if (EvaluateApplyRule(service, rule))
 			rule.AddMatch();
+	}
+
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+		if (EvaluateApplyRule(service, *rule))
+			rule->AddMatch();
 	}
 }

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -141,7 +141,7 @@ void Notification::EvaluateApplyRules(const Host::Ptr& host)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedHostRules(Notification::TypeInstance, Host::TypeInstance, host->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedHostRules(Notification::TypeInstance, host->GetName())) {
 		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}
@@ -156,7 +156,7 @@ void Notification::EvaluateApplyRules(const Service::Ptr& service)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
 		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -137,8 +137,8 @@ void Notification::EvaluateApplyRules(const Host::Ptr& host)
 
 	for (auto& rule : ApplyRule::GetRules(Notification::TypeInstance, Host::TypeInstance))
 	{
-		if (EvaluateApplyRule(host, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(Notification::TypeInstance, Host::TypeInstance, host->GetName())) {
@@ -152,8 +152,8 @@ void Notification::EvaluateApplyRules(const Service::Ptr& service)
 	CONTEXT("Evaluating 'apply' rules for service '" + service->GetName() + "'");
 
 	for (auto& rule : ApplyRule::GetRules(Notification::TypeInstance, Service::TypeInstance)) {
-		if (EvaluateApplyRule(service, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(service, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -17,9 +17,9 @@ INITIALIZE_ONCE([]() {
 	ApplyRule::RegisterType("Notification", { "Host", "Service" });
 });
 
-bool Notification::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule)
+bool Notification::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter)
 {
-	if (!rule.EvaluateFilter(frame))
+	if (!skipFilter && !rule.EvaluateFilter(frame))
 		return false;
 
 	DebugInfo di = rule.GetDebugInfo();
@@ -61,7 +61,7 @@ bool Notification::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, co
 	return true;
 }
 
-bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule)
+bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter)
 {
 	DebugInfo di = rule.GetDebugInfo();
 
@@ -110,7 +110,7 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 				name += instance;
 			}
 
-			if (EvaluateApplyRuleInstance(checkable, name, frame, rule))
+			if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
 				match = true;
 		}
 	} else if (vinstances.IsObjectType<Dictionary>()) {
@@ -123,7 +123,7 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 
-			if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule))
+			if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
 				match = true;
 		}
 	}
@@ -142,7 +142,7 @@ void Notification::EvaluateApplyRules(const Host::Ptr& host)
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(Notification::TypeInstance, Host::TypeInstance, host->GetName())) {
-		if (EvaluateApplyRule(host, *rule))
+		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}
 }
@@ -157,7 +157,7 @@ void Notification::EvaluateApplyRules(const Service::Ptr& service)
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedServiceRules(Notification::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
-		if (EvaluateApplyRule(service, *rule))
+		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}
 }

--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -118,8 +118,8 @@ private:
 
 	void ExecuteNotificationHelper(NotificationType type, const User::Ptr& user, const CheckResult::Ptr& cr, bool force, const String& author = "", const String& text = "");
 
-	static bool EvaluateApplyRuleInstance(const intrusive_ptr<Checkable>& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule);
-	static bool EvaluateApplyRule(const intrusive_ptr<Checkable>& checkable, const ApplyRule& rule);
+	static bool EvaluateApplyRuleInstance(const intrusive_ptr<Checkable>& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
+	static bool EvaluateApplyRule(const intrusive_ptr<Checkable>& checkable, const ApplyRule& rule, bool skipFilter = false);
 
 	static std::map<String, int> m_StateFilterMap;
 	static std::map<String, int> m_TypeFilterMap;

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -138,6 +138,11 @@ void ScheduledDowntime::EvaluateApplyRules(const Host::Ptr& host)
 		if (EvaluateApplyRule(host, rule))
 			rule.AddMatch();
 	}
+
+	for (auto& rule : ApplyRule::GetTargetedHostRules(ScheduledDowntime::TypeInstance, Host::TypeInstance, host->GetName())) {
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
+	}
 }
 
 void ScheduledDowntime::EvaluateApplyRules(const Service::Ptr& service)
@@ -147,5 +152,10 @@ void ScheduledDowntime::EvaluateApplyRules(const Service::Ptr& service)
 	for (auto& rule : ApplyRule::GetRules(ScheduledDowntime::TypeInstance, Service::TypeInstance)) {
 		if (EvaluateApplyRule(service, rule))
 			rule.AddMatch();
+	}
+
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+		if (EvaluateApplyRule(service, *rule))
+			rule->AddMatch();
 	}
 }

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -139,7 +139,7 @@ void ScheduledDowntime::EvaluateApplyRules(const Host::Ptr& host)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedHostRules(ScheduledDowntime::TypeInstance, Host::TypeInstance, host->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedHostRules(ScheduledDowntime::TypeInstance, host->GetName())) {
 		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}
@@ -154,7 +154,7 @@ void ScheduledDowntime::EvaluateApplyRules(const Service::Ptr& service)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
 		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -135,8 +135,8 @@ void ScheduledDowntime::EvaluateApplyRules(const Host::Ptr& host)
 	CONTEXT("Evaluating 'apply' rules for host '" + host->GetName() + "'");
 
 	for (auto& rule : ApplyRule::GetRules(ScheduledDowntime::TypeInstance, Host::TypeInstance)) {
-		if (EvaluateApplyRule(host, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(ScheduledDowntime::TypeInstance, Host::TypeInstance, host->GetName())) {
@@ -150,8 +150,8 @@ void ScheduledDowntime::EvaluateApplyRules(const Service::Ptr& service)
 	CONTEXT("Evaluating 'apply' rules for service '" + service->GetName() + "'");
 
 	for (auto& rule : ApplyRule::GetRules(ScheduledDowntime::TypeInstance, Service::TypeInstance)) {
-		if (EvaluateApplyRule(service, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(service, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -154,7 +154,7 @@ void ScheduledDowntime::EvaluateApplyRules(const Service::Ptr& service)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, service->GetHost()->GetName(), service->GetShortName())) {
 		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -16,9 +16,9 @@ INITIALIZE_ONCE([]() {
 	ApplyRule::RegisterType("ScheduledDowntime", { "Host", "Service" });
 });
 
-bool ScheduledDowntime::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule)
+bool ScheduledDowntime::EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter)
 {
-	if (!rule.EvaluateFilter(frame))
+	if (!skipFilter && !rule.EvaluateFilter(frame))
 		return false;
 
 	DebugInfo di = rule.GetDebugInfo();
@@ -60,7 +60,7 @@ bool ScheduledDowntime::EvaluateApplyRuleInstance(const Checkable::Ptr& checkabl
 	return true;
 }
 
-bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule)
+bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter)
 {
 	DebugInfo di = rule.GetDebugInfo();
 
@@ -109,7 +109,7 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 				name += instance;
 			}
 
-			if (EvaluateApplyRuleInstance(checkable, name, frame, rule))
+			if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
 				match = true;
 		}
 	} else if (vinstances.IsObjectType<Dictionary>()) {
@@ -122,7 +122,7 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 
-			if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule))
+			if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
 				match = true;
 		}
 	}
@@ -140,7 +140,7 @@ void ScheduledDowntime::EvaluateApplyRules(const Host::Ptr& host)
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(ScheduledDowntime::TypeInstance, Host::TypeInstance, host->GetName())) {
-		if (EvaluateApplyRule(host, *rule))
+		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}
 }
@@ -155,7 +155,7 @@ void ScheduledDowntime::EvaluateApplyRules(const Service::Ptr& service)
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedServiceRules(ScheduledDowntime::TypeInstance, Service::TypeInstance, service->GetHost()->GetName(), service->GetName())) {
-		if (EvaluateApplyRule(service, *rule))
+		if (EvaluateApplyRule(service, *rule, true))
 			rule->AddMatch();
 	}
 }

--- a/lib/icinga/scheduleddowntime.hpp
+++ b/lib/icinga/scheduleddowntime.hpp
@@ -51,8 +51,8 @@ private:
 
 	static std::atomic<bool> m_AllConfigLoaded;
 
-	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule);
-	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule);
+	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
+	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter = false);
 };
 
 }

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -124,8 +124,8 @@ void Service::EvaluateApplyRules(const Host::Ptr& host)
 	CONTEXT("Evaluating 'apply' rules for host '" + host->GetName() + "'");
 
 	for (auto& rule : ApplyRule::GetRules(Service::TypeInstance, Host::TypeInstance)) {
-		if (EvaluateApplyRule(host, rule))
-			rule.AddMatch();
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(Service::TypeInstance, Host::TypeInstance, host->GetName())) {

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -128,7 +128,7 @@ void Service::EvaluateApplyRules(const Host::Ptr& host)
 			rule->AddMatch();
 	}
 
-	for (auto& rule : ApplyRule::GetTargetedHostRules(Service::TypeInstance, Host::TypeInstance, host->GetName())) {
+	for (auto& rule : ApplyRule::GetTargetedHostRules(Service::TypeInstance, host->GetName())) {
 		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -16,9 +16,9 @@ INITIALIZE_ONCE([]() {
 	ApplyRule::RegisterType("Service", { "Host" });
 });
 
-bool Service::EvaluateApplyRuleInstance(const Host::Ptr& host, const String& name, ScriptFrame& frame, const ApplyRule& rule)
+bool Service::EvaluateApplyRuleInstance(const Host::Ptr& host, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter)
 {
-	if (!rule.EvaluateFilter(frame))
+	if (!skipFilter && !rule.EvaluateFilter(frame))
 		return false;
 
 	DebugInfo di = rule.GetDebugInfo();
@@ -55,7 +55,7 @@ bool Service::EvaluateApplyRuleInstance(const Host::Ptr& host, const String& nam
 	return true;
 }
 
-bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule)
+bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bool skipFilter)
 {
 	DebugInfo di = rule.GetDebugInfo();
 
@@ -98,7 +98,7 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule)
 				name += instance;
 			}
 
-			if (EvaluateApplyRuleInstance(host, name, frame, rule))
+			if (EvaluateApplyRuleInstance(host, name, frame, rule, skipFilter))
 				match = true;
 		}
 	} else if (vinstances.IsObjectType<Dictionary>()) {
@@ -111,7 +111,7 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule)
 			frame.Locals->Set(rule.GetFKVar(), key);
 			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
 
-			if (EvaluateApplyRuleInstance(host, rule.GetName() + key, frame, rule))
+			if (EvaluateApplyRuleInstance(host, rule.GetName() + key, frame, rule, skipFilter))
 				match = true;
 		}
 	}
@@ -129,7 +129,7 @@ void Service::EvaluateApplyRules(const Host::Ptr& host)
 	}
 
 	for (auto& rule : ApplyRule::GetTargetedHostRules(Service::TypeInstance, Host::TypeInstance, host->GetName())) {
-		if (EvaluateApplyRule(host, *rule))
+		if (EvaluateApplyRule(host, *rule, true))
 			rule->AddMatch();
 	}
 }

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -127,4 +127,9 @@ void Service::EvaluateApplyRules(const Host::Ptr& host)
 		if (EvaluateApplyRule(host, rule))
 			rule.AddMatch();
 	}
+
+	for (auto& rule : ApplyRule::GetTargetedHostRules(Service::TypeInstance, Host::TypeInstance, host->GetName())) {
+		if (EvaluateApplyRule(host, *rule))
+			rule->AddMatch();
+	}
 }

--- a/lib/icinga/service.hpp
+++ b/lib/icinga/service.hpp
@@ -54,8 +54,8 @@ protected:
 private:
 	Host::Ptr m_Host;
 
-	static bool EvaluateApplyRuleInstance(const Host::Ptr& host, const String& name, ScriptFrame& frame, const ApplyRule& rule);
-	static bool EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule);
+	static bool EvaluateApplyRuleInstance(const Host::Ptr& host, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
+	static bool EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bool skipFilter = false);
 };
 
 std::pair<Host::Ptr, Service::Ptr> GetHostService(const Checkable::Ptr& checkable);


### PR DESCRIPTION
not to unnecessarily run e.g. the filter assign where host.name=="example.com"    for all hosts being not example.com.

ref/IP/42584
(PR 3/3)

## Blocked by

* #9543 (I'll benchmark everything together anyway)