### PR TITLE
Freeze globals namespace during config load

### DIFF
--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -247,6 +247,11 @@ bool DaemonUtility::LoadConfigFiles(const std::vector<std::string>& configs,
 		return false;
 	}
 
+	// After evaluating the top-level statements of the config files (happening in ValidateConfigFiles() above),
+	// prevent further modification of the global scope. This allows for a faster execution of the following steps
+	// as Freeze() disables locking as it's not necessary on a read-only data structure anymore.
+	ScriptGlobal::GetGlobals()->Freeze();
+
 	WorkQueue upq(25000, Configuration::Concurrency);
 	upq.SetName("DaemonUtility::LoadConfigFiles");
 	bool result = ConfigItem::CommitItems(ascope.GetContext(), upq, newItems);


### PR DESCRIPTION
This allows for a faster config load due to less locking required.

The change is slightly backwards-incompatible. Before, you could manipulate the globals namespace at a later stage, but disallowing this feels reasonable for the performance benefit alone (which especially shows on many-core machines). Apart from that, it's doubtful if doing so is even useful at all as the DSL provides no mechanism for you to synchronize your operations that may run in parallel. The data structures itself are protected from race conditions, but anything implemented on top of this may still be subject to race conditions. And even if some user has a good reason for doing this, there's a feasible workaround by creating your own namespace like globals.mutable and using that instead.

fixes #9628
closes Icinga/icingaweb2-module-director#2700