### PR TITLE
IcingaDB::PrepareObject(): round Notification#interval and limit it to >=0

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -32,6 +32,7 @@
 #include "remote/zone.hpp"
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <iterator>
 #include <map>
@@ -1387,7 +1388,7 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 			attributes->Set("times_end",notification->GetTimes()->Get("end"));
 		}
 
-		attributes->Set("notification_interval", notification->GetInterval());
+		attributes->Set("notification_interval", std::max(0.0, std::round(notification->GetInterval())));
 		attributes->Set("states", notification->GetStates());
 		attributes->Set("types", notification->GetTypes());
 


### PR DESCRIPTION
otherwise, e.g. with -42.5 (my successful before/after test case btw.), the Go daemon crashes. It expects uints there.