### PR TITLE
Downtime#Start(): trigger flexible downtimes not earlier than fixed ones

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -132,7 +132,8 @@ void Downtime::Start(bool runtimeCreated)
 		Log(LogNotice, "Downtime")
 			<< "Checkable '" << checkable->GetName() << "' already in a NOT-OK state."
 			<< " Triggering downtime now.";
-		TriggerDowntime(checkable->GetLastStateChange());
+
+		TriggerDowntime(std::fmax(std::fmax(GetStartTime(), GetEntryTime()), checkable->GetLastStateChange()));
 	}
 
 	if (GetFixed() && CanBeTriggered()) {


### PR DESCRIPTION
the last state change could be a long time ago. If it's longer than the new downtime's duration, the downtime expires immediately.

trigger time + duration < now

fixes #9797