### PR TITLE
GHA: Docker: run nightly, not for every commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,14 +1,13 @@
 name: Docker image
 
 on:
-  pull_request: {}
-  push:
-    branches:
-      - master
-      - 'support/*'
   release:
     types:
       - published
+  schedule:
+    # for master, every day at midnight
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: docker-${{ github.ref }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         distro:
           - amazonlinux:2


### PR DESCRIPTION
Like Icinga Web 2. Basically it is already covered by the Debian GHA. The additional multi-platform Docker image builds only waste time we don't have while releasing.