### PR TITLE
GitHub Actions: no longer test builds on Fedora 35

### DIFF
--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -30,9 +30,6 @@ jobs:
           - name: fedora
             release: 36
             subscription: false
-          - name: fedora
-            release: 35
-            subscription: false
           - name: sles
             release: '15.4'
             subscription: true


### PR DESCRIPTION
The repositories have been removed so builds are failing anyways, see https://github.com/Icinga/icinga2/actions/runs/3930125277/jobs/6719754837 for example.