### PR TITLE
Icinga DB feature: normalize *Command.arguments[*].{required,skip_key…

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1019,6 +1019,15 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 					}
 				}
 
+				for (const char *attr : {"repeat_key", "required", "skip_key"}) {
+					Value value;
+
+					// Boolify if set.
+					if (values->Get(attr, &value)) {
+						values->Set(attr, value.ToBool());
+					}
+				}
+
 				{
 					Value order;
 


### PR DESCRIPTION
…,repeat_key} to boolean

At the moment, the Icinga DB feature will use that value as-is and serialize it to JSON, resulting in a crash in Icinga DB down the road because it expects a boolean.

fixes #9576
closes #9771

## TODO

* [x] test (@Al2Klimov)