### PR TITLE
GHA: use a CMake version which can set(CMAKE_CXX_STANDARD 17) where possible

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -9,7 +9,7 @@ CMAKE_OPTS=''
 case "$DISTRO" in
   amazonlinux:*)
     amazon-linux-extras install -y epel
-    yum install -y bison ccache cmake gcc-c++ flex ninja-build \
+    yum install -y bison ccache cmake3 gcc-c++ flex ninja-build \
       {libedit,mariadb,ncurses,openssl,postgresql,systemd}-devel
 
     yum install -y bzip2 tar wget
@@ -22,6 +22,7 @@ case "$DISTRO" in
       ./b2
     )
 
+    ln -vs /usr/bin/cmake3 /usr/local/bin/cmake
     ln -vs /usr/bin/ninja-build /usr/local/bin/ninja
     CMAKE_OPTS='-DBOOST_INCLUDEDIR=/boost_1_69_0 -DBOOST_LIBRARYDIR=/boost_1_69_0/stage/lib'
     export LD_LIBRARY_PATH=/boost_1_69_0/stage/lib
@@ -29,9 +30,10 @@ case "$DISTRO" in
 
   centos:*)
     yum install -y centos-release-scl epel-release
-    yum install -y bison ccache cmake devtoolset-11-gcc-c++ flex ninja-build \
+    yum install -y bison ccache cmake3 devtoolset-11-gcc-c++ flex ninja-build \
       {boost169,libedit,mariadb,ncurses,openssl,postgresql,systemd}-devel
 
+    ln -vs /usr/bin/cmake3 /usr/local/bin/cmake
     ln -vs /usr/bin/ccache /usr/lib64/ccache/g++
     CMAKE_OPTS='-DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169'
     ;;


### PR DESCRIPTION
especially on Amazon Linux which seems to have trouble with our workaround: set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")

As you correctly figured out in

* #8429

AL 2 doesn’t get our instructions regarding C++17 introduced in

* #9485

But not set(CMAKE_CXX_STANDARD 17) is the problem, -std=c++17 is. So let’s not jump into that if branch in the first place.

closes #9753

## TODO

* [x] https://git.icinga.com/packages/icinga2/-/merge_requests/6