### PR TITLE
ITL: check_disk: ignore more fuse* filesystems

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -425,7 +425,7 @@ disk\_ignore\_eregi\_path | **Optional.** Regular expression to ignore selected 
 disk\_ignore\_ereg\_path  | **Optional.** Regular expression to ignore selected path or partition. Multiple regular expression strings must be defined as array.
 disk\_timeout             | **Optional.** Seconds before connection times out (default: 10).
 disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB.
-disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fdescfs", "overlay", "nsfs", "squashfs".
+disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.\*" (only Monitoring Plugins support this so far), "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fuse.sshfs", "fdescfs", "overlay", "nsfs", "squashfs".
 disk\_include\_type       | **Optional.** Check only filesystems of indicated type. Multiple regular expression strings must be defined as array.
 disk\_inode\_perfdata     | **Optional.** Display inode usage in perfdata
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1491,9 +1491,11 @@ object CheckCommand "disk" {
 		"mtmfs",
 		"tracefs",
 		"cgroup",
+		"fuse.*", // only Monitoring Plugins support this so far
 		"fuse.gvfsd-fuse",
 		"fuse.gvfs-fuse-daemon",
 		"fuse.portal",
+		"fuse.sshfs",
 		"fdescfs",
 		"overlay",
 		"nsfs",


### PR DESCRIPTION
not to run into permission denials.
Also, ignore fuse.* for the case check_disk already supports it:
    https://github.com/monitoring-plugins/monitoring-plugins/pull/1904