### PR TITLE
Docs: Fix instructions for Fedora

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -151,7 +151,8 @@ yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.r
 
 ```bash
 rpm --import https://packages.icinga.com/icinga.key
-dnf install https://packages.icinga.com/fedora/icinga-rpm-release-$(. /etc/os-release; echo "$VERSION_ID")-latest.noarch.rpm
+dnf install -y 'dnf-command(config-manager)'
+dnf config-manager --add-repo https://packages.icinga.com/fedora/$(. /etc/os-release; echo "$VERSION_ID")/release
 ```
 <!-- {% endif %} -->
 

--- a/doc/02-installation.md.d/04-Fedora.md
+++ b/doc/02-installation.md.d/04-Fedora.md
@@ -1,2 +1,3 @@
+# Install Icinga 2 on Fedora
 <!-- {% set fedora = True %} -->
 <!-- {% include "02-installation.md" %} -->


### PR DESCRIPTION
* First commit fixes missing `Install Icinga 2 on Fedora` heading:
**Current State**
![icinga com_docs_icinga-2_latest_doc_02-installation_04-Fedora_](https://user-images.githubusercontent.com/1894563/219004643-c2cb53d1-74ff-4487-9d80-0296f0c90307.png)
**Expected State**
![icinga com_docs_icinga-2_latest_doc_02-installation_04-Fedora_ (1)](https://user-images.githubusercontent.com/1894563/219004639-3503355d-face-4e6b-b3ef-943b375cf9ae.png)

* Second commit fixes instructions on how to set up our Fedora repository. A long time ago we provided `icinga-rpm-release` RPMs, but that is no longer the case.

fixes #9382
closes #9544