### PR TITLE
Connect(): don't try next DNS record if operation is canceled

### DIFF
--- a/lib/base/tcpsocket.hpp
+++ b/lib/base/tcpsocket.hpp
@@ -6,8 +6,10 @@
 #include "base/i2-base.hpp"
 #include "base/io-engine.hpp"
 #include "base/socket.hpp"
+#include <boost/asio/error.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
+#include <boost/system/system_error.hpp>
 
 namespace icinga
 {
@@ -50,8 +52,10 @@ void Connect(Socket& socket, const String& node, const String& service)
 			socket.connect(current->endpoint());
 
 			break;
-		} catch (const std::exception&) {
-			if (++current == result.end()) {
+		} catch (const std::exception& ex) {
+			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
+
+			if (se && se->code() == boost::asio::error::operation_aborted || ++current == result.end()) {
 				throw;
 			}
 
@@ -79,8 +83,10 @@ void Connect(Socket& socket, const String& node, const String& service, boost::a
 			socket.async_connect(current->endpoint(), yc);
 
 			break;
-		} catch (const std::exception&) {
-			if (++current == result.end()) {
+		} catch (const std::exception& ex) {
+			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
+
+			if (se && se->code() == boost::asio::error::operation_aborted || ++current == result.end()) {
 				throw;
 			}
 


### PR DESCRIPTION
Instead return immediately to meet the caller's expectations.

ref/NC/777425
ref/IP/44784

closes #9708
closes #9710

## Before

```
[2023-02-28 10:19:06 +0100] information/ApiListener: Reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665'
[2023-02-28 10:19:06 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:19:06 +0100] information/NotificationComponent: 'notification' started.
[2023-02-28 10:19:06 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:19:06 +0100] debug/ConfigItem: Activating object 'checker' of type 'CheckerComponent' with priority 300
[2023-02-28 10:19:06 +0100] information/CheckerComponent: 'checker' started.
[2023-02-28 10:19:06 +0100] information/ConfigItem: Activated all objects.
[2023-02-28 10:19:06 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:19:06 +0100] debug/IcingaApplication: In IcingaApplication::Main()
[2023-02-28 10:19:11 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:15 +0100] information/WorkQueue: #5 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2023-02-28 10:19:15 +0100] information/WorkQueue: #4 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2023-02-28 10:19:16 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:19:16 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:19:16 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:16 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:19:16 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:19:16 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:19:21 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:21 +0100] critical/ApiListener: Timeout while reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665', cancelling attempt
[2023-02-28 10:19:26 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:19:26 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:19:26 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:26 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:19:26 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:19:26 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:19:31 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:36 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:19:36 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:36 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:19:36 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:19:36 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:19:36 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:19:41 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:46 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:19:46 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:46 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:19:46 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:19:46 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:19:46 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:19:51 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:56 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:19:56 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:19:56 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:19:56 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:19:56 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:19:56 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:20:01 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:06 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:20:06 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:20:06 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:06 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:20:06 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:20:06 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:20:11 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:16 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:20:16 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:16 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:20:16 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:20:16 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:20:16 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:20:21 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:26 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:20:26 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:20:26 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:26 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:20:26 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:20:26 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:20:31 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:20:36 +0100] critical/ApiListener: Cannot connect to host 'al2klimov.de' on port '5665': Operation timed out
```

## What's the matter

```
--- lib/base/tcpsocket.hpp
+++ lib/base/tcpsocket.hpp
@@ -79,7 +79,9 @@ void Connect(Socket& socket, const String& node, const String& service, boost::a
                        socket.async_connect(current->endpoint(), yc);

                        break;
-               } catch (const std::exception&) {
+               } catch (const std::exception& ex) {
+                       Log(LogCritical, "LOLCAT") << current->endpoint().address().to_string() << " -- " << ex.what();
+
                        if (++current == result.end()) {
                                throw;
                        }
```

```
[2023-02-28 10:25:06 +0100] information/ApiListener: Reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665'
[2023-02-28 10:25:06 +0100] information/NotificationComponent: 'notification' started.
[2023-02-28 10:25:06 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:25:06 +0100] debug/ConfigItem: Activating object 'checker' of type 'CheckerComponent' with priority 300
[2023-02-28 10:25:06 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:25:06 +0100] information/CheckerComponent: 'checker' started.
[2023-02-28 10:25:06 +0100] information/ConfigItem: Activated all objects.
[2023-02-28 10:25:06 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:25:06 +0100] debug/IcingaApplication: In IcingaApplication::Main()
[2023-02-28 10:25:11 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:25:16 +0100] information/WorkQueue: #4 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2023-02-28 10:25:16 +0100] information/WorkQueue: #5 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2023-02-28 10:25:16 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:25:16 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:25:16 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:25:16 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:25:16 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:25:16 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:25:21 +0100] critical/ApiListener: Timeout while reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665', cancelling attempt
[2023-02-28 10:25:21 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:25:21 +0100] critical/LOLCAT: 2a01:4f8:c2c:16ce::1 -- Operation canceled
```

## After

```
[2023-02-28 10:45:39 +0100] information/ApiListener: Reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665'
[2023-02-28 10:45:39 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:45:39 +0100] information/NotificationComponent: 'notification' started.
[2023-02-28 10:45:39 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:45:39 +0100] debug/ConfigItem: Activating object 'checker' of type 'CheckerComponent' with priority 300
[2023-02-28 10:45:39 +0100] information/CheckerComponent: 'checker' started.
[2023-02-28 10:45:39 +0100] information/ConfigItem: Activated all objects.
[2023-02-28 10:45:39 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:45:39 +0100] debug/IcingaApplication: In IcingaApplication::Main()
[2023-02-28 10:45:44 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:45:47 +0100] information/WorkQueue: #4 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2023-02-28 10:45:47 +0100] information/WorkQueue: #5 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2023-02-28 10:45:49 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:45:49 +0100] debug/ApiListener: Not connecting to Endpoint 'al2klimov.de' because we're already trying to connect to it.
[2023-02-28 10:45:49 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:45:49 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:45:49 +0100] notice/ApiListener: Current zone master: alexandersmbp2.int.netways.de
[2023-02-28 10:45:49 +0100] notice/ApiListener: Connected endpoints:
[2023-02-28 10:45:54 +0100] critical/ApiListener: Timeout while reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665', cancelling attempt
[2023-02-28 10:45:54 +0100] critical/ApiListener: Cannot connect to host 'al2klimov.de' on port '5665': Operation canceled
[2023-02-28 10:45:54 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:45:59 +0100] notice/ApiListener: Updating object authority for objects at endpoint 'alexandersmbp2.int.netways.de'.
[2023-02-28 10:45:59 +0100] notice/CheckerComponent: Pending checkables: 0; Idle checkables: 0; Checks/s: 0
[2023-02-28 10:45:59 +0100] debug/ApiListener: Not connecting to Endpoint 'alexandersmbp2.int.netways.de' because that's us.
[2023-02-28 10:45:59 +0100] information/ApiListener: Reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665'
```