### PR TITLE
Influx DB: don't unneccessarily truncate timestamps to whole seconds

### DIFF
--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -554,7 +554,6 @@ Url::Ptr InfluxdbCommonWriter::AssembleBaseUrl()
 	url->SetScheme(GetSslEnable() ? "https" : "http");
 	url->SetHost(GetHost());
 	url->SetPort(GetPort());
-	url->AddQueryElement("precision", "ns");
 
 	return url;
 }

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -37,6 +37,7 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/regex.hpp>
 #include <boost/scoped_array.hpp>
+#include <iomanip>
 #include <memory>
 #include <string>
 #include <utility>
@@ -398,7 +399,7 @@ void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dic
 		}
 	}
 
-	msgbuf << " " <<  static_cast<unsigned long>(ts);
+	msgbuf << " " << std::fixed << std::setprecision(0) << ts * 1.0e9;
 
 	Log(LogDebug, GetReflectionType()->GetName())
 		<< "Checkable '" << checkable->GetName() << "' adds to metric list:'" << msgbuf.str() << "'.";
@@ -553,7 +554,7 @@ Url::Ptr InfluxdbCommonWriter::AssembleBaseUrl()
 	url->SetScheme(GetSslEnable() ? "https" : "http");
 	url->SetHost(GetHost());
 	url->SetPort(GetPort());
-	url->AddQueryElement("precision", "s");
+	url->AddQueryElement("precision", "ns");
 
 	return url;
 }


### PR DESCRIPTION
Instead send timestamps with the highest possible precision (ns). Useful for check intervals <1s.

## Before/after

```
> select * from dummy;
name: dummy
time                hostname metric value
----                -------- ------ -----
1669634632000000000 p/d      lolcat 1
1669634633000000000 p/d      lolcat 1
1669634634000000000 p/d      lolcat 1
1669634635000000000 p/d      lolcat 1
1669634636000000000 p/d      lolcat 1
1669634637000000000 p/d      lolcat 1
1669634638000000000 p/d      lolcat 1
1669634639000000000 p/d      lolcat 1
1669634640000000000 p/d      lolcat 1
1669634641000000000 p/d      lolcat 1
1669634642000000000 p/d      lolcat 1
1669634643000000000 p/d      lolcat 1
1669634644000000000 p/d      lolcat 1
1669634645000000000 p/d      lolcat 1
1669634646000000000 p/d      lolcat 1
1669634647000000000 p/d      lolcat 1
1669634648000000000 p/d      lolcat 1
1669634649000000000 p/d      lolcat 1
1669634650000000000 p/d      lolcat 1
1669634651000000000 p/d      lolcat 1
1669634746813241856 p/d      lolcat 1
1669634747819243008 p/d      lolcat 1
1669634748829480960 p/d      lolcat 1
1669634749837472000 p/d      lolcat 1
1669634750845353984 p/d      lolcat 1
1669634751851262208 p/d      lolcat 1
1669634752858226944 p/d      lolcat 1
1669634753866256896 p/d      lolcat 1
1669634754875664896 p/d      lolcat 1
1669634755882136064 p/d      lolcat 1
1669634756890747136 p/d      lolcat 1
1669634757899697152 p/d      lolcat 1
1669634758907682048 p/d      lolcat 1
1669634759919069952 p/d      lolcat 1
1669634760924881920 p/d      lolcat 1
1669634761930562048 p/d      lolcat 1
1669634762939232000 p/d      lolcat 1
1669634763945729024 p/d      lolcat 1
1669634764953383936 p/d      lolcat 1
1669634765961394944 p/d      lolcat 1
>
```