### PR TITLE
Reduce namespace locking for faster config loads

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -280,17 +280,6 @@ static int Main()
 #endif /* RLIMIT_STACK */
 	}
 
-	/* Calculate additional global constants. */
-	ScriptGlobal::Set("System.PlatformKernel", Utility::GetPlatformKernel(), true);
-	ScriptGlobal::Set("System.PlatformKernelVersion", Utility::GetPlatformKernelVersion(), true);
-	ScriptGlobal::Set("System.PlatformName", Utility::GetPlatformName(), true);
-	ScriptGlobal::Set("System.PlatformVersion", Utility::GetPlatformVersion(), true);
-	ScriptGlobal::Set("System.PlatformArchitecture", Utility::GetPlatformArchitecture(), true);
-
-	ScriptGlobal::Set("System.BuildHostName", ICINGA_BUILD_HOST_NAME, true);
-	ScriptGlobal::Set("System.BuildCompilerName", ICINGA_BUILD_COMPILER_NAME, true);
-	ScriptGlobal::Set("System.BuildCompilerVersion", ICINGA_BUILD_COMPILER_VERSION, true);
-
 	if (!autocomplete)
 		Application::SetResourceLimits();
 

--- a/lib/base/function.hpp
+++ b/lib/base/function.hpp
@@ -61,28 +61,28 @@ private:
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new ConstEmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new ConstEmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new EmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
 		nsp->SetAttribute(#name, new EmbeddedNamespaceValue(sf)); \
-	}, 10)
+	}, InitializePriority::RegisterFunctions)
 
 }
 

--- a/lib/base/initialize.cpp
+++ b/lib/base/initialize.cpp
@@ -5,7 +5,7 @@
 
 using namespace icinga;
 
