### PR TITLE
Adds ProgressPreference SilentlyContinue

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -91,6 +91,8 @@ if (-not $Env:GITHUB_ACTIONS) {
     ThrowOnNativeFailure
 }
 
+# Disable the progress bar for downloads from the Web, which will speed up the entire download process
+$Global:ProgressPreference = 'SilentlyContinue';
 
 Install-Exe -Url "https://packages.icinga.com/windows/dependencies/boost_$($BoostVersion -join '_')-msvc-${MsvcVersion}-${Env:BITS}.exe" -Dir "C:\local\boost_$($BoostVersion -join '_')-Win${Env:BITS}"
 


### PR DESCRIPTION
We should use `$Global:ProgressPreference = 'SilentlyContinue';` to disable the progress bar during download. By doing so, information are directly written to the disk instead of written inside the memory and dumped to the disk afterwards