### PR TITLE
Remove -and notify- expired downtimes immediately, not every 60s

### DIFF
--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -121,7 +121,13 @@ void Timer::Call()
 		throw;
 	}
 
+	auto detached (OnTimerExpiredDetached);
+
 	InternalReschedule(true);
+
+	if (detached) {
+		(*detached)();
+	}
 }
 
 /**

--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -63,6 +63,8 @@ static Defer l_ShutdownTimersCleanlyOnExit (&Timer::Uninitialize);
 
 /**
  * Destructor for the Timer class.
+ *
+ * Unregisters the timer, stops processing events for it and waits for running OnTimerExpired.
  */
 Timer::~Timer()
 {
@@ -170,7 +172,7 @@ void Timer::Start()
 }
 
 /**
- * Unregisters the timer and stops processing events for it.
+ * Unregisters the timer, stops processing events for it and optionally waits for running OnTimerExpired.
  */
 void Timer::Stop(bool wait)
 {

--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -246,7 +246,7 @@ double Timer::GetNext() const
 }
 
 /**
- * Adjusts all timers by adding the specified amount of time to their
+ * Adjusts all periodic timers by adding the specified amount of time to their
  * next scheduled timestamp.
  *
  * @param adjustment The adjustment.
@@ -263,6 +263,11 @@ void Timer::AdjustTimers(double adjustment)
 	std::vector<Timer *> timers;
 
 	for (Timer *timer : idx) {
+		/* Don't schedule the next call if this is not a periodic timer. */
+		if (timer->m_Interval <= 0) {
+			continue;
+		}
+
 		if (std::fabs(now - (timer->m_Next + adjustment)) <
 			std::fabs(now - timer->m_Next)) {
 			timer->m_Next += adjustment;

--- a/lib/base/timer.hpp
+++ b/lib/base/timer.hpp
@@ -4,7 +4,9 @@
 #define TIMER_H
 
 #include "base/i2-base.hpp"
+#include "base/lazy-init.hpp"
 #include "base/object.hpp"
+#include "base/shared.hpp"
 #include <boost/signals2.hpp>
 
 namespace icinga {
@@ -40,6 +42,7 @@ public:
 	double GetNext() const;
 
 	boost::signals2::signal<void(const Timer * const&)> OnTimerExpired;
+	LazyPtr<Shared<boost::signals2::signal<void()>>> OnTimerExpiredDetached;
 
 private:
 	double m_Interval{0}; /**< The interval of the timer. */

--- a/lib/base/timer.hpp
+++ b/lib/base/timer.hpp
@@ -41,7 +41,14 @@ public:
 	void Reschedule(double next = -1);
 	double GetNext() const;
 
+	// Runs whenever the timer is due.
+	// Blocks Stop(true) calls including the one in ~Timer(). I.e. attempts to synchronously call these will deadlock.
+	// Re-schedules a periodic timer after completion. I.e. delays its interval by own execution duration.
 	boost::signals2::signal<void(const Timer * const&)> OnTimerExpired;
+
+	// Runs whenever the timer is due. Doesn't block Stop(true) calls or ~Timer().
+	// I.e. these are safe to call. Re-schedules a periodic timer immediately.
+	// I.e. may get called multiple times in parallel depending on own execution duration and interval.
 	LazyPtr<Shared<boost::signals2::signal<void()>>> OnTimerExpiredDetached;
 
 private:

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -72,6 +72,9 @@ protected:
 	void Start(bool runtimeCreated) override;
 	void Stop(bool runtimeRemoved) override;
 
+	void Pause() override;
+	void Resume() override;
+
 	void ValidateStartTime(const Lazy<Timestamp>& lvalue, const ValidationUtils& utils) override;
 	void ValidateEndTime(const Lazy<Timestamp>& lvalue, const ValidationUtils& utils) override;
 
@@ -81,7 +84,11 @@ private:
 	std::set<Downtime::Ptr> m_Children;
 	mutable std::mutex m_ChildrenMutex;
 
+	Timer::Ptr m_CleanupTimer;
+
 	bool CanBeTriggered();
+
+	void SetupCleanupTimer();
 
 	static void DowntimesStartTimerHandler();
 	static void DowntimesExpireTimerHandler();

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -91,7 +91,7 @@ private:
 	void SetupCleanupTimer();
 
 	static void DowntimesStartTimerHandler();
-	static void DowntimesExpireTimerHandler();
+	static void DowntimesOrphanedTimerHandler();
 };
 
 }


### PR DESCRIPTION
Don't look for expired downtimes in a timer fired every 60s, but fire one timer per downtime once at expire time.

closes #9613
ref/IP/43624