### PR TITLE
Docs: Windows Dev Environment: TL;DR: disable unity build

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -1766,7 +1766,7 @@ cd .\build\
   -DBoost_INCLUDE_DIR=C:\local\boost_1_80_0-Win64 `
   -DBISON_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_bison.exe `
   -DFLEX_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_flex.exe `
-  -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF ..
+  -DICINGA2_WITH_MYSQL=OFF -DICINGA2_WITH_PGSQL=OFF -DICINGA2_UNITY_BUILD=OFF ..
 
 & "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe" .\icinga2.sln
 ```


### PR DESCRIPTION
This enables the individual C++ files, not just unity ones, in VS project tree.