### PR TITLE
Repair DSL Namespace values being constant broken in #9627

### DIFF
--- a/lib/base/namespace.cpp
+++ b/lib/base/namespace.cpp
@@ -58,7 +58,7 @@ void Namespace::Set(const String& field, const Value& value, bool isConst, const
 	auto nsVal = m_Data.find(field);
 
 	if (nsVal == m_Data.end()) {
-		m_Data[field] = NamespaceValue{value, isConst};
+		m_Data[field] = NamespaceValue{value, isConst || m_ConstValues};
 	} else {
 		if (nsVal->second.Const) {
 			BOOST_THROW_EXCEPTION(ScriptError("Constant must not be modified.", debugInfo));

--- a/lib/base/scriptframe.cpp
+++ b/lib/base/scriptframe.cpp
@@ -36,7 +36,7 @@ INITIALIZE_ONCE_WITH_PRIORITY([]() {
 	l_StatsNS = new Namespace(true);
 	globalNS->Set("StatsFunctions", l_StatsNS, true);
 
-	globalNS->Set("Internal", new Namespace(true), true);
+	globalNS->Set("Internal", new Namespace(), true);
 }, InitializePriority::CreateNamespaces);
 
 INITIALIZE_ONCE_WITH_PRIORITY([]() {


### PR DESCRIPTION
    master before #9627 (a0286e9c6) as well as this PR:

    <1> => namespace n { x = 42; x = 42 }
                                 ^^^^^^
    Constant must not be modified.
    <2> =>

    HEAD of #9627 (24b57f0d3):

    <1> => namespace n { x = 42; x = 42 }
    null
    <2> =>

closes #9656