### PR TITLE
ConfigObjectUtility::GetObjectConfigPath(): just return paths of existing objects

### DIFF
--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -332,17 +332,7 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 		params->Set("zone", zoneName);
 
 	if (object->GetPackage() == "_api") {
-		String file;
-
-		try {
-			file = ConfigObjectUtility::GetObjectConfigPath(object->GetReflectionType(), object->GetName());
-		} catch (const std::exception& ex) {
-			Log(LogNotice, "ApiListener")
-				<< "Cannot sync object '" << object->GetName() << "': " << ex.what();
-			return;
-		}
-
-		std::ifstream fp(file.CStr(), std::ifstream::binary);
+		std::ifstream fp(ConfigObjectUtility::GetExistingObjectConfigPath(object).CStr(), std::ifstream::binary);
 		if (!fp)
 			return;
 

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -353,7 +353,9 @@ bool ConfigObjectUtility::DeleteObjectHelper(const ConfigObject::Ptr& object, bo
 		return false;
 	}
 
-	Utility::Remove(GetExistingObjectConfigPath(object));
+	if (object->GetPackage() == "_api") {
+		Utility::Remove(GetExistingObjectConfigPath(object));
+	}
 
 	Log(LogInformation, "ConfigObjectUtility")
 		<< "Deleted object '" << name << "' of type '" << type->GetName() << "'.";

--- a/lib/remote/configobjectutility.hpp
+++ b/lib/remote/configobjectutility.hpp
@@ -22,7 +22,8 @@ class ConfigObjectUtility
 
 public:
 	static String GetConfigDir();
-	static String GetObjectConfigPath(const Type::Ptr& type, const String& fullName);
+	static String ComputeNewObjectConfigPath(const Type::Ptr& type, const String& fullName);
+	static String GetExistingObjectConfigPath(const ConfigObject::Ptr& object);
 	static void RepairPackage(const String& package);
 	static void CreateStorage();
 


### PR DESCRIPTION
instead of computing from scratch if they're in the _api package.

fixes #8834

For now this changes literally nothing as paths of existing objects still follow the scheme of paths of new objects which didn't change. Now Icinga only doesn't expect existing objects at particular paths. However, with the latter in v2.14+ (agent, satellite) we can just change the path scheme of new objects in v2.16+ (master) as we wish. The child nodes will just follow the new scheme of paths of new objects.