### PR TITLE
Checkable#ProcessCheckResult(): remove ack comments only while clearing acks

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -260,6 +260,8 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	/* Store the current last state change for the next iteration. */
 	SetPreviousStateChange(GetLastStateChange());
 
+	bool remove_acknowledgement_comments = false;
+
 	if (stateChange) {
 		SetLastStateChange(cr->GetExecutionEnd());
 
@@ -267,13 +269,9 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 		if (GetAcknowledgement() == AcknowledgementNormal ||
 			(GetAcknowledgement() == AcknowledgementSticky && IsStateOK(new_state))) {
 			ClearAcknowledgement("");
+			remove_acknowledgement_comments = true;
 		}
 	}
-
-	bool remove_acknowledgement_comments = false;
-
-	if (GetAcknowledgement() == AcknowledgementNone)
-		remove_acknowledgement_comments = true;
 
 	bool hardChange = (GetStateType() == StateTypeHard && old_stateType == StateTypeSoft);
 


### PR DESCRIPTION
and not on every check result while checkable isn't acked (yet).

On HA re-connect the offline master first gets runtime created objects incl. ack comments, then some not state changing DOWN check results and finally the ack itself despite ack comments were created together with acks after those DOWN check results.

So after a host went DOWN, HA disconnect and HA re-connect the synced ack comment was removed by the subsequently synced DOWN check result, then the ack itself was synced.

fixes #9652

## Before

https://github.com/Icinga/icinga2/issues/9652#issuecomment-1443989693

## After

