### PR TITLE
Use type Downtime for removing all host downtimes

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1475,7 +1475,7 @@ Example for removing all host downtimes using a host name filter for `icinga2-sa
 ```bash
 curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
  -X POST 'https://localhost:5665/v1/actions/remove-downtime' \
- -d '{ "type": "Host", "filter": "host.name==\"icinga2-satellite2.localdomain\"", "pretty": true }'
+ -d '{ "type": "Downtime", "filter": "host.name==\"icinga2-satellite2.localdomain\"", "pretty": true }'
 ```
 
 ```json


### PR DESCRIPTION
Icinga web 2 version 2.7.6

When trying to remove all services downtime for a given host, the type 'Host' filter does not work. It returns a success message, but the downtime notifications are note removed. 

The type 'Downtime' with filter to search for hostname removes these entries under the 'Downtimes' page in the console.