### PR TITLE
Fix config sync after freezing namespaces

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -427,8 +427,13 @@ static int Main()
 			std::unique_ptr<SetExpression> setExpr{new SetExpression(std::move(expr), OpSetLiteral, MakeLiteral(value))};
 			setExpr->SetOverrideFrozen();
 
-			ScriptFrame frame(true);
-			setExpr->Evaluate(frame);
+			try {
+				ScriptFrame frame(true);
+				setExpr->Evaluate(frame);
+			} catch (const ScriptError& e) {
+				Log(LogCritical, "icinga-app") << "cannot set '" << key << "': " << e.what();
+				return EXIT_FAILURE;
+			}
 		}
 	}
 

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -11,7 +11,7 @@ using namespace icinga;
 
 boost::thread_specific_ptr<std::stack<ScriptFrame *> > ScriptFrame::m_ScriptFrames;
 
-static Namespace::Ptr l_SystemNS, l_StatsNS, l_InternalNS;
+static Namespace::Ptr l_SystemNS, l_StatsNS;
 
 /* Ensure that this gets called with highest priority
  * and wins against other static initializers in lib/icinga, etc.
@@ -36,14 +36,12 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_StatsNS = new Namespace(true);
 	globalNS->Set("StatsFunctions", l_StatsNS, true);
 
-	l_InternalNS = new Namespace(true);
-	globalNS->Set("Internal", l_InternalNS, true);
+	globalNS->Set("Internal", new Namespace(true), true);
 }, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_SystemNS->Freeze();
 	l_StatsNS->Freeze();
-	l_InternalNS->Freeze();
 }, InitializePriority::FreezeNamespaces);
 
 ScriptFrame::ScriptFrame(bool allocLocals)

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -111,6 +111,9 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
 	VERIFY(systemNS);
 
+	Namespace::Ptr internalNS = ScriptGlobal::Get("Internal");
+	VERIFY(internalNS);
+
 	if (!objectsFile.IsEmpty())
 		ConfigCompilerContext::GetInstance()->OpenObjectsFile(objectsFile);
 
@@ -134,7 +137,7 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 	success = true;
 
 	/* Only load zone directory if we're not in staging validation. */
-	if (!systemNS->Contains("ZonesStageVarDir")) {
+	if (!internalNS->Contains("ZonesStageVarDir")) {
 		String zonesEtcDir = Configuration::ZonesDir;
 		if (!zonesEtcDir.IsEmpty() && Utility::PathExists(zonesEtcDir)) {
 			std::set<String> zoneEtcDirs;
@@ -177,8 +180,8 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 	String zonesVarDir = Configuration::DataDir + "/api/zones";
 
 	/* Cluster config sync stage validation needs this. */
-	if (systemNS->Contains("ZonesStageVarDir")) {
-		zonesVarDir = systemNS->Get("ZonesStageVarDir");
+	if (internalNS->Contains("ZonesStageVarDir")) {
+		zonesVarDir = internalNS->Get("ZonesStageVarDir");
 
 		Log(LogNotice, "DaemonUtility")
 			<< "Overriding zones var directory with '" << zonesVarDir << "' for cluster config sync staging.";

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -554,7 +554,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 }
 
 /**
- * Spawns a new validation process with 'System.ZonesStageVarDir' set to override the config validation zone dirs with
+ * Spawns a new validation process with 'Internal.ZonesStageVarDir' set to override the config validation zone dirs with
  * our current stage. Then waits for the validation result and if it was successful, the configuration is copied from
  * stage to production and a restart is triggered. On validation failure, there is no restart and this is logged.
  *
@@ -584,7 +584,7 @@ void ApiListener::TryActivateZonesStage(const std::vector<String>& relativePaths
 
 	// Set the ZonesStageDir. This creates our own local chroot without any additional automated zone includes.
 	args->Add("--define");
-	args->Add("System.ZonesStageVarDir=" + GetApiZonesStageDir());
+	args->Add("Internal.ZonesStageVarDir=" + GetApiZonesStageDir());
 
 	Process::Ptr process = new Process(Process::PrepareCommand(args));
 	process->SetTimeout(Application::GetReloadTimeout());


### PR DESCRIPTION
This was accidentally broken by #9627 because during config sync, a config validation happens that uses `--define System.ZonesStageVarDir=...` which fails on the now frozen namespace.

This commit changes this to use `Internal.ZonesStageVarDir` instead. After all, this is used for internal functionality, users should not directly interact with this flag.

Additionally, it no longer freezes the `Internal` namespace which actually allows using `Internal.ZonesStageVarDir` in the first place. This also fixes `--define Internal.Debug*` which was also broken by said PR. Freezing of the `Internal` namespace is not necessary for performance reasons as it's not searched implicitly (for example when accessing `globals.x`) and should users actually interact with it, they should know by that name that they are on their own.

The PR also includes an additional commit that improves the error handling for `--define` so that a proper error message is shown when a user tries to update something in a read-only namespace rather than resulting in a crash with a crash log.

### Test

Updating the config on master-1, result of the incoming config sync on master-2.

#### Before (a24375bc917b60d6bfeb1a426c0c580328733b9c)

Config sync fails with an error, regardless of whether the config is valid:

```
[2023-02-01 12:48:11 +0100] information/ApiListener: Received configuration updates (5) from endpoint 'master-1' are different to production, triggering validation and reload.
[2023-02-01 12:48:11 +0100] warning/Process: PID 410 was terminated by signal 6 (Aborted)
[2023-02-01 12:48:11 +0100] critical/ApiListener: Config validation failed for staged cluster config sync in '/var/lib/icinga2/api/zones-stage/'. Aborting. Logs: '/var/lib/icinga2/api//zones-stage-startup-last-failed.log'
```

Contents of that log file:

```
[2023-02-01 12:48:11 +0100] critical/Application: Error: Namespace is read-only and must not be modified.


Additional information is available in '/var/log/icinga2/crash/report.1675252091.567308'
<Terminated by signal 6 (Aborted).>
```

#### After (fd1aa73d252f8b18c385283b1d4626cb00935076)

Same setting, config sync works again:

```
[2023-02-01 12:58:51 +0100] information/ApiListener: Received configuration updates (5) from endpoint 'master-1' are different to production, triggering validation and reload.
[...]
[2023-02-01 12:58:58 +0100] information/ApiListener: Config validation for stage '/var/lib/icinga2/api/zones-stage/' was OK, replacing into '/var/lib/icinga2/api/zones/' and triggering reload.
[...]
[2023-02-01 12:59:00 +0100] information/Application: Got reload command: Starting new instance.
[2023-02-01 12:59:00 +0100] information/cli: Loading configuration file(s).
```

fixes #9639