### PR TITLE
Checkable#MakeLocalsForApply(): make regex(), match() and cidr_match() "hot functions"

### DIFF
--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -78,6 +78,42 @@ void Checkable::OnAllConfigLoaded()
 	}
 }
 
+Dictionary::Ptr Checkable::MakeLocalsForApply()
+{
+	static const DictionaryData hotFunctions = ([]() -> DictionaryData {
+		DictionaryData hotFunctions;
+		Namespace::Ptr systemNS = ScriptGlobal::Get("System");
+
+		for (auto fname : { "regex", "match", "cidr_match" }) {
+			hotFunctions.emplace_back(fname, systemNS->Get(fname));
+		}
+
+		return hotFunctions;
+	})();
+
+	/* `match(host.vars.foo, "*bar*")` as an AST:
+	 *
+	 * FunctionCallExpression
+	 *   |- m_FName = VariableExpression
+	 *   |              |- m_Variable = "match"
+	 *   |              \- m_Imports = [
+	 *   |                   IndexerExpression // globals.System
+	 *   |                     |- m_Operand1 = GetScopeExpression
+	 *   |                     |                 \- m_ScopeSpec = ScopeGlobal
+	 *   |                     \- m_Operand2 = LiteralExpression
+	 *   |                                       \- m_Value = "System"
+	 *   |                   ...
+	 *   |                 ]
+	 *   \- m_Args = ...
+	 *
+	 * Instead of looking up "match" in ScriptFrame#Locals, ScriptFrame#Self and
+	 * finally in globals.System (implies looking up "System" in globals first)
+	 * while locking all respective mutexes (see VariableExpression#GetReference()),
+	 * place match() and the other "hot functions" above directly in ScriptFrame#Locals.
+	 */
+	return new Dictionary(hotFunctions);
+}
+
 void Checkable::Start(bool runtimeCreated)
 {
 	double now = Utility::GetTime();

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -320,3 +320,13 @@ void Checkable::CleanDeadlinedExecutions(const Timer * const&)
 		}
 	}
 }
+
+Dictionary::Ptr Checkable::GetFrozenLocalsForApply()
+{
+	if (!m_FrozenLocalsForApply) {
+		m_FrozenLocalsForApply = MakeLocalsForApply();
+		m_FrozenLocalsForApply->Freeze();
+	}
+
+	return m_FrozenLocalsForApply;
+}

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -214,7 +214,7 @@ protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
 
-	virtual Dictionary::Ptr MakeLocalsForApply() = 0;
+	virtual Dictionary::Ptr MakeLocalsForApply();
 
 private:
 	Dictionary::Ptr m_FrozenLocalsForApply;

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -207,12 +207,18 @@ public:
 
 	static Object::Ptr GetPrototype();
 
+	Dictionary::Ptr GetFrozenLocalsForApply();
+
 protected:
 	void Start(bool runtimeCreated) override;
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
 
+	virtual Dictionary::Ptr MakeLocalsForApply() = 0;
+
 private:
+	Dictionary::Ptr m_FrozenLocalsForApply;
+
 	mutable std::mutex m_CheckableMutex;
 	bool m_CheckRunning{false};
 	long m_SchedulingOffset;

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -81,52 +81,50 @@ bool Dependency::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyR
 	if (service)
 		frame.Locals->Set("service", service);
 
-	Value vinstances;
+	bool match = false;
 
 	if (rule.GetFTerm()) {
+		Value vinstances;
+
 		try {
 			vinstances = rule.GetFTerm()->Evaluate(frame);
 		} catch (const std::exception&) {
 			/* Silently ignore errors here and assume there are no instances. */
 			return false;
 		}
-	} else {
-		vinstances = new Array({ "" });
-	}
 
