### PR TITLE
ITL: disk: set vars.disk_units="bytes"

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -374,7 +374,7 @@ disk\_ereg\_path          | **Optional.** Regular expression for path or partiti
 disk\_ignore\_eregi\_path | **Optional.** Regular expression to ignore selected path/partition (case insensitive). Multiple regular expression strings must be defined as array.
 disk\_ignore\_ereg\_path  | **Optional.** Regular expression to ignore selected path or partition. Multiple regular expression strings must be defined as array.
 disk\_timeout             | **Optional.** Seconds before connection times out (default: 10).
-disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB (default: MB).
+disk\_units               | **Optional.** Choose bytes (default), kB, MB, GB, TB.
 disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs", "overlay", "nsfs", "squashfs".
 disk\_include\_type       | **Optional.** Check only filesystems of indicated type. Multiple regular expression strings must be defined as array.
 disk\_inode\_perfdata     | **Optional.** Display inode usage in perfdata

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1476,7 +1476,7 @@ object CheckCommand "disk" {
 
 	vars.disk_wfree = "20%"
 	vars.disk_cfree = "10%"
-	vars.disk_megabytes = true
+	vars.disk_units = "bytes"
 	vars.disk_exclude_type = [
 		"none",
 		"tmpfs",


### PR DESCRIPTION
so that check_disk doesn't output "MB" perfdata.
Those numbers actually represent MiB. Bytes don't have this problem.