### PR TITLE
Application::m_LastReloadFailed: if double isn't always lock free, use uint32_t

### DIFF
--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -9,7 +9,9 @@
 #include "base/logger.hpp"
 #include "base/configuration.hpp"
 #include "base/shared-memory.hpp"
+#include <cstdint>
 #include <iosfwd>
+#include <type_traits>
 
 namespace icinga
 {
@@ -142,7 +144,7 @@ private:
 #ifdef _WIN32
 	static double m_LastReloadFailed;
 #else /* _WIN32 */
-	typedef Atomic<double> AtomicTs;
+	typedef Atomic<std::conditional_t<Atomic<double>::is_always_lock_free, double, uint32_t>> AtomicTs;
 	static_assert(AtomicTs::is_always_lock_free);
 	static SharedMemory<AtomicTs> m_LastReloadFailed;
 #endif /* _WIN32 */


### PR DESCRIPTION


which will overflow in 2106, not 2038.
This fixes a compile failure on 32-bit Raspbian.

## TODO

* [x] OK from reviewer
* [x] OK from GHA
* [x] OK from GitLab
* [x] change log entry