### PR TITLE
Type#GetLoadDependencies(): avoid malloc()

### DIFF
--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -136,9 +136,10 @@ Value Type::GetField(int id) const
 	BOOST_THROW_EXCEPTION(std::runtime_error("Invalid field ID."));
 }
 
-std::vector<String> Type::GetLoadDependencies() const
+const std::unordered_set<Type*>& Type::GetLoadDependencies() const
 {
-	return std::vector<String>();
+	static const std::unordered_set<Type*> noDeps;
+	return noDeps;
 }
 
 int Type::GetActivationPriority() const

--- a/lib/base/type.hpp
+++ b/lib/base/type.hpp
@@ -7,6 +7,7 @@
 #include "base/string.hpp"
 #include "base/object.hpp"
 #include "base/initialize.hpp"
+#include <unordered_set>
 #include <vector>
 
 namespace icinga
@@ -85,7 +86,7 @@ public:
 	void SetField(int id, const Value& value, bool suppress_events = false, const Value& cookie = Empty) override;
 	Value GetField(int id) const override;
 
-	virtual std::vector<String> GetLoadDependencies() const;
+	virtual const std::unordered_set<Type*>& GetLoadDependencies() const;
 	virtual int GetActivationPriority() const;
 
 	typedef std::function<void (const Object::Ptr&, const Value&)> AttributeHandler;

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -450,8 +450,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 			bool unresolved_dep = false;
 
 			/* skip this type (for now) if there are unresolved load dependencies */
-			for (const String& loadDep : type->GetLoadDependencies()) {
-				Type::Ptr pLoadDep = Type::GetByName(loadDep);
+			for (auto pLoadDep : type->GetLoadDependencies()) {
 				if (types.find(pLoadDep) != types.end() && completed_types.find(pLoadDep) == completed_types.end()) {
 					unresolved_dep = true;
 					break;
@@ -516,8 +515,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 			bool unresolved_dep = false;
 
 			/* skip this type (for now) if there are unresolved load dependencies */
-			for (const String& loadDep : type->GetLoadDependencies()) {
-				Type::Ptr pLoadDep = Type::GetByName(loadDep);
+			for (auto pLoadDep : type->GetLoadDependencies()) {
 				if (types.find(pLoadDep) != types.end() && completed_types.find(pLoadDep) == completed_types.end()) {
 					unresolved_dep = true;
 					break;
@@ -567,11 +565,11 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 				return false;
 
 			notified_items = 0;
-			for (const String& loadDep : type->GetLoadDependencies()) {
+			for (auto loadDep : type->GetLoadDependencies()) {
 				upq.ParallelFor(items, [loadDep, &type, &notified_items](const ItemPair& ip) {
 					const ConfigItem::Ptr& item = ip.first;
 
-					if (!item->m_Object || item->m_Type->GetName() != loadDep)
+					if (!item->m_Object || item->m_Type.get() != loadDep)
 						return;
 
 					ActivationScope ascope(item->m_ActivationContext);

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -376,14 +376,16 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		<< "}" << std::endl << std::endl;
 
 	/* GetLoadDependencies */
-	m_Header << "\t" << "std::vector<String> GetLoadDependencies() const override;" << std::endl;
+	m_Header << "\t" << "const std::unordered_set<Type*>& GetLoadDependencies() const override;" << std::endl;
 
-	m_Impl << "std::vector<String> TypeImpl<" << klass.Name << ">::GetLoadDependencies() const" << std::endl
+	m_Impl << "const std::unordered_set<Type*>& TypeImpl<" << klass.Name << ">::GetLoadDependencies() const" << std::endl
 		<< "{" << std::endl
-		<< "\t" << "std::vector<String> deps;" << std::endl;
+		<< "\t" << "static const std::unordered_set<Type*> deps ({" << std::endl;
 
 	for (const std::string& dep : klass.LoadDependencies)
-		m_Impl << "\t" << "deps.emplace_back(\"" << dep << "\");" << std::endl;
+		m_Impl << "\t\t" << "GetByName(\"" << dep << "\").get()," << std::endl;
+
+	m_Impl << "\t" << "});" << std::endl;
 
 	m_Impl << "\t" << "return deps;" << std::endl
 		<< "}" << std::endl << std::endl;


### PR DESCRIPTION
- cache result
- return it by const ref
- do Type::GetByName() for the callers