### PR TITLE
Fix documentation for parse_performance_data DSL function

### DIFF
--- a/doc/18-library-reference.md
+++ b/doc/18-library-reference.md
@@ -446,7 +446,8 @@ Signature:
 function parse_performance_data(pd)
 ```
 
-Parses a performance data string and returns an array describing the values.
+Parses a single performance data value from a string and returns a
+[PerfdataValue](08-advanced-topics.md#advanced-value-types-perfdatavalue) object.
 
 Example:
 


### PR DESCRIPTION
The function does not support parsing multiple values at once but instead generates labels like "foo=1 bar":

    Icinga 2 (version: v2.13.0-729-g8fe957bc2)
    Type $help to view available commands.
    <1> => parse_performance_data("foo=1 bar=2")
    {
    	counter = false
    	crit = null
    	label = "foo=1 bar"
    	max = null
    	min = null
    	type = "PerfdataValue"
    	unit = ""
    	value = 2.000000
    	warn = null
    }

While a function with the documented behavior would probably be more useful, that change can't be made in a compatible way as this would have to change the return type from PerfdataValue to Array.