### PR TITLE
Use a shared_mutex for read `Dictionary` operations

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -37,7 +37,7 @@ Dictionary::Dictionary(std::initializer_list<Dictionary::Pair> init)
  */
 Value Dictionary::Get(const String& key) const
 {
-	ObjectLock olock(this);
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	auto it = m_Data.find(key);
 
@@ -56,7 +56,7 @@ Value Dictionary::Get(const String& key) const
  */
 bool Dictionary::Get(const String& key, Value *result) const
 {
-	ObjectLock olock(this);
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	auto it = m_Data.find(key);
 
@@ -77,6 +77,7 @@ bool Dictionary::Get(const String& key, Value *result) const
 void Dictionary::Set(const String& key, Value value, bool overrideFrozen)
 {
 	ObjectLock olock(this);
+	std::unique_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	if (m_Frozen && !overrideFrozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Value in dictionary must not be modified."));
@@ -91,7 +92,7 @@ void Dictionary::Set(const String& key, Value value, bool overrideFrozen)
  */
 size_t Dictionary::GetLength() const
 {
-	ObjectLock olock(this);
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	return m_Data.size();
 }
@@ -104,7 +105,7 @@ size_t Dictionary::GetLength() const
  */
 bool Dictionary::Contains(const String& key) const
 {
-	ObjectLock olock(this);
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	return (m_Data.find(key) != m_Data.end());
 }
@@ -146,6 +147,7 @@ Dictionary::Iterator Dictionary::End()
 void Dictionary::Remove(Dictionary::Iterator it, bool overrideFrozen)
 {
 	ASSERT(OwnsLock());
+	std::unique_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	if (m_Frozen && !overrideFrozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Dictionary must not be modified."));
@@ -162,6 +164,7 @@ void Dictionary::Remove(Dictionary::Iterator it, bool overrideFrozen)
 void Dictionary::Remove(const String& key, bool overrideFrozen)
 {
 	ObjectLock olock(this);
+	std::unique_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	if (m_Frozen && !overrideFrozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Dictionary must not be modified."));
@@ -183,6 +186,7 @@ void Dictionary::Remove(const String& key, bool overrideFrozen)
 void Dictionary::Clear(bool overrideFrozen)
 {
 	ObjectLock olock(this);
+	std::unique_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	if (m_Frozen && !overrideFrozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Dictionary must not be modified."));
@@ -192,7 +196,7 @@ void Dictionary::Clear(bool overrideFrozen)
 
 void Dictionary::CopyTo(const Dictionary::Ptr& dest) const
 {
-	ObjectLock olock(this);
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	for (const Dictionary::Pair& kv : m_Data) {
 		dest->Set(kv.first, kv.second);
@@ -222,7 +226,7 @@ Object::Ptr Dictionary::Clone() const
 	DictionaryData dict;
 
 	{
-		ObjectLock olock(this);
+		std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 		dict.reserve(GetLength());
 
@@ -242,7 +246,7 @@ Object::Ptr Dictionary::Clone() const
  */
 std::vector<String> Dictionary::GetKeys() const
 {
-	ObjectLock olock(this);
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
 
 	std::vector<String> keys;
 

--- a/lib/base/dictionary.hpp
+++ b/lib/base/dictionary.hpp
@@ -8,6 +8,7 @@
 #include "base/value.hpp"
 #include <boost/range/iterator.hpp>
 #include <map>
+#include <shared_mutex>
 #include <vector>
 
 namespace icinga
@@ -75,6 +76,7 @@ public:
 
 private:
 	std::map<String, Value> m_Data; /**< The data for the dictionary. */
+	mutable std::shared_timed_mutex m_DataMutex;
 	bool m_Frozen{false};
 };
 


### PR DESCRIPTION
This allows multiple parallel read operations resulting in a overall speedup on systems with many cores.

# #9627

| real | user | sys |
|------|------|-----|
| 23m41,989s | 1056m24,028s | 207m46,986s |
| 24m10,306s | 1084m32,750s | 199m45,335s |
| 24m58,666s | 1152m39,816s | 168m35,401s |
| 25m16,643s | 1156m18,189s | 201m20,795s |
| 23m5,677s | 1044m19,698s | 186m54,275s |
| 24m26,794s | 1112m13,336s | 184m30,857s |
| 23m5,215s | 1049m22,950s | 186m35,814s |
| 23m30,688s | 1061m56,622s | 184m29,615s |
| 23m37,115s | 1073m8,501s | 185m36,210s |
| 22m32,282s | 1037m58,185s | 166m31,956s |

# #9627 + this PR

| real | user | sys |
|------|------|-----|
| 21m0,810s | 1116m15,330s | 3m52,515s |
| 21m32,898s | 1150m21,358s | 4m11,779s |
| 20m59,009s | 1115m39,142s | 3m54,868s |
| 21m53,785s | 1171m41,773s | 3m58,269s |
| 21m18,770s | 1128m18,154s | 4m1,864s |
| 21m3,465s | 1124m55,727s | 4m5,976s |
| 21m48,964s | 1165m7,774s | 4m3,180s |
| 20m10,108s | 1077m6,399s | 4m9,552s |
| 20m56,285s | 1118m42,794s | 3m56,123s |
| 20m18,122s | 1084m51,305s | 4m1,666s |