### PR TITLE
Document why Timer::TimerThreadProc() can use Timer members during Timer#~Timer() call

### DIFF
--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -296,6 +296,11 @@ void Timer::TimerThreadProc()
 			break;
 
 		auto it = idx.begin();
+
+		// timer->~Timer() may be called at any moment (if the last
+		// smart pointer gets destroyed) or even already waiting for
+		// l_TimerMutex (before doing anything else) which we have
+		// locked at the moment. Until our unlock using *timer is safe.
 		Timer *timer = *it;
 
 		ch::time_point<ch::system_clock, ch::duration<double>> next (ch::duration<double>(timer->m_Next));


### PR DESCRIPTION
As you requested:

* https://github.com/Icinga/icinga2/pull/9726#discussion_r1152134593