### PR TITLE
GHA: let GitHub cancel redundant jobs

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -7,6 +7,10 @@ on:
       - 'support/*'
   pull_request: {}
 
+concurrency:
+  group: deb-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deb:
     name: .deb
@@ -31,13 +35,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous jobs for the same PR
-        if: "github.event_name == 'pull_request'"
-        uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc
-        with:
-          workflow_id: deb.yml,docker.yml,raspbian.yml,rpm.yml,windows.yml
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout HEAD
         uses: actions/checkout@v1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,18 +10,15 @@ on:
     types:
       - published
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous jobs for the same PR
-        if: "github.event_name == 'pull_request'"
-        uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc
-        with:
-          workflow_id: deb.yml,docker.yml,raspbian.yml,rpm.yml,windows.yml
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Docker image
         uses: Icinga/docker-icinga2@master
         env:

--- a/.github/workflows/raspbian.yml
+++ b/.github/workflows/raspbian.yml
@@ -7,6 +7,10 @@ on:
       - 'support/*'
   pull_request: {}
 
+concurrency:
+  group: raspbian-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   raspbian:
     name: Raspbian
@@ -21,13 +25,6 @@ jobs:
     runs-on: ubuntu-22.04 # revert back to ubuntu-latest once that is 22.04 or later
 
     steps:
-      - name: Cancel previous jobs for the same PR
-        if: "github.event_name == 'pull_request'"
-        uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc
-        with:
-          workflow_id: deb.yml,docker.yml,raspbian.yml,rpm.yml,windows.yml
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout HEAD
         uses: actions/checkout@v1
 

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -7,6 +7,10 @@ on:
       - 'support/*'
   pull_request: {}
 
+concurrency:
+  group: rpm-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rpm:
     name: .rpm (${{ matrix.distro.name }}, ${{ matrix.distro.release }})
@@ -52,13 +56,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous jobs for the same PR
-        if: "github.event_name == 'pull_request'"
-        uses: styfle/cancel-workflow-action@89f242ee29e10c53a841bfe71cc0ce7b2f065abc
-        with:
-          workflow_id: deb.yml,docker.yml,raspbian.yml,rpm.yml,windows.yml
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Vars
         id: vars
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,10 @@ on:
       - 'support/*'
   pull_request: {}
 
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     name: Windows


### PR DESCRIPTION
This will also cancel not yet finished master builds, but that's not too bad.