### PR TITLE
Added missing parameter for check_http

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -544,6 +544,10 @@ object CheckCommand "http" {
 			set_if = "$http_verify_host$"
 			description = "Verify SSL certificate is for the -H hostname (with --sni and -S)"
 		}
+		"--continue-after-certificate" = {
+			set_if = "$http_continue_after_certificate$"
+			description = "Allows the HTTP check to continue after performing the certificate check. Does nothing unless http_certificate is defined."
+		}
 	}
 
 	vars.http_address = "$check_address$"


### PR DESCRIPTION
Missing this parameter in the http check command. See https://community.icinga.com/t/check-vhost-url-and-certificate-with-check-http/10469