### PR TITLE
ElasticsearchWriter#Pause(): call Flush() only once

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -119,7 +119,11 @@ void ElasticsearchWriter::Pause()
 
 	m_FlushTimer->Stop(true);
 	m_WorkQueue.Join();
-	Flush();
+
+	{
+		std::unique_lock<std::mutex> lock (m_DataBufferMutex);
+		Flush();
+	}
 
 	Log(LogInformation, "ElasticsearchWriter")
 		<< "'" << GetName() << "' paused.";

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -118,8 +118,6 @@ void ElasticsearchWriter::Pause()
 	m_HandleNotifications.disconnect();
 
 	m_FlushTimer->Stop(true);
-
-	Flush();
 	m_WorkQueue.Join();
 	Flush();
 


### PR DESCRIPTION
The first Flush() is redundant and may access m_DataBuffer at the same time as some Flush() in m_WorkQueue (race condition) which isn't joined, yet.