### PR TITLE
IcingaDB::PrepareObject(): cut off (0) negative Command#timeout for Redis

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1508,7 +1508,7 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 		Command::Ptr command = static_pointer_cast<Command>(object);
 
 		attributes->Set("command", JsonEncode(command->GetCommandLine()));
-		attributes->Set("timeout", command->GetTimeout());
+		attributes->Set("timeout", std::max(0, command->GetTimeout()));
 
 		return true;
 	}


### PR DESCRIPTION
not to crash the Go daemon which expects positive values there.

fixes #9804