### PR TITLE
Checkable#ProcessCheckResult(): only clean up ack comments older than check result

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -275,7 +275,7 @@ Dictionary::Ptr ApiActions::RemoveAcknowledgement(const ConfigObject::Ptr& objec
 	String removedBy (HttpUtility::GetLastParameter(params, "author"));
 
 	checkable->ClearAcknowledgement(removedBy);
-	checkable->RemoveCommentsByType(CommentAcknowledgement, removedBy);
+	checkable->RemoveAckComments(removedBy);
 
 	return ApiActions::CreateResult(200, "Successfully removed acknowledgement for object '" + checkable->GetName() + "'.");
 }

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -321,7 +321,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	olock.Unlock();
 
 	if (remove_acknowledgement_comments)
-		RemoveAckComments();
+		RemoveAckComments(String(), cr->GetExecutionEnd());
 
 	Dictionary::Ptr vars_after = new Dictionary({
 		{ "state", new_state },

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -321,7 +321,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	olock.Unlock();
 
 	if (remove_acknowledgement_comments)
-		RemoveCommentsByType(CommentAcknowledgement);
+		RemoveAckComments();
 
 	Dictionary::Ptr vars_after = new Dictionary({
 		{ "state", new_state },

--- a/lib/icinga/checkable-comment.cpp
+++ b/lib/icinga/checkable-comment.cpp
@@ -19,14 +19,15 @@ void Checkable::RemoveAllComments()
 	}
 }
 
-void Checkable::RemoveCommentsByType(int type, const String& removedBy)
+void Checkable::RemoveAckComments(const String& removedBy)
 {
 	for (const Comment::Ptr& comment : GetComments()) {
-		/* Do not remove persistent comments from an acknowledgement */
-		if (comment->GetEntryType() == CommentAcknowledgement && comment->GetPersistent())
-			continue;
+		if (comment->GetEntryType() == CommentAcknowledgement) {
+			/* Do not remove persistent comments from an acknowledgement */
+			if (comment->GetPersistent()) {
+				continue;
+			}
 
-		if (comment->GetEntryType() == type) {
 			{
 				ObjectLock oLock (comment);
 				comment->SetRemovedBy(removedBy);

--- a/lib/icinga/checkable-comment.cpp
+++ b/lib/icinga/checkable-comment.cpp
@@ -19,12 +19,16 @@ void Checkable::RemoveAllComments()
 	}
 }
 
-void Checkable::RemoveAckComments(const String& removedBy)
+void Checkable::RemoveAckComments(const String& removedBy, double createdBefore)
 {
 	for (const Comment::Ptr& comment : GetComments()) {
 		if (comment->GetEntryType() == CommentAcknowledgement) {
 			/* Do not remove persistent comments from an acknowledgement */
 			if (comment->GetPersistent()) {
+				continue;
+			}
+
+			if (comment->GetEntryTime() > createdBefore) {
 				continue;
 			}
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -17,6 +17,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <functional>
+#include <limits>
 
 namespace icinga
 {
@@ -156,7 +157,7 @@ public:
 
 	/* Comments */
 	void RemoveAllComments();
-	void RemoveAckComments(const String& removedBy = String());
+	void RemoveAckComments(const String& removedBy = String(), double createdBefore = std::numeric_limits<double>::max());
 
 	std::set<Comment::Ptr> GetComments() const;
 	Comment::Ptr GetLastComment() const;

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -156,7 +156,7 @@ public:
 
 	/* Comments */
 	void RemoveAllComments();
-	void RemoveCommentsByType(int type, const String& removedBy = String());
+	void RemoveAckComments(const String& removedBy = String());
 
 	std::set<Comment::Ptr> GetComments() const;
 	Comment::Ptr GetLastComment() const;

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -665,7 +665,7 @@ void ExternalCommandProcessor::RemoveSvcAcknowledgement(double, const std::vecto
 		service->ClearAcknowledgement("");
 	}
 
-	service->RemoveCommentsByType(CommentAcknowledgement);
+	service->RemoveAckComments();
 }
 
 void ExternalCommandProcessor::AcknowledgeHostProblem(double, const std::vector<String>& arguments)
@@ -738,7 +738,7 @@ void ExternalCommandProcessor::RemoveHostAcknowledgement(double, const std::vect
 		ObjectLock olock(host);
 		host->ClearAcknowledgement("");
 	}
-	host->RemoveCommentsByType(CommentAcknowledgement);
+	host->RemoveAckComments();
 }
 
 void ExternalCommandProcessor::EnableHostgroupSvcChecks(double, const std::vector<String>& arguments)


### PR DESCRIPTION
    Normally if for some reason an ack comment still exists on a checkable not
    acked anymore, still clean it up. But while replaying log config objects
    incl. ack comments come before check results and acks. I.e. 1) ack comment,
    2) DOWN check result and 3) ack. Not 1) DOWN check result, 2) ack and 3) ack
    comment. So the checkable is temporarily not acked, but already has the ack
    comment. In this case the DOWN check result which is older than the ack
    comment shall not clean up the latter.

fixes #9652
closes #9709

## TODO

* [x] testing (@Al2Klimov)
* [x] testing (customer)