### PR TITLE
MacroProcessor::ResolveMacro(): treat quasi-CV-object IcingaApplication as real CV-object

### DIFF
--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -220,13 +220,6 @@ bool IcingaApplication::ResolveMacro(const String& macro, const CheckResult::Ptr
 		return true;
 	}
 
-	Dictionary::Ptr vars = GetVars();
-
-	if (vars && vars->Contains(macro)) {
-		*result = vars->Get(macro);
-		return true;
-	}
-
 	if (macro.Contains("num_services")) {
 		ServiceStatistics ss = CIB::CalculateServiceStats();
 

--- a/lib/icinga/macroprocessor.cpp
+++ b/lib/icinga/macroprocessor.cpp
@@ -111,16 +111,23 @@ bool MacroProcessor::ResolveMacro(const String& macro, const ResolverList& resol
 				if (!resolver.ResolveShortMacros)
 					continue;
 
+				Dictionary::Ptr vars;
 				CustomVarObject::Ptr dobj = dynamic_pointer_cast<CustomVarObject>(resolver.Obj);
 
 				if (dobj) {
-					Dictionary::Ptr vars = dobj->GetVars();
+					vars = dobj->GetVars();
+				} else {
+					auto app (dynamic_pointer_cast<IcingaApplication>(resolver.Obj));
 
-					if (vars && vars->Contains(macro)) {
-						*result = vars->Get(macro);
-						*recursive_macro = true;
-						return true;
+					if (app) {
+						vars = app->GetVars();
 					}
+				}
+
+				if (vars && vars->Contains(macro)) {
+					*result = vars->Get(macro);
+					*recursive_macro = true;
+					return true;
 				}
 			}
 


### PR DESCRIPTION
As MacroProcessor checked just for CustomVarObject base class, but IcingaApplication provided the vars attribute by itself, it had to also resolve CV macros by itself. That logic diverged from MacroProcessor so that macros inside IcingaApplication CVs weren't resolved. Until now.

ref/IP/46031

## Test protocol

### Config

```
object CheckerComponent "cc" { }

object IcingaApplication "app" {
	vars.myecho_1 = "42$$"
}

object CheckCommand "myecho" {
	command = [ "python3", "-c", "import sys; print(sys.argv); exit(128)" ]
	arguments = {
		myecho_1 = "$myecho_1$"
	}
}

object Host NodeName {
	check_command = "myecho"
}
```

### Logs

`[2023-05-31 11:57:08 +0200] warning/PluginCheckTask: Check command for object 'Alexanders-MacBook-Pro-2.local' (PID: 87725, arguments: 'python3' '-c' 'import sys; print(sys.argv); exit(128)' 'myecho_1' '42$') terminated with exit code 128, output: ['-c', 'myecho_1', '42$']`

### Conclusion

$$ now becomes $ as expected. (Before: $$ -> $$)