### PR TITLE
ITL: Change the executable name for check_systemd

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -3586,7 +3586,7 @@ iostat\_cwrite | **Required.** Critical threshold for KB/s writes (default: 200)
 
 #### systemd <a id="plugin-contrib-command-systemd"></a>
 
-The [check_systemd.py](https://github.com/Josef-Friedrich/check_systemd) plugin
+The [check_systemd](https://github.com/Josef-Friedrich/check_systemd) plugin
 will report a degraded system to your monitoring solution. It requires only the [nagiosplugin](https://nagiosplugin.readthedocs.io/en/stable) library.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):

--- a/itl/plugins-contrib.d/systemd.conf
+++ b/itl/plugins-contrib.d/systemd.conf
@@ -1,7 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 object CheckCommand "systemd" {
-	command = [ PluginContribDir + "/check_systemd.py" ]
+	command = [ PluginContribDir + "/check_systemd" ]
 
 	arguments = {
 		"--unit" = {


### PR DESCRIPTION
The check_systemd plugin is packaged as `check_systemd` (without the `.py` extension) in the major Linux distributions, as reported in #9547.

Resolves #9547