### PR TITLE
ApiListener: on connect timeout immediately declare endpoint not connecting anymore

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -553,6 +553,8 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 						<< "Timeout while reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host
 						<< "' and port '" << port << "', cancelling attempt";
 
+					endpoint->SetConnecting(false);
+
 					boost::system::error_code ec;
 					sslConn->lowest_layer().cancel(ec);
 				}


### PR DESCRIPTION
rather than waiting for boost::asio::basic_socket#cancel() to take effect. (I.e. to throw and catch an exception in the main coroutine in ApiListener#AddConnection() and then declare endpoint not connecting anymore.) So the next timer run knows the endpoint shall be re-connected to ASAP. Sometimes ref/NC/777425 runs into the connect timeout, but the connection isn't re-tried as the endpoint is still "connecting". This is the best we can do here.

ref/IP/44784