### PR TITLE
Enable built-in OpenSSL DH parameters to allow DHE TLS ciphers

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -104,6 +104,14 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 #	endif /* SSL_CTX_set_ecdh_auto */
 #endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	// The built-in DH parameters have to be enabled explicitly to allow the use of ciphers that use a DHE key exchange.
+	// SSL_CTX_set_dh_auto is only documented in OpenSSL starting from version 3.0.0 but was already added in 1.1.0.
+	// https://github.com/openssl/openssl/commit/09599b52d4e295c380512ba39958a11994d63401
+	// https://github.com/openssl/openssl/commit/0437309fdf544492e272943e892523653df2f189
+	SSL_CTX_set_dh_auto(sslContext, 1);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
+
 	if (!pubkey.IsEmpty()) {
 		if (!SSL_CTX_use_certificate_chain_file(sslContext, pubkey.CStr())) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);


### PR DESCRIPTION
Non-ECC DHE ciphers in the `cipher_list` attribute of `ApiListener` (the default value includes these) had no effect as no DH parameters were available and therefore the server wouldn't offer these ciphers. OpenSSL provides built-in DH parameters starting from version 1.1.0, however, these have to be enables explicitly using the `SSL_CTX_set_dh_auto()` function. This commit does so and thereby makes it possible to establish a connection to an Icinga 2 server using a DHE cipher.

### Tests

#### Availability of DHE ciphers

Diff of [sslscan](https://github.com/rbsec/sslscan) between the current master and this PR running in container built using [docker-icinga2](https://github.com/icinga/docker-icinga2) (Debian 11, OpenSSL 1.1.1n):

```diff
 Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
 Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA384       Curve 25519 DHE 253
 Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA256       Curve 25519 DHE 253
+Accepted  TLSv1.2  128 bits  DHE-RSA-AES128-GCM-SHA256     DHE 3072 bits
+Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-GCM-SHA384     DHE 3072 bits
 Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256            
```

<details>
<summary>Full output for master</summary>

```
Version: 2.0.16
OpenSSL 3.1.1 30 May 2023

Connected to 172.18.0.13

Testing SSL server 172.18.0.13 on port 5665 using SNI name 172.18.0.13

  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   disabled
TLSv1.1   disabled
TLSv1.2   enabled
TLSv1.3   enabled

  TLS Fallback SCSV:
Server supports TLS Fallback SCSV

  TLS renegotiation:
Session renegotiation not supported

  TLS Compression:
OpenSSL version does not support compression
Rebuild with zlib1g-dev package for zlib support

  Heartbleed:
TLSv1.3 not vulnerable to heartbleed
TLSv1.2 not vulnerable to heartbleed

  Supported Server Cipher(s):
Preferred TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
Accepted  TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
Preferred TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA384       Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA256       Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384            
Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256            

  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.3  192 bits  secp384r1 (NIST P-384)
TLSv1.3  260 bits  secp521r1 (NIST P-521)
TLSv1.3  128 bits  x25519
TLSv1.3  224 bits  x448
TLSv1.2  128 bits  secp256r1 (NIST P-256)
TLSv1.2  192 bits  secp384r1 (NIST P-384)
TLSv1.2  260 bits  secp521r1 (NIST P-521)
TLSv1.2  128 bits  x25519
TLSv1.2  224 bits  x448

  SSL Certificate:
Signature Algorithm: sha256WithRSAEncryption
RSA Key Strength:    4096

Subject:  master-1
Altnames: DNS:master-1
Issuer:   Icinga CA

Not valid before: Apr 14 07:55:25 2023 GMT
Not valid after:  May 15 07:55:25 2024 GMT
```
</details>

<details>
<summary>Full output for this PR</summary>

```
Signature Algorithm: sha256WithRSAEncryption
RSA Key Strength:    4096

Subject:  master-1
Altnames: DNS:master-1
Issuer:   Icinga CA

Not valid before: Apr 14 07:55:25 2023 GMT
Not valid after:  May 15 07:55:25 2024 GMT
jbrost@wh ~ % cat /tmp/tls-dhe  
Version: 2.0.16
OpenSSL 3.1.1 30 May 2023

Connected to 172.18.0.13

Testing SSL server 172.18.0.13 on port 5665 using SNI name 172.18.0.13

  SSL/TLS Protocols:
SSLv2     disabled
SSLv3     disabled
TLSv1.0   disabled
TLSv1.1   disabled
TLSv1.2   enabled
TLSv1.3   enabled

  TLS Fallback SCSV:
Server supports TLS Fallback SCSV

  TLS renegotiation:
Session renegotiation not supported

  TLS Compression:
OpenSSL version does not support compression
Rebuild with zlib1g-dev package for zlib support

  Heartbleed:
TLSv1.3 not vulnerable to heartbleed
TLSv1.2 not vulnerable to heartbleed

  Supported Server Cipher(s):
Preferred TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Curve 25519 DHE 253
Accepted  TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Curve 25519 DHE 253
Accepted  TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Curve 25519 DHE 253
Preferred TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA384       Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-SHA256       Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  DHE-RSA-AES128-GCM-SHA256     DHE 3072 bits
Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-GCM-SHA384     DHE 3072 bits
Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384            
Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256            

  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.3  192 bits  secp384r1 (NIST P-384)
TLSv1.3  260 bits  secp521r1 (NIST P-521)
TLSv1.3  128 bits  x25519
TLSv1.3  224 bits  x448
TLSv1.2  128 bits  secp256r1 (NIST P-256)
TLSv1.2  192 bits  secp384r1 (NIST P-384)
TLSv1.2  260 bits  secp521r1 (NIST P-521)
TLSv1.2  128 bits  x25519
TLSv1.2  224 bits  x448

  SSL Certificate:
Signature Algorithm: sha256WithRSAEncryption
RSA Key Strength:    4096

Subject:  master-1
Altnames: DNS:master-1
Issuer:   Icinga CA

Not valid before: Apr 14 07:55:25 2023 GMT
Not valid after:  May 15 07:55:25 2024 GMT
```
</details>

#### DH group size

Note that with `SSL_CTX_set_dh_auto()`, OpenSSL chooses the DH group based on the key size in the server certificate.
- Icinga generates 4096 bit RSA keys [since v2.0.0](https://github.com/Icinga/icinga2/blob/v2.0.0/lib/base/tlsutility.cpp#L208), which results in a 3072 bit group which is fine.
- With an externally generated certificate with RSA 2048 bit, it uses a 2048 bit group which is also fine.
- For anything smaller (even 2047 bit for that matter), I got an error: `critical/SSL: Error with public key file '/var/lib/icinga2/certs//agent-1.crt': 336245135, "error:140AB18F:SSL routines:SSL_CTX_use_certificate:ee key too small"`, which is probably good as I guess it might use a 1024 bit group otherwise.

### Limitations

- This fix only works for OpenSSL ≥ 1.1.0, i.e. DHE ciphers will still be unavailable on distributions that are stuck with OpenSSL 1.0.2 (CentOS/RHEL 7, Amazon Linux 2, SLES 12). For those, we would have to provide and load a DH group ourselves which requires way more work than this single-line fix, which probably isn't worth it given that these are on their way to being EOL (mid-2025 for Amazon Linux 2, 2024 for the others) and no user seemed to actually have noticed the missing ciphers so far. And even if someone comes up with a good reason to support this, we can still implement an `#else` branch.

refs https://github.com/Icinga/icinga2/pull/9809#issuecomment-1612643258