### PR TITLE
ApplyRule#GetF*Var(): return by const ref

### DIFF
--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -37,11 +37,6 @@ String ApplyRule::GetPackage() const
 	return m_Package;
 }
 
-String ApplyRule::GetFKVar() const
-{
-	return m_FKVar;
-}
-
 String ApplyRule::GetFVVar() const
 {
 	return m_FVVar;

--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -37,11 +37,6 @@ String ApplyRule::GetPackage() const
 	return m_Package;
 }
 
-String ApplyRule::GetFVVar() const
-{
-	return m_FVVar;
-}
-
 Expression::Ptr ApplyRule::GetFTerm() const
 {
 	return m_FTerm;

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -55,7 +55,12 @@ public:
 	Expression::Ptr GetExpression() const;
 	Expression::Ptr GetFilter() const;
 	String GetPackage() const;
-	String GetFKVar() const;
+
+	inline const String& GetFKVar() const noexcept
+	{
+		return m_FKVar;
+	}
+
 	String GetFVVar() const;
 	Expression::Ptr GetFTerm() const;
 	bool GetIgnoreOnError() const;

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -61,7 +61,11 @@ public:
 		return m_FKVar;
 	}
 
-	String GetFVVar() const;
+	inline const String& GetFVVar() const noexcept
+	{
+		return m_FVVar;
+	}
+
 	Expression::Ptr GetFTerm() const;
 	bool GetIgnoreOnError() const;
 	DebugInfo GetDebugInfo() const;


### PR DESCRIPTION
to avoid malloc().