### PR TITLE
Stream#Read(): remove de facto unused param allow_partial

### DIFF
--- a/lib/base/fifo.cpp
+++ b/lib/base/fifo.cpp
@@ -57,10 +57,8 @@ void FIFO::Optimize()
 /**
  * Implements IOQueue::Read.
  */
-size_t FIFO::Read(void *buffer, size_t count, bool allow_partial)
+size_t FIFO::Read(void *buffer, size_t count)
 {
-	ASSERT(allow_partial);
-
 	if (count > m_DataSize)
 		count = m_DataSize;
 

--- a/lib/base/fifo.hpp
+++ b/lib/base/fifo.hpp
@@ -23,7 +23,7 @@ public:
 
 	~FIFO() override;
 
-	size_t Read(void *buffer, size_t count, bool allow_partial = false) override;
+	size_t Read(void *buffer, size_t count) override;
 	void Write(const void *buffer, size_t count) override;
 	void Close() override;
 	bool IsEof() const override;

--- a/lib/base/networkstream.cpp
+++ b/lib/base/networkstream.cpp
@@ -23,11 +23,9 @@ void NetworkStream::Close()
  * @param count The number of bytes to read from the queue.
  * @returns The number of bytes actually read.
  */
-size_t NetworkStream::Read(void *buffer, size_t count, bool allow_partial)
+size_t NetworkStream::Read(void *buffer, size_t count)
 {
 	size_t rc;
-
-	ASSERT(allow_partial);
 
 	if (m_Eof)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Tried to read from closed socket."));

--- a/lib/base/networkstream.hpp
+++ b/lib/base/networkstream.hpp
@@ -22,7 +22,7 @@ public:
 
 	NetworkStream(Socket::Ptr socket);
 
-	size_t Read(void *buffer, size_t count, bool allow_partial = false) override;
+	size_t Read(void *buffer, size_t count) override;
 	void Write(const void *buffer, size_t count) override;
 
 	void Close() override;

--- a/lib/base/stdiostream.cpp
+++ b/lib/base/stdiostream.cpp
@@ -21,7 +21,7 @@ StdioStream::~StdioStream()
 	Close();
 }
 
-size_t StdioStream::Read(void *buffer, size_t size, bool allow_partial)
+size_t StdioStream::Read(void *buffer, size_t size)
 {
 	ObjectLock olock(this);
 

--- a/lib/base/stdiostream.hpp
+++ b/lib/base/stdiostream.hpp
@@ -18,7 +18,7 @@ public:
 	StdioStream(std::iostream *innerStream, bool ownsStream);
 	~StdioStream() override;
 
-	size_t Read(void *buffer, size_t size, bool allow_partial = false) override;
+	size_t Read(void *buffer, size_t size) override;
 	void Write(const void *buffer, size_t size) override;
 
 	void Close() override;

--- a/lib/base/stream.cpp
+++ b/lib/base/stream.cpp
@@ -124,7 +124,7 @@ bool StreamReadContext::FillFromStream(const Stream::Ptr& stream, bool may_wait)
 		if (stream->IsEof())
 			break;
 
-		size_t rc = stream->Read(Buffer + Size, 4096, true);
+		size_t rc = stream->Read(Buffer + Size, 4096);
 
 		Size += rc;
 		count += rc;

--- a/lib/base/stream.hpp
+++ b/lib/base/stream.hpp
@@ -60,10 +60,9 @@ public:
 	 * @param buffer The buffer where data should be stored. May be nullptr if you're
 	 *		 not actually interested in the data.
 	 * @param count The number of bytes to read from the queue.
-	 * @param allow_partial Whether to allow partial reads.
 	 * @returns The number of bytes actually read.
 	 */
-	virtual size_t Read(void *buffer, size_t count, bool allow_partial = false) = 0;
+	virtual size_t Read(void *buffer, size_t count) = 0;
 
 	/**
 	 * Writes data to the stream.

--- a/test/base-fifo.cpp
+++ b/test/base-fifo.cpp
@@ -25,12 +25,12 @@ BOOST_AUTO_TEST_CASE(io)
 	BOOST_CHECK(fifo->GetAvailableBytes() == 5);
 
 	char buffer1[2];
-	fifo->Read(buffer1, 2, true);
+	fifo->Read(buffer1, 2);
 	BOOST_CHECK(memcmp(buffer1, "he", 2) == 0);
 	BOOST_CHECK(fifo->GetAvailableBytes() == 3);
 
 	char buffer2[5];
-	size_t rc = fifo->Read(buffer2, 5, true);
+	size_t rc = fifo->Read(buffer2, 5);
 	BOOST_CHECK(rc == 3);
 	BOOST_CHECK(memcmp(buffer2, "llo", 3) == 0);
 	BOOST_CHECK(fifo->GetAvailableBytes() == 0);


### PR DESCRIPTION
The only caller passes true, so no one forbids partial reads (even implicitly). All usages in the implementation just assert it being true (allowed).