### PR TITLE
Namespace: replace behavior classes with a bool

### DIFF
--- a/lib/base/json-script.cpp
+++ b/lib/base/json-script.cpp
@@ -15,14 +15,13 @@ static String JsonEncodeShim(const Value& value)
 }
 
 INITIALIZE_ONCE([]() {
-	auto jsonNSBehavior = new ConstNamespaceBehavior();
-	Namespace::Ptr jsonNS = new Namespace(jsonNSBehavior);
+	Namespace::Ptr jsonNS = new Namespace(true);
 
 	/* Methods */
 	jsonNS->Set("encode", new Function("Json#encode", JsonEncodeShim, { "value" }, true));
 	jsonNS->Set("decode", new Function("Json#decode", JsonDecode, { "value" }, true));
 
-	jsonNSBehavior->Freeze();
+	jsonNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
 	systemNS->SetAttribute("Json", new ConstEmbeddedNamespaceValue(jsonNS));

--- a/lib/base/math-script.cpp
+++ b/lib/base/math-script.cpp
@@ -142,8 +142,7 @@ static double MathSign(double x)
 }
 
 INITIALIZE_ONCE([]() {
-	auto mathNSBehavior = new ConstNamespaceBehavior();
-	Namespace::Ptr mathNS = new Namespace(mathNSBehavior);
+	Namespace::Ptr mathNS = new Namespace(true);
 
 	/* Constants */
 	mathNS->Set("E", 2.71828182845904523536);
@@ -178,7 +177,7 @@ INITIALIZE_ONCE([]() {
 	mathNS->Set("isinf", new Function("Math#isinf", MathIsinf, { "x" }, true));
 	mathNS->Set("sign", new Function("Math#sign", MathSign, { "x" }, true));
 
-	mathNSBehavior->Freeze();
+	mathNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
 	systemNS->SetAttribute("Math", new ConstEmbeddedNamespaceValue(mathNS));

--- a/lib/base/namespace.hpp
+++ b/lib/base/namespace.hpp
@@ -41,24 +41,6 @@ struct ConstEmbeddedNamespaceValue : public EmbeddedNamespaceValue
 	void Set(const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) override;
 };
 
-class Namespace;
-
-struct NamespaceBehavior
-{
-	virtual void Register(const boost::intrusive_ptr<Namespace>& ns, const String& field, const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) const;
-	virtual void Remove(const boost::intrusive_ptr<Namespace>& ns, const String& field, bool overrideFrozen);
-};
-
-struct ConstNamespaceBehavior : public NamespaceBehavior
-{
-	void Register(const boost::intrusive_ptr<Namespace>& ns, const String& field, const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) const override;
-	void Remove(const boost::intrusive_ptr<Namespace>& ns, const String& field, bool overrideFrozen) override;
-	void Freeze();
-
-private:
-	bool m_Frozen;
-};
-
 /**
  * A namespace.
  *
@@ -73,13 +55,14 @@ public:
 
 	typedef std::map<String, NamespaceValue::Ptr>::value_type Pair;
 
-	Namespace(NamespaceBehavior *behavior = new NamespaceBehavior);
+	explicit Namespace(bool constValues = false);
 
 	Value Get(const String& field) const;
 	bool Get(const String& field, Value *value) const;
 	void Set(const String& field, const Value& value, bool overrideFrozen = false);
 	bool Contains(const String& field) const;
 	void Remove(const String& field, bool overrideFrozen = false);
+	void Freeze();
 
 	NamespaceValue::Ptr GetAttribute(const String& field) const;
 	void SetAttribute(const String& field, const NamespaceValue::Ptr& nsVal);
@@ -99,7 +82,8 @@ public:
 
 private:
 	std::map<String, NamespaceValue::Ptr> m_Data;
-	std::unique_ptr<NamespaceBehavior> m_Behavior;
+	bool m_ConstValues;
+	bool m_Frozen;
 };
 
 Namespace::Iterator begin(const Namespace::Ptr& x);

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -930,7 +930,7 @@ ExpressionResult ApplyExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhin
 
 ExpressionResult NamespaceExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const
 {
-	Namespace::Ptr ns = new Namespace(new ConstNamespaceBehavior());
+	Namespace::Ptr ns = new Namespace(true);
 
 	ScriptFrame innerFrame(true, ns);
 	ExpressionResult result = m_Expression->Evaluate(innerFrame);

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -58,9 +58,8 @@ void IcingaApplication::StaticInitialize()
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 	VERIFY(globalNS);
 
-	auto icingaNSBehavior = new ConstNamespaceBehavior();
-	icingaNSBehavior->Freeze();
-	Namespace::Ptr icingaNS = new Namespace(icingaNSBehavior);
+	Namespace::Ptr icingaNS = new Namespace(true);
+	icingaNS->Freeze();
 	globalNS->SetAttribute("Icinga", new ConstEmbeddedNamespaceValue(icingaNS));
 }
 


### PR DESCRIPTION
In essence, namespace behaviors acted as hooks for update operations on namespaces. Two behaviors were implemented:

- `NamespaceBehavior`: allows the update operation unless it acts on a value that itself was explicitly marked as constant.
- `ConstNamespaceBehavior`: initially allows insert operations but marks the individual values as const. Additionally provides a `Freeze()` member function. After this was called, updates are rejected unless a special `overrideFrozen` flag is set explicitly.

This marvel of object-oriented programming can be replaced with a simple bool. This commit basically replaces `Namespace::m_Behavior` with `Namespace::m_ConstValues` and inlines the behavior functions where they were called. While doing so, the code was slightly simplified by assuming that `m_ConstValues` is true if `m_Frozen` is true. This is similar to what the API allowed in the old code as you could only freeze a `ConstNamespaceBehavior`. However, this PR moves the `Freeze()` member function and the related `m_Freeze` member variable to the `Namespace` class. So now the API allows any namespace to be frozen. The new code also makes sense with the previously mentioned simplification: a `Namespace` with `m_ConstValues = false` can be modified without restrictions until `Freeze()` is called. When this is done, it becomes read-only.

The changes outside of `lib/base/namespace.*` just adapt the code to the slightly changed API.

This PR serves as a basis for #9607 as that PR makes use of `m_Frozen` directly within the `Namespace` class. But this change is probably worth it for code simplification reasons alone.