### PR TITLE
Set ReloadTimeout to a more realistic value

### DIFF
--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -499,7 +499,7 @@ Constant            | Description
 --------------------|-------------------
 Vars                |**Read-write.** Contains a dictionary with global custom variables. Not set by default.
 NodeName            |**Read-write.** Contains the cluster node name. Set to the local hostname by default.
-ReloadTimeout       |**Read-write.** Defines the reload timeout for child processes. Defaults to `300s`.
+ReloadTimeout       |**Read-write.** Defines the reload timeout for child processes. Defaults to `30m`.
 Environment         |**Read-write.** The name of the Icinga environment. Included in the SNI host name for outbound connections. Not set by default.
 RunAsUser           |**Read-write.** Defines the user the Icinga 2 daemon is running as. Set in the Icinga 2 sysconfig.
 RunAsGroup          |**Read-write.** Defines the group the Icinga 2 daemon is running as. Set in the Icinga 2 sysconfig.

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -45,7 +45,7 @@ void IcingaApplication::StaticInitialize()
 
 	ScriptGlobal::Set("NodeName", node_name);
 
-	ScriptGlobal::Set("ReloadTimeout", 300);
+	ScriptGlobal::Set("ReloadTimeout", 30 * 60);
 	ScriptGlobal::Set("MaxConcurrentChecks", 512);
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");


### PR DESCRIPTION
to give the Director triggered config validation subprocess more time, so it doesn't time out and get killed in a real-world setup.

See ref/IP/43728