### PR TITLE
IcingaDB::PrepareObject(): round Notification#times.{begin,end} not to crash Go daemon

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1383,8 +1383,16 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 			attributes->Set("timeperiod_id", GetObjectIdentifier(timeperiod));
 
 		if (notification->GetTimes()) {
-			attributes->Set("times_begin", notification->GetTimes()->Get("begin"));
-			attributes->Set("times_end",notification->GetTimes()->Get("end"));
+			auto begin (notification->GetTimes()->Get("begin"));
+			auto end (notification->GetTimes()->Get("end"));
+
+			if (begin != Empty) {
+				attributes->Set("times_begin", std::round((double)begin));
+			}
+
+			if (end != Empty) {
+				attributes->Set("times_end", std::round((double)end));
+			}
 		}
 
 		attributes->Set("notification_interval", notification->GetInterval());

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1386,11 +1386,11 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 			auto begin (notification->GetTimes()->Get("begin"));
 			auto end (notification->GetTimes()->Get("end"));
 
-			if (begin != Empty) {
+			if (begin != Empty && (double)begin >= 0) {
 				attributes->Set("times_begin", std::round((double)begin));
 			}
 
-			if (end != Empty) {
+			if (end != Empty && (double)end >= 0) {
 				attributes->Set("times_end", std::round((double)end));
 			}
 		}


### PR DESCRIPTION
The latter expects ints, not floats - not to mention strings. Luckily Icinga already enforces numeric strings so that we can cast it to number.

refs #9793

## Test case

Standard config plus:

```
times = {
  	begin = "-42.5"
	#end = "-42.5"
  }
```

## Before

### -42.5

`2023-06-20T10:25:23.821+0200	FATAL	icingadb	json: cannot unmarshal number -42.5 into Go value of type int64`

### "-42.5"

`2023-06-20T10:26:25.967+0200	FATAL	icingadb	json: cannot unmarshal string into Go value of type int64`