### PR TITLE
Command#arguments: enforce boolean repeat_key, required and skip_key

### DIFF
--- a/lib/icinga/command.ti
+++ b/lib/icinga/command.ti
@@ -35,9 +35,9 @@ validator Command {
 			String value;
 			Function value;
 			String description;
-			Number "required";
-			Number skip_key;
-			Number repeat_key;
+			Boolean "required";
+			Boolean skip_key;
+			Boolean repeat_key;
 			String set_if;
 			Function set_if;
 			Number order;

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -1176,6 +1176,12 @@ void ClassCompiler::CodeGenValidator(const std::string& name, const std::string&
 					<< "\t\t\t" << "Convert::ToDouble(value);" << std::endl
 					<< "\t\t\t" << "return;" << std::endl
 					<< "\t\t" << "} catch (...) { }" << std::endl;
+			} else if (rule.Type == "Boolean") {
+				// Not a try-convert-catch like in Number because everything can be bool-casted.
+				// Not an empty-or-scalar like in String because this would duplicate that.
+				// Only requiring specifically the boolean datatype makes a difference to Number or String.
+				m_Impl << "\t\t" << "if (value.IsBoolean())" << std::endl
+					<< "\t\t\t" << "return;" << std::endl;
 			}
 		}
 


### PR DESCRIPTION
as documented. Neither ITL, nor Director are violating this.
On the other hand Icinga DB expects booleans there and crashes otherwise.

fixes #9576

Checked ITL via daemon -C and Director via config diff of a changed IfW command.