### PR TITLE
Prevent ObjectLock from being copied

### DIFF
--- a/lib/base/objectlock.hpp
+++ b/lib/base/objectlock.hpp
@@ -17,6 +17,9 @@ public:
 	ObjectLock(const Object::Ptr& object);
 	ObjectLock(const Object *object);
 
+	ObjectLock(const ObjectLock&) = delete;
+	ObjectLock& operator=(const ObjectLock&) = delete;
+
 	~ObjectLock();
 
 	void Lock();


### PR DESCRIPTION
Copying an ObjectLock results in the underlying mutex being unlocked too often. There's also no good reason for copying a scoped locking class (if at all, it should be moved).

There seems to be no place in the code base that actually copies this, so this doesn't fix any bugs, it will just prevent introducing such bugs.