### PR TITLE
Add syslog logging to SELinux

### DIFF
--- a/tools/selinux/icinga2.te
+++ b/tools/selinux/icinga2.te
@@ -110,6 +110,7 @@ manage_dirs_pattern(icinga2_t, icinga2_log_t, icinga2_log_t)
 manage_files_pattern(icinga2_t, icinga2_log_t, icinga2_log_t)
 manage_lnk_files_pattern(icinga2_t, icinga2_log_t, icinga2_log_t)
 logging_log_filetrans(icinga2_t, icinga2_log_t, { dir file lnk_file })
+logging_send_syslog_msg(icinga2_t)
 
 manage_dirs_pattern(icinga2_t, icinga2_var_lib_t, icinga2_var_lib_t)
 manage_files_pattern(icinga2_t, icinga2_var_lib_t, icinga2_var_lib_t)


### PR DESCRIPTION
This PR adds logging_send_syslog_msg(icinga2_t) to the SELinux policy. [An issue](https://github.com/Icinga/icinga2/issues/9665) notified us about our Icinga 2 SELinux policy not writing to syslog while using sudo even if icinga2_run_sudo is set to true.
After testing it became clear that this issue isn't related to sudo specifically; this PR adds a policy for the icinga2_t domain in general. 

fixes #9665