### PR TITLE
INITIALIZE_ONCE_WITH_PRIORITY: use enum for priority values and use std::function

### DIFF
--- a/lib/base/function.hpp
+++ b/lib/base/function.hpp
@@ -61,28 +61,28 @@ private:
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new ConstEmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new ConstEmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new EmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new EmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 }
 

--- a/lib/base/initialize.cpp
+++ b/lib/base/initialize.cpp
@@ -5,7 +5,7 @@
 
 using namespace icinga;
 
-bool icinga::InitializeOnceHelper(void (*func)(), int priority)
+bool icinga::InitializeOnceHelper(const std::function<void()>& func, int priority)
 {
 	Loader::AddDeferredInitializer(func, priority);
 	return true;

--- a/lib/base/initialize.cpp
+++ b/lib/base/initialize.cpp
@@ -5,7 +5,7 @@
 
 using namespace icinga;
 
-bool icinga::InitializeOnceHelper(const std::function<void()>& func, int priority)
+bool icinga::InitializeOnceHelper(const std::function<void()>& func, InitializePriority priority)
 {
 	Loader::AddDeferredInitializer(func, priority);
 	return true;

--- a/lib/base/initialize.hpp
+++ b/lib/base/initialize.hpp
@@ -9,12 +9,25 @@
 namespace icinga
 {
 
+enum class InitializePriority {
+	CreateNamespaces = 1000,
+	InitIcingaApplication = 50,
+	RegisterTypeType = 20,
+	RegisterObjectType = 20,
+	RegisterPrimitiveTypes = 15,
+	RegisterBuiltinTypes = 15,
+	RegisterFunctions = 10,
+	RegisterTypes = 10,
+	EvaluateConfigFragments = 5,
+	Default = 0,
+};
+
 #define I2_TOKENPASTE(x, y) x ## y
 #define I2_TOKENPASTE2(x, y) I2_TOKENPASTE(x, y)
 
 #define I2_UNIQUE_NAME(prefix) I2_TOKENPASTE2(prefix, __COUNTER__)
 
-bool InitializeOnceHelper(const std::function<void()>& func, int priority = 0);
+bool InitializeOnceHelper(const std::function<void()>& func, InitializePriority priority = InitializePriority::Default);
 
 #define INITIALIZE_ONCE(func)									\
 	namespace { namespace I2_UNIQUE_NAME(io) {							\

--- a/lib/base/initialize.hpp
+++ b/lib/base/initialize.hpp
@@ -9,17 +9,22 @@
 namespace icinga
 {
 
+/**
+ * Priority values for use with the INITIALIZE_ONCE_WITH_PRIORITY macro.
+ *
+ * The values are given in the order of initialization.
+ */
 enum class InitializePriority {
-	CreateNamespaces = 1000,
-	InitIcingaApplication = 50,
-	RegisterTypeType = 20,
-	RegisterObjectType = 20,
-	RegisterPrimitiveTypes = 15,
-	RegisterBuiltinTypes = 15,
-	RegisterFunctions = 10,
-	RegisterTypes = 10,
-	EvaluateConfigFragments = 5,
-	Default = 0,
+	CreateNamespaces,
+	InitIcingaApplication,
+	RegisterTypeType,
+	RegisterObjectType,
+	RegisterPrimitiveTypes,
+	RegisterBuiltinTypes,
+	RegisterFunctions,
+	RegisterTypes,
+	EvaluateConfigFragments,
+	Default,
 };
 
 #define I2_TOKENPASTE(x, y) x ## y

--- a/lib/base/initialize.hpp
+++ b/lib/base/initialize.hpp
@@ -4,6 +4,7 @@
 #define INITIALIZE_H
 
 #include "base/i2-base.hpp"
+#include <functional>
 
 namespace icinga
 {
@@ -13,7 +14,7 @@ namespace icinga
 
 #define I2_UNIQUE_NAME(prefix) I2_TOKENPASTE2(prefix, __COUNTER__)
 
-bool InitializeOnceHelper(void (*func)(), int priority = 0);
+bool InitializeOnceHelper(const std::function<void()>& func, int priority = 0);
 
 #define INITIALIZE_ONCE(func)									\
 	namespace { namespace I2_UNIQUE_NAME(io) {							\

--- a/lib/base/loader.cpp
+++ b/lib/base/loader.cpp
@@ -25,7 +25,7 @@ void Loader::ExecuteDeferredInitializers()
 	}
 }
 
-void Loader::AddDeferredInitializer(const std::function<void()>& callback, int priority)
+void Loader::AddDeferredInitializer(const std::function<void()>& callback, InitializePriority priority)
 {
 	if (!GetDeferredInitializers().get())
 		GetDeferredInitializers().reset(new std::priority_queue<DeferredInitializer>());

--- a/lib/base/loader.cpp
+++ b/lib/base/loader.cpp
@@ -7,9 +7,9 @@
 
 using namespace icinga;
 
-boost::thread_specific_ptr<std::priority_queue<DeferredInitializer> >& Loader::GetDeferredInitializers()
+boost::thread_specific_ptr<Loader::DeferredInitializerPriorityQueue>& Loader::GetDeferredInitializers()
 {
-	static boost::thread_specific_ptr<std::priority_queue<DeferredInitializer> > initializers;
+	static boost::thread_specific_ptr<DeferredInitializerPriorityQueue> initializers;
 	return initializers;
 }
 
@@ -28,7 +28,7 @@ void Loader::ExecuteDeferredInitializers()
 void Loader::AddDeferredInitializer(const std::function<void()>& callback, InitializePriority priority)
 {
 	if (!GetDeferredInitializers().get())
-		GetDeferredInitializers().reset(new std::priority_queue<DeferredInitializer>());
+		GetDeferredInitializers().reset(new Loader::DeferredInitializerPriorityQueue());
 
 	GetDeferredInitializers().get()->push(DeferredInitializer(callback, priority));
 }

--- a/lib/base/loader.hpp
+++ b/lib/base/loader.hpp
@@ -19,9 +19,9 @@ public:
 		: m_Callback(std::move(callback)), m_Priority(priority)
 	{ }
 
-	bool operator<(const DeferredInitializer& other) const
+	bool operator>(const DeferredInitializer& other) const
 	{
-		return m_Priority < other.m_Priority;
+		return m_Priority > other.m_Priority;
 	}
 
 	void operator()()
@@ -48,7 +48,12 @@ public:
 private:
 	Loader();
 
-	static boost::thread_specific_ptr<std::priority_queue<DeferredInitializer> >& GetDeferredInitializers();
+	// Deferred initializers are run in the order of the definition of their enum values.
+	// Therefore, initializers that should be run first have lower enum values and
+	// the order of the std::priority_queue has to be reversed using std::greater.
+	using DeferredInitializerPriorityQueue = std::priority_queue<DeferredInitializer, std::vector<DeferredInitializer>, std::greater<>>;
+
+	static boost::thread_specific_ptr<DeferredInitializerPriorityQueue>& GetDeferredInitializers();
 };
 
 }

--- a/lib/base/loader.hpp
+++ b/lib/base/loader.hpp
@@ -4,6 +4,7 @@
 #define LOADER_H
 
 #include "base/i2-base.hpp"
+#include "base/initialize.hpp"
 #include "base/string.hpp"
 #include <boost/thread/tss.hpp>
 #include <queue>
@@ -14,7 +15,7 @@ namespace icinga
 struct DeferredInitializer
 {
 public:
-	DeferredInitializer(std::function<void ()> callback, int priority)
+	DeferredInitializer(std::function<void ()> callback, InitializePriority priority)
 		: m_Callback(std::move(callback)), m_Priority(priority)
 	{ }
 
@@ -30,7 +31,7 @@ public:
 
 private:
 	std::function<void ()> m_Callback;
-	int m_Priority;
+	InitializePriority m_Priority;
 };
 
 /**
@@ -41,7 +42,7 @@ private:
 class Loader
 {
 public:
-	static void AddDeferredInitializer(const std::function<void ()>& callback, int priority = 0);
+	static void AddDeferredInitializer(const std::function<void ()>& callback, InitializePriority priority = InitializePriority::Default);
 	static void ExecuteDeferredInitializers();
 
 private:

--- a/lib/base/objecttype.cpp
+++ b/lib/base/objecttype.cpp
@@ -12,7 +12,7 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	type->SetPrototype(Object::GetPrototype());
 	Type::Register(type);
 	Object::TypeInstance = type;
-}, 20);
+}, InitializePriority::RegisterObjectType);
 
 String ObjectType::GetName() const
 {

--- a/lib/base/primitivetype.hpp
+++ b/lib/base/primitivetype.hpp
@@ -37,7 +37,7 @@ private:
 		icinga::Type::Ptr t = new PrimitiveType(#type, "None"); 	\
 		t->SetPrototype(prototype);					\
 		icinga::Type::Register(t);					\
-	}, 15)
+	}, InitializePriority::RegisterBuiltinTypes)
 
 #define REGISTER_PRIMITIVE_TYPE_FACTORY(type, base, prototype, factory)		\
 	INITIALIZE_ONCE_WITH_PRIORITY([]() {					\
@@ -45,7 +45,7 @@ private:
 		t->SetPrototype(prototype);					\
 		icinga::Type::Register(t);					\
 		type::TypeInstance = t;						\
-	}, 15);									\
+	}, InitializePriority::RegisterPrimitiveTypes);	\
 	DEFINE_TYPE_INSTANCE(type)
 
 #define REGISTER_PRIMITIVE_TYPE(type, base, prototype)				\

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -35,11 +35,11 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 
 	l_InternalNS = new Namespace(true);
 	globalNS->SetAttribute("Internal", new ConstEmbeddedNamespaceValue(l_InternalNS));
-}, 1000);
+}, InitializePriority::CreateNamespaces);
 
-INITIALIZE_ONCE_WITH_PRIORITY([]() {
+INITIALIZE_ONCE([]() {
 	l_InternalNS->Freeze();
-}, 0);
+});
 
 ScriptFrame::ScriptFrame(bool allocLocals)
 	: Locals(allocLocals ? new Dictionary() : nullptr), Self(ScriptGlobal::GetGlobals()), Sandboxed(false), Depth(0)

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -15,7 +15,7 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	type->SetPrototype(TypeType::GetPrototype());
 	Type::TypeInstance = type;
 	Type::Register(type);
-}, 20);
+}, InitializePriority::RegisterTypeType);
 
 String Type::ToString() const
 {

--- a/lib/base/type.hpp
+++ b/lib/base/type.hpp
@@ -128,7 +128,7 @@ class TypeImpl
 		icinga::Type::Ptr t = new TypeImpl<type>(); \
 		type::TypeInstance = t; \
 		icinga::Type::Register(t); \
-	}, 10); \
+	}, InitializePriority::RegisterTypes); \
 	DEFINE_TYPE_INSTANCE(type)
 
 #define REGISTER_TYPE_WITH_PROTOTYPE(type, prototype) \
@@ -137,7 +137,7 @@ class TypeImpl
 		t->SetPrototype(prototype); \
 		type::TypeInstance = t; \
 		icinga::Type::Register(t); \
-	}, 10); \
+	}, InitializePriority::RegisterTypes); \
 	DEFINE_TYPE_INSTANCE(type)
 
 #define DEFINE_TYPE_INSTANCE(type) \

--- a/lib/config/configfragment.hpp
+++ b/lib/config/configfragment.hpp
@@ -21,6 +21,6 @@
 			std::cerr << icinga::DiagnosticInformation(ex) << std::endl; \
 			icinga::Application::Exit(1); \
 		} \
-	}, 5)
+	}, icinga::InitializePriority::EvaluateConfigFragments)
 
 #endif /* CONFIGFRAGMENT_H */

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -26,7 +26,7 @@ static Timer::Ptr l_RetentionTimer;
 
 REGISTER_TYPE(IcingaApplication);
 /* Ensure that the priority is lower than the basic System namespace initialization in scriptframe.cpp. */
-INITIALIZE_ONCE_WITH_PRIORITY(&IcingaApplication::StaticInitialize, 50);
+INITIALIZE_ONCE_WITH_PRIORITY(&IcingaApplication::StaticInitialize, InitializePriority::InitIcingaApplication);
 
 void IcingaApplication::StaticInitialize()
 {


### PR DESCRIPTION
This PR does the following:

1. `InitializeOnceHelper`: use `std::function` instead of C function pointer
  `InitializeOnceHelper` calls `Loader::AddDeferredInitializer` which takes a `std::function`, so it's eventually converted to that anyways. This commit just does this a bit earlier, and by saving the step of the intermediate C function pointer, this would now also work for capturing lambdas (which there are none of at the moment).
2. `INITIALIZE_ONCE_WITH_PRIORITY`: use enum for priority values
  Change the type of the priority values from int to a new enum. By replacing the magic int values throughout the code base with named values, there is now a single place where all priority values are defined and you get an overview over the initialization order.
3. `InitializePriority`: don't explicitly specify values
  Now that all values are in one place, there is no reason for this numbering with gaps anymore. If you need to insert a new value in between, you can just do so in the enum.
  This reverses the sort order of the enum, thereby requiring a change to the sort order of the `std::priority_queue` containing the elements.

Some priority values were split into multiple enum values as I didn't find a good value that describes all cases. With change (3), these are executed in a more restricted order than before.