### PR TITLE
GHA: Drop openSUSE 15.3 (EOL)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
           - debian:11 # and Raspbian 11
           - fedora:36
           - fedora:37
-          - opensuse/leap:15.3 # and SLES 15.3
+          - opensuse/leap:15.3 # SLES 15.3
           - opensuse/leap:15.4 # and SLES 15.4
           - rockylinux:8 # RHEL 8
           - rockylinux:9 # RHEL 9


### PR DESCRIPTION
Follow-up of https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/37