### PR TITLE
IcingaDB::PrepareObject(): convert non-null Checkable#check_timeout to number

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1272,10 +1272,11 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 
 	if (type == Host::TypeInstance || type == Service::TypeInstance) {
 		Checkable::Ptr checkable = static_pointer_cast<Checkable>(object);
+		auto checkTimeout (checkable->GetCheckTimeout());
 
 		attributes->Set("checkcommand_name", checkable->GetCheckCommand()->GetName());
 		attributes->Set("max_check_attempts", checkable->GetMaxCheckAttempts());
-		attributes->Set("check_timeout", checkable->GetCheckTimeout());
+		attributes->Set("check_timeout", checkTimeout.IsEmpty() ? checkable->GetCheckCommand()->GetTimeout() : (double)checkTimeout);
 		attributes->Set("check_interval", checkable->GetCheckInterval());
 		attributes->Set("check_retry_interval", checkable->GetRetryInterval());
 		attributes->Set("active_checks_enabled", checkable->GetEnableActiveChecks());


### PR DESCRIPTION
and, in case of null, fall back to Checkable#check_command.timeout, just like IcingaDB#SerializeState(). Otherwise the Go daemon crashes. It expects a number.

fixes #9791

## Setup

* Icinga 2: standard config, api setup, feature enable icingadb, `object Host "42" { check_command = "dummy"; check_timeout = "42" }`
* Redis, Icinga DB, MySQL: nothing special

## Before

```
2023-06-15T12:26:34.024+0200	INFO	config-sync	Inserting 33 items of type notificationcommand argument
2023-06-15T12:26:34.025+0200	WARN	config-sync	Aborted initial state sync after 96.537249ms
2023-06-15T12:26:34.025+0200	WARN	config-sync	Aborted config sync after 96.637219ms
2023-06-15T12:26:34.026+0200	FATAL	icingadb	json: cannot unmarshal string into Go struct field Host.check_timeout of type float64
can't unmarshal JSON into *v1.Host
github.com/icinga/icingadb/internal.UnmarshalJSON
	/Users/aklimov/NET/WS/icingadb/internal/internal.go:47
github.com/icinga/icingadb/pkg/icingaredis.CreateEntities.func1.1
	/Users/aklimov/NET/WS/icingadb/pkg/icingaredis/utils.go:56
golang.org/x/sync/errgroup.(*Group).Go.func1
	/Users/aklimov/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57
runtime.goexit
	/usr/local/Cellar/go/1.20.4/libexec/src/runtime/asm_amd64.s:1598
```

## After

```
2023-06-15T12:28:38.526+0200	INFO	config-sync	Finished initial state sync in 219.779129ms
2023-06-15T12:28:38.532+0200	INFO	config-sync	Inserting 1 items of type user
2023-06-15T12:28:38.535+0200	INFO	config-sync	Inserting 520 items of type customvar flat
2023-06-15T12:28:38.546+0200	INFO	config-sync	Inserting 3 items of type servicegroup
2023-06-15T12:28:38.768+0200	INFO	icingadb	Starting config runtime updates sync
2023-06-15T12:28:38.768+0200	INFO	icingadb	Starting history retention
2023-06-15T12:28:38.768+0200	INFO	config-sync	Finished config sync in 461.861837ms
```