### PR TITLE
ElasticsearchWriter#Pause(): call Flush() only once

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -118,7 +118,11 @@ void ElasticsearchWriter::Pause()
 	m_HandleNotifications.disconnect();
 
 	m_WorkQueue.Join();
-	Flush();
+
+	{
+		std::unique_lock<std::mutex> lock (m_DataBufferMutex);
+		Flush();
+	}
 
 	Log(LogInformation, "ElasticsearchWriter")
 		<< "'" << GetName() << "' paused.";

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -117,7 +117,6 @@ void ElasticsearchWriter::Pause()
 	m_HandleStateChanges.disconnect();
 	m_HandleNotifications.disconnect();
 
-	Flush();
 	m_WorkQueue.Join();
 	Flush();
 


### PR DESCRIPTION
Backport of #9810