### PR TITLE
 Move Types namespace into type.cpp and simplify Type::GetByName()

### DIFF
--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -11,7 +11,7 @@ using namespace icinga;
 
 boost::thread_specific_ptr<std::stack<ScriptFrame *> > ScriptFrame::m_ScriptFrames;
 
-static Namespace::Ptr l_SystemNS, l_TypesNS, l_StatsNS, l_InternalNS;
+static Namespace::Ptr l_SystemNS, l_StatsNS, l_InternalNS;
 
 /* Ensure that this gets called with highest priority
  * and wins against other static initializers in lib/icinga, etc.
@@ -33,9 +33,6 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 
 	l_SystemNS->Set("Configuration", new Configuration());
 
-	l_TypesNS = new Namespace(true);
-	globalNS->Set("Types", l_TypesNS, true);
-
 	l_StatsNS = new Namespace(true);
 	globalNS->Set("StatsFunctions", l_StatsNS, true);
 
@@ -45,7 +42,6 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_SystemNS->Freeze();
-	l_TypesNS->Freeze();
 	l_StatsNS->Freeze();
 	l_InternalNS->Freeze();
 }, InitializePriority::FreezeNamespaces);


### PR DESCRIPTION
This PR moves the initialization of the `globals.Types` namespace to `type.cpp` in order to keep a pointer to the `Namespace` object in `Type::m_Namespace` and simplify `Type::GetByName()` using it.

The dynamic type check is moved into an assertion after freezing the namespace.

This PR is my suggested alternative to #9553 based on #9627.

closes #9553  // edit by @Al2Klimov