### PR TITLE
ApiListener#AddConnection(): on timeout destroy the connect attempt strand

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -84,9 +84,12 @@ boost::asio::io_context& IoEngine::GetIoContext()
 	return m_IoContext;
 }
 
-IoEngine::IoEngine() : m_IoContext(), m_KeepAlive(boost::asio::make_work_guard(m_IoContext)), m_Threads(decltype(m_Threads)::size_type(std::thread::hardware_concurrency() * 2u)), m_AlreadyExpiredTimer(m_IoContext)
+IoEngine::IoEngine()
+	: m_IoContext(), m_KeepAlive(boost::asio::make_work_guard(m_IoContext)), m_Threads(decltype(m_Threads)::size_type(std::thread::hardware_concurrency() * 2u)),
+	m_AlreadyExpiredTimer(m_IoContext), m_NeverExpiringTimer(m_IoContext)
 {
 	m_AlreadyExpiredTimer.expires_at(boost::posix_time::neg_infin);
+	m_NeverExpiringTimer.expires_at(boost::posix_time::pos_infin);
 	m_CpuBoundSemaphore.store(std::thread::hardware_concurrency() * 3u / 2u);
 
 	for (auto& thread : m_Threads) {

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -125,6 +125,12 @@ public:
 		Get().m_AlreadyExpiredTimer.async_wait(yc);
 	}
 
+	static inline
+	void AwaitCurrentCoroutineUnwinding(boost::asio::yield_context yc)
+	{
+		Get().m_NeverExpiringTimer.async_wait(yc);
+	}
+
 private:
 	IoEngine();
 
@@ -136,6 +142,7 @@ private:
 	boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_KeepAlive;
 	std::vector<std::thread> m_Threads;
 	boost::asio::deadline_timer m_AlreadyExpiredTimer;
+	boost::asio::deadline_timer m_NeverExpiringTimer;
 	std::atomic_int_fast32_t m_CpuBoundSemaphore;
 };
 

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -576,7 +576,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 }
 
 void ApiListener::NewClientHandler(
-	boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
+	boost::asio::yield_context yc, std::shared_ptr<boost::asio::io_context::strand> strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {
@@ -613,7 +613,7 @@ static const auto l_MyCapabilities (ApiCapabilities::ExecuteArbitraryCommand);
  * @param client The new client.
  */
 void ApiListener::NewClientHandlerInternal(
-	boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
+	boost::asio::yield_context yc, std::shared_ptr<boost::asio::io_context::strand> strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -492,7 +492,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 			lock.unlock();
 			sslConn->lowest_layer() = std::move(socket);
 
-			auto strand (Shared<asio::io_context::strand>::Make(io));
+			auto strand (std::make_shared<asio::io_context::strand>(io));
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn](asio::yield_context yc) {
 				Timeout::Ptr timeout(new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
@@ -532,7 +532,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 	}
 
 	auto& io (IoEngine::Get().GetIoContext());
-	auto strand (Shared<asio::io_context::strand>::Make(io));
+	auto strand (std::make_shared<asio::io_context::strand>(io));
 
 	IoEngine::SpawnCoroutine(*strand, [this, strand, endpoint, &io](asio::yield_context yc) {
 		String host = endpoint->GetHost();
@@ -576,7 +576,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 }
 
 void ApiListener::NewClientHandler(
-	boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+	boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {
@@ -613,7 +613,7 @@ static const auto l_MyCapabilities (ApiCapabilities::ExecuteArbitraryCommand);
  * @param client The new client.
  */
 void ApiListener::NewClientHandlerInternal(
-	boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+	boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -190,11 +190,11 @@ private:
 	void AddConnection(const Endpoint::Ptr& endpoint);
 
 	void NewClientHandler(
-		boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
+		boost::asio::yield_context yc, std::shared_ptr<boost::asio::io_context::strand> strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void NewClientHandlerInternal(
-		boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
+		boost::asio::yield_context yc, std::shared_ptr<boost::asio::io_context::strand> strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server);

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -190,11 +190,11 @@ private:
 	void AddConnection(const Endpoint::Ptr& endpoint);
 
 	void NewClientHandler(
-		boost::asio::yield_context yc, std::shared_ptr<boost::asio::io_context::strand> strand,
+		boost::asio::yield_context yc, const std::weak_ptr<boost::asio::io_context::strand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void NewClientHandlerInternal(
-		boost::asio::yield_context yc, std::shared_ptr<boost::asio::io_context::strand> strand,
+		boost::asio::yield_context yc, const std::weak_ptr<boost::asio::io_context::strand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server);

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -23,6 +23,7 @@
 #include <boost/asio/ssl/context.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <set>
 
@@ -189,11 +190,11 @@ private:
 	void AddConnection(const Endpoint::Ptr& endpoint);
 
 	void NewClientHandler(
-		boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+		boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void NewClientHandlerInternal(
-		boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+		boost::asio::yield_context yc, const std::shared_ptr<boost::asio::io_context::strand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server);


### PR DESCRIPTION
    async-ly (to avoid deadlocks) so all involved coroutines are unwinded (via
    exception). ref/NC/777425 has shown that boost::asio::basic_socket#cancel()
    seems not to be reliable enough to trigger an exception. If not triggered,
    coroutines representing a failed connect attempt hang for a long time. That
    "pending" connect attempt prevents new trials.

closes #9708

## TODO

* [x] testing (@Al2Klimov)