### PR TITLE
CMakeLists.txt: complete list of distros with CMake < v3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 2.8.8)
 set(BOOST_MIN_VERSION "1.66.0")
 
-if("${CMAKE_VERSION}" VERSION_LESS "3.8") # SLES 12.5
+if("${CMAKE_VERSION}" VERSION_LESS "3.8") # SLES 12.5, RHEL 7, AL 2
   if(NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
   endif()


### PR DESCRIPTION
so we know exactly when we can drop the -std=c++17 workaround for set(CMAKE_CXX_STANDARD 17).

* Not important for 2.13.x
* Not important for 2.14
* Just important **for us** as dev

## Tests

https://github.com/Icinga/icinga2/actions/runs/4860270794/jobs/8663886170