```
twintowers-master2-1        | [2023-02-27 10:34:38 +0000] information/ApiListener: Applying config update from endpoint 'master1' of zone 'master'.
twintowers-master2-1        | [2023-02-27 10:34:38 +0000] information/ConfigObjectUtility: Created and activated object '0!54a6a961-0b83-4cc5-971f-f380cafe534a' of type 'Comment'.
twintowers-icingadb2-1      | 2023-02-27T10:34:38.894Z	INFO	config-sync	Inserting 1 items of type comment
twintowers-master2-1        | [2023-02-27 10:34:38 +0000] information/ConfigObjectUtility: Created and activated object '1!cc525eb7-dd2e-41fd-866e-9ec0eca97a18' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:38 +0000] information/ApiListener: Our production configuration is more recent than the received configuration update. Ignoring configuration file update for path '/var/lib/icinga2/api/zones-stage/master'. Current timestamp '2023-02-27 10:30:19 +0000' (1677493819.440800) >= received timestamp '2023-02-27 10:30:19 +0000' (1677493819.440800).
twintowers-master2-1        | [2023-02-27 10:34:38 +0000] information/ApiListener: Received configuration for zone 'master' from endpoint 'master1'. Comparing the timestamp and checksums.
twintowers-icingadb2-1      | 2023-02-27T10:34:38.949Z	INFO	config-sync	Updating 1 items of type host state
twintowers-master2-1        | [2023-02-27 10:34:38 +0000] information/ApiListener: Stage: Updating received configuration file '/var/lib/icinga2/api/zones-stage/master//_etc/my.conf' for zone 'master'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '10!0f08c45c-0558-4c79-a789-dd3392f83dfa' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Applying configuration file update for path '/var/lib/icinga2/api/zones-stage/master' (350 Bytes).
twintowers-master1-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Finished syncing runtime objects to endpoint 'master2'.
twintowers-master1-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Finished sending runtime config updates for endpoint 'master2' in zone 'master'.
twintowers-master1-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Sending replay log for endpoint 'master2' in zone 'master'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Received configuration updates (1) from endpoint 'master1' are equal to production, skipping validation and reload.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '11!b3746911-4267-4332-8901-fc2e794d5b7b' of type 'Comment'.
twintowers-master1-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Replayed 300 messages.
twintowers-master1-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Finished sending replay log for endpoint 'master2' in zone 'master'.
twintowers-master1-1        | [2023-02-27 10:34:39 +0000] information/ApiListener: Finished syncing endpoint 'master2' in zone 'master'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '12!28e1f5b1-51f9-4f88-be56-83338eb0585e' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '13!00207ba2-2f63-478b-9bc4-4b5608a9e2d6' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '14!e5735dbe-e46d-4a9b-9b7d-fa3f31e8a64a' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '15!637789b0-0a56-40f7-9db8-f920de82f5e8' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '16!2d86f4fc-2102-4e9e-8879-cfb655dd213d' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '17!cd80e993-61c9-414c-9619-ac20f2602880' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '18!3f64316a-25af-4f4e-be80-e265bcd00288' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '19!1c8eecf9-91cd-4e78-b50f-fc2655bba0ae' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/IcingaDB: Initial config/status dump finished in 0.561385 seconds.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '2!c6229221-8462-4c56-8773-6b3e59f95ad5' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '20!ec279ac2-b83b-4b62-aef0-f8efb7ea05c0' of type 'Comment'.
twintowers-redis2-1         | 1:M 27 Feb 2023 10:34:39.394 * 10000 changes in 60 seconds. Saving...
twintowers-redis2-1         | 1:M 27 Feb 2023 10:34:39.396 * Background saving started by pid 16
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '21!9d684785-e62a-4245-bcd3-3d386069c80b' of type 'Comment'.
twintowers-icingadb2-1      | 2023-02-27T10:34:39.416Z	INFO	icingadb	Starting state runtime updates sync
twintowers-icingadb2-1      | 2023-02-27T10:34:39.417Z	INFO	config-sync	Finished initial state sync in 621.82299ms
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '22!ab53f00e-db80-4cdd-9973-501d1c9e0941' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '23!4320902d-fb75-4724-a0cc-fff43f21ac95' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '24!36b723ae-7339-45cb-adc1-6d97e23050fb' of type 'Comment'.
twintowers-icingadb2-1      | 2023-02-27T10:34:39.512Z	INFO	icingadb	Starting config runtime updates sync
twintowers-icingadb2-1      | 2023-02-27T10:34:39.513Z	INFO	icingadb	Starting history retention
twintowers-icingadb2-1      | 2023-02-27T10:34:39.513Z	INFO	config-sync	Finished config sync in 717.917139ms
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '25!0300f07b-148c-45e7-b8a3-2b96055dddca' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '26!f4732b6c-74f8-4d9d-9370-e7b70b0aa0b1' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '27!5f678695-4ae3-46fc-9ea0-b451b55cf63d' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '28!f976da75-6e7d-4931-be49-78dd79e9ceeb' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '29!d0763a5f-1ad4-40e4-9d54-eb33b89feaa0' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '3!d5e16ab5-2f91-412e-8230-218beeb09184' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '30!11c72d32-0186-4b7e-ab42-99906badf2e8' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '31!c46c4f4d-65bc-4461-b41e-500ff86ec35a' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '32!7615ea07-9d4d-44a8-9fc4-09bcff782d5b' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '33!b768c214-3775-4867-852d-a83a5002cdce' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '34!ba202a4b-eba8-4c2a-a45c-6924632322cb' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '35!477e24d3-df53-4755-bf15-6ae6ded89ef3' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '36!dd666fbf-61d9-45dc-a673-b498c10c98b2' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '37!993a9e06-4090-4c65-a1c3-bae40dcc82be' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:39 +0000] information/ConfigObjectUtility: Created and activated object '38!da870143-cd4b-4e21-821b-fefac8ea4079' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '39!9365fc3c-1718-441f-a98f-ef02b2428c07' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '4!508397bf-7d37-4236-8794-821d0af652c9' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '40!0acd71e4-86a3-45e2-a37b-ac06769f8b2a' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '41!5a4c4bf5-922c-48c5-922a-12d57b8c53e8' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '42!5ce02271-e3c7-4613-8f29-75512dc98872' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '43!cc092ddd-3bd8-43da-9758-9db6ca7b8ffe' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '44!c1b2f33b-6273-4750-9176-723993680b94' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '45!6ddca150-a3c3-4178-b182-8e20fd1cc8e5' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '46!65930a36-d034-4995-b064-9de9de1bd174' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '47!9abfa256-be23-4079-808c-7c0db94de486' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '48!80c22163-4fc6-4c5b-b4e6-4ca78f2daace' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '49!bf6360ca-0627-422b-b620-143e7bdd901c' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '5!c0988d12-7ec1-41dd-aca6-a43463e21a9f' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '50!2d846e7e-e5e7-42d0-acad-fc691b35c3de' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '51!a66c3b04-9c36-44ca-a9ed-4d3b7e2fa112' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '52!6bbea58b-bc35-43d4-85fd-5e1255e71449' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '53!f067d913-b26c-440e-bf8b-c1512b8b4b27' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '54!39b69ebb-22ce-43c8-b0a0-afd60d8dfbfe' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '55!e1164516-154e-4e88-acea-e4fa6552ce99' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '56!a5b4ca34-218d-436b-b57c-fa74eaef261f' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '57!bce3d74a-64d7-4423-8ab9-ea7106c363b0' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '58!9cdd320f-23d0-4370-975f-398cee5fb5a0' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '59!53b91b1b-83a2-4903-ad19-6939d058f7d5' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '6!cafe38a4-81bc-4a99-94c1-65552da76836' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '60!aa022892-a536-49be-a541-2a1c7a9121bd' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '61!3318471b-2668-4e13-a5d3-1da9b9606fe0' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '62!c248dd8e-db5d-454b-a18e-7c78f03810bf' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '63!aed6c837-0a5e-4c83-84c5-2a95927a420e' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '64!607af256-9c67-4b3d-a712-c0a6709825d1' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:40 +0000] information/ConfigObjectUtility: Created and activated object '65!a2101ac2-4d70-49b3-9b5d-d51f59b373ea' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '66!0d9a97f8-8405-4098-a48c-6cabf543520c' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '67!72aee288-68d9-4136-9bf3-0873164faee9' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '68!125066a2-f02d-4075-88b9-ffc3c0abb654' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '69!5bc68903-66a1-47b4-a546-40d19f596c7d' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '7!fefadcdd-ae36-4c94-8ad8-cc356d1b798c' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '70!94e7c963-e511-4a0a-ac1e-a3ac338a5a6c' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '71!b223c02d-c3cf-45dc-8f66-efb6291afbb7' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '72!df471cc5-6991-49f3-8c80-777e33890c8a' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '73!865260cb-9751-4b8f-9101-0cc737f07a9f' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '74!400f8297-97ac-4885-97a6-c00131403e13' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '75!74053a58-da1e-49ef-87df-83f3b1ed30c1' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '76!1b3393a9-5301-4e2d-8df7-81d33b1394c8' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '77!deba4aab-5f0c-44ff-bfe7-b9021288a3ff' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '78!f2b67799-c8e4-45fd-b87e-fd56c9d653d7' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '79!040e8f90-4ba6-43e0-91fb-ab198d987267' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '8!0f0b9f89-7068-4593-8b83-c2b4472f6892' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '80!f331a175-5c80-4583-a9e0-3411e679d60b' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '81!9819c56c-cf4f-4e6d-8167-2a59a6b84194' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '82!08b99254-16c1-4dca-a5fe-08abc33d87f5' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '83!f9bff600-ef2d-4f43-9131-1b72573b2a9a' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '84!08fd06d1-ea98-4cd5-887d-1cb72f87d416' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '85!e0fd5c04-4ed3-4eac-acd1-5979bd7a207a' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '86!ada2f4c8-63d6-4464-9ddb-523b1d3427ea' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '87!bad078e6-4c9d-4df6-8845-63c9f938d33e' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '88!a8d57c22-4424-41fb-90c7-70aaf131e945' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '89!4c0c981a-c916-4471-9ca0-de069a83378e' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '9!8d1d8fea-df64-4050-a48a-fd28bc285b8d' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '90!9b68674f-2a3c-4044-9d9e-0d7eefdc3f91' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '91!5882d2f1-e68b-40e8-9ed8-e2e2e893e7d5' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '92!52fa92da-7137-41c2-b366-1d9296d980c6' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '93!ad55e8b5-687d-4fb3-bed8-0f924ef927c9' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '94!bc8d64af-1c25-4e52-871a-a3a7c8e7b84f' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '95!950c34ab-106c-4e62-ac5f-65a67c246c0f' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '96!05d886cc-aa1c-4556-9de9-57531786909d' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '97!3d415d86-c2a0-4412-94bf-f6f2e9e61bf9' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '98!2f0e916f-73f0-470f-96bf-9e5590048397' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:41 +0000] information/ConfigObjectUtility: Created and activated object '99!7d1cb45f-972d-4192-be72-7a62066ec7be' of type 'Comment'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '0'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '1'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '10'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '11'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '12'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '13'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '14'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '15'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '16'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '17'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '18'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '19'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '2'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '20'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '21'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '22'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '23'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '24'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '25'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '26'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '27'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '28'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '29'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '3'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '30'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '31'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '32'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '33'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '34'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '35'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '36'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '37'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '38'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '39'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '4'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '40'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '41'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '42'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '43'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '44'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '45'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '46'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '47'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '48'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '49'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '5'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '50'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '51'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '52'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '53'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '54'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '55'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '56'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '57'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '58'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '59'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '6'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '60'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '61'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '62'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '63'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '64'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '65'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '66'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '67'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '68'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '69'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '7'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '70'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '71'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '72'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '73'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '74'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '75'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '76'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '77'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '78'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '79'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '8'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '80'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '81'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '82'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '83'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '84'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '85'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '86'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '87'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '88'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '89'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '9'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '90'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '91'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '92'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '93'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '94'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '95'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '96'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '97'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '98'.
twintowers-master2-1        | [2023-02-27 10:34:42 +0000] information/Checkable: Acknowledgement set for checkable '99'.
twintowers-redis2-1         | 16:C 27 Feb 2023 10:34:42.733 * DB saved on disk
twintowers-redis2-1         | 16:C 27 Feb 2023 10:34:42.734 * Fork CoW for RDB: current 1 MB, peak 1 MB, average 1 MB
twintowers-redis2-1         | 1:M 27 Feb 2023 10:34:42.836 * Background saving terminated with success
twintowers-web2-1           | 172.20.0.1 - - [27/Feb/2023:10:34:44 +0000] "GET /application-state/summary HTTP/1.1" 200 495 "http://localhost:8082/icingadb/hosts?host.state.is_problem=y&sort=host.state.severity%20desc&limit=500" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 OPR/95.0.0.0"
twintowers-web2-1           | 172.20.0.1 - - [27/Feb/2023:10:34:44 +0000] "GET /layout/menu HTTP/1.1" 200 1747 "http://localhost:8082/icingadb/hosts?host.state.is_problem=y&sort=host.state.severity%20desc&limit=500" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 OPR/95.0.0.0"
twintowers-web2-1           | 172.20.0.1 - - [27/Feb/2023:10:34:44 +0000] "GET /icingadb/hosts?host.state.is_problem=y&sort=host.state.severity%20desc&limit=500 HTTP/1.1" 200 4389 "http://localhost:8082/icingadb/hosts?host.state.is_problem=y&sort=host.state.severity%20desc&limit=500" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 OPR/95.0.0.0"
twintowers-master2-1        | [2023-02-27 10:34:48 +0000] information/WorkQueue: #6 (ApiListener, RelayQueue) items: 0, rate: 10/s (600/min 600/5min 600/15min);
twintowers-master2-1        | [2023-02-27 10:34:48 +0000] information/WorkQueue: #7 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
twintowers-master2-1        | [2023-02-27 10:34:48 +0000] information/IcingaDB: Pending queries: 0 (Input: 175/s; Output: 175/s)
```