### PR TITLE
Added support for Fedora 37 into RPM build workflow

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -28,6 +28,9 @@ jobs:
             release: al2:x86_64
             subscription: true
           - name: fedora
+            release: 37
+            subscription: false
+          - name: fedora
             release: 36
             subscription: false
           - name: fedora


### PR DESCRIPTION
This pull requests adds Fedora 37 to the build matrix in the RPM build workflow.

This pull requests requires changes to the rpm.spec (at https://git.icinga.com/packaging/rpm-icinga2) and Docker images (at https://git.icinga.com/build-docker/fedora) to include Fedora 37 and point to the right dependencies.

https://github.com/Icinga/icinga2/issues/9587