### PR TITLE
Build: define BOOST_ALLOW_DEPRECATED_HEADERS to suppress compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,8 @@ add_definitions(-DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
 
 add_definitions(-DBOOST_FILESYSTEM_NO_DEPRECATED)
 
+add_definitions(-DBOOST_ALLOW_DEPRECATED_HEADERS)
+
 # Required for Boost v1.74+
 add_definitions(-DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
 


### PR DESCRIPTION
We have to support a wide range of Boost versions, with possibly different headers being available/deprecated or not. We already (have to) support [1.66, 1.81], 16 different versions. If we gonna support e.g. CentOS 7 till 2024, that will increase. More versions = more deprecated headers.