### PR TITLE
Don't define/use OpenSSL*Callback() for/in OpenSSL > v1.1

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -17,7 +17,6 @@ namespace icinga
 {
 
 static bool l_SSLInitialized = false;
-static std::mutex *l_Mutexes;
 static std::mutex l_RandomMutex;
 
 String GetOpenSSLVersion()
@@ -29,7 +28,9 @@ String GetOpenSSLVersion()
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 }
 
-#ifdef CRYPTO_LOCK
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+static std::mutex *l_Mutexes;
+
 static void OpenSSLLockingCallback(int mode, int type, const char *, int)
 {
 	if (mode & CRYPTO_LOCK)
@@ -46,7 +47,7 @@ static unsigned long OpenSSLIDCallback()
 	return (unsigned long)pthread_self();
 #endif /* _WIN32 */
 }
-#endif /* CRYPTO_LOCK */
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 /**
  * Initializes the OpenSSL library.
@@ -61,11 +62,11 @@ void InitializeOpenSSL()
 
 	SSL_COMP_get_compression_methods();
 
-#ifdef CRYPTO_LOCK
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	l_Mutexes = new std::mutex[CRYPTO_num_locks()];
 	CRYPTO_set_locking_callback(&OpenSSLLockingCallback);
 	CRYPTO_set_id_callback(&OpenSSLIDCallback);
-#endif /* CRYPTO_LOCK */
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 	l_SSLInitialized = true;
 }


### PR DESCRIPTION
Since OpenSSL v1.1 the macros they're passed to expand to nothing creating the illusion those functions aren't used. That triggers compiler warnings.