### PR TITLE
ProcessSpawnImpl(): remove redundant _exit(128);

### DIFF
--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -181,7 +181,6 @@ static Value ProcessSpawnImpl(struct msghdr *msgh, const Dictionary::Ptr& reques
 			strncat(errmsg, ") failed", sizeof(errmsg) - strlen(errmsg) - 1);
 			errmsg[sizeof(errmsg) - 1] = '\0';
 			perror(errmsg);
-			_exit(128);
 		}
 
 		_exit(128);


### PR DESCRIPTION
Now this if doesn’t _exit(128) by itself, but "return" to the outer if which immediately _exit(128)s.