### PR TITLE
Utility::GetPlatformKernelVersion(): also output the build number

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -1749,7 +1749,7 @@ String Utility::GetPlatformKernelVersion()
 	GetVersionEx(&info);
 
 	std::ostringstream msgbuf;
-	msgbuf << info.dwMajorVersion << "." << info.dwMinorVersion;
+	msgbuf << info.dwMajorVersion << "." << info.dwMinorVersion << "." << info.dwBuildNumber;
 
 	return msgbuf.str();
 #else /* _WIN32 */


### PR DESCRIPTION
I.e. output 6.2.9200, not just 6.2.