### PR TITLE
Add role icinga2adm_r to SELinux policies

### DIFF
--- a/tools/selinux/icinga2.te
+++ b/tools/selinux/icinga2.te
@@ -267,6 +267,7 @@ optional_policy(`
 # Icinga2 Admin Role
 #
 
+role icinga2adm_r;
 userdom_unpriv_user_template(icinga2adm)
 
 icinga2_admin(icinga2adm_t, icinga2adm_r)


### PR DESCRIPTION
By default, newly-created files and directories inherit the SELinux type of their parent directories. This is how we've been doing things for a while now, but behaviour seems to have changed for some systems. 
So it is required for `role icinga2adm_r`, setting the role to our SELinux admin level role, to be called before calling `userdom_unpriv_user_template(icinga2adm)` to allow for proper role and domain creation. 
I've tested this on RHEL 9:
```
# semanage boolean -l | grep icinga
httpd_can_connect_icinga2_api  (on   ,   on)  Allow httpd to can connect icinga2 api
httpd_can_write_icinga2_command (on   ,   on)  Allow httpd to can write icinga2 command
icinga2_can_connect_all        (off  ,  off)  Allow icinga2 to can connect all
icinga2_run_sudo               (off  ,  off)  Allow icinga2 to run sudo
icinga2adm_exec_content        (on   ,   on)  Allow icinga2adm to exec content
``` 
Without this fix, this command doesn't print anything. 

See [Issue icinga-packaging/#276](https://github.com/Icinga/icinga-packaging/issues/276) for more info. 