-bool icinga::InitializeOnceHelper(void (*func)(), int priority)
+bool icinga::InitializeOnceHelper(const std::function<void()>& func, InitializePriority priority)
 {
 	Loader::AddDeferredInitializer(func, priority);
 	return true;

--- a/lib/base/initialize.hpp
+++ b/lib/base/initialize.hpp
@@ -25,6 +25,7 @@ enum class InitializePriority {
 	RegisterTypes,
 	EvaluateConfigFragments,
 	Default,
+	FreezeNamespaces,
 };
 
 #define I2_TOKENPASTE(x, y) x ## y

--- a/lib/base/initialize.hpp
+++ b/lib/base/initialize.hpp
@@ -4,16 +4,35 @@
 #define INITIALIZE_H
 
 #include "base/i2-base.hpp"
+#include <functional>
 
 namespace icinga
 {
+
+/**
+ * Priority values for use with the INITIALIZE_ONCE_WITH_PRIORITY macro.
+ *
+ * The values are given in the order of initialization.
+ */
+enum class InitializePriority {
+	CreateNamespaces,
+	InitIcingaApplication,
+	RegisterTypeType,
+	RegisterObjectType,
+	RegisterPrimitiveTypes,
+	RegisterBuiltinTypes,
+	RegisterFunctions,
+	RegisterTypes,
+	EvaluateConfigFragments,
+	Default,
+};
 
 #define I2_TOKENPASTE(x, y) x ## y
 #define I2_TOKENPASTE2(x, y) I2_TOKENPASTE(x, y)
 
 #define I2_UNIQUE_NAME(prefix) I2_TOKENPASTE2(prefix, __COUNTER__)
 
-bool InitializeOnceHelper(void (*func)(), int priority = 0);
+bool InitializeOnceHelper(const std::function<void()>& func, InitializePriority priority = InitializePriority::Default);
 
 #define INITIALIZE_ONCE(func)									\
 	namespace { namespace I2_UNIQUE_NAME(io) {							\

--- a/lib/base/json-script.cpp
+++ b/lib/base/json-script.cpp
@@ -15,14 +15,13 @@ static String JsonEncodeShim(const Value& value)
 }
 
 INITIALIZE_ONCE([]() {
-	auto jsonNSBehavior = new ConstNamespaceBehavior();
-	Namespace::Ptr jsonNS = new Namespace(jsonNSBehavior);
+	Namespace::Ptr jsonNS = new Namespace(true);
 
 	/* Methods */
 	jsonNS->Set("encode", new Function("Json#encode", JsonEncodeShim, { "value" }, true));
 	jsonNS->Set("decode", new Function("Json#decode", JsonDecode, { "value" }, true));
 
-	jsonNSBehavior->Freeze();
+	jsonNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
 	systemNS->SetAttribute("Json", new ConstEmbeddedNamespaceValue(jsonNS));

--- a/lib/base/loader.cpp
+++ b/lib/base/loader.cpp
@@ -7,9 +7,9 @@
 
 using namespace icinga;
 
-boost::thread_specific_ptr<std::priority_queue<DeferredInitializer> >& Loader::GetDeferredInitializers()
+boost::thread_specific_ptr<Loader::DeferredInitializerPriorityQueue>& Loader::GetDeferredInitializers()
 {
-	static boost::thread_specific_ptr<std::priority_queue<DeferredInitializer> > initializers;
+	static boost::thread_specific_ptr<DeferredInitializerPriorityQueue> initializers;
 	return initializers;
 }
 
@@ -25,10 +25,10 @@ void Loader::ExecuteDeferredInitializers()
 	}
 }
 
-void Loader::AddDeferredInitializer(const std::function<void()>& callback, int priority)
+void Loader::AddDeferredInitializer(const std::function<void()>& callback, InitializePriority priority)
 {
 	if (!GetDeferredInitializers().get())
-		GetDeferredInitializers().reset(new std::priority_queue<DeferredInitializer>());
+		GetDeferredInitializers().reset(new Loader::DeferredInitializerPriorityQueue());
 
 	GetDeferredInitializers().get()->push(DeferredInitializer(callback, priority));
 }

--- a/lib/base/math-script.cpp
+++ b/lib/base/math-script.cpp
@@ -142,8 +142,7 @@ static double MathSign(double x)
 }
 
 INITIALIZE_ONCE([]() {
-	auto mathNSBehavior = new ConstNamespaceBehavior();
-	Namespace::Ptr mathNS = new Namespace(mathNSBehavior);
+	Namespace::Ptr mathNS = new Namespace(true);
 
 	/* Constants */
 	mathNS->Set("E", 2.71828182845904523536);
@@ -178,7 +177,7 @@ INITIALIZE_ONCE([]() {
 	mathNS->Set("isinf", new Function("Math#isinf", MathIsinf, { "x" }, true));
 	mathNS->Set("sign", new Function("Math#sign", MathSign, { "x" }, true));
 
-	mathNSBehavior->Freeze();
+	mathNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
 	systemNS->SetAttribute("Math", new ConstEmbeddedNamespaceValue(mathNS));

--- a/lib/base/namespace.hpp
+++ b/lib/base/namespace.hpp
@@ -41,24 +41,6 @@ struct ConstEmbeddedNamespaceValue : public EmbeddedNamespaceValue
 	void Set(const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) override;
 };
 
-class Namespace;
-
-struct NamespaceBehavior
-{
-	virtual void Register(const boost::intrusive_ptr<Namespace>& ns, const String& field, const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) const;
-	virtual void Remove(const boost::intrusive_ptr<Namespace>& ns, const String& field, bool overrideFrozen);
-};
-
-struct ConstNamespaceBehavior : public NamespaceBehavior
-{
-	void Register(const boost::intrusive_ptr<Namespace>& ns, const String& field, const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) const override;
-	void Remove(const boost::intrusive_ptr<Namespace>& ns, const String& field, bool overrideFrozen) override;
-	void Freeze();
-
-private:
-	bool m_Frozen;
-};
-
 /**
  * A namespace.
  *
@@ -73,13 +55,14 @@ public:
 
 	typedef std::map<String, NamespaceValue::Ptr>::value_type Pair;
 
-	Namespace(NamespaceBehavior *behavior = new NamespaceBehavior);
+	explicit Namespace(bool constValues = false);
 
 	Value Get(const String& field) const;
 	bool Get(const String& field, Value *value) const;
 	void Set(const String& field, const Value& value, bool overrideFrozen = false);
 	bool Contains(const String& field) const;
 	void Remove(const String& field, bool overrideFrozen = false);
+	void Freeze();
 
 	NamespaceValue::Ptr GetAttribute(const String& field) const;
 	void SetAttribute(const String& field, const NamespaceValue::Ptr& nsVal);
@@ -99,7 +82,8 @@ public:
 
 private:
 	std::map<String, NamespaceValue::Ptr> m_Data;
-	std::unique_ptr<NamespaceBehavior> m_Behavior;
+	bool m_ConstValues;
+	bool m_Frozen;
 };
 
 Namespace::Iterator begin(const Namespace::Ptr& x);

--- a/lib/base/objectlock.cpp
+++ b/lib/base/objectlock.cpp
@@ -25,6 +25,25 @@ ObjectLock::ObjectLock(const Object *object)
 		Lock();
 }
 
+ObjectLock::ObjectLock(ObjectLock&& other) noexcept
+{
+	std::swap(m_Object, other.m_Object);
+	std::swap(m_Locked, other.m_Locked);
+}
+
+ObjectLock& ObjectLock::operator=(ObjectLock&& other) noexcept
+{
+	if (m_Locked) {
+		Unlock();
+	}
+	m_Object = nullptr;
+
+	std::swap(m_Object, other.m_Object);
+	std::swap(m_Locked, other.m_Locked);
+
+	return *this;
+}
+
 void ObjectLock::Lock()
 {
 	ASSERT(!m_Locked && m_Object);

--- a/lib/base/objectlock.hpp
+++ b/lib/base/objectlock.hpp
@@ -20,6 +20,9 @@ public:
 	ObjectLock(const ObjectLock&) = delete;
 	ObjectLock& operator=(const ObjectLock&) = delete;
 
+	ObjectLock(ObjectLock&&) noexcept;
+	ObjectLock& operator=(ObjectLock&&) noexcept;
+
 	~ObjectLock();
 
 	void Lock();

--- a/lib/base/objecttype.cpp
+++ b/lib/base/objecttype.cpp
@@ -12,7 +12,7 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	type->SetPrototype(Object::GetPrototype());
 	Type::Register(type);
 	Object::TypeInstance = type;
-}, 20);
+}, InitializePriority::RegisterObjectType);
 
 String ObjectType::GetName() const
 {

--- a/lib/base/primitivetype.hpp
+++ b/lib/base/primitivetype.hpp
@@ -37,7 +37,7 @@ private:
 		icinga::Type::Ptr t = new PrimitiveType(#type, "None"); 	\
 		t->SetPrototype(prototype);					\
 		icinga::Type::Register(t);					\
-	}, 15)
+	}, InitializePriority::RegisterBuiltinTypes)
 
 #define REGISTER_PRIMITIVE_TYPE_FACTORY(type, base, prototype, factory)		\
 	INITIALIZE_ONCE_WITH_PRIORITY([]() {					\
@@ -45,7 +45,7 @@ private:
 		t->SetPrototype(prototype);					\
 		icinga::Type::Register(t);					\
 		type::TypeInstance = t;						\
-	}, 15);									\
+	}, InitializePriority::RegisterPrimitiveTypes);	\
 	DEFINE_TYPE_INSTANCE(type)
 
 #define REGISTER_PRIMITIVE_TYPE(type, base, prototype)				\

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -35,11 +35,11 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 
 	l_InternalNS = new Namespace(true);
 	globalNS->SetAttribute("Internal", new ConstEmbeddedNamespaceValue(l_InternalNS));
-}, 1000);
+}, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_InternalNS->Freeze();
-}, 0);
+}, InitializePriority::Default);
 
 ScriptFrame::ScriptFrame(bool allocLocals)
 	: Locals(allocLocals ? new Dictionary() : nullptr), Self(ScriptGlobal::GetGlobals()), Sandboxed(false), Depth(0)

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -5,12 +5,13 @@
 #include "base/namespace.hpp"
 #include "base/exception.hpp"
 #include "base/configuration.hpp"
+#include "base/utility.hpp"
 
 using namespace icinga;
 
 boost::thread_specific_ptr<std::stack<ScriptFrame *> > ScriptFrame::m_ScriptFrames;
 
-static Namespace::Ptr l_InternalNS;
+static Namespace::Ptr l_SystemNS, l_TypesNS, l_StatsNS, l_InternalNS;
 
 /* Ensure that this gets called with highest priority
  * and wins against other static initializers in lib/icinga, etc.
@@ -19,27 +20,35 @@ static Namespace::Ptr l_InternalNS;
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 
-	Namespace::Ptr systemNS = new Namespace(true);
-	systemNS->Freeze();
-	globalNS->SetAttribute("System", new ConstEmbeddedNamespaceValue(systemNS));
+	l_SystemNS = new Namespace(true);
+	l_SystemNS->Set("PlatformKernel", Utility::GetPlatformKernel());
+	l_SystemNS->Set("PlatformKernelVersion", Utility::GetPlatformKernelVersion());
+	l_SystemNS->Set("PlatformName", Utility::GetPlatformName());
+	l_SystemNS->Set("PlatformVersion", Utility::GetPlatformVersion());
+	l_SystemNS->Set("PlatformArchitecture", Utility::GetPlatformArchitecture());
+	l_SystemNS->Set("BuildHostName", ICINGA_BUILD_HOST_NAME);
+	l_SystemNS->Set("BuildCompilerName", ICINGA_BUILD_COMPILER_NAME);
+	l_SystemNS->Set("BuildCompilerVersion", ICINGA_BUILD_COMPILER_VERSION);
+	globalNS->SetAttribute("System", new ConstEmbeddedNamespaceValue(l_SystemNS));
 
-	systemNS->SetAttribute("Configuration", new EmbeddedNamespaceValue(new Configuration()));
+	l_SystemNS->SetAttribute("Configuration", new EmbeddedNamespaceValue(new Configuration()));
 
-	Namespace::Ptr typesNS = new Namespace(true);
-	typesNS->Freeze();
-	globalNS->SetAttribute("Types", new ConstEmbeddedNamespaceValue(typesNS));
+	l_TypesNS = new Namespace(true);
+	globalNS->SetAttribute("Types", new ConstEmbeddedNamespaceValue(l_TypesNS));
 
-	Namespace::Ptr statsNS = new Namespace(true);
-	statsNS->Freeze();
-	globalNS->SetAttribute("StatsFunctions", new ConstEmbeddedNamespaceValue(statsNS));
+	l_StatsNS = new Namespace(true);
+	globalNS->SetAttribute("StatsFunctions", new ConstEmbeddedNamespaceValue(l_StatsNS));
 
 	l_InternalNS = new Namespace(true);
 	globalNS->SetAttribute("Internal", new ConstEmbeddedNamespaceValue(l_InternalNS));
 }, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
+	l_SystemNS->Freeze();
+	l_TypesNS->Freeze();
+	l_StatsNS->Freeze();
 	l_InternalNS->Freeze();
-}, InitializePriority::Default);
+}, InitializePriority::FreezeNamespaces);
 
 ScriptFrame::ScriptFrame(bool allocLocals)
 	: Locals(allocLocals ? new Dictionary() : nullptr), Self(ScriptGlobal::GetGlobals()), Sandboxed(false), Depth(0)

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -15,7 +15,7 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	type->SetPrototype(TypeType::GetPrototype());
 	Type::TypeInstance = type;
 	Type::Register(type);
-}, 20);
+}, InitializePriority::RegisterTypeType);
 
 String Type::ToString() const
 {

--- a/lib/base/type.hpp
+++ b/lib/base/type.hpp
@@ -128,7 +128,7 @@ class TypeImpl
 		icinga::Type::Ptr t = new TypeImpl<type>(); \
 		type::TypeInstance = t; \
 		icinga::Type::Register(t); \
-	}, 10); \
+	}, InitializePriority::RegisterTypes); \
 	DEFINE_TYPE_INSTANCE(type)
 
 #define REGISTER_TYPE_WITH_PROTOTYPE(type, prototype) \
@@ -137,7 +137,7 @@ class TypeImpl
 		t->SetPrototype(prototype); \
 		type::TypeInstance = t; \
 		icinga::Type::Register(t); \
-	}, 10); \
+	}, InitializePriority::RegisterTypes); \
 	DEFINE_TYPE_INSTANCE(type)
 
 #define DEFINE_TYPE_INSTANCE(type) \

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -241,6 +241,11 @@ bool DaemonUtility::LoadConfigFiles(const std::vector<std::string>& configs,
 		return false;
 	}
 
+	// After evaluating the top-level statements of the config files (happening in ValidateConfigFiles() above),
+	// prevent further modification of the global scope. This allows for a faster execution of the following steps
+	// as Freeze() disables locking as it's not necessary on a read-only data structure anymore.
+	ScriptGlobal::GetGlobals()->Freeze();
+
 	WorkQueue upq(25000, Configuration::Concurrency);
 	upq.SetName("DaemonUtility::LoadConfigFiles");
 	bool result = ConfigItem::CommitItems(ascope.GetContext(), upq, newItems);

--- a/lib/config/configfragment.hpp
+++ b/lib/config/configfragment.hpp
@@ -21,6 +21,6 @@
 			std::cerr << icinga::DiagnosticInformation(ex) << std::endl; \
 			icinga::Application::Exit(1); \
 		} \
-	}, 5)
+	}, icinga::InitializePriority::EvaluateConfigFragments)
 
 #endif /* CONFIGFRAGMENT_H */

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -930,7 +930,7 @@ ExpressionResult ApplyExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhin
 
 ExpressionResult NamespaceExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const
 {
-	Namespace::Ptr ns = new Namespace(new ConstNamespaceBehavior());
+	Namespace::Ptr ns = new Namespace(true);
 
 	ScriptFrame innerFrame(true, ns);
 	ExpressionResult result = m_Expression->Evaluate(innerFrame);

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -58,9 +58,8 @@ void IcingaApplication::StaticInitialize()
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 	VERIFY(globalNS);
 
-	auto icingaNSBehavior = new ConstNamespaceBehavior();
-	icingaNSBehavior->Freeze();
-	Namespace::Ptr icingaNS = new Namespace(icingaNSBehavior);
+	Namespace::Ptr icingaNS = new Namespace(true);
+	icingaNS->Freeze();
 	globalNS->SetAttribute("Icinga", new ConstEmbeddedNamespaceValue(icingaNS));
 }
 

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -26,7 +26,7 @@ static Timer::Ptr l_RetentionTimer;
 
 REGISTER_TYPE(IcingaApplication);
 /* Ensure that the priority is lower than the basic System namespace initialization in scriptframe.cpp. */
-INITIALIZE_ONCE_WITH_PRIORITY(&IcingaApplication::StaticInitialize, 50);
+INITIALIZE_ONCE_WITH_PRIORITY(&IcingaApplication::StaticInitialize, InitializePriority::InitIcingaApplication);
 
 void IcingaApplication::StaticInitialize()
 {


### PR DESCRIPTION
This PR improves the config load performance by reduce the amount of locking required. This results in a noticeable speedup, especially on many-core machines. This is achieved by two related changes.

### Disable locking after `Namespace::Freeze()`

This PR changes the behavior of `Namespace::Freeze()` to fully freeze the namespace. This means that no more modifications can be done to it, not even by setting `overrideFrozen = true` from within C++ code.

As this makes the namespace completely read-only after `Freeze()` was called, no more locking is required for read operations. Thus, this commit makes all lock operations for read operations no-ops afterwards.

This required some changes to the initialization phase as that heavily depended on `overrideFrozen`. A new priority for `INITIALIZE_ONCE_WITH_PRIORITY` is introduced: `FreezeNamespaces`. It is run after the `Default` priority (used by `INITIALIZE_ONCE`) which allows initializers running at the `Default` priority to still insert into the namespaces.

Some constants were only inserted in Main(), these were moved to an initializer function.

### Freeze `globals` namespace during config load

This brings the performance benefit from the previous change to the `globals` namespace. However, for this namespace, it is desired that users can change is, so the freeze must happen at some point during the config load. This is done after the top level scopes of the files were evaluated, but before the config items are committed to create the actual config objects. This allows the freeze to speed up the apply rule evaluation phase.

The change is slightly backwards-incompatible. Before, you could manipulate the `globals` namespace at a later stage, but disallowing this feels reasonable for the performance benefit alone. Apart from that, it's doubtful if doing so is even useful at all as the DSL provides no mechanism for you to synchronize your operations that may run in parallel. The data structures itself are protected from race conditions, but anything implemented on top of this may still be subject to race conditions. And even if some user has a good reason for doing this, there's a feasible workaround by creating your own namespace like `globals.mutable` and using that instead.

Example configuration snippet that will no longer be accepted with this PR:

```
globals.foo = 23 // valid

object HostGroup "g" {
	globals.bar = 42 // valid before, invalid with this PR
}
```

Note: All but the last three commits are from the dependencies #9603 and #9606. These PRs basically do some code-cleanup that makes this PR nicer. I recommend looking at them separately first.

### Benchmark

The performance improvements by this PR show better, the more CPU cores are available. This is quite reasonable, as there was an exclusive mutex before, at some time you reach a point where the mutex is always locked by some core. The following histograms show the time it took to do `icinga2 daemon -C` on this [icinga2.conf](https://github.com/Icinga/icinga2/files/10228441/icinga2.conf.txt).

Blue is the state of the master branch this set of PRs is based on, orange is that plus the two dependencies of this PR. These two overlap pretty good, so the other two PRs have no or minimal impact on performance. These two serve as the baseline.

Green is this PR, red is another branch I created for comparing no locking to a `std::shared_timed_mutex`. In general, both perform much better than the baseline. Both increase the user cpu time while reducing the system cpu time much more, resulting in a big decrease in total cpu time (user + system).

Comparing no locking to the shared mutex, there's no to little difference in wall clock time, however the total CPU time is less for no locking (not too surprising, reading an atomic bool is cheaper than acquiring and releasing a read lock on a shared mutex). No change in wall clock time suggests that the CPU wasn't fully saturated so the extra time was just available.

However, I also did a few manual tests with a much larger real world config that takes much longer to validate. These suggest that depending on the config, no locking may still give you around a 10% improvement compared to the shared mutex. But don't give too much on the exact numbers, these are based on manually running both 2 times.

![histograms](https://user-images.githubusercontent.com/18552/207615783-a5de1eae-d63a-4ab1-8c24-85becbac8c44.png)

### TODO

* [ ] Look through the docs if anything needs changes or additions.
* [ ] Rebase after #9603 and #9606 were merged.

### Blocked by
* #9603 - this PR now makes use of the `m_Frozen` member variable directly in `Namespace`.
* #9606 - without that, this PR would introduce some new magic priority like `-10`.