### PR TITLE
Namespace: use rwlock and disable read locking after freeze

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -280,17 +280,6 @@ static int Main()
 #endif /* RLIMIT_STACK */
 	}
 
-	/* Calculate additional global constants. */
-	ScriptGlobal::Set("System.PlatformKernel", Utility::GetPlatformKernel(), true);
-	ScriptGlobal::Set("System.PlatformKernelVersion", Utility::GetPlatformKernelVersion(), true);
-	ScriptGlobal::Set("System.PlatformName", Utility::GetPlatformName(), true);
-	ScriptGlobal::Set("System.PlatformVersion", Utility::GetPlatformVersion(), true);
-	ScriptGlobal::Set("System.PlatformArchitecture", Utility::GetPlatformArchitecture(), true);
-
-	ScriptGlobal::Set("System.BuildHostName", ICINGA_BUILD_HOST_NAME, true);
-	ScriptGlobal::Set("System.BuildCompilerName", ICINGA_BUILD_COMPILER_NAME, true);
-	ScriptGlobal::Set("System.BuildCompilerVersion", ICINGA_BUILD_COMPILER_VERSION, true);
-
 	if (!autocomplete)
 		Application::SetResourceLimits();
 

--- a/lib/base/function.hpp
+++ b/lib/base/function.hpp
@@ -60,28 +60,28 @@ private:
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->Set(#name, sf, true, true); \
+		nsp->Set(#name, sf, true); \
 	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->Set(#name, sf, true, true); \
+		nsp->Set(#name, sf, true); \
 	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->Set(#name, sf, false, true); \
+		nsp->Set(#name, sf, false); \
 	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->SetAttribute(#name, sf, false, true); \
+		nsp->SetAttribute(#name, sf, false); \
 	}, InitializePriority::RegisterFunctions)
 
 }

--- a/lib/base/function.hpp
+++ b/lib/base/function.hpp
@@ -60,28 +60,28 @@ private:
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->SetAttribute(#name, new ConstEmbeddedNamespaceValue(sf)); \
+		nsp->Set(#name, sf, true, true); \
 	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->SetAttribute(#name, new ConstEmbeddedNamespaceValue(sf)); \
+		nsp->Set(#name, sf, true, true); \
 	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), false); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->SetAttribute(#name, new EmbeddedNamespaceValue(sf)); \
+		nsp->Set(#name, sf, false, true); \
 	}, InitializePriority::RegisterFunctions)
 
 #define REGISTER_SAFE_FUNCTION_NONCONST(ns, name, callback, args) \
 	INITIALIZE_ONCE_WITH_PRIORITY([]() { \
 		Function::Ptr sf = new icinga::Function(#ns "#" #name, callback, String(args).Split(":"), true); \
 		Namespace::Ptr nsp = ScriptGlobal::Get(#ns); \
-		nsp->SetAttribute(#name, new EmbeddedNamespaceValue(sf)); \
+		nsp->SetAttribute(#name, sf, false, true); \
 	}, InitializePriority::RegisterFunctions)
 
 }

--- a/lib/base/initialize.hpp
+++ b/lib/base/initialize.hpp
@@ -25,6 +25,7 @@ enum class InitializePriority {
 	RegisterTypes,
 	EvaluateConfigFragments,
 	Default,
+	FreezeNamespaces,
 };
 
 #define I2_TOKENPASTE(x, y) x ## y

--- a/lib/base/json-script.cpp
+++ b/lib/base/json-script.cpp
@@ -24,5 +24,5 @@ INITIALIZE_ONCE([]() {
 	jsonNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
-	systemNS->Set("Json", jsonNS, true, true);
+	systemNS->Set("Json", jsonNS, true);
 });

--- a/lib/base/json-script.cpp
+++ b/lib/base/json-script.cpp
@@ -24,5 +24,5 @@ INITIALIZE_ONCE([]() {
 	jsonNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
-	systemNS->SetAttribute("Json", new ConstEmbeddedNamespaceValue(jsonNS));
+	systemNS->Set("Json", jsonNS, true, true);
 });

--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -95,7 +95,7 @@ void EncodeNamespace(JsonEncoder<prettyPrint>& stateMachine, const Namespace::Pt
 	ObjectLock olock(ns);
 	for (const Namespace::Pair& kv : ns) {
 		stateMachine.Key(Utility::ValidateUTF8(kv.first));
-		Encode(stateMachine, kv.second->Get());
+		Encode(stateMachine, kv.second.Val);
 	}
 
 	stateMachine.EndObject();

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -40,11 +40,11 @@ std::mutex Logger::m_UpdateMinLogSeverityMutex;
 Atomic<LogSeverity> Logger::m_MinLogSeverity (LogDebug);
 
 INITIALIZE_ONCE([]() {
-	ScriptGlobal::Set("System.LogDebug", LogDebug, true);
-	ScriptGlobal::Set("System.LogNotice", LogNotice, true);
-	ScriptGlobal::Set("System.LogInformation", LogInformation, true);
-	ScriptGlobal::Set("System.LogWarning", LogWarning, true);
-	ScriptGlobal::Set("System.LogCritical", LogCritical, true);
+	ScriptGlobal::Set("System.LogDebug", LogDebug);
+	ScriptGlobal::Set("System.LogNotice", LogNotice);
+	ScriptGlobal::Set("System.LogInformation", LogInformation);
+	ScriptGlobal::Set("System.LogWarning", LogWarning);
+	ScriptGlobal::Set("System.LogCritical", LogCritical);
 });
 
 /**

--- a/lib/base/math-script.cpp
+++ b/lib/base/math-script.cpp
@@ -180,5 +180,5 @@ INITIALIZE_ONCE([]() {
 	mathNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
-	systemNS->SetAttribute("Math", new ConstEmbeddedNamespaceValue(mathNS));
+	systemNS->Set("Math", mathNS, true, true);
 });

--- a/lib/base/math-script.cpp
+++ b/lib/base/math-script.cpp
@@ -180,5 +180,5 @@ INITIALIZE_ONCE([]() {
 	mathNS->Freeze();
 
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
-	systemNS->Set("Math", mathNS, true, true);
+	systemNS->Set("Math", mathNS, true);
 });

--- a/lib/base/namespace-script.cpp
+++ b/lib/base/namespace-script.cpp
@@ -63,7 +63,7 @@ static Array::Ptr NamespaceValues()
 	ArrayData values;
 	ObjectLock olock(self);
 	for (const Namespace::Pair& kv : self) {
-		values.push_back(kv.second->Get());
+		values.push_back(kv.second.Val);
 	}
 	return new Array(std::move(values));
 }

--- a/lib/base/namespace.hpp
+++ b/lib/base/namespace.hpp
@@ -8,6 +8,7 @@
 #include "base/shared-object.hpp"
 #include "base/value.hpp"
 #include "base/debuginfo.hpp"
+#include <atomic>
 #include <map>
 #include <vector>
 #include <memory>
@@ -68,9 +69,9 @@ public:
 
 	Value Get(const String& field) const;
 	bool Get(const String& field, Value *value) const;
-	void Set(const String& field, const Value& value, bool isConst = false, bool overrideFrozen = false, const DebugInfo& debugInfo = DebugInfo());
+	void Set(const String& field, const Value& value, bool isConst = false, const DebugInfo& debugInfo = DebugInfo());
 	bool Contains(const String& field) const;
-	void Remove(const String& field, bool overrideFrozen = false);
+	void Remove(const String& field);
 	void Freeze();
 
 	Iterator Begin();
@@ -86,10 +87,12 @@ public:
 	static Object::Ptr GetPrototype();
 
 private:
+	std::shared_lock<std::shared_timed_mutex> ReadLockUnlessFrozen() const;
+
 	std::map<String, NamespaceValue> m_Data;
 	mutable std::shared_timed_mutex m_DataMutex;
 	bool m_ConstValues;
-	bool m_Frozen;
+	std::atomic<bool> m_Frozen;
 };
 
 Namespace::Iterator begin(const Namespace::Ptr& x);

--- a/lib/base/namespace.hpp
+++ b/lib/base/namespace.hpp
@@ -15,31 +15,12 @@
 namespace icinga
 {
 
-struct NamespaceValue : public SharedObject
+struct NamespaceValue
 {
-	DECLARE_PTR_TYPEDEFS(NamespaceValue);
-
-	virtual Value Get(const DebugInfo& debugInfo = DebugInfo()) const = 0;
-	virtual void Set(const Value& value, bool overrideFrozen, const DebugInfo& debugInfo = DebugInfo()) = 0;
+	Value Val;
+	bool Const;
 };
 
-struct EmbeddedNamespaceValue : public NamespaceValue
-{
-	EmbeddedNamespaceValue(const Value& value);
-
-	Value Get(const DebugInfo& debugInfo) const override;
-	void Set(const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) override;
-
-private:
-	Value m_Value;
-};
-
-struct ConstEmbeddedNamespaceValue : public EmbeddedNamespaceValue
-{
-	using EmbeddedNamespaceValue::EmbeddedNamespaceValue;
-
-	void Set(const Value& value, bool overrideFrozen, const DebugInfo& debugInfo) override;
-};
 
 /**
  * A namespace.
@@ -51,22 +32,18 @@ class Namespace final : public Object
 public:
 	DECLARE_OBJECT(Namespace);
 
-	typedef std::map<String, NamespaceValue::Ptr>::iterator Iterator;
+	typedef std::map<String, NamespaceValue>::iterator Iterator;
 
-	typedef std::map<String, NamespaceValue::Ptr>::value_type Pair;
+	typedef std::map<String, NamespaceValue>::value_type Pair;
 
 	explicit Namespace(bool constValues = false);
 
 	Value Get(const String& field) const;
 	bool Get(const String& field, Value *value) const;
-	void Set(const String& field, const Value& value, bool overrideFrozen = false);
+	void Set(const String& field, const Value& value, bool isConst = false, bool overrideFrozen = false, const DebugInfo& debugInfo = DebugInfo());
 	bool Contains(const String& field) const;
 	void Remove(const String& field, bool overrideFrozen = false);
 	void Freeze();
-
-	NamespaceValue::Ptr GetAttribute(const String& field) const;
-	void SetAttribute(const String& field, const NamespaceValue::Ptr& nsVal);
-	void RemoveAttribute(const String& field);
 
 	Iterator Begin();
 	Iterator End();
@@ -81,7 +58,7 @@ public:
 	static Object::Ptr GetPrototype();
 
 private:
-	std::map<String, NamespaceValue::Ptr> m_Data;
+	std::map<String, NamespaceValue> m_Data;
 	bool m_ConstValues;
 	bool m_Frozen;
 };

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -5,12 +5,13 @@
 #include "base/namespace.hpp"
 #include "base/exception.hpp"
 #include "base/configuration.hpp"
+#include "base/utility.hpp"
 
 using namespace icinga;
 
 boost::thread_specific_ptr<std::stack<ScriptFrame *> > ScriptFrame::m_ScriptFrames;
 
-static Namespace::Ptr l_InternalNS;
+static Namespace::Ptr l_SystemNS, l_TypesNS, l_StatsNS, l_InternalNS;
 
 /* Ensure that this gets called with highest priority
  * and wins against other static initializers in lib/icinga, etc.
@@ -19,27 +20,35 @@ static Namespace::Ptr l_InternalNS;
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 
-	Namespace::Ptr systemNS = new Namespace(true);
-	systemNS->Freeze();
-	globalNS->SetAttribute("System", new ConstEmbeddedNamespaceValue(systemNS));
+	l_SystemNS = new Namespace(true);
+	l_SystemNS->Set("PlatformKernel", Utility::GetPlatformKernel());
+	l_SystemNS->Set("PlatformKernelVersion", Utility::GetPlatformKernelVersion());
+	l_SystemNS->Set("PlatformName", Utility::GetPlatformName());
+	l_SystemNS->Set("PlatformVersion", Utility::GetPlatformVersion());
+	l_SystemNS->Set("PlatformArchitecture", Utility::GetPlatformArchitecture());
+	l_SystemNS->Set("BuildHostName", ICINGA_BUILD_HOST_NAME);
+	l_SystemNS->Set("BuildCompilerName", ICINGA_BUILD_COMPILER_NAME);
+	l_SystemNS->Set("BuildCompilerVersion", ICINGA_BUILD_COMPILER_VERSION);
+	globalNS->SetAttribute("System", new ConstEmbeddedNamespaceValue(l_SystemNS));
 
-	systemNS->SetAttribute("Configuration", new EmbeddedNamespaceValue(new Configuration()));
+	l_SystemNS->SetAttribute("Configuration", new EmbeddedNamespaceValue(new Configuration()));
 
-	Namespace::Ptr typesNS = new Namespace(true);
-	typesNS->Freeze();
-	globalNS->SetAttribute("Types", new ConstEmbeddedNamespaceValue(typesNS));
+	l_TypesNS = new Namespace(true);
+	globalNS->SetAttribute("Types", new ConstEmbeddedNamespaceValue(l_TypesNS));
 
-	Namespace::Ptr statsNS = new Namespace(true);
-	statsNS->Freeze();
-	globalNS->SetAttribute("StatsFunctions", new ConstEmbeddedNamespaceValue(statsNS));
+	l_StatsNS = new Namespace(true);
+	globalNS->SetAttribute("StatsFunctions", new ConstEmbeddedNamespaceValue(l_StatsNS));
 
 	l_InternalNS = new Namespace(true);
 	globalNS->SetAttribute("Internal", new ConstEmbeddedNamespaceValue(l_InternalNS));
 }, InitializePriority::CreateNamespaces);
 
-INITIALIZE_ONCE([]() {
+INITIALIZE_ONCE_WITH_PRIORITY([]() {
+	l_SystemNS->Freeze();
+	l_TypesNS->Freeze();
+	l_StatsNS->Freeze();
 	l_InternalNS->Freeze();
-});
+}, InitializePriority::FreezeNamespaces);
 
 ScriptFrame::ScriptFrame(bool allocLocals)
 	: Locals(allocLocals ? new Dictionary() : nullptr), Self(ScriptGlobal::GetGlobals()), Sandboxed(false), Depth(0)

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -29,18 +29,18 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_SystemNS->Set("BuildHostName", ICINGA_BUILD_HOST_NAME);
 	l_SystemNS->Set("BuildCompilerName", ICINGA_BUILD_COMPILER_NAME);
 	l_SystemNS->Set("BuildCompilerVersion", ICINGA_BUILD_COMPILER_VERSION);
-	globalNS->Set("System", l_SystemNS, false, true);
+	globalNS->Set("System", l_SystemNS, true);
 
-	l_SystemNS->Set("Configuration", new Configuration(), false, true);
+	l_SystemNS->Set("Configuration", new Configuration());
 
 	l_TypesNS = new Namespace(true);
-	globalNS->Set("Types", l_TypesNS, false, true);
+	globalNS->Set("Types", l_TypesNS, true);
 
 	l_StatsNS = new Namespace(true);
-	globalNS->Set("StatsFunctions", l_StatsNS, false, true);
+	globalNS->Set("StatsFunctions", l_StatsNS, true);
 
 	l_InternalNS = new Namespace(true);
-	globalNS->Set("Internal", l_InternalNS, false, true);
+	globalNS->Set("Internal", l_InternalNS, true);
 }, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -29,18 +29,18 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_SystemNS->Set("BuildHostName", ICINGA_BUILD_HOST_NAME);
 	l_SystemNS->Set("BuildCompilerName", ICINGA_BUILD_COMPILER_NAME);
 	l_SystemNS->Set("BuildCompilerVersion", ICINGA_BUILD_COMPILER_VERSION);
-	globalNS->SetAttribute("System", new ConstEmbeddedNamespaceValue(l_SystemNS));
+	globalNS->Set("System", l_SystemNS, false, true);
 
-	l_SystemNS->SetAttribute("Configuration", new EmbeddedNamespaceValue(new Configuration()));
+	l_SystemNS->Set("Configuration", new Configuration(), false, true);
 
 	l_TypesNS = new Namespace(true);
-	globalNS->SetAttribute("Types", new ConstEmbeddedNamespaceValue(l_TypesNS));
+	globalNS->Set("Types", l_TypesNS, false, true);
 
 	l_StatsNS = new Namespace(true);
-	globalNS->SetAttribute("StatsFunctions", new ConstEmbeddedNamespaceValue(l_StatsNS));
+	globalNS->Set("StatsFunctions", l_StatsNS, false, true);
 
 	l_InternalNS = new Namespace(true);
-	globalNS->SetAttribute("Internal", new ConstEmbeddedNamespaceValue(l_InternalNS));
+	globalNS->Set("Internal", l_InternalNS, false, true);
 }, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {

--- a/lib/base/scriptglobal.cpp
+++ b/lib/base/scriptglobal.cpp
@@ -65,7 +65,7 @@ void ScriptGlobal::Set(const String& name, const Value& value, bool overrideFroz
 
 void ScriptGlobal::SetConst(const String& name, const Value& value)
 {
-	GetGlobals()->SetAttribute(name, new ConstEmbeddedNamespaceValue(value));
+	GetGlobals()->Set(name, value, true);
 }
 
 bool ScriptGlobal::Exists(const String& name)
@@ -93,7 +93,7 @@ void ScriptGlobal::WriteToFile(const String& filename)
 
 	ObjectLock olock(m_Globals);
 	for (const Namespace::Pair& kv : m_Globals) {
-		Value value = kv.second->Get();
+		Value value = kv.second.Val;
 
 		if (value.IsObject())
 			value = Convert::ToString(value);

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -71,11 +71,11 @@ enum MatchType
 
 void ScriptUtils::StaticInitialize()
 {
-	ScriptGlobal::Set("System.MatchAll", MatchAll, true);
-	ScriptGlobal::Set("System.MatchAny", MatchAny, true);
+	ScriptGlobal::Set("System.MatchAll", MatchAll);
+	ScriptGlobal::Set("System.MatchAny", MatchAny);
 
-	ScriptGlobal::Set("System.GlobFile", GlobFile, true);
-	ScriptGlobal::Set("System.GlobDirectory", GlobDirectory, true);
+	ScriptGlobal::Set("System.GlobFile", GlobFile);
+	ScriptGlobal::Set("System.GlobDirectory", GlobDirectory);
 }
 
 String ScriptUtils::CastString(const Value& value)

--- a/lib/base/serializer.cpp
+++ b/lib/base/serializer.cpp
@@ -131,7 +131,7 @@ static Dictionary::Ptr SerializeNamespace(const Namespace::Ptr& input, int attri
 	ObjectLock olock(input);
 
 	for (const Namespace::Pair& kv : input) {
-		Value val = kv.second->Get();
+		Value val = kv.second.Val;
 		stack.Push(kv.first, val);
 
 		auto serialized (SerializeInternal(val, attributeTypes, stack, dryRun));

--- a/lib/base/sysloglogger.cpp
+++ b/lib/base/sysloglogger.cpp
@@ -19,26 +19,26 @@ std::map<String, int> SyslogHelper::m_FacilityMap;
 
 void SyslogHelper::StaticInitialize()
 {
-	ScriptGlobal::Set("System.FacilityAuth", "LOG_AUTH", true);
-	ScriptGlobal::Set("System.FacilityAuthPriv", "LOG_AUTHPRIV", true);
-	ScriptGlobal::Set("System.FacilityCron", "LOG_CRON", true);
-	ScriptGlobal::Set("System.FacilityDaemon", "LOG_DAEMON", true);
-	ScriptGlobal::Set("System.FacilityFtp", "LOG_FTP", true);
-	ScriptGlobal::Set("System.FacilityKern", "LOG_KERN", true);
-	ScriptGlobal::Set("System.FacilityLocal0", "LOG_LOCAL0", true);
-	ScriptGlobal::Set("System.FacilityLocal1", "LOG_LOCAL1", true);
-	ScriptGlobal::Set("System.FacilityLocal2", "LOG_LOCAL2", true);
-	ScriptGlobal::Set("System.FacilityLocal3", "LOG_LOCAL3", true);
-	ScriptGlobal::Set("System.FacilityLocal4", "LOG_LOCAL4", true);
-	ScriptGlobal::Set("System.FacilityLocal5", "LOG_LOCAL5", true);
-	ScriptGlobal::Set("System.FacilityLocal6", "LOG_LOCAL6", true);
-	ScriptGlobal::Set("System.FacilityLocal7", "LOG_LOCAL7", true);
-	ScriptGlobal::Set("System.FacilityLpr", "LOG_LPR", true);
-	ScriptGlobal::Set("System.FacilityMail", "LOG_MAIL", true);
-	ScriptGlobal::Set("System.FacilityNews", "LOG_NEWS", true);
-	ScriptGlobal::Set("System.FacilitySyslog", "LOG_SYSLOG", true);
-	ScriptGlobal::Set("System.FacilityUser", "LOG_USER", true);
-	ScriptGlobal::Set("System.FacilityUucp", "LOG_UUCP", true);
+	ScriptGlobal::Set("System.FacilityAuth", "LOG_AUTH");
+	ScriptGlobal::Set("System.FacilityAuthPriv", "LOG_AUTHPRIV");
+	ScriptGlobal::Set("System.FacilityCron", "LOG_CRON");
+	ScriptGlobal::Set("System.FacilityDaemon", "LOG_DAEMON");
+	ScriptGlobal::Set("System.FacilityFtp", "LOG_FTP");
+	ScriptGlobal::Set("System.FacilityKern", "LOG_KERN");
+	ScriptGlobal::Set("System.FacilityLocal0", "LOG_LOCAL0");
+	ScriptGlobal::Set("System.FacilityLocal1", "LOG_LOCAL1");
+	ScriptGlobal::Set("System.FacilityLocal2", "LOG_LOCAL2");
+	ScriptGlobal::Set("System.FacilityLocal3", "LOG_LOCAL3");
+	ScriptGlobal::Set("System.FacilityLocal4", "LOG_LOCAL4");
+	ScriptGlobal::Set("System.FacilityLocal5", "LOG_LOCAL5");
+	ScriptGlobal::Set("System.FacilityLocal6", "LOG_LOCAL6");
+	ScriptGlobal::Set("System.FacilityLocal7", "LOG_LOCAL7");
+	ScriptGlobal::Set("System.FacilityLpr", "LOG_LPR");
+	ScriptGlobal::Set("System.FacilityMail", "LOG_MAIL");
+	ScriptGlobal::Set("System.FacilityNews", "LOG_NEWS");
+	ScriptGlobal::Set("System.FacilitySyslog", "LOG_SYSLOG");
+	ScriptGlobal::Set("System.FacilityUser", "LOG_USER");
+	ScriptGlobal::Set("System.FacilityUucp", "LOG_UUCP");
 
 	m_FacilityMap["LOG_AUTH"] = LOG_AUTH;
 	m_FacilityMap["LOG_AUTHPRIV"] = LOG_AUTHPRIV;

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -24,7 +24,7 @@ String Type::ToString() const
 
 void Type::Register(const Type::Ptr& type)
 {
-	ScriptGlobal::Set("Types." + type->GetName(), type, true);
+	ScriptGlobal::Set("Types." + type->GetName(), type);
 }
 
 Type::Ptr Type::GetByName(const String& name)

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -54,7 +54,7 @@ std::vector<Type::Ptr> Type::GetAllTypes()
 		ObjectLock olock(typesNS);
 
 		for (const Namespace::Pair& kv : typesNS) {
-			Value value = kv.second->Get();
+			Value value = kv.second.Val;
 
 			if (value.IsObjectType<Type>())
 				types.push_back(value);

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -675,20 +675,11 @@ ExpressionResult SetConstExpression::DoEvaluate(ScriptFrame& frame, DebugHint *d
 {
 	auto globals = ScriptGlobal::GetGlobals();
 
-	auto attr = globals->GetAttribute(m_Name);
-
-	if (dynamic_pointer_cast<ConstEmbeddedNamespaceValue>(attr)) {
-		std::ostringstream msgbuf;
-		msgbuf << "Value for constant '" << m_Name << "' was modified. This behaviour is deprecated.\n";
-		ShowCodeLocation(msgbuf, GetDebugInfo(), false);
-		Log(LogWarning, msgbuf.str());
-	}
-
 	ExpressionResult operandres = m_Operand->Evaluate(frame);
 	CHECK_RESULT(operandres);
 	Value operand = operandres.GetValue();
 
-	globals->SetAttribute(m_Name, new ConstEmbeddedNamespaceValue(operand));
+	globals->Set(m_Name, operand, true);
 
 	return Empty;
 }

--- a/lib/db_ido/dbquery.cpp
+++ b/lib/db_ido/dbquery.cpp
@@ -12,22 +12,22 @@ std::map<String, int> DbQuery::m_CategoryFilterMap;
 
 void DbQuery::StaticInitialize()
 {
-	ScriptGlobal::Set("Icinga.DbCatConfig", DbCatConfig, true);
-	ScriptGlobal::Set("Icinga.DbCatState", DbCatState, true);
-	ScriptGlobal::Set("Icinga.DbCatAcknowledgement", DbCatAcknowledgement, true);
-	ScriptGlobal::Set("Icinga.DbCatComment", DbCatComment, true);
-	ScriptGlobal::Set("Icinga.DbCatDowntime", DbCatDowntime, true);
-	ScriptGlobal::Set("Icinga.DbCatEventHandler", DbCatEventHandler, true);
-	ScriptGlobal::Set("Icinga.DbCatExternalCommand", DbCatExternalCommand, true);
-	ScriptGlobal::Set("Icinga.DbCatFlapping", DbCatFlapping, true);
-	ScriptGlobal::Set("Icinga.DbCatCheck", DbCatCheck, true);
-	ScriptGlobal::Set("Icinga.DbCatLog", DbCatLog, true);
-	ScriptGlobal::Set("Icinga.DbCatNotification", DbCatNotification, true);
-	ScriptGlobal::Set("Icinga.DbCatProgramStatus", DbCatProgramStatus, true);
-	ScriptGlobal::Set("Icinga.DbCatRetention", DbCatRetention, true);
-	ScriptGlobal::Set("Icinga.DbCatStateHistory", DbCatStateHistory, true);
+	ScriptGlobal::Set("Icinga.DbCatConfig", DbCatConfig);
+	ScriptGlobal::Set("Icinga.DbCatState", DbCatState);
+	ScriptGlobal::Set("Icinga.DbCatAcknowledgement", DbCatAcknowledgement);
+	ScriptGlobal::Set("Icinga.DbCatComment", DbCatComment);
+	ScriptGlobal::Set("Icinga.DbCatDowntime", DbCatDowntime);
+	ScriptGlobal::Set("Icinga.DbCatEventHandler", DbCatEventHandler);
+	ScriptGlobal::Set("Icinga.DbCatExternalCommand", DbCatExternalCommand);
+	ScriptGlobal::Set("Icinga.DbCatFlapping", DbCatFlapping);
+	ScriptGlobal::Set("Icinga.DbCatCheck", DbCatCheck);
+	ScriptGlobal::Set("Icinga.DbCatLog", DbCatLog);
+	ScriptGlobal::Set("Icinga.DbCatNotification", DbCatNotification);
+	ScriptGlobal::Set("Icinga.DbCatProgramStatus", DbCatProgramStatus);
+	ScriptGlobal::Set("Icinga.DbCatRetention", DbCatRetention);
+	ScriptGlobal::Set("Icinga.DbCatStateHistory", DbCatStateHistory);
 
-	ScriptGlobal::Set("Icinga.DbCatEverything", DbCatEverything, true);
+	ScriptGlobal::Set("Icinga.DbCatEverything", DbCatEverything);
 
 	m_CategoryFilterMap["DbCatConfig"] = DbCatConfig;
 	m_CategoryFilterMap["DbCatState"] = DbCatState;

--- a/lib/icinga/checkresult.cpp
+++ b/lib/icinga/checkresult.cpp
@@ -9,13 +9,13 @@ using namespace icinga;
 REGISTER_TYPE(CheckResult);
 
 INITIALIZE_ONCE([]() {
-	ScriptGlobal::Set("Icinga.ServiceOK", ServiceOK, true);
-	ScriptGlobal::Set("Icinga.ServiceWarning", ServiceWarning, true);
-	ScriptGlobal::Set("Icinga.ServiceCritical", ServiceCritical, true);
-	ScriptGlobal::Set("Icinga.ServiceUnknown", ServiceUnknown, true);
+	ScriptGlobal::Set("Icinga.ServiceOK", ServiceOK);
+	ScriptGlobal::Set("Icinga.ServiceWarning", ServiceWarning);
+	ScriptGlobal::Set("Icinga.ServiceCritical", ServiceCritical);
+	ScriptGlobal::Set("Icinga.ServiceUnknown", ServiceUnknown);
 
-	ScriptGlobal::Set("Icinga.HostUp", HostUp, true);
-	ScriptGlobal::Set("Icinga.HostDown", HostDown, true);
+	ScriptGlobal::Set("Icinga.HostUp", HostUp);
+	ScriptGlobal::Set("Icinga.HostDown", HostDown);
 })
 
 double CheckResult::CalculateExecutionTime() const

--- a/lib/icinga/cib.cpp
+++ b/lib/icinga/cib.cpp
@@ -269,7 +269,7 @@ std::pair<Dictionary::Ptr, Array::Ptr> CIB::GetFeatureStats()
 		ObjectLock olock(statsFunctions);
 
 		for (const Namespace::Pair& kv : statsFunctions)
-			static_cast<Function::Ptr>(kv.second->Get())->Invoke({ status, perfdata });
+			static_cast<Function::Ptr>(kv.second.Val)->Invoke({ status, perfdata });
 	}
 
 	return std::make_pair(status, perfdata);

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -31,9 +31,9 @@ INITIALIZE_ONCE(&Downtime::StaticInitialize);
 
 void Downtime::StaticInitialize()
 {
-	ScriptGlobal::Set("Icinga.DowntimeNoChildren", "DowntimeNoChildren", true);
-	ScriptGlobal::Set("Icinga.DowntimeTriggeredChildren", "DowntimeTriggeredChildren", true);
-	ScriptGlobal::Set("Icinga.DowntimeNonTriggeredChildren", "DowntimeNonTriggeredChildren", true);
+	ScriptGlobal::Set("Icinga.DowntimeNoChildren", "DowntimeNoChildren");
+	ScriptGlobal::Set("Icinga.DowntimeTriggeredChildren", "DowntimeTriggeredChildren");
+	ScriptGlobal::Set("Icinga.DowntimeNonTriggeredChildren", "DowntimeNonTriggeredChildren");
 }
 
 String DowntimeNameComposer::MakeName(const String& shortName, const Object::Ptr& context) const

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -54,14 +54,14 @@ void IcingaApplication::StaticInitialize()
 	/* Ensure that the System namespace is already initialized. Otherwise this is a programming error. */
 	VERIFY(systemNS);
 
-	systemNS->Set("ApplicationType", "IcingaApplication");
-	systemNS->Set("ApplicationVersion", Application::GetAppVersion());
+	systemNS->Set("ApplicationType", "IcingaApplication", false, true);
+	systemNS->Set("ApplicationVersion", Application::GetAppVersion(), false, true);
 
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 	VERIFY(globalNS);
 
 	l_IcingaNS = new Namespace(true);
-	globalNS->SetAttribute("Icinga", new ConstEmbeddedNamespaceValue(l_IcingaNS));
+	globalNS->Set("Icinga", l_IcingaNS, true);
 }
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -54,8 +54,8 @@ void IcingaApplication::StaticInitialize()
 	/* Ensure that the System namespace is already initialized. Otherwise this is a programming error. */
 	VERIFY(systemNS);
 
-	systemNS->Set("ApplicationType", "IcingaApplication", false, true);
-	systemNS->Set("ApplicationVersion", Application::GetAppVersion(), false, true);
+	systemNS->Set("ApplicationType", "IcingaApplication", true);
+	systemNS->Set("ApplicationVersion", Application::GetAppVersion(), true);
 
 	Namespace::Ptr globalNS = ScriptGlobal::GetGlobals();
 	VERIFY(globalNS);

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -63,22 +63,22 @@ Dictionary::Ptr NotificationNameComposer::ParseName(const String& name) const
 
 void Notification::StaticInitialize()
 {
-	ScriptGlobal::Set("Icinga.OK", "OK", true);
-	ScriptGlobal::Set("Icinga.Warning", "Warning", true);
-	ScriptGlobal::Set("Icinga.Critical", "Critical", true);
-	ScriptGlobal::Set("Icinga.Unknown", "Unknown", true);
-	ScriptGlobal::Set("Icinga.Up", "Up", true);
-	ScriptGlobal::Set("Icinga.Down", "Down", true);
+	ScriptGlobal::Set("Icinga.OK", "OK");
+	ScriptGlobal::Set("Icinga.Warning", "Warning");
+	ScriptGlobal::Set("Icinga.Critical", "Critical");
+	ScriptGlobal::Set("Icinga.Unknown", "Unknown");
+	ScriptGlobal::Set("Icinga.Up", "Up");
+	ScriptGlobal::Set("Icinga.Down", "Down");
 
-	ScriptGlobal::Set("Icinga.DowntimeStart", "DowntimeStart", true);
-	ScriptGlobal::Set("Icinga.DowntimeEnd", "DowntimeEnd", true);
-	ScriptGlobal::Set("Icinga.DowntimeRemoved", "DowntimeRemoved", true);
-	ScriptGlobal::Set("Icinga.Custom", "Custom", true);
-	ScriptGlobal::Set("Icinga.Acknowledgement", "Acknowledgement", true);
-	ScriptGlobal::Set("Icinga.Problem", "Problem", true);
-	ScriptGlobal::Set("Icinga.Recovery", "Recovery", true);
-	ScriptGlobal::Set("Icinga.FlappingStart", "FlappingStart", true);
-	ScriptGlobal::Set("Icinga.FlappingEnd", "FlappingEnd", true);
+	ScriptGlobal::Set("Icinga.DowntimeStart", "DowntimeStart");
+	ScriptGlobal::Set("Icinga.DowntimeEnd", "DowntimeEnd");
+	ScriptGlobal::Set("Icinga.DowntimeRemoved", "DowntimeRemoved");
+	ScriptGlobal::Set("Icinga.Custom", "Custom");
+	ScriptGlobal::Set("Icinga.Acknowledgement", "Acknowledgement");
+	ScriptGlobal::Set("Icinga.Problem", "Problem");
+	ScriptGlobal::Set("Icinga.Recovery", "Recovery");
+	ScriptGlobal::Set("Icinga.FlappingStart", "FlappingStart");
+	ScriptGlobal::Set("Icinga.FlappingEnd", "FlappingEnd");
 
 	m_StateFilterMap["OK"] = StateFilterOK;
 	m_StateFilterMap["Warning"] = StateFilterWarning;

--- a/lib/icingadb/icingadb-stats.cpp
+++ b/lib/icingadb/icingadb-stats.cpp
@@ -24,7 +24,7 @@ Dictionary::Ptr IcingaDB::GetStats()
 
 	for (auto& kv : statsFunctions)
 	{
-		Function::Ptr func = kv.second->Get();
+		Function::Ptr func = kv.second.Val;
 
 		if (!func)
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid status function name."));

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -35,7 +35,7 @@ public:
 			Namespace::Ptr globals = ScriptGlobal::GetGlobals();
 			ObjectLock olock(globals);
 			for (const Namespace::Pair& kv : globals) {
-				addTarget(GetTargetForVar(kv.first, kv.second->Get()));
+				addTarget(GetTargetForVar(kv.first, kv.second.Val));
 			}
 		}
 	}


### PR DESCRIPTION
This PR improves the config load performance by reduce the amount of locking required. This results in a noticeable speedup, especially on many-core machines. This is achieved by two related changes.

This PR replaces #9607 which had basically the same goal but would have introduced breaking changes that would affect Director. This PR on the other hand introduces no breaking changes.

### Use a rwlock in namespaces

Before this PR, all operations on `Namespace` objects were synchronized using `ObjectLock` which is an exclusive lock. This PR adds a `std::shared_timed_mutex` to `Namespace` which is now used for synchronizing the read operations, therefore allowing parallel read operations on all namespaces.

This new mutex is only used internally, if the namespace has to be locked internally, this still has to be done with the `ObjectLock`. There is a new comment in the code explaining the interaction of these two locks in detail.

### Disable locking after `Namespace::Freeze()`

This PR changes the behavior of `Namespace::Freeze()` to fully freeze the namespace. This means that no more modifications can be done to it, not even by setting `overrideFrozen = true` from within C++ code.

As this makes the namespace completely read-only after `Freeze()` was called, no more locking is required for read operations. Thus, this commit makes all lock operations for read operations no-ops afterwards.

This required some changes to the initialization phase as that heavily depended on `overrideFrozen`. A new priority for `INITIALIZE_ONCE_WITH_PRIORITY` is introduced: `FreezeNamespaces`. It is run after the `Default` priority (used by `INITIALIZE_ONCE`) which allows initializers running at the `Default` priority to still insert into the namespaces.

Some constants were only inserted in `Main()`, these were moved to an initializer function.

The individual new commits in this PR also have extensive commit messages, so I suggest also looking at them individually.

### Benchmark

The performance improvements by this PR show better, the more CPU cores are available. This is quite reasonable, as there was an exclusive mutex before, at some time you reach a point where the mutex is always locked by some core. The following histograms show the time it took to do `icinga2 daemon -C` on this [icinga2.conf](https://github.com/Icinga/icinga2/files/10228441/icinga2.conf.txt) on a dual Xeon E5-2680v4 machine (28 cores, 56 threads).

Versions benchmarked:
* blue (locking-base): same baseline commit as the benchmarks in #9607, effectively has the same performance as the master branch at that time
* orange (freeze-nolock): PR #9607 (freeze globals namespace, don't acquire `ObjectLock` after freeze, but read operations on unfrozen namespaces still acquire the exclusive `ObjectLock`)
* green (shared-mutex): uses a rwlock just as in this PR, but still performs all locking operations on frozen namespaces
* red (shared-mutex-freeze-nolock): this PR (rwlock, don't acquire read locks after freeze, but globals namespace is not frozen)

Note: the benchmarks were done with an older version of this PR before it was rebased onto the current master. Apart from that, there were no changes to the implementation.

![histograms](https://user-images.githubusercontent.com/18552/212630895-85b806e8-b3b2-4018-8a94-aa08548c686c.png)

All three variants  show a very significant improvement over the baseline. This PR and #9607 are very close together in all measurements. From the raw numbers, it looks like this PR might perform a little better than #9607 but I'm pretty sure that either one can perform better based on the config (do more reads on `globals` and #9607 performs better (as it's frozen), add a custom namespace (that won't be frozen) and do more reads on that and this PR will perform better).

The version that only uses a shared mutex but does no optimization on frozen namespaces performs almost as good as the other two in regards to wall clock time, but when considering the user and thus total CPU time used, it's a bit worse that the other two variants. So this PR leaves a little more resources for the rest of the system (which might be a running instance during a config deployment), so doing the rather simple additional optimization on frozen namespaces is definitely worth it.

#### wall clock time
| version | min | avg | median | max | stddev |
| --- | --- | --- | --- | --- | --- |
| icinga/icinga2:namespace-locking-base-v2.13.0-516-gf11b612f8 | 15.801s | 17.408s | 17.343s | 21.134s | 0.740s |
| icinga/icinga2:namespace-freeze-nolock-v2.13.0-519-gf75b77a33 | 9.292s | 12.931s | 13.061s | 14.330s | 0.666s |
| icinga/icinga2:namespace-shared-mutex-v2.13.0-519-g882e26e2d | 9.860s | 13.008s | 13.116s | 15.142s | 0.673s |
| icinga/icinga2:namespace-shared-mutex-freeze-nolock-v2.13.0-521-g9e2a782d2 | 8.756s | 12.614s | 12.724s | 13.983s | 0.714s |

#### total cpu time
| version | min | avg | median | max | stddev |
| --- | --- | --- | --- | --- | --- |
| namespace-locking-base-v2.13.0-516-gf11b612f8 | 648.668s | 687.974s | 686.662s | 733.894s | 16.500s |
| namespace-freeze-nolock-v2.13.0-519-gf75b77a33 | 268.270s | 322.513s | 320.930s | 362.766s | 13.956s |
| namespace-shared-mutex-v2.13.0-519-g882e26e2d | 325.065s | 358.470s | 357.312s | 400.005s | 14.745s |
| namespace-shared-mutex-freeze-nolock-v2.13.0-521-g9e2a782d2 | 286.420s | 318.268s | 316.029s | 368.705s | 15.280s |

#### user cpu time
| version | min | avg | median | max | stddev |
| --- | --- | --- | --- | --- | --- |
| namespace-locking-base-v2.13.0-516-gf11b612f8 | 102.693s | 122.502s | 122.112s | 137.975s | 3.524s |
| namespace-freeze-nolock-v2.13.0-519-gf75b77a33 | 234.748s | 284.070s | 282.657s | 323.145s | 13.280s |
| namespace-shared-mutex-v2.13.0-519-g882e26e2d | 286.498s | 319.714s | 318.660s | 361.553s | 14.296s |
| namespace-shared-mutex-freeze-nolock-v2.13.0-521-g9e2a782d2 | 248.377s | 279.257s | 277.182s | 329.789s | 14.686s |

#### system cpu time
| version | min | avg | median | max | stddev |
| --- | --- | --- | --- | --- | --- |
| namespace-locking-base-v2.13.0-516-gf11b612f8 | 529.753s | 565.472s | 564.495s | 615.121s | 15.750s |
| namespace-freeze-nolock-v2.13.0-519-gf75b77a33 | 33.522s | 38.442s | 38.423s | 42.178s | 1.111s |
| namespace-shared-mutex-v2.13.0-519-g882e26e2d | 35.182s | 38.756s | 38.641s | 44.993s | 0.981s |
| namespace-shared-mutex-freeze-nolock-v2.13.0-521-g9e2a782d2 | 34.804s | 39.010s | 38.935s | 42.291s | 1.004s |

### TODO

* [x] Rebase after #9603 and #9606 were merged.

### Blocked by
* #9603 - this PR now makes use of the `m_Frozen` member variable directly in `Namespace`.
* #9606 - without that, this PR would introduce some new magic priority like `-10`.