### PR TITLE
Checkable#IsInDowntime(): ignore downtime expiration

### DIFF
--- a/lib/icinga/checkable-downtime.cpp
+++ b/lib/icinga/checkable-downtime.cpp
@@ -26,7 +26,7 @@ void Checkable::TriggerDowntimes(double triggerTime)
 bool Checkable::IsInDowntime() const
 {
 	for (const Downtime::Ptr& downtime : GetDowntimes()) {
-		if (downtime->IsInEffect())
+		if (downtime->IsInEffect() || downtime->IsExpired())
 			return true;
 	}
 


### PR DESCRIPTION
i.e. consider a checkable still being in downtime if it has 1+ triggered but expired downtimes. Downtime::DowntimesExpireTimerHandler() removes expired downtimes regularily, so their checkables won't be forever "in downtime". But now Checkable#IsInDowntime() suppresses NotificationComponent::NotificationTimerHandler() (problem notifications) until actual downtime removal and the respective notification.

ref/IP/43624

## Before

![Bildschirm­foto 2022-12-14 um 15 31 47](https://user-images.githubusercontent.com/6053266/207642277-94eed2ea-1622-476f-aa1b-009a81858ea0.png)

## After

![Bildschirm­foto 2022-12-14 um 16 46 32](https://user-images.githubusercontent.com/6053266/207642431-8fcef2f2-8d73-4944-a204-9c0e7f9f9c75.png)