### PR TITLE
Fix Logger Severity String Parse

### DIFF
--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -85,19 +85,28 @@ std::set<Logger::Ptr> Logger::GetLoggers()
  *
  * @returns The minimum severity.
  */
-LogSeverity Logger::GetMinSeverity() const
+LogSeverity Logger::GetMinSeverity()
+{
+	if (min_severity == boost::none) {
+		CacheMinSeverity();
+	}
+	return *min_severity;
+}
+
+/**
+ * Retrieves and caches the minimum severity for this logger.
+ */
+void Logger::CacheMinSeverity()
 {
 	String severity = GetSeverity();
 	if (severity.IsEmpty())
-		return LogInformation;
+		min_severity.emplace(LogInformation);
 	else {
 		LogSeverity ls = LogInformation;
-
 		try {
 			ls = Logger::StringToSeverity(severity);
-		} catch (const std::exception&) { /* use the default level */ }
-
-		return ls;
+		} catch (const std::exception &) { /* use the default level */ }
+		min_severity.emplace(ls);
 	}
 }
 
@@ -202,7 +211,7 @@ bool Logger::IsTimestampEnabled()
 void Logger::SetSeverity(const String& value, bool suppress_events, const Value& cookie)
 {
 	ObjectImpl<Logger>::SetSeverity(value, suppress_events, cookie);
-
+	min_severity.emplace(StringToSeverity(value));
 	UpdateMinLogSeverity();
 }
 

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -8,6 +8,7 @@
 #include "base/logger-ti.hpp"
 #include <set>
 #include <sstream>
+#include <boost/optional.hpp>
 
 namespace icinga
 {
@@ -54,7 +55,7 @@ public:
 	static String SeverityToString(LogSeverity severity);
 	static LogSeverity StringToSeverity(const String& severity);
 
-	LogSeverity GetMinSeverity() const;
+	LogSeverity GetMinSeverity();
 
 	/**
 	 * Processes the log entry and writes it to the log that is
@@ -104,6 +105,10 @@ private:
 	static LogSeverity m_ConsoleLogSeverity;
 	static std::mutex m_UpdateMinLogSeverityMutex;
 	static Atomic<LogSeverity> m_MinLogSeverity;
+
+	void CacheMinSeverity();
+
+	boost::optional<LogSeverity> min_severity;
 };
 
 class Log


### PR DESCRIPTION
parsed severity string is cached as an optional variable. so parsing would be called only once for each logger.

fixes #9534