### PR TITLE
Main process: ignore SIGHUP

### DIFF
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -499,6 +499,14 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 					sa.sa_handler = SIG_DFL;
 
 					(void)sigaction(SIGUSR1, &sa, nullptr);
+				}
+
+				{
+					struct sigaction sa;
+					memset(&sa, 0, sizeof(sa));
+
+					sa.sa_handler = SIG_IGN;
+
 					(void)sigaction(SIGHUP, &sa, nullptr);
 				}
 


### PR DESCRIPTION
On OpenBSD rcctl reload icinga2 SIGHUPs all "icinga2" processes, not just our umbrella. We must handle this.

fixes #9563