### PR TITLE
mkclass: in TypeImpl<T>::GetFieldId(name) hash name w/o collisions if possible

### DIFF
--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -276,7 +276,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			if (jumptable[hash].size() > 1)
 				collisions++;
 		}
-	} while (collisions >= 5 && hlen < 8);
+	} while (collisions && hlen < 100);
 
 	if (!klass.Fields.empty()) {
 		m_Impl << "\tswitch (static_cast<int>(Utility::SDBM(name, " << hlen << "))) {" << std::endl;


### PR DESCRIPTION
at the cost of longer hash input to compare name to only one string. The latter saves config load time.

And no, unordered_map makes it only worse.

## Before

real    21m6.059s
user    238m57.113s
sys     1m6.642s

real    21m28.448s
user    244m13.486s
sys     1m11.864s

real    22m58.923s
user    257m8.651s
sys     1m9.427s

real    23m25.785s
user    261m56.763s
sys     1m9.136s

real    24m39.977s
user    278m52.337s
sys     1m11.573s

## After

real    21m14.092s
user    240m56.280s
sys     1m11.056s

real    21m45.595s
user    247m20.241s
sys     1m9.585s

real    22m3.570s
user    249m12.680s
sys     1m9.213s

real    22m30.595s
user    251m22.411s
sys     1m15.193s

real    23m27.525s
user    266m36.891s
sys     1m10.473s