-	bool match = false;
+		if (vinstances.IsObjectType<Array>()) {
+			if (!rule.GetFVVar().IsEmpty())
+				BOOST_THROW_EXCEPTION(ScriptError("Dictionary iterator requires value to be a dictionary.", di));
 
-	if (vinstances.IsObjectType<Array>()) {
-		if (!rule.GetFVVar().IsEmpty())
-			BOOST_THROW_EXCEPTION(ScriptError("Dictionary iterator requires value to be a dictionary.", di));
+			Array::Ptr arr = vinstances;
 
-		Array::Ptr arr = vinstances;
+			ObjectLock olock(arr);
+			for (const Value& instance : arr) {
+				String name = rule.GetName();
 
-		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
-			String name = rule.GetName();
-
-			if (!rule.GetFKVar().IsEmpty()) {
 				frame.Locals->Set(rule.GetFKVar(), instance);
 				name += instance;
+
+				if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
+					match = true;
 			}
+		} else if (vinstances.IsObjectType<Dictionary>()) {
+			if (rule.GetFVVar().IsEmpty())
+				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
-			if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
-				match = true;
+			Dictionary::Ptr dict = vinstances;
+
+			for (const String& key : dict->GetKeys()) {
+				frame.Locals->Set(rule.GetFKVar(), key);
+				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+
+				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
+					match = true;
+			}
 		}
-	} else if (vinstances.IsObjectType<Dictionary>()) {
-		if (rule.GetFVVar().IsEmpty())
-			BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
-
-		Dictionary::Ptr dict = vinstances;
-
-		for (const String& key : dict->GetKeys()) {
-			frame.Locals->Set(rule.GetFKVar(), key);
-			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
-
-			if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
-				match = true;
-		}
+	} else if (EvaluateApplyRuleInstance(checkable, rule.GetName(), frame, rule, skipFilter)) {
+		match = true;
 	}
 
 	return match;

--- a/lib/icinga/dependency-apply.cpp
+++ b/lib/icinga/dependency-apply.cpp
@@ -114,12 +114,13 @@ bool Dependency::EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyR
 				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
 			Dictionary::Ptr dict = vinstances;
+			ObjectLock olock (dict);
 
-			for (const String& key : dict->GetKeys()) {
-				frame.Locals->Set(rule.GetFKVar(), key);
-				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+			for (auto& kv : dict) {
+				frame.Locals->Set(rule.GetFKVar(), kv.first);
+				frame.Locals->Set(rule.GetFVVar(), kv.second);
 
-				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
+				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;
 			}
 		}

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -331,5 +331,9 @@ bool Host::ResolveMacro(const String& macro, const CheckResult::Ptr&, Value *res
 
 Dictionary::Ptr Host::MakeLocalsForApply()
 {
-	return new Dictionary({{ "host", this }});
+	auto locals (Checkable::MakeLocalsForApply());
+
+	locals->Set("host", this);
+
+	return locals;
 }

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -328,3 +328,8 @@ bool Host::ResolveMacro(const String& macro, const CheckResult::Ptr&, Value *res
 
 	return false;
 }
+
+Dictionary::Ptr Host::MakeLocalsForApply()
+{
+	return new Dictionary({{ "host", this }});
+}

--- a/lib/icinga/host.hpp
+++ b/lib/icinga/host.hpp
@@ -57,6 +57,8 @@ protected:
 
 	void CreateChildObjects(const Type::Ptr& childType) override;
 
+	Dictionary::Ptr MakeLocalsForApply() override;
+
 private:
 	mutable std::mutex m_ServicesMutex;
 	std::map<String, intrusive_ptr<Service> > m_Services;

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -113,12 +113,13 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
 			Dictionary::Ptr dict = vinstances;
+			ObjectLock olock (dict);
 
-			for (const String& key : dict->GetKeys()) {
-				frame.Locals->Set(rule.GetFKVar(), key);
-				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+			for (auto& kv : dict) {
+				frame.Locals->Set(rule.GetFKVar(), kv.first);
+				frame.Locals->Set(rule.GetFVVar(), kv.second);
 
-				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
+				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;
 			}
 		}

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -69,16 +69,20 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 	msgbuf << "Evaluating 'apply' rule (" << di << ")";
 	CONTEXT(msgbuf.str());
 
-	Host::Ptr host;
-	Service::Ptr service;
-	tie(host, service) = GetHostService(checkable);
+	ScriptFrame frame (false);
 
-	ScriptFrame frame(true);
-	if (rule.GetScope())
-		rule.GetScope()->CopyTo(frame.Locals);
-	frame.Locals->Set("host", host);
-	if (service)
-		frame.Locals->Set("service", service);
+	if (rule.GetScope() || rule.GetFTerm()) {
+		frame.Locals = new Dictionary();
+
+		if (rule.GetScope()) {
+			rule.GetScope()->CopyTo(frame.Locals);
+		}
+
+		checkable->GetFrozenLocalsForApply()->CopyTo(frame.Locals);
+		frame.Locals->Freeze();
+	} else {
+		frame.Locals = checkable->GetFrozenLocalsForApply();
+	}
 
 	bool match = false;
 
@@ -102,7 +106,7 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 			for (const Value& instance : arr) {
 				String name = rule.GetName();
 
-				frame.Locals->Set(rule.GetFKVar(), instance);
+				frame.Locals->Set(rule.GetFKVar(), instance, true);
 				name += instance;
 
 				if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
@@ -116,8 +120,8 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 			ObjectLock olock (dict);
 
 			for (auto& kv : dict) {
-				frame.Locals->Set(rule.GetFKVar(), kv.first);
-				frame.Locals->Set(rule.GetFVVar(), kv.second);
+				frame.Locals->Set(rule.GetFKVar(), kv.first, true);
+				frame.Locals->Set(rule.GetFVVar(), kv.second, true);
 
 				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;

--- a/lib/icinga/notification-apply.cpp
+++ b/lib/icinga/notification-apply.cpp
@@ -80,52 +80,50 @@ bool Notification::EvaluateApplyRule(const Checkable::Ptr& checkable, const Appl
 	if (service)
 		frame.Locals->Set("service", service);
 
-	Value vinstances;
+	bool match = false;
 
 	if (rule.GetFTerm()) {
+		Value vinstances;
+
 		try {
 			vinstances = rule.GetFTerm()->Evaluate(frame);
 		} catch (const std::exception&) {
 			/* Silently ignore errors here and assume there are no instances. */
 			return false;
 		}
-	} else {
-		vinstances = new Array({ "" });
-	}
 
-	bool match = false;
+		if (vinstances.IsObjectType<Array>()) {
+			if (!rule.GetFVVar().IsEmpty())
+				BOOST_THROW_EXCEPTION(ScriptError("Dictionary iterator requires value to be a dictionary.", di));
 
-	if (vinstances.IsObjectType<Array>()) {
-		if (!rule.GetFVVar().IsEmpty())
-			BOOST_THROW_EXCEPTION(ScriptError("Dictionary iterator requires value to be a dictionary.", di));
+			Array::Ptr arr = vinstances;
 
-		Array::Ptr arr = vinstances;
+			ObjectLock olock(arr);
+			for (const Value& instance : arr) {
+				String name = rule.GetName();
 
-		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
-			String name = rule.GetName();
-
-			if (!rule.GetFKVar().IsEmpty()) {
 				frame.Locals->Set(rule.GetFKVar(), instance);
 				name += instance;
+
+				if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
+					match = true;
 			}
+		} else if (vinstances.IsObjectType<Dictionary>()) {
+			if (rule.GetFVVar().IsEmpty())
+				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
-			if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
-				match = true;
+			Dictionary::Ptr dict = vinstances;
+
+			for (const String& key : dict->GetKeys()) {
+				frame.Locals->Set(rule.GetFKVar(), key);
+				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+
+				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
+					match = true;
+			}
 		}
-	} else if (vinstances.IsObjectType<Dictionary>()) {
-		if (rule.GetFVVar().IsEmpty())
-			BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
-
-		Dictionary::Ptr dict = vinstances;
-
-		for (const String& key : dict->GetKeys()) {
-			frame.Locals->Set(rule.GetFKVar(), key);
-			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
-
-			if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
-				match = true;
-		}
+	} else if (EvaluateApplyRuleInstance(checkable, rule.GetName(), frame, rule, skipFilter)) {
+		match = true;
 	}
 
 	return match;

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -112,12 +112,13 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
 			Dictionary::Ptr dict = vinstances;
+			ObjectLock olock (dict);
 
-			for (const String& key : dict->GetKeys()) {
-				frame.Locals->Set(rule.GetFKVar(), key);
-				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+			for (auto& kv : dict) {
+				frame.Locals->Set(rule.GetFKVar(), kv.first);
+				frame.Locals->Set(rule.GetFVVar(), kv.second);
 
-				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + key, frame, rule, skipFilter))
+				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;
 			}
 		}

--- a/lib/icinga/scheduleddowntime-apply.cpp
+++ b/lib/icinga/scheduleddowntime-apply.cpp
@@ -68,16 +68,20 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 	msgbuf << "Evaluating 'apply' rule (" << di << ")";
 	CONTEXT(msgbuf.str());
 
-	Host::Ptr host;
-	Service::Ptr service;
-	tie(host, service) = GetHostService(checkable);
+	ScriptFrame frame (false);
 
-	ScriptFrame frame(true);
-	if (rule.GetScope())
-		rule.GetScope()->CopyTo(frame.Locals);
-	frame.Locals->Set("host", host);
-	if (service)
-		frame.Locals->Set("service", service);
+	if (rule.GetScope() || rule.GetFTerm()) {
+		frame.Locals = new Dictionary();
+
+		if (rule.GetScope()) {
+			rule.GetScope()->CopyTo(frame.Locals);
+		}
+
+		checkable->GetFrozenLocalsForApply()->CopyTo(frame.Locals);
+		frame.Locals->Freeze();
+	} else {
+		frame.Locals = checkable->GetFrozenLocalsForApply();
+	}
 
 	bool match = false;
 
@@ -101,7 +105,7 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 			for (const Value& instance : arr) {
 				String name = rule.GetName();
 
-				frame.Locals->Set(rule.GetFKVar(), instance);
+				frame.Locals->Set(rule.GetFKVar(), instance, true);
 				name += instance;
 
 				if (EvaluateApplyRuleInstance(checkable, name, frame, rule, skipFilter))
@@ -115,8 +119,8 @@ bool ScheduledDowntime::EvaluateApplyRule(const Checkable::Ptr& checkable, const
 			ObjectLock olock (dict);
 
 			for (auto& kv : dict) {
-				frame.Locals->Set(rule.GetFKVar(), kv.first);
-				frame.Locals->Set(rule.GetFVVar(), kv.second);
+				frame.Locals->Set(rule.GetFKVar(), kv.first, true);
+				frame.Locals->Set(rule.GetFVVar(), kv.second, true);
 
 				if (EvaluateApplyRuleInstance(checkable, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -68,52 +68,52 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bo
 		rule.GetScope()->CopyTo(frame.Locals);
 	frame.Locals->Set("host", host);
 
-	Value vinstances;
+	bool match = false;
 
 	if (rule.GetFTerm()) {
+		Value vinstances;
+
 		try {
 			vinstances = rule.GetFTerm()->Evaluate(frame);
 		} catch (const std::exception&) {
 			/* Silently ignore errors here and assume there are no instances. */
 			return false;
 		}
-	} else {
-		vinstances = new Array({ "" });
-	}
 
-	bool match = false;
+		if (vinstances.IsObjectType<Array>()) {
+			if (!rule.GetFVVar().IsEmpty())
+				BOOST_THROW_EXCEPTION(ScriptError("Dictionary iterator requires value to be a dictionary.", di));
 
-	if (vinstances.IsObjectType<Array>()) {
-		if (!rule.GetFVVar().IsEmpty())
-			BOOST_THROW_EXCEPTION(ScriptError("Dictionary iterator requires value to be a dictionary.", di));
+			Array::Ptr arr = vinstances;
 
-		Array::Ptr arr = vinstances;
+			ObjectLock olock(arr);
+			for (const Value& instance : arr) {
+				String name = rule.GetName();
 
-		ObjectLock olock(arr);
-		for (const Value& instance : arr) {
-			String name = rule.GetName();
+				if (!rule.GetFKVar().IsEmpty()) {
+					frame.Locals->Set(rule.GetFKVar(), instance);
+					name += instance;
+				}
 
-			if (!rule.GetFKVar().IsEmpty()) {
-				frame.Locals->Set(rule.GetFKVar(), instance);
-				name += instance;
+				if (EvaluateApplyRuleInstance(host, name, frame, rule, skipFilter))
+					match = true;
 			}
+		} else if (vinstances.IsObjectType<Dictionary>()) {
+			if (rule.GetFVVar().IsEmpty())
+				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
-			if (EvaluateApplyRuleInstance(host, name, frame, rule, skipFilter))
-				match = true;
+			Dictionary::Ptr dict = vinstances;
+
+			for (const String& key : dict->GetKeys()) {
+				frame.Locals->Set(rule.GetFKVar(), key);
+				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+
+				if (EvaluateApplyRuleInstance(host, rule.GetName() + key, frame, rule, skipFilter))
+					match = true;
+			}
 		}
-	} else if (vinstances.IsObjectType<Dictionary>()) {
-		if (rule.GetFVVar().IsEmpty())
-			BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
-
-		Dictionary::Ptr dict = vinstances;
-
-		for (const String& key : dict->GetKeys()) {
-			frame.Locals->Set(rule.GetFKVar(), key);
-			frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
-
-			if (EvaluateApplyRuleInstance(host, rule.GetName() + key, frame, rule, skipFilter))
-				match = true;
-		}
+	} else if (EvaluateApplyRuleInstance(host, rule.GetName(), frame, rule, skipFilter)) {
+		match = true;
 	}
 
 	return match;

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -63,10 +63,20 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bo
 	msgbuf << "Evaluating 'apply' rule (" << di << ")";
 	CONTEXT(msgbuf.str());
 
-	ScriptFrame frame(true);
-	if (rule.GetScope())
-		rule.GetScope()->CopyTo(frame.Locals);
-	frame.Locals->Set("host", host);
+	ScriptFrame frame (false);
+
+	if (rule.GetScope() || rule.GetFTerm()) {
+		frame.Locals = new Dictionary();
+
+		if (rule.GetScope()) {
+			rule.GetScope()->CopyTo(frame.Locals);
+		}
+
+		host->GetFrozenLocalsForApply()->CopyTo(frame.Locals);
+		frame.Locals->Freeze();
+	} else {
+		frame.Locals = host->GetFrozenLocalsForApply();
+	}
 
 	bool match = false;
 
@@ -91,7 +101,7 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bo
 				String name = rule.GetName();
 
 				if (!rule.GetFKVar().IsEmpty()) {
-					frame.Locals->Set(rule.GetFKVar(), instance);
+					frame.Locals->Set(rule.GetFKVar(), instance, true);
 					name += instance;
 				}
 
@@ -106,8 +116,8 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bo
 			ObjectLock olock (dict);
 
 			for (auto& kv : dict) {
-				frame.Locals->Set(rule.GetFKVar(), kv.first);
-				frame.Locals->Set(rule.GetFVVar(), kv.second);
+				frame.Locals->Set(rule.GetFKVar(), kv.first, true);
+				frame.Locals->Set(rule.GetFVVar(), kv.second, true);
 
 				if (EvaluateApplyRuleInstance(host, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;

--- a/lib/icinga/service-apply.cpp
+++ b/lib/icinga/service-apply.cpp
@@ -103,12 +103,13 @@ bool Service::EvaluateApplyRule(const Host::Ptr& host, const ApplyRule& rule, bo
 				BOOST_THROW_EXCEPTION(ScriptError("Array iterator requires value to be an array.", di));
 
 			Dictionary::Ptr dict = vinstances;
+			ObjectLock olock (dict);
 
-			for (const String& key : dict->GetKeys()) {
-				frame.Locals->Set(rule.GetFKVar(), key);
-				frame.Locals->Set(rule.GetFVVar(), dict->Get(key));
+			for (auto& kv : dict) {
+				frame.Locals->Set(rule.GetFKVar(), kv.first);
+				frame.Locals->Set(rule.GetFVVar(), kv.second);
 
-				if (EvaluateApplyRuleInstance(host, rule.GetName() + key, frame, rule, skipFilter))
+				if (EvaluateApplyRuleInstance(host, rule.GetName() + kv.first, frame, rule, skipFilter))
 					match = true;
 			}
 		}

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -285,3 +285,11 @@ std::pair<Host::Ptr, Service::Ptr> icinga::GetHostService(const Checkable::Ptr& 
 	else
 		return std::make_pair(static_pointer_cast<Host>(checkable), nullptr);
 }
+
+Dictionary::Ptr Service::MakeLocalsForApply()
+{
+	return new Dictionary({
+		{ "host", m_Host },
+		{ "service", this }
+	});
+}

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -288,8 +288,10 @@ std::pair<Host::Ptr, Service::Ptr> icinga::GetHostService(const Checkable::Ptr& 
 
 Dictionary::Ptr Service::MakeLocalsForApply()
 {
-	return new Dictionary({
-		{ "host", m_Host },
-		{ "service", this }
-	});
+	auto locals (Checkable::MakeLocalsForApply());
+
+	locals->Set("host", m_Host);
+	locals->Set("service", this);
+
+	return locals;
 }

--- a/lib/icinga/service.hpp
+++ b/lib/icinga/service.hpp
@@ -51,6 +51,8 @@ public:
 protected:
 	void CreateChildObjects(const Type::Ptr& childType) override;
 
+	Dictionary::Ptr MakeLocalsForApply() override;
+
 private:
 	Host::Ptr m_Host;
 


### PR DESCRIPTION
by including them in ScriptFrame#Locals to reduce their lookup latency.

## Blocked by

* #9573