### PR TITLE
Logger#object_filter: restrict Logger to messages referring to specific objects

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -89,7 +89,7 @@ static void HandleLegacyDefines()
 	Value localStateDir = Configuration::LocalStateDir;
 
 	if (!localStateDir.IsEmpty()) {
-		Log(LogWarning, "icinga-app")
+		Log(LogWarning, "icinga-app", nullptr)
 			<< "Please do not set the deprecated 'LocalStateDir' constant,"
 			<< " use the 'DataDir', 'LogDir', 'CacheDir' and 'SpoolDir' constants instead!"
 			<< " For compatibility reasons, these are now set based on the 'LocalStateDir' constant.";
@@ -113,7 +113,7 @@ static void HandleLegacyDefines()
 
 	Value sysconfDir = Configuration::SysconfDir;
 	if (!sysconfDir.IsEmpty()) {
-		Log(LogWarning, "icinga-app")
+		Log(LogWarning, "icinga-app", nullptr)
 			<< "Please do not set the deprecated 'Sysconfdir' constant, use the 'ConfigDir' constant instead! For compatibility reasons, their value is set based on the 'SysconfDir' constant.";
 
 #ifdef _WIN32
@@ -129,7 +129,7 @@ static void HandleLegacyDefines()
 
 	Value runDir = Configuration::RunDir;
 	if (!runDir.IsEmpty()) {
-		Log(LogWarning, "icinga-app")
+		Log(LogWarning, "icinga-app", nullptr)
 			<< "Please do not set the deprecated 'RunDir' constant, use the 'InitRunDir' constant instead! For compatibility reasons, their value is set based on the 'RunDir' constant.";
 
 #ifdef _WIN32
@@ -158,7 +158,7 @@ static int Main()
 		try {
 			autoindex = Convert::ToLong(argv[2]);
 		} catch (const std::invalid_argument&) {
-			Log(LogCritical, "icinga-app")
+			Log(LogCritical, "icinga-app", nullptr)
 				<< "Invalid index for --autocomplete: " << argv[2];
 			return EXIT_FAILURE;
 		}
@@ -199,7 +199,7 @@ static int Main()
 
 		Configuration::InitRunDir = dataPrefix + "\\var\\run\\icinga2";
 	} else {
-		Log(LogWarning, "icinga-app", "Registry key could not be read. Falling back to built-in paths.");
+		Log(LogWarning, "icinga-app", nullptr, "Registry key could not be read. Falling back to built-in paths.");
 
 #endif /* _WIN32 */
 		Configuration::ConfigDir = ICINGA_CONFIGDIR;
@@ -315,7 +315,7 @@ static int Main()
 		CLICommand::ParseCommand(argc, argv, visibleDesc, hiddenDesc, positionalDesc,
 			vm, cmdname, command, autocomplete);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "icinga-app")
+		Log(LogCritical, "icinga-app", nullptr)
 			<< "Error while parsing command-line options: " << ex.what();
 		return EXIT_FAILURE;
 	}
@@ -427,7 +427,7 @@ static int Main()
 				ScriptFrame frame(true);
 				setExpr->Evaluate(frame);
 			} catch (const ScriptError& e) {
-				Log(LogCritical, "icinga-app") << "cannot set '" << key << "': " << e.what();
+				Log(LogCritical, "icinga-app", nullptr) << "cannot set '" << key << "': " << e.what();
 				return EXIT_FAILURE;
 			}
 		}
@@ -476,7 +476,7 @@ static int Main()
 				logLevel = Logger::StringToSeverity(severity);
 			} catch (std::exception&) {
 				/* Inform user and exit */
-				Log(LogCritical, "icinga-app", "Invalid log level set. Default is 'information'.");
+				Log(LogCritical, "icinga-app", nullptr, "Invalid log level set. Default is 'information'.");
 				return EXIT_FAILURE;
 			}
 
@@ -489,7 +489,7 @@ static int Main()
 			try {
 				appName = Utility::BaseName(Application::GetArgV()[0]);
 			} catch (const std::bad_alloc&) {
-				Log(LogCritical, "icinga-app", "Allocation failed.");
+				Log(LogCritical, "icinga-app", nullptr, "Allocation failed.");
 				return EXIT_FAILURE;
 			}
 
@@ -565,7 +565,7 @@ static int Main()
 #ifndef _WIN32
 		if (command->GetImpersonationLevel() == ImpersonateRoot) {
 			if (getuid() != 0) {
-				Log(LogCritical, "cli", "This command must be run as root.");
+				Log(LogCritical, "cli", nullptr, "This command must be run as root.");
 				return 0;
 			}
 		} else if (command && command->GetImpersonationLevel() == ImpersonateIcinga) {
@@ -580,10 +580,10 @@ static int Main()
 				struct group* gr = getgrnam(group.CStr());
 				if (!gr) {
 					if (errno == 0) {
-						Log(LogCritical, "cli")
+						Log(LogCritical, "cli", nullptr)
 							<< "Invalid group specified: " << group;
 					} else {
-						Log(LogCritical, "cli")
+						Log(LogCritical, "cli", nullptr)
 							<< "getgrnam() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 					}
 					return EXIT_FAILURE;
@@ -594,17 +594,17 @@ static int Main()
 
 			if (getgid() != gid) {
 				if (!vm.count("reload-internal") && setgroups(0, nullptr) < 0) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "setgroups() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Please rerun this command as a privileged user or using the \"" << user << "\" account.";
 					return EXIT_FAILURE;
 				}
 
 				if (setgid(gid) < 0) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "setgid() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Please rerun this command as a privileged user or using the \"" << user << "\" account.";
 					return EXIT_FAILURE;
 				}
@@ -626,11 +626,11 @@ static int Main()
 
 			if (!uid) {
 				if (errno == 0) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Invalid user specified: " << user;
 					return EXIT_FAILURE;
 				} else {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "getpwnam() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 					return EXIT_FAILURE;
 				}
@@ -641,17 +641,17 @@ static int Main()
 				// initgroups() is only called when either getpwuid() or getpwnam() returned a valid user entry.
 				// Otherwise it makes no sense to set any additional groups.
 				if (!vm.count("reload-internal") && pw && initgroups(user.CStr(), pw->pw_gid) < 0) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "initgroups() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Please rerun this command as a privileged user or using the \"" << user << "\" account.";
 					return EXIT_FAILURE;
 				}
 
 				if (setuid(*uid) < 0) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "setuid() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Please rerun this command as a privileged user or using the \"" << user << "\" account.";
 					return EXIT_FAILURE;
 				}
@@ -664,14 +664,14 @@ static int Main()
 			args = vm["arg"].as<std::vector<std::string> >();
 
 		if (static_cast<int>(args.size()) < command->GetMinArguments()) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Too few arguments. Command needs at least " << command->GetMinArguments()
 				<< " argument" << (command->GetMinArguments() != 1 ? "s" : "") << ".";
 			return EXIT_FAILURE;
 		}
 
 		if (command->GetMaxArguments() >= 0 && static_cast<int>(args.size()) > command->GetMaxArguments()) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Too many arguments. At most " << command->GetMaxArguments()
 				<< " argument" << (command->GetMaxArguments() != 1 ? "s" : "") << " may be specified.";
 			return EXIT_FAILURE;

--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -176,7 +176,7 @@ void Application::SetResourceLimits()
 
 	if (fileLimit != 0) {
 		if (fileLimit < (rlim_t)GetDefaultRLimitFiles()) {
-			Log(LogWarning, "Application")
+			Log(LogWarning, "Application", m_Instance)
 				<< "The user-specified value for RLimitFiles cannot be smaller than the default value (" << GetDefaultRLimitFiles() << "). Using the default value instead.";
 			fileLimit = GetDefaultRLimitFiles();
 		}
@@ -185,10 +185,10 @@ void Application::SetResourceLimits()
 		rl.rlim_max = rl.rlim_cur;
 
 		if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
-			Log(LogWarning, "Application")
+			Log(LogWarning, "Application", m_Instance)
 			    << "Failed to adjust resource limit for open file handles (RLIMIT_NOFILE) with error \"" << strerror(errno) << "\"";
 #	else /* RLIMIT_NOFILE */
-		Log(LogNotice, "Application", "System does not support adjusting the resource limit for open file handles (RLIMIT_NOFILE)");
+		Log(LogNotice, "Application", m_Instance, "System does not support adjusting the resource limit for open file handles (RLIMIT_NOFILE)");
 #	endif /* RLIMIT_NOFILE */
 	}
 
@@ -197,7 +197,7 @@ void Application::SetResourceLimits()
 
 	if (processLimit != 0) {
 		if (processLimit < (rlim_t)GetDefaultRLimitProcesses()) {
-			Log(LogWarning, "Application")
+			Log(LogWarning, "Application", m_Instance)
 				<< "The user-specified value for RLimitProcesses cannot be smaller than the default value (" << GetDefaultRLimitProcesses() << "). Using the default value instead.";
 			processLimit = GetDefaultRLimitProcesses();
 		}
@@ -206,10 +206,10 @@ void Application::SetResourceLimits()
 		rl.rlim_max = rl.rlim_cur;
 
 		if (setrlimit(RLIMIT_NPROC, &rl) < 0)
-			Log(LogWarning, "Application")
+			Log(LogWarning, "Application", m_Instance)
 			    << "Failed adjust resource limit for number of processes (RLIMIT_NPROC) with error \"" << strerror(errno) << "\"";
 #	else /* RLIMIT_NPROC */
-		Log(LogNotice, "Application", "System does not support adjusting the resource limit for number of processes (RLIMIT_NPROC)");
+		Log(LogNotice, "Application", m_Instance, "System does not support adjusting the resource limit for number of processes (RLIMIT_NPROC)");
 #	endif /* RLIMIT_NPROC */
 	}
 
@@ -226,7 +226,7 @@ void Application::SetResourceLimits()
 	}
 
 	if (getrlimit(RLIMIT_STACK, &rl) < 0) {
-		Log(LogWarning, "Application", "Could not determine resource limit for stack size (RLIMIT_STACK)");
+		Log(LogWarning, "Application", m_Instance, "Could not determine resource limit for stack size (RLIMIT_STACK)");
 		rl.rlim_max = RLIM_INFINITY;
 	}
 
@@ -236,7 +236,7 @@ void Application::SetResourceLimits()
 
 	if (stackLimit != 0) {
 		if (stackLimit < (rlim_t)GetDefaultRLimitStack()) {
-			Log(LogWarning, "Application")
+			Log(LogWarning, "Application", m_Instance)
 				<< "The user-specified value for RLimitStack cannot be smaller than the default value (" << GetDefaultRLimitStack() << "). Using the default value instead.";
 			stackLimit = GetDefaultRLimitStack();
 		}
@@ -247,7 +247,7 @@ void Application::SetResourceLimits()
 			rl.rlim_cur = rl.rlim_max;
 
 		if (setrlimit(RLIMIT_STACK, &rl) < 0)
-			Log(LogWarning, "Application")
+			Log(LogWarning, "Application", m_Instance)
 			    << "Failed adjust resource limit for stack size (RLIMIT_STACK) with error \"" << strerror(errno) << "\"";
 		else if (set_stack_rlimit) {
 			char **new_argv = static_cast<char **>(malloc(sizeof(char *) * (argc + 2)));
@@ -275,7 +275,7 @@ void Application::SetResourceLimits()
 			_exit(EXIT_FAILURE);
 		}
 #	else /* RLIMIT_STACK */
-		Log(LogNotice, "Application", "System does not support adjusting the resource limit for stack size (RLIMIT_STACK)");
+		Log(LogNotice, "Application", m_Instance, "System does not support adjusting the resource limit for stack size (RLIMIT_STACK)");
 #	endif /* RLIMIT_STACK */
 	}
 #endif /* __linux__ */
@@ -320,7 +320,7 @@ void Application::RunEventLoop()
 				m_ReloadProcess = StartReloadProcess();
 			}
 #else /* _WIN32 */
-			Log(LogNotice, "Application")
+			Log(LogNotice, "Application", this)
 				<< "Got reload command, forwarding to umbrella process (PID " << m_UmbrellaProcess << ")";
 
 			(void)kill(m_UmbrellaProcess, SIGHUP);
@@ -330,7 +330,7 @@ void Application::RunEventLoop()
 			Utility::Sleep(2.5);
 
 			if (m_RequestReopenLogs) {
-				Log(LogNotice, "Application", "Reopening log files");
+				Log(LogNotice, "Application", this, "Reopening log files");
 				m_RequestReopenLogs = false;
 				OnReopenLogs();
 			}
@@ -340,7 +340,7 @@ void Application::RunEventLoop()
 
 			if (std::fabs(timeDiff) > 15) {
 				/* We made a significant jump in time. */
-				Log(LogInformation, "Application")
+				Log(LogInformation, "Application", this)
 					<< "We jumped "
 					<< (timeDiff < 0 ? "forward" : "backward")
 					<< " in time: " << std::fabs(timeDiff) << " seconds";
@@ -352,7 +352,7 @@ void Application::RunEventLoop()
 		}
 	}
 
-	Log(LogInformation, "Application", "Shutting down...");
+	Log(LogInformation, "Application", this, "Shutting down...");
 
 	ConfigObject::StopObjects();
 	Application::GetInstance()->OnShutdown();
@@ -381,7 +381,7 @@ static void ReloadProcessCallbackInternal(const ProcessResult& pr)
 {
 	if (pr.ExitStatus != 0) {
 		Application::SetLastReloadFailed(Utility::GetTime());
-		Log(LogCritical, "Application", "Found error in config: reloading aborted");
+		Log(LogCritical, "Application", nullptr, "Found error in config: reloading aborted");
 	}
 #ifdef _WIN32
 	else
@@ -423,7 +423,7 @@ pid_t Application::StartReloadProcess()
 	process->SetTimeout(reloadTimeout);
 	process->Run(&ReloadProcessCallback);
 
-	Log(LogInformation, "Application")
+	Log(LogInformation, "Application", this)
 		<< "Got reload command: Started new instance with PID '"
 		<< (unsigned long)(process->GetPID()) << "' (timeout is "
 		<< reloadTimeout << "s).";
@@ -437,7 +437,7 @@ pid_t Application::StartReloadProcess()
  */
 void Application::RequestShutdown()
 {
-	Log(LogInformation, "Application", "Received request to shut down.");
+	Log(LogInformation, "Application", m_Instance, "Received request to shut down.");
 
 	m_ShuttingDown = true;
 }
@@ -715,7 +715,7 @@ void Application::AttachDebugger(const String& filename, bool interactive)
  */
 void Application::SigUsr1Handler(int)
 {
-	Log(LogInformation, "Application")
+	Log(LogInformation, "Application", m_Instance)
 		<< "Received USR1 signal, reopening application logs.";
 
 	RequestReopenLogs();
@@ -758,7 +758,7 @@ void Application::SigAbrtHandler(int)
 		std::ofstream ofs;
 		ofs.open(fname.CStr());
 
-		Log(LogCritical, "Application")
+		Log(LogCritical, "Application", m_Instance)
 			<< "Icinga 2 has terminated unexpectedly. Additional information can be found in '" << fname << "'" << "\n";
 
 		ofs << "Caught SIGABRT.\n"
@@ -773,7 +773,7 @@ void Application::SigAbrtHandler(int)
 		ofs << "\n";
 		ofs.close();
 	} else {
-		Log(LogCritical, "Application", "Icinga 2 has terminated unexpectedly. Attaching debugger...");
+		Log(LogCritical, "Application", m_Instance, "Icinga 2 has terminated unexpectedly. Attaching debugger...");
 	}
 
 	AttachDebugger(fname, interactive_debugger);
@@ -883,7 +883,7 @@ void Application::ExceptionHandler()
 		try {
 			RethrowUncaughtException();
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "Application")
+			Log(LogCritical, "Application", m_Instance)
 				<< DiagnosticInformation(ex, false) << "\n"
 				<< "\n"
 				<< "Additional information is available in '" << fname << "'" << "\n";
@@ -947,7 +947,7 @@ LONG CALLBACK Application::SEHUnhandledExceptionFilter(PEXCEPTION_POINTERS exi)
 	std::ofstream ofs;
 	ofs.open(fname.CStr());
 
-	Log(LogCritical, "Application")
+	Log(LogCritical, "Application", m_Instance)
 		<< "Icinga 2 has terminated unexpectedly. Additional information can be found in '" << fname << "'";
 
 	ofs << "Caught unhandled SEH exception.\n"
@@ -1010,7 +1010,7 @@ int Application::Run()
 	try {
 		UpdatePidFile(Configuration::PidPath);
 	} catch (const std::exception&) {
-		Log(LogCritical, "Application")
+		Log(LogCritical, "Application", this)
 			<< "Cannot update PID file '" << Configuration::PidPath << "'. Aborting.";
 		return EXIT_FAILURE;
 	}
@@ -1048,7 +1048,7 @@ void Application::UpdatePidFile(const String& filename, pid_t pid)
 		m_PidFile = fopen(filename.CStr(), "w");
 
 	if (!m_PidFile) {
-		Log(LogCritical, "Application")
+		Log(LogCritical, "Application", this)
 			<< "Could not open PID file '" << filename << "'.";
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not open PID file '" + filename + "'"));
 	}
@@ -1066,13 +1066,13 @@ void Application::UpdatePidFile(const String& filename, pid_t pid)
 	lock.l_whence = SEEK_SET;
 
 	if (fcntl(fd, F_SETLK, &lock) < 0) {
-		Log(LogCritical, "Application", "Could not lock PID file. Make sure that only one instance of the application is running.");
+		Log(LogCritical, "Application", this, "Could not lock PID file. Make sure that only one instance of the application is running.");
 
 		Application::Exit(EXIT_FAILURE);
 	}
 
 	if (ftruncate(fd, 0) < 0) {
-		Log(LogCritical, "Application")
+		Log(LogCritical, "Application", this)
 			<< "ftruncate() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(posix_error()

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -480,13 +480,13 @@ void ConfigObject::SetAuthority(bool authority)
 
 void ConfigObject::DumpObjects(const String& filename, int attributeTypes)
 {
-	Log(LogInformation, "ConfigObject")
+	Log(LogInformation, "ConfigObject", nullptr)
 		<< "Dumping program state to file '" << filename << "'";
 
 	try {
 		Utility::Glob(filename + ".tmp.*", &Utility::Remove, GlobFile);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "ConfigObject") << DiagnosticInformation(ex);
+		Log(LogWarning, "ConfigObject", nullptr) << DiagnosticInformation(ex);
 	}
 
 	AtomicFile fp (filename, 0600);
@@ -533,7 +533,7 @@ void ConfigObject::RestoreObject(const String& message, int attributeTypes)
 		return;
 
 #ifdef I2_DEBUG
-	Log(LogDebug, "ConfigObject")
+	Log(LogDebug, "ConfigObject", object)
 		<< "Restoring object '" << name << "' of type '" << type << "'.";
 #endif /* I2_DEBUG */
 	Dictionary::Ptr update = persistentObject->Get("update");
@@ -547,7 +547,7 @@ void ConfigObject::RestoreObjects(const String& filename, int attributeTypes)
 	if (!Utility::PathExists(filename))
 		return;
 
-	Log(LogInformation, "ConfigObject")
+	Log(LogInformation, "ConfigObject", nullptr)
 		<< "Restoring program state from file '" << filename << "'";
 
 	std::fstream fp;
@@ -597,7 +597,7 @@ void ConfigObject::RestoreObjects(const String& filename, int attributeTypes)
 		}
 	}
 
-	Log(LogInformation, "ConfigObject")
+	Log(LogInformation, "ConfigObject", nullptr)
 		<< "Restored " << restored << " objects. Loaded " << no_state << " new objects without state.";
 }
 
@@ -619,7 +619,7 @@ void ConfigObject::StopObjects()
 
 		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
 #ifdef I2_DEBUG
-			Log(LogDebug, "ConfigObject")
+			Log(LogDebug, "ConfigObject", object)
 				<< "Deactivate() called for config object '" << object->GetName() << "' with type '" << type->GetName() << "'.";
 #endif /* I2_DEBUG */
 			object->Deactivate();

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -435,10 +435,22 @@ void ConfigObject::OnAllConfigLoaded()
 
 		toDo.pop_back();
 
-		if (m_AllParentsAffectingLogging.emplace(current.get()).second) {
+		if (m_AllParentsAffectingLogging.Data.emplace(current.get()).second) {
 			current->GetParentsAffectingLogging(toDo);
 		}
 	} while (!toDo.empty());
+
+	m_AllParentsAffectingLogging.Frozen.store(true);
+}
+
+const std::set<ConfigObject*>& ConfigObject::GetAllParentsAffectingLogging() const
+{
+	if (m_AllParentsAffectingLogging.Frozen.load(std::memory_order_relaxed)) {
+		return m_AllParentsAffectingLogging.Data;
+	}
+
+	static const std::set<ConfigObject*> fallback;
+	return fallback;
 }
 
 void ConfigObject::CreateChildObjects(const Type::Ptr&)

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -435,7 +435,7 @@ void ConfigObject::OnAllConfigLoaded()
 
 		toDo.pop_back();
 
-		if (m_AllParentsAffectingLogging.Data.emplace(current.get()).second) {
+		if (m_AllParentsAffectingLogging.Data.emplace(current->GetReflectionType(), current->GetName()).second) {
 			current->GetParentsAffectingLogging(toDo);
 		}
 	} while (!toDo.empty());
@@ -443,13 +443,13 @@ void ConfigObject::OnAllConfigLoaded()
 	m_AllParentsAffectingLogging.Frozen.store(true);
 }
 
-const std::set<ConfigObject*>& ConfigObject::GetAllParentsAffectingLogging() const
+const std::set<std::pair<Type::Ptr, String>>& ConfigObject::GetAllParentsAffectingLogging() const
 {
 	if (m_AllParentsAffectingLogging.Frozen.load(std::memory_order_relaxed)) {
 		return m_AllParentsAffectingLogging.Data;
 	}
 
-	static const std::set<ConfigObject*> fallback;
+	static const std::set<std::pair<Type::Ptr, String>> fallback;
 	return fallback;
 }
 

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -427,6 +427,18 @@ void ConfigObject::OnAllConfigLoaded()
 
 	if (!zoneName.IsEmpty())
 		m_Zone = ctype->GetObject(zoneName);
+
+	std::vector<Ptr> toDo {this};
+
+	do {
+		auto current (toDo.back());
+
+		toDo.pop_back();
+
+		if (m_AllParentsAffectingLogging.emplace(current.get()).second) {
+			current->GetParentsAffectingLogging(toDo);
+		}
+	} while (!toDo.empty());
 }
 
 void ConfigObject::CreateChildObjects(const Type::Ptr&)

--- a/lib/base/configobject.hpp
+++ b/lib/base/configobject.hpp
@@ -12,6 +12,7 @@
 #include "base/dictionary.hpp"
 #include <boost/signals2.hpp>
 #include <set>
+#include <utility>
 
 namespace icinga
 {
@@ -65,7 +66,7 @@ public:
 	virtual void OnStateLoaded();
 
 	Dictionary::Ptr GetSourceLocation() const override;
-	const std::set<ConfigObject*>& GetAllParentsAffectingLogging() const;
+	const std::set<std::pair<Type::Ptr, String>>& GetAllParentsAffectingLogging() const;
 
 	template<typename T>
 	static intrusive_ptr<T> GetObject(const String& name)
@@ -89,7 +90,7 @@ private:
 	ConfigObject::Ptr m_Zone;
 
 	struct {
-		std::set<ConfigObject*> Data;
+		std::set<std::pair<Type::Ptr, String>> Data;
 		Atomic<bool> Frozen {false};
 	} m_AllParentsAffectingLogging;
 

--- a/lib/base/configobject.hpp
+++ b/lib/base/configobject.hpp
@@ -5,6 +5,7 @@
 #define CONFIGOBJECT_H
 
 #include "base/i2-base.hpp"
+#include "base/atomic.hpp"
 #include "base/configobject-ti.hpp"
 #include "base/object.hpp"
 #include "base/type.hpp"
@@ -64,6 +65,7 @@ public:
 	virtual void OnStateLoaded();
 
 	Dictionary::Ptr GetSourceLocation() const override;
+	const std::set<ConfigObject*>& GetAllParentsAffectingLogging() const;
 
 	template<typename T>
 	static intrusive_ptr<T> GetObject(const String& name)
@@ -85,7 +87,11 @@ public:
 
 private:
 	ConfigObject::Ptr m_Zone;
-	std::set<ConfigObject*> m_AllParentsAffectingLogging;
+
+	struct {
+		std::set<ConfigObject*> Data;
+		Atomic<bool> Frozen {false};
+	} m_AllParentsAffectingLogging;
 
 	static void RestoreObject(const String& message, int attributeTypes);
 };

--- a/lib/base/configobject.hpp
+++ b/lib/base/configobject.hpp
@@ -10,6 +10,7 @@
 #include "base/type.hpp"
 #include "base/dictionary.hpp"
 #include <boost/signals2.hpp>
+#include <set>
 
 namespace icinga
 {
@@ -84,6 +85,7 @@ public:
 
 private:
 	ConfigObject::Ptr m_Zone;
+	std::set<ConfigObject*> m_AllParentsAffectingLogging;
 
 	static void RestoreObject(const String& message, int attributeTypes);
 };

--- a/lib/base/configobject.ti
+++ b/lib/base/configobject.ti
@@ -67,7 +67,7 @@ abstract class ConfigObject : ConfigObjectBase < ConfigType
 				return shortName;
 		}}}
 	};
-	[config, no_user_modify] name(Zone) zone (ZoneName);
+	[config, no_user_modify, parent_affecting_logging] name(Zone) zone (ZoneName);
 	[config, no_user_modify] String package;
 	[config, get_protected, no_user_modify] Array::Ptr templates;
 	[config, no_storage, no_user_modify] Dictionary::Ptr source_location {

--- a/lib/base/filelogger.cpp
+++ b/lib/base/filelogger.cpp
@@ -36,7 +36,7 @@ void FileLogger::Start(bool runtimeCreated)
 
 	ObjectImpl<FileLogger>::Start(runtimeCreated);
 
-	Log(LogInformation, "FileLogger")
+	Log(LogInformation, "FileLogger", this)
 		<< "'" << GetName() << "' started.";
 }
 

--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -172,8 +172,8 @@ void IoEngine::RunEventLoop()
 		} catch (const TerminateIoThread&) {
 			break;
 		} catch (const std::exception& e) {
-			Log(LogCritical, "IoEngine", "Exception during I/O operation!");
-			Log(LogDebug, "IoEngine") << "Exception during I/O operation: " << DiagnosticInformation(e);
+			Log(LogCritical, "IoEngine", nullptr, "Exception during I/O operation!");
+			Log(LogDebug, "IoEngine", nullptr) << "Exception during I/O operation: " << DiagnosticInformation(e);
 		}
 	}
 }

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -137,10 +137,10 @@ public:
 			try {
 				f(yc);
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "IoEngine") << "Exception in coroutine: " << DiagnosticInformation(ex);
+				Log(LogCritical, "IoEngine", nullptr) << "Exception in coroutine: " << DiagnosticInformation(ex);
 			} catch (...) {
 				try {
-					Log(LogCritical, "IoEngine", "Exception in coroutine!");
+					Log(LogCritical, "IoEngine", nullptr, "Exception in coroutine!");
 				} catch (...) {
 				}
 

--- a/lib/base/library.cpp
+++ b/lib/base/library.cpp
@@ -27,7 +27,7 @@ Library::Library(const String& name)
 	path = "lib" + name + ".so." + Application::GetAppSpecVersion();
 #endif /* _WIN32 */
 
-	Log(LogNotice, "Library")
+	Log(LogNotice, "Library", nullptr)
 		<< "Loading library '" << path << "'";
 
 #ifdef _WIN32

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -67,14 +67,14 @@ void Logger::Start(bool runtimeCreated)
 void Logger::SetObjectFilter(const Dictionary::Ptr& value, bool suppress_events, const Value& cookie)
 {
 	ObjectImpl<Logger>::SetObjectFilter(value, suppress_events, cookie);
-	CheckObjectFilter();
+	UpdateCheckObjectFilterCache();
 }
 
 void Logger::OnAllConfigLoaded()
 {
 	ObjectImpl<Logger>::OnAllConfigLoaded();
 	m_CalledOnAllConfigLoaded.store(true);
-	CheckObjectFilter();
+	UpdateCheckObjectFilterCache();
 }
 
 void Logger::Stop(bool runtimeRemoved)
@@ -299,7 +299,7 @@ void Logger::UpdateMinLogSeverity()
 	m_MinLogSeverity.store(result);
 }
 
-void Logger::CheckObjectFilter()
+void Logger::UpdateCheckObjectFilterCache()
 {
 	if (!m_CalledOnAllConfigLoaded.load()) {
 		return;
@@ -308,27 +308,43 @@ void Logger::CheckObjectFilter()
 	auto filter (GetObjectFilter());
 
 	if (!filter) {
+		ObjectLock lock (this);
+		m_ObjectFilterCache.clear();
 		return;
 	}
 
-	ObjectLock lock (filter);
+	std::vector<ConfigObject*> allObjects;
 
-	for (auto& kv : filter) {
-		auto type (Type::GetByName(kv.first));
-		auto ctype (dynamic_cast<ConfigType*>(type.get()));
-		Array::Ptr objects = kv.second;
+	{
+		ObjectLock lock (filter);
 
-		if (ctype && objects) {
-			ObjectLock lock (objects);
+		for (auto& kv : filter) {
+			auto type (Type::GetByName(kv.first));
+			auto ctype (dynamic_cast<ConfigType*>(type.get()));
+			Array::Ptr objects = kv.second;
 
-			for (String object : objects) {
-				if (!ctype->GetObject(object)) {
-					Log(LogWarning, GetReflectionType()->GetName())
-						<< "Missing " << kv.first << " '" << object << "' in object filter of '" << GetName() << "'.";
+			if (ctype && objects) {
+				ObjectLock lock (objects);
+
+				for (String name : objects) {
+					auto object (ctype->GetObject(name));
+
+					if (object) {
+						allObjects.emplace_back(object.get());
+					} else {
+						Log(LogWarning, GetReflectionType()->GetName())
+							<< "Missing " << kv.first << " '" << name << "' in name filter of '" << GetName() << "'.";
+					}
 				}
 			}
 		}
 	}
+
+	std::sort(allObjects.begin(), allObjects.end());
+
+	ObjectLock lock (this);
+
+	m_ObjectFilterCache.swap(allObjects);
 }
 
 Log::Log(LogSeverity severity, String facility, const String& message)

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -315,7 +315,7 @@ void Logger::UpdateCheckObjectFilterCache()
 		return;
 	}
 
-	std::vector<ConfigObject*> allObjects;
+	std::vector<std::pair<Type::Ptr, String>> allObjects;
 
 	{
 		ObjectLock lock (filter);
@@ -329,11 +329,9 @@ void Logger::UpdateCheckObjectFilterCache()
 				ObjectLock lock (objects);
 
 				for (String name : objects) {
-					auto object (ctype->GetObject(name));
+					allObjects.emplace_back(type, name);
 
-					if (object) {
-						allObjects.emplace_back(object.get());
-					} else {
+					if (!ctype->GetObject(name)) {
 						Log(LogWarning, GetReflectionType()->GetName(), this)
 							<< "Missing " << kv.first << " '" << name << "' in name filter of '" << GetName() << "'.";
 					}
@@ -411,7 +409,7 @@ Log::~Log()
 
 			auto& allowed (logger->GetObjectFilterCache());
 			auto& indirect (m_Involved->GetAllParentsAffectingLogging());
-			std::vector<ConfigObject*> intersection;
+			std::vector<std::pair<Type::Ptr, String>> intersection;
 
 			std::set_intersection(allowed.begin(), allowed.end(), indirect.begin(), indirect.end(), std::back_inserter(intersection));
 

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -76,6 +76,47 @@ void Logger::Stop(bool runtimeRemoved)
 	ObjectImpl<Logger>::Stop(runtimeRemoved);
 }
 
+void Logger::ValidateObjectFilter(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils)
+{
+	ObjectImpl<Logger>::ValidateObjectFilter(lvalue, utils);
+
+	auto filter (lvalue());
+
+	if (filter) {
+		ObjectLock lock (filter);
+
+		for (auto& kv : filter) {
+			auto type (Type::GetByName(kv.first));
+
+			if (!type) {
+				BOOST_THROW_EXCEPTION(
+					ValidationError(this, {"object_filter"}, "No such type: '" + kv.first + "'")
+				);
+			}
+
+			if (!dynamic_cast<ConfigType*>(type.get())) {
+				BOOST_THROW_EXCEPTION(
+					ValidationError(this, {"object_filter"}, "Not a config object type: '" + kv.first + "'")
+				);
+			}
+
+			Array::Ptr objects = kv.second;
+
+			if (objects) {
+				ObjectLock lock (objects);
+
+				for (auto& object : objects) {
+					if (object.GetType() != ValueString) {
+						BOOST_THROW_EXCEPTION(
+							ValidationError(this, {"object_filter", kv.first}, "Must be an array of strings.")
+						);
+					}
+				}
+			}
+		}
+	}
+}
+
 std::set<Logger::Ptr> Logger::GetLoggers()
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -348,18 +348,14 @@ void Logger::UpdateCheckObjectFilterCache()
 }
 
 Log::Log(LogSeverity severity, String facility, const String& message)
-	: Log(severity, std::move(facility))
-{
-	*this << message;
-}
-
-Log::Log(LogSeverity severity, String facility)
 {
 	// Only fully initialize the object if it's actually going to be logged.
 	if (severity >= Logger::GetMinLogSeverity()) {
 		m_Severity = severity;
 		m_Facility = std::move(facility);
 		m_Buffer.emplace();
+
+		*this << message;
 	}
 }
 

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -15,7 +15,9 @@
 #endif /* _WIN32 */
 #include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <utility>
+#include <vector>
 
 using namespace icinga;
 
@@ -394,11 +396,31 @@ Log::~Log()
 	for (const Logger::Ptr& logger : Logger::GetLoggers()) {
 		ObjectLock llock(logger);
 
-		if (!logger->IsActive())
+		if (!logger->IsActive()) {
 			continue;
+		}
 
-		if (entry.Severity >= logger->GetMinSeverity())
-			logger->ProcessLogEntry(entry);
+		if (entry.Severity < logger->GetMinSeverity()) {
+			continue;
+		}
+
+		if (logger->GetObjectFilter()) {
+			if (!m_Involved) {
+				continue;
+			}
+
+			auto& allowed (logger->GetObjectFilterCache());
+			auto& indirect (m_Involved->GetAllParentsAffectingLogging());
+			std::vector<ConfigObject*> intersection;
+
+			std::set_intersection(allowed.begin(), allowed.end(), indirect.begin(), indirect.end(), std::back_inserter(intersection));
+
+			if (intersection.empty()) {
+				continue;
+			}
+		}
+
+		logger->ProcessLogEntry(entry);
 
 #ifdef I2_DEBUG /* I2_DEBUG */
 		/* Always flush, don't depend on the timer. Enable this for development sprints on Linux/macOS only. Windows crashes. */

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -332,7 +332,7 @@ void Logger::UpdateCheckObjectFilterCache()
 					if (object) {
 						allObjects.emplace_back(object.get());
 					} else {
-						Log(LogWarning, GetReflectionType()->GetName())
+						Log(LogWarning, GetReflectionType()->GetName(), this)
 							<< "Missing " << kv.first << " '" << name << "' in name filter of '" << GetName() << "'.";
 					}
 				}
@@ -347,12 +347,13 @@ void Logger::UpdateCheckObjectFilterCache()
 	m_ObjectFilterCache.swap(allObjects);
 }
 
-Log::Log(LogSeverity severity, String facility, const String& message)
+Log::Log(LogSeverity severity, String facility, const ConfigObject::ConstPtr& involved, const String& message)
 {
 	// Only fully initialize the object if it's actually going to be logged.
 	if (severity >= Logger::GetMinLogSeverity()) {
 		m_Severity = severity;
 		m_Facility = std::move(facility);
+		m_Involved = involved;
 		m_Buffer.emplace();
 
 		*this << message;

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -64,6 +64,19 @@ void Logger::Start(bool runtimeCreated)
 	UpdateMinLogSeverity();
 }
 
+void Logger::SetObjectFilter(const Dictionary::Ptr& value, bool suppress_events, const Value& cookie)
+{
+	ObjectImpl<Logger>::SetObjectFilter(value, suppress_events, cookie);
+	CheckObjectFilter();
+}
+
+void Logger::OnAllConfigLoaded()
+{
+	ObjectImpl<Logger>::OnAllConfigLoaded();
+	m_CalledOnAllConfigLoaded.store(true);
+	CheckObjectFilter();
+}
+
 void Logger::Stop(bool runtimeRemoved)
 {
 	{
@@ -284,6 +297,38 @@ void Logger::UpdateMinLogSeverity()
 #endif /* _WIN32 */
 
 	m_MinLogSeverity.store(result);
+}
+
+void Logger::CheckObjectFilter()
+{
+	if (!m_CalledOnAllConfigLoaded.load()) {
+		return;
+	}
+
+	auto filter (GetObjectFilter());
+
+	if (!filter) {
+		return;
+	}
+
+	ObjectLock lock (filter);
+
+	for (auto& kv : filter) {
+		auto type (Type::GetByName(kv.first));
+		auto ctype (dynamic_cast<ConfigType*>(type.get()));
+		Array::Ptr objects = kv.second;
+
+		if (ctype && objects) {
+			ObjectLock lock (objects);
+
+			for (String object : objects) {
+				if (!ctype->GetObject(object)) {
+					Log(LogWarning, GetReflectionType()->GetName())
+						<< "Missing " << kv.first << " '" << object << "' in object filter of '" << GetName() << "'.";
+				}
+			}
+		}
+	}
 }
 
 Log::Log(LogSeverity severity, String facility, const String& message)

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -8,9 +8,11 @@
 #include "base/i2-base.hpp"
 #include "base/configobject.hpp"
 #include "base/logger-ti.hpp"
+#include "base/type.hpp"
 #include <optional>
 #include <set>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 namespace icinga
@@ -95,7 +97,7 @@ public:
 	void SetObjectFilter(const Dictionary::Ptr& value, bool suppress_events = false, const Value& cookie = Empty) override;
 	void OnAllConfigLoaded() override;
 
-	inline const std::vector<ConfigObject*>& GetObjectFilterCache() const
+	const std::vector<std::pair<Type::Ptr, String>>& GetObjectFilterCache() const
 	{
 		return m_ObjectFilterCache;
 	}
@@ -120,7 +122,7 @@ private:
 	static Atomic<LogSeverity> m_MinLogSeverity;
 
 	Atomic<bool> m_CalledOnAllConfigLoaded {false};
-	std::vector<ConfigObject*> m_ObjectFilterCache;
+	std::vector<std::pair<Type::Ptr, String>> m_ObjectFilterCache;
 };
 
 class Log

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -124,9 +124,7 @@ public:
 	Log(const Log& other) = delete;
 	Log& operator=(const Log& rhs) = delete;
 
-	Log(LogSeverity severity, String facility, const String& message);
-	Log(LogSeverity severity, String facility);
-
+	Log(LogSeverity severity, String facility, const String& message = String());
 	~Log();
 
 	template<typename T>

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -6,6 +6,7 @@
 
 #include "base/atomic.hpp"
 #include "base/i2-base.hpp"
+#include "base/configobject.hpp"
 #include "base/logger-ti.hpp"
 #include <optional>
 #include <set>
@@ -124,7 +125,7 @@ public:
 	Log(const Log& other) = delete;
 	Log& operator=(const Log& rhs) = delete;
 
-	Log(LogSeverity severity, String facility, const String& message = String());
+	Log(LogSeverity severity, String facility, const ConfigObject::ConstPtr& involved, const String& message = String());
 	~Log();
 
 	template<typename T>
@@ -140,6 +141,8 @@ public:
 private:
 	LogSeverity m_Severity;
 	String m_Facility;
+	ConfigObject::ConstPtr m_Involved;
+
 	/**
 	 * Stream for incrementally generating the log message. If the message will be discarded as it's level currently
 	 * isn't logged, it will be empty as the stream doesn't need to be initialized in this case.

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -94,6 +94,7 @@ public:
 protected:
 	void Start(bool runtimeCreated) override;
 	void Stop(bool runtimeRemoved) override;
+	void ValidateObjectFilter(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils) override;
 
 private:
 	static void UpdateMinLogSeverity();

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -95,6 +95,11 @@ public:
 	void SetObjectFilter(const Dictionary::Ptr& value, bool suppress_events = false, const Value& cookie = Empty) override;
 	void OnAllConfigLoaded() override;
 
+	inline const std::vector<ConfigObject*>& GetObjectFilterCache() const
+	{
+		return m_ObjectFilterCache;
+	}
+
 protected:
 	void Start(bool runtimeCreated) override;
 	void Stop(bool runtimeRemoved) override;

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <set>
 #include <sstream>
+#include <vector>
 
 namespace icinga
 {
@@ -101,7 +102,7 @@ protected:
 private:
 	static void UpdateMinLogSeverity();
 
-	void CheckObjectFilter();
+	void UpdateCheckObjectFilterCache();
 
 	static std::mutex m_Mutex;
 	static std::set<Logger::Ptr> m_Loggers;
@@ -113,6 +114,7 @@ private:
 	static Atomic<LogSeverity> m_MinLogSeverity;
 
 	Atomic<bool> m_CalledOnAllConfigLoaded {false};
+	std::vector<ConfigObject*> m_ObjectFilterCache;
 };
 
 class Log

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -90,6 +90,8 @@ public:
 
 	void SetSeverity(const String& value, bool suppress_events = false, const Value& cookie = Empty) override;
 	void ValidateSeverity(const Lazy<String>& lvalue, const ValidationUtils& utils) override final;
+	void SetObjectFilter(const Dictionary::Ptr& value, bool suppress_events = false, const Value& cookie = Empty) override;
+	void OnAllConfigLoaded() override;
 
 protected:
 	void Start(bool runtimeCreated) override;
@@ -99,6 +101,8 @@ protected:
 private:
 	static void UpdateMinLogSeverity();
 
+	void CheckObjectFilter();
+
 	static std::mutex m_Mutex;
 	static std::set<Logger::Ptr> m_Loggers;
 	static bool m_ConsoleLogEnabled;
@@ -107,6 +111,8 @@ private:
 	static LogSeverity m_ConsoleLogSeverity;
 	static std::mutex m_UpdateMinLogSeverityMutex;
 	static Atomic<LogSeverity> m_MinLogSeverity;
+
+	Atomic<bool> m_CalledOnAllConfigLoaded {false};
 };
 
 class Log

--- a/lib/base/logger.ti
+++ b/lib/base/logger.ti
@@ -13,7 +13,7 @@ abstract class Logger : ConfigObject
 	[config, set_virtual] String severity {
 		default {{{ return "information"; }}}
 	};
-	[config] Dictionary::Ptr object_filter;
+	[config, set_virtual] Dictionary::Ptr object_filter;
 };
 
 validator Logger {

--- a/lib/base/logger.ti
+++ b/lib/base/logger.ti
@@ -13,6 +13,13 @@ abstract class Logger : ConfigObject
 	[config, set_virtual] String severity {
 		default {{{ return "information"; }}}
 	};
+	[config] Dictionary::Ptr object_filter;
+};
+
+validator Logger {
+	Dictionary object_filter {
+		Array "*";
+	};
 };
 
 }

--- a/lib/base/perfdatavalue.cpp
+++ b/lib/base/perfdatavalue.cpp
@@ -286,7 +286,7 @@ PerfdataValue::Ptr PerfdataValue::Parse(const String& perfdata)
 			auto uom (l_CiUoMs.find(ciUnit.GetData()));
 
 			if (uom == l_CiUoMs.end()) {
-				Log(LogDebug, "PerfdataValue")
+				Log(LogDebug, "PerfdataValue", nullptr)
 					<< "Invalid performance data unit: " << unit;
 
 				unit = "";
@@ -401,7 +401,7 @@ Value PerfdataValue::ParseWarnCritMinMaxToken(const std::vector<String>& tokens,
 		return Convert::ToDouble(tokens[index]);
 	else {
 		if (tokens.size() > index && tokens[index] != "")
-			Log(LogDebug, "PerfdataValue")
+			Log(LogDebug, "PerfdataValue", nullptr)
 				<< "Ignoring unsupported perfdata " << description << " range, value: '" << tokens[index] << "'.";
 		return Empty;
 	}

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -690,7 +690,7 @@ void Process::IOThreadProc(int tid)
 			if (pfds[0].revents & (POLLIN | POLLHUP | POLLERR)) {
 				char buffer[512];
 				if (read(l_EventFDs[tid][0], buffer, sizeof(buffer)) < 0)
-					Log(LogCritical, "base", "Read from event FD failed.");
+					Log(LogCritical, "base", nullptr, "Read from event FD failed.");
 			}
 #endif /* _WIN32 */
 
@@ -947,7 +947,7 @@ void Process::Run(const std::function<void(const ProcessResult&)>& callback)
 	m_FD = outReadPipe;
 	m_PID = pi.dwProcessId;
 
-	Log(LogNotice, "Process")
+	Log(LogNotice, "Process", nullptr)
 		<< "Running command " << PrettyPrintArguments(m_Arguments) << ": PID " << m_PID;
 
 #else /* _WIN32 */
@@ -984,10 +984,10 @@ void Process::Run(const std::function<void(const ProcessResult&)>& callback)
 
 	if (m_PID == -1) {
 		m_OutputStream << "Fork failed with error code " << errno << " (" << Utility::FormatErrorNumber(errno) << ")";
-		Log(LogCritical, "Process", m_OutputStream.str());
+		Log(LogCritical, "Process", nullptr, m_OutputStream.str());
 	}
 
-	Log(LogNotice, "Process")
+	Log(LogNotice, "Process", nullptr)
 		<< "Running command " << PrettyPrintArguments(m_Arguments) << ": PID " << m_PID;
 
 	(void)close(outfds[1]);
@@ -1013,7 +1013,7 @@ void Process::Run(const std::function<void(const ProcessResult&)>& callback)
 	SetEvent(l_Events[tid]);
 #else /* _WIN32 */
 	if (write(l_EventFDs[tid][1], "T", 1) < 0 && errno != EINTR && errno != EAGAIN)
-		Log(LogCritical, "base", "Write to event FD failed.");
+		Log(LogCritical, "base", nullptr, "Write to event FD failed.");
 #endif /* _WIN32 */
 }
 
@@ -1039,7 +1039,7 @@ bool Process::DoEvents()
 			auto deadline (m_Result.ExecutionStart + timeout);
 
 			if (deadline < now && !m_SentSigterm) {
-				Log(LogWarning, "Process")
+				Log(LogWarning, "Process", nullptr)
 					<< "Terminating process " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
 					<< ") after timeout of " << timeout << " seconds";
 
@@ -1047,7 +1047,7 @@ bool Process::DoEvents()
 
 				int error = ProcessKill(m_Process, SIGTERM);
 				if (error) {
-					Log(LogWarning, "Process")
+					Log(LogWarning, "Process", nullptr)
 						<< "Couldn't terminate the process " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
 						<< "): [errno " << error << "] " << strerror(error);
 				}
@@ -1061,7 +1061,7 @@ bool Process::DoEvents()
 		auto deadline (m_Result.ExecutionStart + timeout);
 
 		if (deadline < now) {
-			Log(LogWarning, "Process")
+			Log(LogWarning, "Process", nullptr)
 				<< "Killing process group " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
 				<< ") after timeout of " << timeout << " seconds";
 
@@ -1071,7 +1071,7 @@ bool Process::DoEvents()
 #else /* _WIN32 */
 			int error = ProcessKill(-m_Process, SIGKILL);
 			if (error) {
-				Log(LogWarning, "Process")
+				Log(LogWarning, "Process", nullptr)
 					<< "Couldn't kill the process group " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
 					<< "): [errno " << error << "] " << strerror(error);
 				if (error != ESRCH) {
@@ -1119,7 +1119,7 @@ bool Process::DoEvents()
 	DWORD exitcode;
 	GetExitCodeProcess(m_Process, &exitcode);
 
-	Log(LogNotice, "Process")
+	Log(LogNotice, "Process", nullptr)
 		<< "PID " << m_PID << " (" << PrettyPrintArguments(m_Arguments) << ") terminated with exit code " << exitcode;
 #else /* _WIN32 */
 	int status = 0;
@@ -1129,12 +1129,12 @@ bool Process::DoEvents()
 	} else if (ProcessWaitPID(m_Process, &status) != m_Process) {
 		exitcode = 128;
 
-		Log(LogWarning, "Process")
+		Log(LogWarning, "Process", nullptr)
 			<< "PID " << m_PID << " (" << PrettyPrintArguments(m_Arguments) << ") died mysteriously: waitpid failed";
 	} else if (WIFEXITED(status)) {
 		exitcode = WEXITSTATUS(status);
 
-		Log msg(LogNotice, "Process");
+		Log msg (LogNotice, "Process", nullptr);
 		msg << "PID " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
 			<< ") terminated with exit code " << exitcode;
 
@@ -1154,7 +1154,7 @@ bool Process::DoEvents()
 			signame += ")";
 		}
 
-		Log(LogWarning, "Process")
+		Log(LogWarning, "Process", nullptr)
 			<< "PID " << m_PID << " was terminated by signal " << signame;
 
 		std::ostringstream outputbuf;

--- a/lib/base/scriptglobal.cpp
+++ b/lib/base/scriptglobal.cpp
@@ -82,7 +82,7 @@ Namespace::Ptr ScriptGlobal::GetGlobals()
 
 void ScriptGlobal::WriteToFile(const String& filename)
 {
-	Log(LogInformation, "ScriptGlobal")
+	Log(LogInformation, "ScriptGlobal", nullptr)
 		<< "Dumping variables to file '" << filename << "'";
 
 	AtomicFile fp (filename, 0600);

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -338,9 +338,9 @@ void ScriptUtils::Log(const std::vector<Value>& arguments)
 	}
 
 	if (message.IsString() || (!message.IsObjectType<Array>() && !message.IsObjectType<Dictionary>()))
-		::Log(severity, facility, message);
+		::Log(severity, facility, nullptr, message);
 	else
-		::Log(severity, facility, JsonEncode(message));
+		::Log(severity, facility, nullptr, JsonEncode(message));
 }
 
 Array::Ptr ScriptUtils::Range(const std::vector<Value>& arguments)

--- a/lib/base/socket.cpp
+++ b/lib/base/socket.cpp
@@ -120,14 +120,14 @@ std::pair<String, String> Socket::GetDetailsFromSockaddr(sockaddr *address, sock
 	if (getnameinfo(address, len, host, sizeof(host), service,
 		sizeof(service), NI_NUMERICHOST | NI_NUMERICSERV) < 0) {
 #ifndef _WIN32
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "getnameinfo() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
 			<< boost::errinfo_api_function("getnameinfo")
 			<< boost::errinfo_errno(errno));
 #else /* _WIN32 */
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "getnameinfo() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -153,14 +153,14 @@ std::pair<String, String> Socket::GetClientAddressDetails()
 
 	if (getsockname(GetFD(), (sockaddr *)&sin, &len) < 0) {
 #ifndef _WIN32
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "getsockname() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
 			<< boost::errinfo_api_function("getsockname")
 			<< boost::errinfo_errno(errno));
 #else /* _WIN32 */
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "getsockname() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -203,14 +203,14 @@ std::pair<String, String> Socket::GetPeerAddressDetails()
 
 	if (getpeername(GetFD(), (sockaddr *)&sin, &len) < 0) {
 #ifndef _WIN32
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "getpeername() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
 			<< boost::errinfo_api_function("getpeername")
 			<< boost::errinfo_errno(errno));
 #else /* _WIN32 */
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "getpeername() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -246,14 +246,14 @@ void Socket::Listen()
 {
 	if (listen(GetFD(), SOMAXCONN) < 0) {
 #ifndef _WIN32
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "listen() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
 			<< boost::errinfo_api_function("listen")
 			<< boost::errinfo_errno(errno));
 #else /* _WIN32 */
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "listen() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -278,14 +278,14 @@ size_t Socket::Write(const void *buffer, size_t count)
 
 	if (rc < 0) {
 #ifndef _WIN32
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "send() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
 			<< boost::errinfo_api_function("send")
 			<< boost::errinfo_errno(errno));
 #else /* _WIN32 */
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "send() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -312,14 +312,14 @@ size_t Socket::Read(void *buffer, size_t count)
 
 	if (rc < 0) {
 #ifndef _WIN32
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "recv() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
 			<< boost::errinfo_api_function("recv")
 			<< boost::errinfo_errno(errno));
 #else /* _WIN32 */
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "recv() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -343,7 +343,7 @@ Socket::Ptr Socket::Accept()
 
 #ifndef _WIN32
 	if (fd < 0) {
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "accept() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -352,7 +352,7 @@ Socket::Ptr Socket::Accept()
 	}
 #else /* _WIN32 */
 	if (fd == INVALID_SOCKET) {
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "accept() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -385,7 +385,7 @@ bool Socket::Poll(bool read, bool write, struct timeval *timeout)
 	rc = select(GetFD() + 1, &readfds, &writefds, &exceptfds, timeout);
 
 	if (rc < 0) {
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "select() failed with error code " << WSAGetLastError() << ", \"" << Utility::FormatErrorNumber(WSAGetLastError()) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -401,7 +401,7 @@ bool Socket::Poll(bool read, bool write, struct timeval *timeout)
 	rc = poll(&pfd, 1, timeout ? (timeout->tv_sec + 1000 + timeout->tv_usec / 1000) : -1);
 
 	if (rc < 0) {
-		Log(LogCritical, "Socket")
+		Log(LogCritical, "Socket", nullptr)
 			<< "poll() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()

--- a/lib/base/tcpsocket.cpp
+++ b/lib/base/tcpsocket.cpp
@@ -46,7 +46,7 @@ void TcpSocket::Bind(const String& node, const String& service, int family)
 		service.CStr(), &hints, &result);
 
 	if (rc != 0) {
-		Log(LogCritical, "TcpSocket")
+		Log(LogCritical, "TcpSocket", nullptr)
 			<< "getaddrinfo() failed with error code " << rc << ", \"" << gai_strerror(rc) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -102,7 +102,7 @@ void TcpSocket::Bind(const String& node, const String& service, int family)
 	freeaddrinfo(result);
 
 	if (GetFD() == INVALID_SOCKET) {
-		Log(LogCritical, "TcpSocket")
+		Log(LogCritical, "TcpSocket", nullptr)
 			<< "Invalid socket: " << Utility::FormatErrorNumber(error);
 
 #ifndef _WIN32
@@ -138,7 +138,7 @@ void TcpSocket::Connect(const String& node, const String& service)
 	int rc = getaddrinfo(node.CStr(), service.CStr(), &hints, &result);
 
 	if (rc != 0) {
-		Log(LogCritical, "TcpSocket")
+		Log(LogCritical, "TcpSocket", nullptr)
 			<< "getaddrinfo() failed with error code " << rc << ", \"" << gai_strerror(rc) << "\"";
 
 		BOOST_THROW_EXCEPTION(socket_error()
@@ -169,7 +169,7 @@ void TcpSocket::Connect(const String& node, const String& service)
 #else /* _WIN32 */
 			error = errno;
 #endif /* _WIN32 */
-			Log(LogWarning, "TcpSocket")
+			Log(LogWarning, "TcpSocket", nullptr)
 				<< "setsockopt() unable to enable TCP keep-alives with error code " << rc;
 		}
 
@@ -196,7 +196,7 @@ void TcpSocket::Connect(const String& node, const String& service)
 	freeaddrinfo(result);
 
 	if (GetFD() == INVALID_SOCKET) {
-		Log(LogCritical, "TcpSocket")
+		Log(LogCritical, "TcpSocket", nullptr)
 			<< "Invalid socket: " << Utility::FormatErrorNumber(error);
 
 #ifndef _WIN32

--- a/lib/base/threadpool.hpp
+++ b/lib/base/threadpool.hpp
@@ -65,11 +65,11 @@ public:
 				try {
 					callback();
 				} catch (const std::exception& ex) {
-					Log(LogCritical, "ThreadPool")
+					Log(LogCritical, "ThreadPool", nullptr)
 						<< "Exception thrown in event handler:\n"
 						<< DiagnosticInformation(ex);
 				} catch (...) {
-					Log(LogCritical, "ThreadPool", "Exception of unknown type thrown in event handler.");
+					Log(LogCritical, "ThreadPool", nullptr, "Exception of unknown type thrown in event handler.");
 				}
 			});
 

--- a/lib/base/timer.cpp
+++ b/lib/base/timer.cpp
@@ -298,7 +298,7 @@ void Timer::TimerThreadProc()
 {
 	namespace ch = std::chrono;
 
-	Log(LogDebug, "Timer", "TimerThreadProc started.");
+	Log(LogDebug, "Timer", nullptr, "TimerThreadProc started.");
 
 	Utility::SetThreadName("Timer Thread");
 

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -131,7 +131,7 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 	if (!pubkey.IsEmpty()) {
 		if (!SSL_CTX_use_certificate_chain_file(sslContext, pubkey.CStr())) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error with public key file '" << pubkey << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("SSL_CTX_use_certificate_chain_file")
@@ -143,7 +143,7 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 	if (!privkey.IsEmpty()) {
 		if (!SSL_CTX_use_PrivateKey_file(sslContext, privkey.CStr(), SSL_FILETYPE_PEM)) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error with private key file '" << privkey << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("SSL_CTX_use_PrivateKey_file")
@@ -153,7 +153,7 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 
 		if (!SSL_CTX_check_private_key(sslContext)) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error checking private key '" << privkey << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("SSL_CTX_check_private_key")
@@ -164,7 +164,7 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 	if (cakey.IsEmpty()) {
 		if (!SSL_CTX_set_default_verify_paths(sslContext)) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error loading system's root CAs: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("SSL_CTX_set_default_verify_paths")
@@ -173,7 +173,7 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 	} else {
 		if (!SSL_CTX_load_verify_locations(sslContext, cakey.CStr(), nullptr)) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error loading and verifying locations in ca key file '" << cakey << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("SSL_CTX_load_verify_locations")
@@ -186,7 +186,7 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 		cert_names = SSL_load_client_CA_file(cakey.CStr());
 		if (!cert_names) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error loading client ca key file '" << cakey << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("SSL_load_client_CA_file")
@@ -230,7 +230,7 @@ void SetCipherListToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& con
 
 	if (SSL_CTX_set_cipher_list(context->native_handle(), cipherList.CStr()) == 0) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Cipher list '"
 			<< cipherList
 			<< "' does not specify any usable ciphers: "
@@ -255,7 +255,7 @@ void SetCipherListToSSLContext(const Shared<boost::asio::ssl::context>::Ptr& con
 		cipherNames->Add(cipher_name);
 	}
 
-	Log(LogNotice, "TlsUtility")
+	Log(LogNotice, "TlsUtility", nullptr)
 		<< "Available TLS cipher list: " << cipherNames->Join(" ");
 #endif /* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 }
@@ -340,7 +340,7 @@ void SetTlsProtocolminToSSLContext(const Shared<boost::asio::ssl::context>::Ptr&
 		char errbuf[256];
 
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error setting minimum TLS protocol version: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SSL_CTX_set_min_proto_version")
@@ -380,7 +380,7 @@ void AddCRLToSSLContext(X509_STORE *x509_store, const String& crlPath)
 
 	if (!lookup) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error adding X509 store lookup: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("X509_STORE_add_lookup")
@@ -389,7 +389,7 @@ void AddCRLToSSLContext(X509_STORE *x509_store, const String& crlPath)
 
 	if (X509_LOOKUP_load_file(lookup, crlPath.CStr(), X509_FILETYPE_PEM) != 1) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error loading crl file '" << crlPath << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("X509_LOOKUP_load_file")
@@ -412,7 +412,7 @@ static String GetX509NameCN(X509NameConstPtr name)
 
 	if (rc == -1) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error with x509 NAME getting text by NID: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("X509_NAME_get_text_by_NID")
@@ -447,7 +447,7 @@ std::shared_ptr<X509> GetX509Certificate(const String& pemfile)
 
 	if (!fpcert) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error creating new BIO: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("BIO_new")
@@ -456,7 +456,7 @@ std::shared_ptr<X509> GetX509Certificate(const String& pemfile)
 
 	if (BIO_read_filename(fpcert, pemfile.CStr()) < 0) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error reading pem file '" << pemfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("BIO_read_filename")
@@ -467,7 +467,7 @@ std::shared_ptr<X509> GetX509Certificate(const String& pemfile)
 	cert = PEM_read_bio_X509_AUX(fpcert, nullptr, nullptr, nullptr);
 	if (!cert) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on bio X509 AUX reading pem file '" << pemfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("PEM_read_bio_X509_AUX")
@@ -499,7 +499,7 @@ int MakeX509CSR(
 
 	if (!rsa || !e) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error while creating RSA key: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("RSA_generate_key")
@@ -510,7 +510,7 @@ int MakeX509CSR(
 
 	if (!RSA_generate_key_ex(rsa, 4096, e, nullptr)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error while creating RSA key: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("RSA_generate_key")
@@ -519,14 +519,14 @@ int MakeX509CSR(
 
 	BN_free(e);
 
-	Log(LogInformation, "base")
+	Log(LogInformation, "base", nullptr)
 		<< "Writing private key to '" << keyfile << "'.";
 
 	BIO *bio = BIO_new_file(const_cast<char *>(keyfile.CStr()), "w");
 
 	if (!bio) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error while opening private RSA key file '" << keyfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("BIO_new_file")
@@ -536,7 +536,7 @@ int MakeX509CSR(
 
 	if (!PEM_write_bio_RSAPrivateKey(bio, rsa, nullptr, nullptr, 0, nullptr, nullptr)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error while writing private RSA key to file '" << keyfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("PEM_write_bio_RSAPrivateKey")
@@ -561,14 +561,14 @@ int MakeX509CSR(
 
 		X509_NAME_free(subject);
 
-		Log(LogInformation, "base")
+		Log(LogInformation, "base", nullptr)
 			<< "Writing X509 certificate to '" << certfile << "'.";
 
 		bio = BIO_new_file(const_cast<char *>(certfile.CStr()), "w");
 
 		if (!bio) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error while opening certificate file '" << certfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("BIO_new_file")
@@ -578,7 +578,7 @@ int MakeX509CSR(
 
 		if (!PEM_write_bio_X509(bio, cert.get())) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error while writing certificate to file '" << certfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("PEM_write_bio_X509")
@@ -611,7 +611,7 @@ int MakeX509CSR(
 		if (!X509_REQ_set_subject_name(req, name.get())) {
 			unsigned long err = ERR_peek_error();
 			ERR_error_string_n(err, errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error while setting CSR subject name: " << err << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("X509_REQ_set_subject_name")
@@ -632,14 +632,14 @@ int MakeX509CSR(
 
 		X509_REQ_sign(req, key, EVP_sha256());
 
-		Log(LogInformation, "base")
+		Log(LogInformation, "base", nullptr)
 			<< "Writing certificate signing request to '" << csrfile << "'.";
 
 		bio = BIO_new_file(const_cast<char *>(csrfile.CStr()), "w");
 
 		if (!bio) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error while opening CSR file '" << csrfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("BIO_new_file")
@@ -649,7 +649,7 @@ int MakeX509CSR(
 
 		if (!PEM_write_bio_X509_REQ(bio, req)) {
 			ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-			Log(LogCritical, "SSL")
+			Log(LogCritical, "SSL", nullptr)
 				<< "Error while writing CSR to file '" << csrfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 			BOOST_THROW_EXCEPTION(openssl_error()
 				<< boost::errinfo_api_function("PEM_write_bio_X509")
@@ -694,7 +694,7 @@ std::shared_ptr<X509> CreateCert(
 
 	if (!SHA1_Init(&context)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA1 Init: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA1_Init")
@@ -703,7 +703,7 @@ std::shared_ptr<X509> CreateCert(
 
 	if (!SHA1_Update(&context, (unsigned char*)id.CStr(), id.GetLength())) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA1 Update: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA1_Update")
@@ -712,7 +712,7 @@ std::shared_ptr<X509> CreateCert(
 
 	if (!SHA1_Final(digest, &context)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA1 Final: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA1_Final")
@@ -777,7 +777,7 @@ std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509NameConstPtr subj
 
 	if (!cakeybio) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Could not open CA key file '" << cakeyfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		return std::shared_ptr<X509>();
 	}
@@ -786,7 +786,7 @@ std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509NameConstPtr subj
 
 	if (!rsa) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Could not read RSA key from CA key file '" << cakeyfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		return std::shared_ptr<X509>();
 	}
@@ -956,7 +956,7 @@ String SHA1(const String& s, bool binary)
 
 	if (!SHA1_Init(&context)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA Init: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA1_Init")
@@ -965,7 +965,7 @@ String SHA1(const String& s, bool binary)
 
 	if (!SHA1_Update(&context, (unsigned char*)s.CStr(), s.GetLength())) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA Update: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA1_Update")
@@ -974,7 +974,7 @@ String SHA1(const String& s, bool binary)
 
 	if (!SHA1_Final(digest, &context)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA Final: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA1_Final")
@@ -995,7 +995,7 @@ String SHA256(const String& s)
 
 	if (!SHA256_Init(&context)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA256 Init: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA256_Init")
@@ -1004,7 +1004,7 @@ String SHA256(const String& s)
 
 	if (!SHA256_Update(&context, (unsigned char*)s.CStr(), s.GetLength())) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA256 Update: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA256_Update")
@@ -1013,7 +1013,7 @@ String SHA256(const String& s)
 
 	if (!SHA256_Final(digest, &context)) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error on SHA256 Final: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("SHA256_Final")
@@ -1042,7 +1042,7 @@ String RandomString(int length)
 		char errbuf[256];
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
 
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Error for RAND_bytes: " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		BOOST_THROW_EXCEPTION(openssl_error()
 			<< boost::errinfo_api_function("RAND_bytes")

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -773,7 +773,7 @@ void Utility::RenameFile(const String& source, const String& target)
 			fs::rename(sourcePath, targetPath);
 
 			if (retries > 0) {
-				Log(LogWarning, "Utility") << "Renaming '" << source << "' to '" << target
+				Log(LogWarning, "Utility", nullptr) << "Renaming '" << source << "' to '" << target
 					<< "' succeeded after " << retries << " retries";
 			}
 
@@ -789,7 +789,7 @@ void Utility::RenameFile(const String& source, const String& target)
 			}
 
 			if (error != last_error) {
-				Log(LogWarning, "Utility") << "Renaming '" << source << "' to '" << target << "' failed: "
+				Log(LogWarning, "Utility", nullptr) << "Renaming '" << source << "' to '" << target << "' failed: "
 					<< ex.code().message() << " (trying up to " << remaining << " more times)";
 				last_error = error;
 			}
@@ -827,10 +827,10 @@ bool Utility::SetFileOwnership(const String& file, const String& user, const Str
 
 		if (!pw) {
 			if (errno == 0) {
-				Log(LogCritical, "cli")
+				Log(LogCritical, "cli", nullptr)
 					<< "Invalid user specified: " << user;
 			} else {
-				Log(LogCritical, "cli") << "getpwnam() failed with error code " << errno << ", \""
+				Log(LogCritical, "cli", nullptr) << "getpwnam() failed with error code " << errno << ", \""
 					<< Utility::FormatErrorNumber(errno) << "\"";
 			}
 			return false;
@@ -849,10 +849,10 @@ bool Utility::SetFileOwnership(const String& file, const String& user, const Str
 
 		if (!gr) {
 			if (errno == 0) {
-				Log(LogCritical, "cli")
+				Log(LogCritical, "cli", nullptr)
 					<< "Invalid group specified: " << group;
 			} else {
-				Log(LogCritical, "cli") << "getgrnam() failed with error code " << errno << ", \""
+				Log(LogCritical, "cli", nullptr) << "getgrnam() failed with error code " << errno << ", \""
 					<< Utility::FormatErrorNumber(errno) << "\"";
 			}
 			return false;
@@ -862,7 +862,7 @@ bool Utility::SetFileOwnership(const String& file, const String& user, const Str
 	}
 
 	if (chown(file.CStr(), uid, gid) < 0) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "chown() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 		return false;
 	}

--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -57,7 +57,7 @@ std::unique_lock<std::mutex> WorkQueue::AcquireLock()
 void WorkQueue::EnqueueUnlocked(std::unique_lock<std::mutex>& lock, std::function<void ()>&& function, WorkQueuePriority priority)
 {
 	if (!m_Spawned) {
-		Log(LogNotice, "WorkQueue")
+		Log(LogNotice, "WorkQueue", nullptr)
 			<< "Spawning WorkQueue threads for '" << m_Name << "'";
 
 		for (int i = 0; i < m_ThreadCount; i++) {
@@ -121,7 +121,7 @@ void WorkQueue::Join(bool stop)
 		m_Threads.join_all();
 		m_Spawned = false;
 
-		Log(LogNotice, "WorkQueue")
+		Log(LogNotice, "WorkQueue", nullptr)
 			<< "Stopped WorkQueue threads for '" << m_Name << "'";
 	}
 }
@@ -175,11 +175,11 @@ void WorkQueue::ReportExceptions(const String& facility, bool verbose) const
 	std::vector<std::exception_ptr> exceptions = GetExceptions();
 
 	for (const auto& eptr : exceptions) {
-		Log(LogCritical, facility)
+		Log(LogCritical, facility, nullptr)
 			<< DiagnosticInformation(eptr, verbose);
 	}
 
-	Log(LogCritical, facility)
+	Log(LogCritical, facility, nullptr)
 		<< exceptions.size() << " error" << (exceptions.size() != 1 ? "s" : "");
 }
 
@@ -217,7 +217,7 @@ void WorkQueue::StatusTimerHandler()
 
 	/* Log if there are pending items, or 5 minute timeout is reached. */
 	if (pending > 0 || m_StatusTimerTimeout < now) {
-		Log(m_StatsLogLevel, "WorkQueue")
+		Log(m_StatsLogLevel, "WorkQueue", nullptr)
 			<< "#" << m_ID << " (" << m_Name << ") "
 			<< "items: " << pending << ", "
 			<< "rate: " << std::setw(2) << GetTaskCount(60) / 60.0 << "/s "

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -62,7 +62,7 @@ void CheckerComponent::Start(bool runtimeCreated)
 {
 	ObjectImpl<CheckerComponent>::Start(runtimeCreated);
 
-	Log(LogInformation, "CheckerComponent")
+	Log(LogInformation, "CheckerComponent", this)
 		<< "'" << GetName() << "' started.";
 
 
@@ -86,7 +86,7 @@ void CheckerComponent::Stop(bool runtimeRemoved)
 	m_ResultTimer->Stop(true);
 	m_Thread.join();
 
-	Log(LogInformation, "CheckerComponent")
+	Log(LogInformation, "CheckerComponent", this)
 		<< "'" << GetName() << "' stopped.";
 
 	ObjectImpl<CheckerComponent>::Stop(runtimeRemoved);
@@ -140,7 +140,7 @@ void CheckerComponent::CheckThreadProc()
 
 		if (!forced) {
 			if (!checkable->IsReachable(DependencyCheckExecution)) {
-				Log(LogNotice, "CheckerComponent")
+				Log(LogNotice, "CheckerComponent", checkable)
 					<< "Skipping check for object '" << checkable->GetName() << "': Dependency failed.";
 				check = false;
 			}
@@ -150,12 +150,12 @@ void CheckerComponent::CheckThreadProc()
 			tie(host, service) = GetHostService(checkable);
 
 			if (host && !service && (!checkable->GetEnableActiveChecks() || !icingaApp->GetEnableHostChecks())) {
-				Log(LogNotice, "CheckerComponent")
+				Log(LogNotice, "CheckerComponent", host)
 					<< "Skipping check for host '" << host->GetName() << "': active host checks are disabled";
 				check = false;
 			}
 			if (host && service && (!checkable->GetEnableActiveChecks() || !icingaApp->GetEnableServiceChecks())) {
-				Log(LogNotice, "CheckerComponent")
+				Log(LogNotice, "CheckerComponent", service)
 					<< "Skipping check for service '" << service->GetName() << "': active service checks are disabled";
 				check = false;
 			}
@@ -173,7 +173,7 @@ void CheckerComponent::CheckThreadProc()
 						nextCheck = tp->GetValidEnd();
 					}
 
-					Log(LogNotice, "CheckerComponent")
+					Log(LogNotice, "CheckerComponent", checkable)
 						<< "Skipping check for object '" << checkable->GetName()
 						<< "', as not in check period '" << tp->GetName() << "', until "
 						<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", nextCheck);
@@ -191,7 +191,7 @@ void CheckerComponent::CheckThreadProc()
 			if (nextCheck > 0) {
 				checkable->SetNextCheck(nextCheck);
 			} else {
-				Log(LogDebug, "CheckerComponent")
+				Log(LogDebug, "CheckerComponent", checkable)
 					<< "Checks for checkable '" << checkable->GetName() << "' are disabled. Rescheduling check.";
 
 				checkable->UpdateNextCheck();
@@ -205,7 +205,7 @@ void CheckerComponent::CheckThreadProc()
 
 		csi = GetCheckableScheduleInfo(checkable);
 
-		Log(LogDebug, "CheckerComponent")
+		Log(LogDebug, "CheckerComponent", checkable)
 			<< "Scheduling info for checkable '" << checkable->GetName() << "' ("
 			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", checkable->GetNextCheck()) << "): Object '"
 			<< csi.Object->GetName() << "', Next Check: "
@@ -221,7 +221,7 @@ void CheckerComponent::CheckThreadProc()
 			checkable->SetForceNextCheck(false);
 		}
 
-		Log(LogDebug, "CheckerComponent")
+		Log(LogDebug, "CheckerComponent", checkable)
 			<< "Executing check for '" << checkable->GetName() << "'";
 
 		Checkable::IncreasePendingChecks();
@@ -257,7 +257,7 @@ void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable)
 
 		checkable->ProcessCheckResult(cr, m_WaitGroup);
 
-		Log(LogCritical, "checker", output);
+		Log(LogCritical, "checker", checkable, output);
 	}
 
 	Checkable::DecreasePendingChecks();
@@ -280,7 +280,7 @@ void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable)
 		}
 	}
 
-	Log(LogDebug, "CheckerComponent")
+	Log(LogDebug, "CheckerComponent", checkable)
 		<< "Check finished for object '" << checkable->GetName() << "'";
 }
 
@@ -295,7 +295,7 @@ void CheckerComponent::ResultTimerHandler()
 			<< (CIB::GetActiveHostChecksStatistics(60) + CIB::GetActiveServiceChecksStatistics(60)) / 60.0;
 	}
 
-	Log(LogNotice, "CheckerComponent", msgbuf.str());
+	Log(LogNotice, "CheckerComponent", this, msgbuf.str());
 }
 
 void CheckerComponent::ObjectHandler(const ConfigObject::Ptr& object)

--- a/lib/cli/apisetuputility.cpp
+++ b/lib/cli/apisetuputility.cpp
@@ -58,10 +58,10 @@ bool ApiSetupUtility::SetupMaster(const String& cn, bool prompt_restart)
 
 bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 {
-	Log(LogInformation, "cli", "Generating new CA.");
+	Log(LogInformation, "cli", nullptr, "Generating new CA.");
 
 	if (PkiUtility::NewCa() > 0)
-		Log(LogWarning, "cli", "Found CA, skipping and using the existing one.");
+		Log(LogWarning, "cli", nullptr, "Found CA, skipping and using the existing one.");
 
 	String pki_path = ApiListener::GetCertsDir();
 	Utility::MkDirP(pki_path, 0700);
@@ -70,7 +70,7 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 	String group = Configuration::RunAsGroup;
 
 	if (!Utility::SetFileOwnership(pki_path, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << pki_path << "'.";
 	}
 
@@ -78,12 +78,12 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 	String csr = pki_path + "/" + cn + ".csr";
 
 	if (Utility::PathExists(key)) {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Private key file '" << key << "' already exists, not generating new certificate.";
 		return true;
 	}
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Generating new CSR in '" << csr << "'.";
 
 	if (Utility::PathExists(key))
@@ -92,21 +92,21 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 		NodeUtility::CreateBackupFile(csr);
 
 	if (PkiUtility::NewCert(cn, key, csr, "") > 0) {
-		Log(LogCritical, "cli", "Failed to create certificate signing request.");
+		Log(LogCritical, "cli", nullptr, "Failed to create certificate signing request.");
 		return false;
 	}
 
 	/* Sign the CSR with the CA key */
 	String cert = pki_path + "/" + cn + ".crt";
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Signing CSR with CA and writing certificate to '" << cert << "'.";
 
 	if (Utility::PathExists(cert))
 		NodeUtility::CreateBackupFile(cert);
 
 	if (PkiUtility::SignCsr(csr, cert) != 0) {
-		Log(LogCritical, "cli", "Could not sign CSR.");
+		Log(LogCritical, "cli", nullptr, "Could not sign CSR.");
 		return false;
 	}
 
@@ -116,7 +116,7 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 	String ca_key = ca_path + "/ca.key";
 	String target_ca = pki_path + "/ca.crt";
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Copying CA certificate to '" << target_ca << "'.";
 
 	if (Utility::PathExists(target_ca))
@@ -128,7 +128,7 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 	/* fix permissions: root -> icinga daemon user */
 	for (const String& file : { ca_path, ca, ca_key, target_ca, key, csr, cert }) {
 		if (!Utility::SetFileOwnership(file, user, group)) {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << file << "'.";
 		}
 	}
@@ -139,9 +139,9 @@ bool ApiSetupUtility::SetupMasterCertificates(const String& cn)
 bool ApiSetupUtility::SetupMasterApiUser()
 {
 	if (!Utility::PathExists(GetConfdPath())) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Path '" << GetConfdPath() << "' do not exist.";
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Creating path '" << GetConfdPath() << "'.";
 
 		Utility::MkDirP(GetConfdPath(), 0755);
@@ -152,12 +152,12 @@ bool ApiSetupUtility::SetupMasterApiUser()
 	String apiUsersPath = GetConfdPath() + "/api-users.conf";
 
 	if (Utility::PathExists(apiUsersPath)) {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "API user config file '" << apiUsersPath << "' already exists, not creating config file.";
 		return true;
 	}
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Adding new ApiUser '" << api_username << "' in '" << apiUsersPath << "'.";
 
 	NodeUtility::CreateBackupFile(apiUsersPath);
@@ -190,7 +190,7 @@ bool ApiSetupUtility::SetupMasterEnableApi()
 	/*
 	* Enable the API feature
 	*/
-	Log(LogInformation, "cli", "Enabling the 'api' feature.");
+	Log(LogInformation, "cli", nullptr, "Enabling the 'api' feature.");
 
 	FeatureUtility::EnableFeatures({ "api" });
 

--- a/lib/cli/caremovecommand.cpp
+++ b/lib/cli/caremovecommand.cpp
@@ -62,7 +62,7 @@ int CARemoveCommand::Run(const boost::program_options::variables_map&, const std
 	String requestFile = ApiListener::GetCertificateRequestsDir() + "/" + fingerPrint + ".json";
 
 	if (!Utility::PathExists(requestFile)) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "No request exists for fingerprint '" << fingerPrint << "'.";
 		return 1;
 	}
@@ -71,14 +71,14 @@ int CARemoveCommand::Run(const boost::program_options::variables_map&, const std
 	std::shared_ptr<X509> certRequest = StringToCertificate(request->Get("cert_request"));
 
 	if (!certRequest) {
-		Log(LogCritical, "cli", "Certificate request is invalid. Could not parse X.509 certificate for the 'cert_request' attribute.");
+		Log(LogCritical, "cli", nullptr, "Certificate request is invalid. Could not parse X.509 certificate for the 'cert_request' attribute.");
 		return 1;
 	}
 
 	String cn = GetCertificateCN(certRequest);
 
 	if (request->Contains("cert_response")) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Certificate request for CN '" << cn << "' already signed, removal is not possible.";
 		return 1;
 	}
@@ -87,7 +87,7 @@ int CARemoveCommand::Run(const boost::program_options::variables_map&, const std
 
 	Utility::Remove(requestFile);
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Certificate request for CN " << cn << " removed.";
 
 	return 0;

--- a/lib/cli/carestorecommand.cpp
+++ b/lib/cli/carestorecommand.cpp
@@ -62,7 +62,7 @@ int CARestoreCommand::Run(const boost::program_options::variables_map&, const st
 	String removedRequestFile = ApiListener::GetCertificateRequestsDir() + "/" + fingerPrint + ".removed";
 
 	if (!Utility::PathExists(removedRequestFile)) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot find removed fingerprint '" << fingerPrint << "', bailing out.";
 		return 1;
 	}
@@ -71,7 +71,7 @@ int CARestoreCommand::Run(const boost::program_options::variables_map&, const st
 	std::shared_ptr<X509> certRequest = StringToCertificate(request->Get("cert_request"));
 
 	if (!certRequest) {
-		Log(LogCritical, "cli", "Certificate request is invalid. Could not parse X.509 certificate for the 'cert_request' attribute.");
+		Log(LogCritical, "cli", nullptr, "Certificate request is invalid. Could not parse X.509 certificate for the 'cert_request' attribute.");
 		/* Purge the file when we know that it is broken. */
 		Utility::Remove(removedRequestFile);
 		return 1;
@@ -81,7 +81,7 @@ int CARestoreCommand::Run(const boost::program_options::variables_map&, const st
 
 	Utility::Remove(removedRequestFile);
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Restored certificate request for CN '" << GetCertificateCN(certRequest) << "', sign it with:\n"
 	       	<< "\"icinga2 ca sign " << fingerPrint << "\"";
 

--- a/lib/cli/casigncommand.cpp
+++ b/lib/cli/casigncommand.cpp
@@ -61,7 +61,7 @@ int CASignCommand::Run(const boost::program_options::variables_map&, const std::
 	String requestFile = ApiListener::GetCertificateRequestsDir() + "/" + ap[0] + ".json";
 
 	if (!Utility::PathExists(requestFile)) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "No request exists for fingerprint '" << ap[0] << "'.";
 		return 1;
 	}
@@ -76,7 +76,7 @@ int CASignCommand::Run(const boost::program_options::variables_map&, const std::
 	std::shared_ptr<X509> certRequest = StringToCertificate(certRequestText);
 
 	if (!certRequest) {
-		Log(LogCritical, "cli", "Certificate request is invalid. Could not parse X.509 certificate for the 'cert_request' attribute.");
+		Log(LogCritical, "cli", nullptr, "Certificate request is invalid. Could not parse X.509 certificate for the 'cert_request' attribute.");
 		return 1;
 	}
 
@@ -93,7 +93,7 @@ int CASignCommand::Run(const boost::program_options::variables_map&, const std::
 	BIO_free(out);
 
 	if (!certResponse) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Could not sign certificate for '" << subject << "'.";
 		return 1;
 	}
@@ -102,7 +102,7 @@ int CASignCommand::Run(const boost::program_options::variables_map&, const std::
 
 	Utility::SaveJsonFile(requestFile, 0600, request);
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Signed certificate for '" << subject << "'.";
 
 	return 0;

--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -265,7 +265,7 @@ int ConsoleCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std:
 		try {
 			l_Url = new Url(addr);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "ConsoleCommand", ex.what());
+			Log(LogCritical, "ConsoleCommand", nullptr, ex.what());
 			return EXIT_FAILURE;
 		}
 
@@ -459,7 +459,7 @@ incomplete:
 					/* Re-throw the exception for the outside try-catch block. */
 					throw;
 				} catch (const std::exception& ex) {
-					Log(LogCritical, "ConsoleCommand")
+					Log(LogCritical, "ConsoleCommand", nullptr)
 						<< "HTTP query failed: " << ex.what();
 
 #ifdef HAVE_EDITLINE
@@ -549,7 +549,7 @@ Shared<AsioTlsStream>::Ptr ConsoleCommand::Connect()
 	try {
 		sslContext = MakeAsioSslContext(l_CertPath, l_KeyPath, l_CaPath);
 	} catch(const std::exception& ex) {
-		Log(LogCritical, "DebugConsole")
+		Log(LogCritical, "DebugConsole", nullptr)
 			<< "Cannot make SSL context: " << ex.what();
 		throw;
 	}
@@ -562,7 +562,7 @@ Shared<AsioTlsStream>::Ptr ConsoleCommand::Connect()
 	try {
 		icinga::Connect(stream->lowest_layer(), host, port);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "DebugConsole")
+		Log(LogWarning, "DebugConsole", nullptr)
 			<< "Cannot connect to REST API on host '" << host << "' port '" << port << "': " << ex.what();
 		throw;
 	}
@@ -572,14 +572,14 @@ Shared<AsioTlsStream>::Ptr ConsoleCommand::Connect()
 	try {
 		tlsStream.handshake(tlsStream.client);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "DebugConsole")
+		Log(LogWarning, "DebugConsole", nullptr)
 			<< "TLS handshake with host '" << host << "' failed: " << ex.what();
 		throw;
 	}
 
 	if (!tlsStream.IsVerifyOK()) {
 		String message = "TLS certificate verification for common name '" + l_CommonName + "' failed: " + tlsStream.GetVerifyError();
-		Log(LogCritical, "DebugConsole", message);
+		Log(LogCritical, "DebugConsole", nullptr, message);
 		BOOST_THROW_EXCEPTION(std::runtime_error(message));
 	}
 
@@ -616,7 +616,7 @@ Dictionary::Ptr ConsoleCommand::SendRequest()
 		http::write(*l_TlsStream, request);
 		l_TlsStream->flush();
 	} catch (const std::exception &ex) {
-		Log(LogWarning, "DebugConsole")
+		Log(LogWarning, "DebugConsole", nullptr)
 			<< "Cannot write HTTP request to REST API at URL '" << l_Url->Format(true) << "': " << ex.what();
 		throw;
 	}
@@ -627,7 +627,7 @@ Dictionary::Ptr ConsoleCommand::SendRequest()
 	try {
 		http::read(*l_TlsStream, buf, parser);
 	} catch (const std::exception &ex) {
-		Log(LogWarning, "DebugConsole")
+		Log(LogWarning, "DebugConsole", nullptr)
 			<< "Failed to parse HTTP response from REST API at URL '" << l_Url->Format(true) << "': " << ex.what();
 		throw;
 	}

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -72,14 +72,14 @@ static void Daemonize() noexcept
 	try {
 		Application::UninitializeBase();
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Failed to stop thread pool before daemonizing, unexpected error: " << DiagnosticInformation(ex);
 		exit(EXIT_FAILURE);
 	}
 
 	pid_t pid = fork();
 	if (pid == -1) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "fork() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 		exit(EXIT_FAILURE);
 	}
@@ -99,10 +99,10 @@ static void Daemonize() noexcept
 		} while (readpid != pid && ret == 0);
 
 		if (ret == pid) {
-			Log(LogCritical, "cli", "The daemon could not be started. See log output for details.");
+			Log(LogCritical, "cli", nullptr, "The daemon could not be started. See log output for details.");
 			_exit(EXIT_FAILURE);
 		} else if (ret == -1) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "waitpid() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 			_exit(EXIT_FAILURE);
 		}
@@ -110,13 +110,13 @@ static void Daemonize() noexcept
 		_exit(EXIT_SUCCESS);
 	}
 
-	Log(LogDebug, "Daemonize()")
+	Log(LogDebug, "Daemonize()", nullptr)
 		<< "Child process with PID " << Utility::GetPid() << " continues; re-initializing base.";
 
 	// Detach from controlling terminal
 	pid_t sid = setsid();
 	if (sid == -1) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "setsid() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 		exit(EXIT_FAILURE);
 	}
@@ -124,7 +124,7 @@ static void Daemonize() noexcept
 	try {
 		Application::InitializeBase();
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Failed to re-initialize thread pool after daemonizing: " << DiagnosticInformation(ex);
 		exit(EXIT_FAILURE);
 	}
@@ -250,32 +250,32 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 	double delay = GetDebugWorkerDelay();
 
 	if (delay > 0.0) {
-		Log(LogInformation, "RunWorker")
+		Log(LogInformation, "RunWorker", nullptr)
 			<< "DEBUG: Current PID: " << Utility::GetPid() << ". Sleeping for " << delay << " seconds to allow lldb/gdb -p <PID> attachment.";
 
 		Utility::Sleep(delay);
 	}
 #endif /* I2_DEBUG */
 
-	Log(LogInformation, "cli", "Loading configuration file(s).");
+	Log(LogInformation, "cli", nullptr, "Loading configuration file(s).");
 	NotifyStatus("Loading configuration file(s)...");
 
 	{
 		std::vector<ConfigItem::Ptr> newItems;
 
 		if (!DaemonUtility::LoadConfigFiles(configs, newItems, l_ObjectsPath, Configuration::VarsPath)) {
-			Log(LogCritical, "cli", "Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.");
+			Log(LogCritical, "cli", nullptr, "Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.");
 			NotifyStatus("Config validation failed.");
 			return EXIT_FAILURE;
 		}
 
 #ifndef _WIN32
-		Log(LogNotice, "cli")
+		Log(LogNotice, "cli", nullptr)
 			<< "Notifying umbrella process (PID " << l_UmbrellaPid << ") about the config loading success";
 
 		(void)kill(l_UmbrellaPid, SIGUSR2);
 
-		Log(LogNotice, "cli")
+		Log(LogNotice, "cli", nullptr)
 			<< "Waiting for the umbrella process to let us doing the actual work";
 
 		NotifyStatus("Waiting for the umbrella process to let us doing the actual work...");
@@ -289,7 +289,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 			Utility::Sleep(0.2);
 		}
 
-		Log(LogNotice, "cli")
+		Log(LogNotice, "cli", nullptr)
 			<< "The umbrella process let us continuing";
 #endif /* _WIN32 */
 
@@ -299,7 +299,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 		try {
 			ConfigObject::RestoreObjects(Configuration::StatePath);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Failed to restore state file: " << DiagnosticInformation(ex);
 
 			NotifyStatus("Failed to restore state file.");
@@ -311,7 +311,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 
 		// activate config only after daemonization: it starts threads and that is not compatible with fork()
 		if (!ConfigItem::ActivateItems(newItems, false, true, true)) {
-			Log(LogCritical, "cli", "Error activating configuration.");
+			Log(LogCritical, "cli", nullptr, "Error activating configuration.");
 
 			NotifyStatus("Error activating configuration.");
 
@@ -327,7 +327,7 @@ int RunWorker(const std::vector<std::string>& configs, bool closeConsoleLog = fa
 		String configDir = ConfigObjectUtility::GetConfigDir();
 		ConfigItem::RemoveIgnoredItems(configDir);
 	} catch (const std::exception& ex) {
-		Log(LogNotice, "cli")
+		Log(LogNotice, "cli", nullptr)
 			<< "Cannot clean ignored downtimes/comments: " << ex.what();
 	}
 
@@ -468,13 +468,13 @@ static void NotifyWatchdog()
  */
 static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool closeConsoleLog = false, const String& stderrFile = String())
 {
-	Log(LogNotice, "cli")
+	Log(LogNotice, "cli", nullptr)
 		<< "Spawning seamless worker process doing the actual work";
 
 	try {
 		Application::UninitializeBase();
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Failed to stop thread pool before forking, unexpected error: " << DiagnosticInformation(ex);
 		exit(EXIT_FAILURE);
 	}
@@ -488,13 +488,13 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 
 	switch (pid) {
 		case -1:
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "fork() failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 
 			try {
 				Application::InitializeBase();
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "cli")
+				Log(LogCritical, "cli", nullptr)
 					<< "Failed to re-initialize thread pool after forking (parent): " << DiagnosticInformation(ex);
 				exit(EXIT_FAILURE);
 			}
@@ -540,7 +540,7 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 				try {
 					Application::InitializeBase();
 				} catch (const std::exception& ex) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Failed to re-initialize thread pool after forking (child): " << DiagnosticInformation(ex);
 					_exit(EXIT_FAILURE);
 				}
@@ -548,14 +548,14 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 				try {
 					Process::InitializeSpawnHelper();
 				} catch (const std::exception& ex) {
-					Log(LogCritical, "cli")
+					Log(LogCritical, "cli", nullptr)
 						<< "Failed to initialize process spawn helper after forking (child): " << DiagnosticInformation(ex);
 					_exit(EXIT_FAILURE);
 				}
 
 				_exit(RunWorker(configs, closeConsoleLog, stderrFile));
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "cli") << "Exception in main process: " << DiagnosticInformation(ex);
+				Log(LogCritical, "cli", nullptr) << "Exception in main process: " << DiagnosticInformation(ex);
 				_exit(EXIT_FAILURE);
 			} catch (...) {
 				_exit(EXIT_FAILURE);
@@ -565,7 +565,7 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 			l_CurrentlyStartingUnixWorkerPid.store(pid);
 			(void)sigprocmask(SIG_UNBLOCK, &l_UnixWorkerSignals, nullptr);
 
-			Log(LogNotice, "cli")
+			Log(LogNotice, "cli", nullptr)
 				<< "Spawned worker process (PID " << pid << "), waiting for it to load its config";
 
 			// Wait for the newly spawned process to either load its config or fail.
@@ -575,7 +575,7 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 #endif /* HAVE_SYSTEMD */
 
 				if (waitpid(pid, nullptr, WNOHANG) > 0) {
-					Log(LogNotice, "cli")
+					Log(LogNotice, "cli", nullptr)
 						<< "Worker process couldn't load its config";
 
 					pid = -2;
@@ -583,7 +583,7 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 				}
 
 				if (l_CurrentlyStartingUnixWorkerReady.load()) {
-					Log(LogNotice, "cli")
+					Log(LogNotice, "cli", nullptr)
 						<< "Worker process successfully loaded its config";
 					break;
 				}
@@ -598,7 +598,7 @@ static pid_t StartUnixWorker(const std::vector<std::string>& configs, bool close
 			try {
 				Application::InitializeBase();
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "cli")
+				Log(LogCritical, "cli", nullptr)
 					<< "Failed to re-initialize thread pool after forking (parent): " << DiagnosticInformation(ex);
 				exit(EXIT_FAILURE);
 			}
@@ -633,7 +633,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 
 	Logger::EnableTimestamp();
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Icinga application loader (version: " << Application::GetAppVersion()
 #ifdef I2_DEBUG
 		<< "; debug"
@@ -651,7 +651,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 
 	if (vm.count("dump-objects")) {
 		if (!vm.count("validate")) {
-			Log(LogCritical, "cli", "--dump-objects is not allowed without -C");
+			Log(LogCritical, "cli", nullptr, "--dump-objects is not allowed without -C");
 			return EXIT_FAILURE;
 		}
 
@@ -659,23 +659,23 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 	}
 
 	if (vm.count("validate")) {
-		Log(LogInformation, "cli", "Loading configuration file(s).");
+		Log(LogInformation, "cli", nullptr, "Loading configuration file(s).");
 
 		std::vector<ConfigItem::Ptr> newItems;
 
 		if (!DaemonUtility::LoadConfigFiles(configs, newItems, l_ObjectsPath, Configuration::VarsPath)) {
-			Log(LogCritical, "cli", "Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.");
+			Log(LogCritical, "cli", nullptr, "Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.");
 			return EXIT_FAILURE;
 		}
 
-		Log(LogInformation, "cli", "Finished validating the configuration file(s).");
+		Log(LogInformation, "cli", nullptr, "Finished validating the configuration file(s).");
 		return EXIT_SUCCESS;
 	}
 
 	{
 		pid_t runningpid = Application::ReadPidFile(Configuration::PidPath);
 		if (runningpid > 0) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Another instance of Icinga already running with PID " << runningpid;
 			return EXIT_FAILURE;
 		}
@@ -697,7 +697,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 	try {
 		app.UpdatePidFile(Configuration::PidPath);
 	} catch (const std::exception&) {
-		Log(LogCritical, "Application")
+		Log(LogCritical, "Application", nullptr)
 			<< "Cannot update PID file '" << Configuration::PidPath << "'. Aborting.";
 		return EXIT_FAILURE;
 	}
@@ -710,7 +710,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 	if (vm.count("daemonize")) {
 		// After disabling the console log, any further errors will go to the configured log only.
 		// Let's try to make this clear and say good bye.
-		Log(LogInformation, "cli", "Closing console log.");
+		Log(LogInformation, "cli", nullptr, "Closing console log.");
 
 		String errorLog;
 		if (vm.count("errorlog"))
@@ -724,7 +724,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 	try {
 		return RunWorker(configs);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")	<< "Exception in main process: " << DiagnosticInformation(ex);
+		Log(LogCritical, "cli", nullptr) << "Exception in main process: " << DiagnosticInformation(ex);
 		return EXIT_FAILURE;
 	} catch (...) {
 		return EXIT_FAILURE;
@@ -763,7 +763,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 	if (closeConsoleLog) {
 		// After disabling the console log, any further errors will go to the configured log only.
 		// Let's try to make this clear and say good bye.
-		Log(LogInformation, "cli", "Closing console log.");
+		Log(LogInformation, "cli", nullptr, "Closing console log.");
 
 		CloseStdIO(errorLog);
 		Logger::DisableConsoleLog();
@@ -792,7 +792,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 		if (!requestedTermination) {
 			int termSig = l_TermSignal.load();
 			if (termSig != -1) {
-				Log(LogNotice, "cli")
+				Log(LogNotice, "cli", nullptr)
 					<< "Got signal " << termSig << ", forwarding to seamless worker (PID " << currentWorker << ")";
 
 				(void)kill(currentWorker, termSig);
@@ -808,7 +808,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 		}
 
 		if (l_RequestedReload.exchange(false)) {
-			Log(LogInformation, "Application")
+			Log(LogInformation, "Application", nullptr)
 				<< "Got reload command: Starting new instance.";
 
 #ifdef HAVE_SYSTEMD
@@ -825,11 +825,11 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 				case -1:
 					break;
 				case -2:
-					Log(LogCritical, "Application", "Found error in config: reloading aborted");
+					Log(LogCritical, "Application", nullptr, "Found error in config: reloading aborted");
 					Application::SetLastReloadFailed(Utility::GetTime());
 					break;
 				default:
-					Log(LogInformation, "Application")
+					Log(LogInformation, "Application", nullptr)
 						<< "Reload done, old process shutting down. Child process with PID '" << nextWorker << "' is taking over.";
 
 					NotifyStatus("Shutting down old instance...");
@@ -846,7 +846,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 	#endif /* HAVE_SYSTEMD */
 						}
 
-						Log(LogNotice, "cli")
+						Log(LogNotice, "cli", nullptr)
 							<< "Waited for " << Utility::FormatDuration(Utility::GetTime() - start) << " on old process to exit.";
 					}
 
@@ -865,7 +865,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 		}
 
 		if (l_RequestedReopenLogs.exchange(false)) {
-			Log(LogNotice, "cli")
+			Log(LogNotice, "cli", nullptr)
 				<< "Got signal " << SIGUSR1 << ", forwarding to seamless worker (PID " << currentWorker << ")";
 
 			(void)kill(currentWorker, SIGUSR1);
@@ -874,7 +874,7 @@ int DaemonCommand::Run(const po::variables_map& vm, [[maybe_unused]] const std::
 		{
 			int status;
 			if (waitpid(currentWorker, &status, WNOHANG) > 0) {
-				Log(LogNotice, "cli")
+				Log(LogNotice, "cli", nullptr)
 					<< "Seamless worker (PID " << currentWorker << ") stopped, stopping as well";
 
 #ifdef HAVE_SYSTEMD

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -25,7 +25,7 @@ static bool ExecuteExpression(Expression *expression)
 		ScriptFrame frame(true);
 		expression->Evaluate(frame);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "config", DiagnosticInformation(ex));
+		Log(LogCritical, "config", nullptr, DiagnosticInformation(ex));
 		return false;
 	}
 
@@ -76,7 +76,7 @@ static bool IncludeNonLocalZone(const String& zonePath, const String& package, b
 	 * from zones.d in etc or api package directory, or a local marker file)
 	 */
 	if (ConfigCompiler::HasZoneConfigAuthority(zoneName) || Utility::PathExists(zonePath + "/.authoritative")) {
-		Log(LogNotice, "config")
+		Log(LogNotice, "config", nullptr)
 			<< "Ignoring non local config include for zone '" << zoneName << "': We already have an authoritative copy included.";
 		return true;
 	}
@@ -129,7 +129,7 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 				if (!success)
 					return false;
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "cli", "Could not compile config files: " + DiagnosticInformation(ex, false));
+				Log(LogCritical, "cli", nullptr, "Could not compile config files: " + DiagnosticInformation(ex, false));
 				Application::Exit(1);
 			}
 		}
@@ -162,7 +162,7 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 			}
 
 			for (auto& zoneEtcDir : zoneEtcDirs) {
-				Log(LogWarning, "config")
+				Log(LogWarning, "config", nullptr)
 					<< "Ignoring directory '" << zoneEtcDir << "' for unknown zone '" << Utility::BaseName(zoneEtcDir) << "'.";
 			}
 		}
@@ -187,7 +187,7 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 	if (internalNS->Contains("ZonesStageVarDir")) {
 		zonesVarDir = internalNS->Get("ZonesStageVarDir");
 
-		Log(LogNotice, "DaemonUtility")
+		Log(LogNotice, "DaemonUtility", nullptr)
 			<< "Overriding zones var directory with '" << zonesVarDir << "' for cluster config sync staging.";
 	}
 
@@ -211,7 +211,7 @@ bool DaemonUtility::ValidateConfigFiles(const std::vector<std::string>& configs,
 		}
 
 		for (auto& zoneEtcDir : zoneVarDirs) {
-			Log(LogWarning, "config")
+			Log(LogWarning, "config", nullptr)
 				<< "Ignoring directory '" << zoneEtcDir << "' for unknown zone '" << Utility::BaseName(zoneEtcDir) << "'.";
 		}
 	}
@@ -265,7 +265,7 @@ bool DaemonUtility::LoadConfigFiles(const std::vector<std::string>& configs,
 	try {
 		ScriptGlobal::WriteToFile(varsfile);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli", "Could not write vars file: " + DiagnosticInformation(ex, false));
+		Log(LogCritical, "cli", nullptr, "Could not write vars file: " + DiagnosticInformation(ex, false));
 		Application::Exit(1);
 	}
 

--- a/lib/cli/featuredisablecommand.cpp
+++ b/lib/cli/featuredisablecommand.cpp
@@ -48,7 +48,7 @@ ImpersonationLevel FeatureDisableCommand::GetImpersonationLevel() const
 int FeatureDisableCommand::Run(const boost::program_options::variables_map&, const std::vector<std::string>& ap) const
 {
 	if (ap.empty()) {
-		Log(LogCritical, "cli", "Cannot disable feature(s). Name(s) are missing!");
+		Log(LogCritical, "cli", nullptr, "Cannot disable feature(s). Name(s) are missing!");
 		return 0;
 	}
 

--- a/lib/cli/featureutility.cpp
+++ b/lib/cli/featureutility.cpp
@@ -46,13 +46,13 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 	String features_enabled_dir = GetFeaturesEnabledPath();
 
 	if (!Utility::PathExists(features_available_dir) ) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot parse available features. Path '" << features_available_dir << "' does not exist.";
 		return 1;
 	}
 
 	if (!Utility::PathExists(features_enabled_dir) ) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot enable features. Path '" << features_enabled_dir << "' does not exist.";
 		return 1;
 	}
@@ -63,7 +63,7 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 		String source = features_available_dir + "/" + feature + ".conf";
 
 		if (!Utility::PathExists(source) ) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot enable feature '" << feature << "'. Source file '" << source + "' does not exist.";
 			errors.push_back(feature);
 			continue;
@@ -72,7 +72,7 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 		String target = features_enabled_dir + "/" + feature + ".conf";
 
 		if (Utility::PathExists(target) ) {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Feature '" << feature << "' already enabled.";
 			continue;
 		}
@@ -84,7 +84,7 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 		String relativeSource = "../features-available/" + feature + ".conf";
 
 		if (symlink(relativeSource.CStr(), target.CStr()) < 0) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot enable feature '" << feature << "'. Linking source '" << relativeSource << "' to target file '" << target
 				<< "' failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\".";
 			errors.push_back(feature);
@@ -97,7 +97,7 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 		fp.close();
 
 		if (fp.fail()) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot enable feature '" << feature << "'. Failed to open file '" << target << "'.";
 			errors.push_back(feature);
 			continue;
@@ -106,7 +106,7 @@ int FeatureUtility::EnableFeatures(const std::vector<std::string>& features)
 	}
 
 	if (!errors.empty()) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot enable feature(s): " << boost::algorithm::join(errors, " ");
 		errors.clear();
 		return 1;
@@ -120,7 +120,7 @@ int FeatureUtility::DisableFeatures(const std::vector<std::string>& features)
 	String features_enabled_dir = GetFeaturesEnabledPath();
 
 	if (!Utility::PathExists(features_enabled_dir) ) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot disable features. Path '" << features_enabled_dir << "' does not exist.";
 		return 0;
 	}
@@ -131,13 +131,13 @@ int FeatureUtility::DisableFeatures(const std::vector<std::string>& features)
 		String target = features_enabled_dir + "/" + feature + ".conf";
 
 		if (!Utility::PathExists(target) ) {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Feature '" << feature << "' already disabled.";
 			continue;
 		}
 
 		if (unlink(target.CStr()) < 0) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot disable feature '" << feature << "'. Unlinking target file '" << target
 				<< "' failed with error code " << errno << ", \"" + Utility::FormatErrorNumber(errno) << "\".";
 			errors.push_back(feature);
@@ -149,7 +149,7 @@ int FeatureUtility::DisableFeatures(const std::vector<std::string>& features)
 	}
 
 	if (!errors.empty()) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot disable feature(s): " << boost::algorithm::join(errors, " ");
 		errors.clear();
 		return 1;
@@ -238,7 +238,7 @@ void FeatureUtility::CollectFeatures(const String& feature_file, std::vector<Str
 	String feature = Utility::BaseName(feature_file);
 	boost::algorithm::replace_all(feature, ".conf", "");
 
-	Log(LogDebug, "cli")
+	Log(LogDebug, "cli", nullptr)
 		<< "Adding feature: " << feature;
 	features.push_back(feature);
 }

--- a/lib/cli/internalsignalcommand.cpp
+++ b/lib/cli/internalsignalcommand.cpp
@@ -61,9 +61,9 @@ int InternalSignalCommand::Run(const boost::program_options::variables_map& vm, 
 	if (signal == "SIGUSR1")
 		return kill(vm["pid"].as<int>(), SIGUSR1);
 
-	Log(LogCritical, "cli") << "Unsupported signal \"" << signal << "\"";
+	Log(LogCritical, "cli", nullptr) << "Unsupported signal \"" << signal << "\"";
 #else
-	Log(LogCritical, "cli", "Unsupported action on Windows.");
+	Log(LogCritical, "cli", nullptr, "Unsupported action on Windows.");
 #endif /* _Win32 */
 	return 1;
 }

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -85,7 +85,7 @@ ImpersonationLevel NodeSetupCommand::GetImpersonationLevel() const
 int NodeSetupCommand::Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const
 {
 	if (!ap.empty()) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Ignoring parameters: " << boost::algorithm::join(ap, " ");
 	}
 
@@ -99,13 +99,13 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 {
 	/* Ignore not required parameters */
 	if (vm.count("ticket"))
-		Log(LogWarning, "cli", "Master for Node setup: Ignoring --ticket");
+		Log(LogWarning, "cli", nullptr, "Master for Node setup: Ignoring --ticket");
 
 	if (vm.count("endpoint"))
-		Log(LogWarning, "cli", "Master for Node setup: Ignoring --endpoint");
+		Log(LogWarning, "cli", nullptr, "Master for Node setup: Ignoring --endpoint");
 
 	if (vm.count("trustedcert"))
-		Log(LogWarning, "cli", "Master for Node setup: Ignoring --trustedcert");
+		Log(LogWarning, "cli", nullptr, "Master for Node setup: Ignoring --trustedcert");
 
 	String cn = Utility::GetFQDN();
 
@@ -124,31 +124,31 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 	/* check whether the user wants to generate a new certificate or not */
 	String existingPath = ApiListener::GetCertsDir() + "/" + cn + ".crt";
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Checking in existing certificates for common name '" << cn << "'...";
 
 	if (Utility::PathExists(existingPath)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Certificate '" << existingPath << "' for CN '" << cn << "' already exists. Not generating new certificate.";
 	} else {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Certificates not yet generated. Running 'api setup' now.";
 
 		ApiSetupUtility::SetupMasterCertificates(cn);
 	}
 
-	Log(LogInformation, "cli", "Generating master configuration for Icinga 2.");
+	Log(LogInformation, "cli", nullptr, "Generating master configuration for Icinga 2.");
 	ApiSetupUtility::SetupMasterApiUser();
 
 	if (!FeatureUtility::CheckFeatureEnabled("api")) {
 		ApiSetupUtility::SetupMasterEnableApi();
 	} else {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "'api' feature already enabled.\n";
 	}
 
 	/* write zones.conf and update with zone + endpoint information */
-	Log(LogInformation, "cli", "Generating zone and object configuration.");
+	Log(LogInformation, "cli", nullptr, "Generating zone and object configuration.");
 
 	std::vector<String> globalZones {};
 	if (!vm.count("no-default-global-zones")) {
@@ -161,7 +161,7 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 
 	for (decltype(setupGlobalZones.size()) i = 0; i < setupGlobalZones.size(); i++) {
 		if (std::find(globalZones.begin(), globalZones.end(), setupGlobalZones[i]) != globalZones.end()) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "The global zone '" << setupGlobalZones[i] << "' is already specified.";
 			return 1;
 		}
@@ -173,7 +173,7 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 	NodeUtility::GenerateNodeMasterIcingaConfig(endpointName, zoneName, globalZones);
 
 	/* Update the ApiListener config. */
-	Log(LogInformation, "cli", "Updating the APIListener feature.");
+	Log(LogInformation, "cli", nullptr, "Updating the APIListener feature.");
 
 	String apipath = FeatureUtility::GetFeaturesAvailablePath() + "/api.conf";
 	NodeUtility::CreateBackupFile(apipath);
@@ -214,7 +214,7 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 
 	/* update constants.conf with NodeName = CN + TicketSalt = random value */
 	if (endpointName != Utility::GetFQDN()) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "CN/Endpoint name '" <<  endpointName << "' does not match the default FQDN '" << Utility::GetFQDN() << "'. Requires update for NodeName constant in constants.conf!";
 	}
 
@@ -225,16 +225,16 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 
 	NodeUtility::UpdateConstant("TicketSalt", salt);
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Edit the api feature config file '" << apipath << "' and set a secure 'ticket_salt' attribute.";
 
 	if (vm.count("disable-confd")) {
 		/* Disable conf.d inclusion */
 		if (NodeUtility::UpdateConfiguration("\"conf.d\"", false, true)) {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "Disabled conf.d inclusion";
 		} else {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Tried to disable conf.d inclusion but failed, possibly it's already disabled.";
 		}
 
@@ -244,13 +244,13 @@ int NodeSetupCommand::SetupMaster(const boost::program_options::variables_map& v
 		if (Utility::PathExists(apiUsersFilePath)) {
 			NodeUtility::UpdateConfiguration("\"conf.d/api-users.conf\"", true, false);
 		} else {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Included file doesn't exist " << apiUsersFilePath;
 		}
 	}
 
 	/* tell the user to reload icinga2 */
-	Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
+	Log(LogInformation, "cli", nullptr, "Make sure to restart Icinga 2.");
 
 	return 0;
 }
@@ -259,20 +259,20 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 {
 	/* require at least one endpoint. Ticket is optional. */
 	if (!vm.count("endpoint")) {
-		Log(LogCritical, "cli", "You need to specify at least one endpoint (--endpoint).");
+		Log(LogCritical, "cli", nullptr, "You need to specify at least one endpoint (--endpoint).");
 		return 1;
 	}
 
 	if (!vm.count("zone")) {
-		Log(LogCritical, "cli", "You need to specify the local zone (--zone).");
+		Log(LogCritical, "cli", nullptr, "You need to specify the local zone (--zone).");
 		return 1;
 	}
 
 	/* Deprecation warnings. TODO: Remove in 2.10.0. */
 	if (vm.count("master_zone"))
-		Log(LogWarning, "cli", "The 'master_zone' parameter has been deprecated. Use 'parent_zone' instead.");
+		Log(LogWarning, "cli", nullptr, "The 'master_zone' parameter has been deprecated. Use 'parent_zone' instead.");
 	if (vm.count("master_host"))
-		Log(LogWarning, "cli", "The 'master_host' parameter has been deprecated. Use 'parent_host' instead.");
+		Log(LogWarning, "cli", nullptr, "The 'master_host' parameter has been deprecated. Use 'parent_host' instead.");
 
 	String ticket;
 
@@ -280,10 +280,10 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		ticket = vm["ticket"].as<std::string>();
 
 	if (ticket.IsEmpty()) {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Requesting certificate without a ticket.";
 	} else {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Requesting certificate with ticket '" << ticket << "'.";
 	}
 
@@ -297,7 +297,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 	if (!vm.count("master_host") && !vm.count("parent_host")) {
 		connectToParent = false;
 
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Node to master/satellite connection setup skipped. Please configure your parent node to\n"
 			<< "connect to this node by setting the 'host' attribute for the node Endpoint object.\n";
 	} else {
@@ -318,7 +318,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		if (tokens.size() == 2)
 			parentPort = tokens[1];
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Verifying parent host connection information: host '" << parentHost << "', port '" << parentPort << "'.";
 
 	}
@@ -329,7 +329,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 	if (vm.count("cn"))
 		cn = vm["cn"].as<std::string>();
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Using the following CN (defaults to FQDN): '" << cn << "'.";
 
 	/* pki request a signed certificate from the master */
@@ -340,7 +340,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 	String group = Configuration::RunAsGroup;
 
 	if (!Utility::SetFileOwnership(certsDir, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << certsDir << "'. Verify it yourself!";
 	}
 
@@ -354,13 +354,13 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		NodeUtility::CreateBackupFile(cert);
 
 	if (PkiUtility::NewCert(cn, key, String(), cert) != 0) {
-		Log(LogCritical, "cli", "Failed to generate new self-signed certificate.");
+		Log(LogCritical, "cli", nullptr, "Failed to generate new self-signed certificate.");
 		return 1;
 	}
 
 	/* fix permissions: root -> icinga daemon user */
 	if (!Utility::SetFileOwnership(key, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << key << "'. Verify it yourself!";
 	}
 
@@ -370,7 +370,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		 * the trustedParentCert to prove the trust relationship (fetched with 'pki save-cert').
 		 */
 		if (!vm.count("trustedcert")) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Please pass the trusted cert retrieved from the parent node (master or satellite)\n"
 				<< "(Hint: 'icinga2 pki save-cert --host <parenthost> --port <5665> --key local.key --cert local.crt --trustedcert trusted-parent.crt').";
 			return 1;
@@ -381,14 +381,14 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		try{
 			trustedParentCert = GetX509Certificate(trustedCert);
 		} catch (const std::exception&) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Can't read trusted cert at '" << trustedCert << "'.";
 			return 1;
 		}
 
 		try {
 			if (IsCa(trustedParentCert)) {
-				Log(LogCritical, "cli")
+				Log(LogCritical, "cli", nullptr)
 					<< "The trusted parent certificate is NOT a client certificate. It seems you passed the 'ca.crt' CA certificate via '--trustedcert' parameter.";
 				return 1;
 			}
@@ -396,13 +396,13 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 			/* Swallow the error and do not run the check on unsupported OpenSSL platforms. */
 		}
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Verifying trusted certificate file '" << vm["trustedcert"].as<std::string>() << "'.";
 
-		Log(LogInformation, "cli", "Requesting a signed certificate from the parent Icinga node.");
+		Log(LogInformation, "cli", nullptr, "Requesting a signed certificate from the parent Icinga node.");
 
 		if (PkiUtility::RequestCertificate(parentHost, parentPort, key, cert, ca, trustedParentCert, ticket) > 0) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Failed to fetch signed certificate from parent Icinga node '"
 				<< parentHost << ", "
 				<< parentPort << "'. Please try again.";
@@ -413,37 +413,37 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		 * Tell the user to manually copy the ca.crt file
 		 * into DataDir + "/certs"
 		 */
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "\nNo connection to the parent node was specified.\n\n"
 			<< "Please copy the public CA certificate from your master/satellite\n"
 			<< "into '" << ca << "' before starting Icinga 2.\n";
 
 		if (Utility::PathExists(ca)) {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "\nFound public CA certificate in '" << ca << "'.\n"
 				<< "Please verify that it is the same as on your master/satellite.\n";
 		}
 	}
 
 	if (!Utility::SetFileOwnership(ca, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << ca << "'. Verify it yourself!";
 	}
 
 	/* fix permissions (again) when updating the signed certificate */
 	if (!Utility::SetFileOwnership(cert, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user << "' group '" << group << "' on file '" << cert << "'. Verify it yourself!";
 	}
 
 	/* disable the notifications feature */
-	Log(LogInformation, "cli", "Disabling the Notification feature.");
+	Log(LogInformation, "cli", nullptr, "Disabling the Notification feature.");
 
 	FeatureUtility::DisableFeatures({ "notification" });
 
 	/* enable the ApiListener config */
 
-	Log(LogInformation, "cli", "Updating the ApiListener feature.");
+	Log(LogInformation, "cli", nullptr, "Updating the ApiListener feature.");
 
 	FeatureUtility::EnableFeatures({ "api" });
 
@@ -484,7 +484,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 	fp.Commit();
 
 	/* Generate zones configuration. */
-	Log(LogInformation, "cli", "Generating zone and object configuration.");
+	Log(LogInformation, "cli", nullptr, "Generating zone and object configuration.");
 
 	/* Setup command hardcodes this as FQDN */
 	String endpointName = cn;
@@ -510,7 +510,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 
 	for (decltype(setupGlobalZones.size()) i = 0; i < setupGlobalZones.size(); i++) {
 		if (std::find(globalZones.begin(), globalZones.end(), setupGlobalZones[i]) != globalZones.end()) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "The global zone '" << setupGlobalZones[i] << "' is already specified.";
 			return 1;
 		}
@@ -523,7 +523,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 
 	/* update constants.conf with NodeName = CN */
 	if (endpointName != Utility::GetFQDN()) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "CN/Endpoint name '" << endpointName << "' does not match the default FQDN '"
 			<< Utility::GetFQDN() << "'. Requires an update for the NodeName constant in constants.conf!";
 	}
@@ -536,7 +536,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 		AtomicFile af (ticketPath, 0600);
 
 		if (!Utility::SetFileOwnership(af.GetTempFilename(), user, group)) {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Cannot set ownership for user '" << user
 				<< "' group '" << group
 				<< "' on file '" << ticketPath << "'. Verify it yourself!";
@@ -548,12 +548,12 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 
 	/* If no parent connection was made, the user must supply the ca.crt before restarting Icinga 2.*/
 	if (!connectToParent) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "No connection to the parent node was specified.\n\n"
 			<< "Please copy the public CA certificate from your master/satellite\n"
 			<< "into '" << ca << "' before starting Icinga 2.\n";
 	} else {
-		Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
+		Log(LogInformation, "cli", nullptr, "Make sure to restart Icinga 2.");
 	}
 
 	if (vm.count("disable-confd")) {
@@ -562,7 +562,7 @@ int NodeSetupCommand::SetupNode(const boost::program_options::variables_map& vm)
 	}
 
 	/* tell the user to reload icinga2 */
-	Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
+	Log(LogInformation, "cli", nullptr, "Make sure to restart Icinga 2.");
 
 	return 0;
 }

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -145,7 +145,7 @@ int NodeUtility::GenerateNodeMasterIcingaConfig(const String& endpointName, cons
 
 bool NodeUtility::WriteNodeConfigObjects(const String& filename, const Array::Ptr& objects)
 {
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Dumping config items to file '" << filename << "'.";
 
 	/* create a backup first */
@@ -159,7 +159,7 @@ bool NodeUtility::WriteNodeConfigObjects(const String& filename, const Array::Pt
 	String group = Configuration::RunAsGroup;
 
 	if (!Utility::SetFileOwnership(path, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user << "' group '" << group << "' on path '" << path << "'. Verify it yourself!";
 	}
 
@@ -193,7 +193,7 @@ bool NodeUtility::CreateBackupFile(const String& target, bool isPrivate)
 	String backup = target + ".orig";
 
 	if (Utility::PathExists(backup)) {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Backup file '" << backup << "' already exists. Skipping backup.";
 		return false;
 	}
@@ -205,7 +205,7 @@ bool NodeUtility::CreateBackupFile(const String& target, bool isPrivate)
 		chmod(backup.CStr(), 0600);
 #endif /* _WIN32 */
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Created backup file '" << backup << "'.";
 
 	return true;
@@ -240,7 +240,7 @@ void NodeUtility::SerializeObject(std::ostream& fp, const Dictionary::Ptr& objec
 bool NodeUtility::GetConfigurationIncludeState(const String& value, bool recursive) {
 	String configurationFile = Configuration::ConfigDir + "/icinga2.conf";
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Reading '" << configurationFile << "'.";
 
 	std::ifstream ifp(configurationFile.CStr());
@@ -288,7 +288,7 @@ bool NodeUtility::UpdateConfiguration(const String& value, bool include, bool re
 {
 	String configurationFile = Configuration::ConfigDir + "/icinga2.conf";
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Updating '" << value << "' include in '" << configurationFile << "'.";
 
 	NodeUtility::CreateBackupFile(configurationFile);
@@ -317,7 +317,7 @@ bool NodeUtility::UpdateConfiguration(const String& value, bool include, bool re
 			} else if (line.find(affectedInclude) != std::string::npos) {
 				found = true;
 
-				Log(LogInformation, "cli")
+				Log(LogInformation, "cli", nullptr)
 					<< "Include statement '" + affectedInclude + "' already set.";
 
 				ofp << line << "\n";
@@ -352,7 +352,7 @@ void NodeUtility::UpdateConstant(const String& name, const String& value)
 {
 	String constantsConfPath = NodeUtility::GetConstantsConfPath();
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Updating '" << name << "' constant in '" << constantsConfPath << "'.";
 
 	NodeUtility::CreateBackupFile(constantsConfPath);

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -169,7 +169,7 @@ wizard_endpoint_loop_start:
 	std::getline(std::cin, answer);
 
 	if (answer.empty()) {
-		Log(LogWarning, "cli", "Master/Satellite CN is required! Please retry.");
+		Log(LogWarning, "cli", nullptr, "Master/Satellite CN is required! Please retry.");
 		goto wizard_endpoint_loop_start;
 	}
 
@@ -189,7 +189,7 @@ wizard_endpoint_loop_start:
 	if (choice.Contains("n")) {
 		connectToParent = false;
 
-		Log(LogWarning, "cli", "Node to master/satellite connection setup skipped");
+		Log(LogWarning, "cli", nullptr, "Node to master/satellite connection setup skipped");
 		std::cout << "Connection setup skipped. Please configure your parent node to\n"
 			<< "connect to this node by setting the 'host' attribute for the node Endpoint object.\n";
 
@@ -205,7 +205,7 @@ wizard_endpoint_loop_start:
 		std::getline(std::cin, answer);
 
 		if (answer.empty()) {
-			Log(LogWarning, "cli", "Please enter the parent endpoint (master/satellite) connection information.");
+			Log(LogWarning, "cli", nullptr, "Please enter the parent endpoint (master/satellite) connection information.");
 			goto wizard_endpoint_loop_start;
 		}
 
@@ -261,7 +261,7 @@ wizard_endpoint_loop_start:
 	String group = Configuration::RunAsGroup;
 
 	if (!Utility::SetFileOwnership(certsDir, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user
 			<< "' group '" << group
 			<< "' on file '" << certsDir << "'. Verify it yourself!";
@@ -276,7 +276,7 @@ wizard_endpoint_loop_start:
 		NodeUtility::CreateBackupFile(nodeCert);
 
 	if (PkiUtility::NewCert(cn, nodeKey, Empty, nodeCert) > 0) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Failed to create new self-signed certificate for CN '"
 			<< cn << "'. Please try again.";
 		return 1;
@@ -284,7 +284,7 @@ wizard_endpoint_loop_start:
 
 	/* fix permissions: root -> icinga daemon user */
 	if (!Utility::SetFileOwnership(nodeKey, user, group)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "Cannot set ownership for user '" << user
 			<< "' group '" << group
 			<< "' on file '" << nodeKey << "'. Verify it yourself!";
@@ -295,13 +295,13 @@ wizard_endpoint_loop_start:
 	/* Check whether we should connect to the parent node and present its trusted certificate. */
 	if (connectToParent) {
 		//save-cert and store the master certificate somewhere
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Fetching public certificate from master ("
 			<< parentHost << ", " << parentPort << "):\n";
 
 		trustedParentCert = PkiUtility::FetchCert(parentHost, parentPort);
 		if (!trustedParentCert) {
-			Log(LogCritical, "cli", "Peer did not present a valid certificate.");
+			Log(LogCritical, "cli", nullptr, "Peer did not present a valid certificate.");
 			return 1;
 		}
 
@@ -313,11 +313,11 @@ wizard_endpoint_loop_start:
 		std::getline (std::cin, answer);
 		boost::algorithm::to_lower(answer);
 		if (answer != "y") {
-			Log(LogWarning, "cli", "Process aborted.");
+			Log(LogWarning, "cli", nullptr, "Process aborted.");
 			return 1;
 		}
 
-		Log(LogInformation, "cli", "Received trusted parent certificate.\n");
+		Log(LogInformation, "cli", nullptr, "Received trusted parent certificate.\n");
 	}
 
 wizard_ticket:
@@ -346,10 +346,10 @@ wizard_ticket:
 		ticket = ticket.Trim();
 
 		if (ticket.IsEmpty()) {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "Requesting certificate without a ticket.";
 		} else {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "Requesting certificate with ticket '" << ticket << "'.";
 		}
 
@@ -360,7 +360,7 @@ wizard_ticket:
 
 		if (PkiUtility::RequestCertificate(parentHost, parentPort, nodeKey,
 			nodeCert, nodeCA, trustedParentCert, ticket) > 0) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Failed to fetch signed certificate from master '"
 				<< parentHost << ", "
 				<< parentPort << "'. Please try again.";
@@ -369,7 +369,7 @@ wizard_ticket:
 
 		/* fix permissions (again) when updating the signed certificate */
 		if (!Utility::SetFileOwnership(nodeCert, user, group)) {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Cannot set ownership for user '" << user
 				<< "' group '" << group << "' on file '"
 				<< nodeCert << "'. Verify it yourself!";
@@ -442,11 +442,11 @@ wizard_ticket:
 		<< ConsoleColorTag(Console_Normal);
 
 	/* disable the notifications feature on agent/satellite nodes */
-	Log(LogInformation, "cli", "Disabling the Notification feature.");
+	Log(LogInformation, "cli", nullptr, "Disabling the Notification feature.");
 
 	FeatureUtility::DisableFeatures({ "notification" });
 
-	Log(LogInformation, "cli", "Enabling the ApiListener feature.");
+	Log(LogInformation, "cli", nullptr, "Enabling the ApiListener feature.");
 
 	FeatureUtility::EnableFeatures({ "api" });
 
@@ -472,7 +472,7 @@ wizard_ticket:
 	fp.Commit();
 
 	/* Zones configuration. */
-	Log(LogInformation, "cli", "Generating local zones.conf.");
+	Log(LogInformation, "cli", nullptr, "Generating local zones.conf.");
 
 	/* Setup command hardcodes this as FQDN */
 	String endpointName = cn;
@@ -538,13 +538,13 @@ wizard_global_zone_loop_start:
 		if (choice.Contains("y"))
 			goto wizard_global_zone_loop_start;
 	} else
-		Log(LogInformation, "cli", "No additional global Zones have been specified");
+		Log(LogInformation, "cli", nullptr, "No additional global Zones have been specified");
 
 	/* Generate node configuration. */
 	NodeUtility::GenerateNodeIcingaConfig(endpointName, zoneName, parentZoneName, endpoints, globalZones);
 
 	if (endpointName != Utility::GetFQDN()) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "CN/Endpoint name '" << endpointName << "' does not match the default FQDN '"
 			<< Utility::GetFQDN() << "'. Requires update for NodeName constant in constants.conf!";
 	}
@@ -557,7 +557,7 @@ wizard_global_zone_loop_start:
 		AtomicFile af (ticketPath, 0600);
 
 		if (!Utility::SetFileOwnership(af.GetTempFilename(), user, group)) {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Cannot set ownership for user '" << user
 				<< "' group '" << group
 				<< "' on file '" << ticketPath << "'. Verify it yourself!";
@@ -569,12 +569,12 @@ wizard_global_zone_loop_start:
 
 	/* If no parent connection was made, the user must supply the ca.crt before restarting Icinga 2.*/
 	if (!connectToParent) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "No connection to the parent node was specified.\n\n"
 			<< "Please copy the public CA certificate from your master/satellite\n"
 			<< "into '" << nodeCA << "' before starting Icinga 2.\n";
 	} else {
-		Log(LogInformation, "cli", "Make sure to restart Icinga 2.");
+		Log(LogInformation, "cli", nullptr, "Make sure to restart Icinga 2.");
 	}
 
 	/* Disable conf.d inclusion */
@@ -585,7 +585,7 @@ wizard_global_zone_loop_start:
 	choice = answer;
 
 	if (choice.Contains("n"))
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "conf.d directory has not been disabled.";
 	else {
 		std::cout << ConsoleColorTag(Console_Bold | Console_ForegroundGreen)
@@ -709,7 +709,7 @@ wizard_global_zone_loop_start:
 		if (choice.Contains("y"))
 			goto wizard_global_zone_loop_start;
 	} else
-		Log(LogInformation, "cli", "No additional global Zones have been specified");
+		Log(LogInformation, "cli", nullptr, "No additional global Zones have been specified");
 
 	/* Generate master configuration. */
 	NodeUtility::GenerateNodeMasterIcingaConfig(endpointName, zoneName, globalZones);
@@ -760,12 +760,12 @@ wizard_global_zone_loop_start:
 
 	/* update constants.conf with NodeName = CN + TicketSalt = random value */
 	if (cn != Utility::GetFQDN()) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "CN '" << cn << "' does not match the default FQDN '"
 			<< Utility::GetFQDN() << "'. Requires an update for the NodeName constant in constants.conf!";
 	}
 
-	Log(LogInformation, "cli", "Updating constants.conf.");
+	Log(LogInformation, "cli", nullptr, "Updating constants.conf.");
 
 	NodeUtility::CreateBackupFile(NodeUtility::GetConstantsConfPath());
 
@@ -784,7 +784,7 @@ wizard_global_zone_loop_start:
 	choice = answer;
 
 	if (choice.Contains("n"))
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "conf.d directory has not been disabled.";
 	else {
 		std::cout << ConsoleColorTag(Console_Bold | Console_ForegroundGreen)
@@ -807,7 +807,7 @@ wizard_global_zone_loop_start:
 		if (Utility::PathExists(apiUsersFilePath)) {
 			NodeUtility::UpdateConfiguration("\"conf.d/api-users.conf\"", true, false);
 		} else {
-			Log(LogWarning, "cli")
+			Log(LogWarning, "cli", nullptr)
 				<< "Included file '" << apiUsersFilePath << "' does not exist.";
 		}
 	}

--- a/lib/cli/objectlistcommand.cpp
+++ b/lib/cli/objectlistcommand.cpp
@@ -68,9 +68,9 @@ int ObjectListCommand::Run(const boost::program_options::variables_map& vm, [[ma
 	String objectfile = Configuration::ObjectsPath;
 
 	if (!Utility::PathExists(objectfile)) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot open objects file '" << Configuration::ObjectsPath << "'.";
-		Log(LogCritical, "cli", "Run 'icinga2 daemon -C --dump-objects' to validate config and generate the cache file.");
+		Log(LogCritical, "cli", nullptr, "Run 'icinga2 daemon -C --dump-objects' to validate config and generate the cache file.");
 		return 1;
 	}
 
@@ -116,14 +116,14 @@ int ObjectListCommand::Run(const boost::program_options::variables_map& vm, [[ma
 		std::cout << "\n";
 	}
 
-	Log(LogNotice, "cli")
+	Log(LogNotice, "cli", nullptr)
 		<< "Parsed " << objects_count << " objects.";
 
 	auto objectsPathCtime (GetCtime(Configuration::ObjectsPath));
 	auto varsPathCtime (GetCtime(Configuration::VarsPath));
 
 	if (objectsPathCtime < varsPathCtime) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "This data is " << Utility::FormatDuration(varsPathCtime - objectsPathCtime)
 			<< " older than the last Icinga config (re)load. It may be outdated. Consider running 'icinga2 daemon -C --dump-objects' first.";
 	}

--- a/lib/cli/pkinewcertcommand.cpp
+++ b/lib/cli/pkinewcertcommand.cpp
@@ -46,12 +46,12 @@ std::vector<String> PKINewCertCommand::GetArgumentSuggestions(const String& argu
 int PKINewCertCommand::Run(const boost::program_options::variables_map& vm, [[maybe_unused]] const std::vector<std::string>& ap) const
 {
 	if (!vm.count("cn")) {
-		Log(LogCritical, "cli", "Common name (--cn) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Common name (--cn) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("key")) {
-		Log(LogCritical, "cli", "Key file path (--key) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Key file path (--key) must be specified.");
 		return 1;
 	}
 

--- a/lib/cli/pkirequestcommand.cpp
+++ b/lib/cli/pkirequestcommand.cpp
@@ -55,27 +55,27 @@ std::vector<String> PKIRequestCommand::GetArgumentSuggestions(const String& argu
 int PKIRequestCommand::Run(const boost::program_options::variables_map& vm, [[maybe_unused]] const std::vector<std::string>& ap) const
 {
 	if (!vm.count("host")) {
-		Log(LogCritical, "cli", "Icinga 2 host (--host) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Icinga 2 host (--host) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("key")) {
-		Log(LogCritical, "cli", "Key input file path (--key) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Key input file path (--key) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("cert")) {
-		Log(LogCritical, "cli", "Certificate output file path (--cert) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Certificate output file path (--cert) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("ca")) {
-		Log(LogCritical, "cli", "CA certificate output file path (--ca) must be specified.");
+		Log(LogCritical, "cli", nullptr, "CA certificate output file path (--ca) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("trustedcert")) {
-		Log(LogCritical, "cli", "Trusted certificate input file path (--trustedcert) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Trusted certificate input file path (--trustedcert) must be specified.");
 		return 1;
 	}
 

--- a/lib/cli/pkisavecertcommand.cpp
+++ b/lib/cli/pkisavecertcommand.cpp
@@ -56,25 +56,25 @@ std::vector<String> PKISaveCertCommand::GetArgumentSuggestions(const String& arg
 int PKISaveCertCommand::Run(const boost::program_options::variables_map& vm, [[maybe_unused]] const std::vector<std::string>& ap) const
 {
 	if (!vm.count("host")) {
-		Log(LogCritical, "cli", "Icinga 2 host (--host) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Icinga 2 host (--host) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("trustedcert")) {
-		Log(LogCritical, "cli", "Trusted certificate output file path (--trustedcert) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Trusted certificate output file path (--trustedcert) must be specified.");
 		return 1;
 	}
 
 	String host = vm["host"].as<std::string>();
 	String port = vm["port"].as<std::string>();
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Retrieving TLS certificate for '" << host << ":" << port << "'.";
 
 	std::shared_ptr<X509> cert = PkiUtility::FetchCert(host, port);
 
 	if (!cert) {
-		Log(LogCritical, "cli", "Failed to fetch certificate from host.");
+		Log(LogCritical, "cli", nullptr, "Failed to fetch certificate from host.");
 		return 1;
 	}
 

--- a/lib/cli/pkisigncsrcommand.cpp
+++ b/lib/cli/pkisigncsrcommand.cpp
@@ -44,12 +44,12 @@ std::vector<String> PKISignCSRCommand::GetArgumentSuggestions(const String& argu
 int PKISignCSRCommand::Run(const boost::program_options::variables_map& vm, [[maybe_unused]] const std::vector<std::string>& ap) const
 {
 	if (!vm.count("csr")) {
-		Log(LogCritical, "cli", "Certificate signing request file path (--csr) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Certificate signing request file path (--csr) must be specified.");
 		return 1;
 	}
 
 	if (!vm.count("cert")) {
-		Log(LogCritical, "cli", "Certificate file path (--cert) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Certificate file path (--cert) must be specified.");
 		return 1;
 	}
 

--- a/lib/cli/pkiticketcommand.cpp
+++ b/lib/cli/pkiticketcommand.cpp
@@ -38,7 +38,7 @@ void PKITicketCommand::InitParameters(boost::program_options::options_descriptio
 int PKITicketCommand::Run(const boost::program_options::variables_map& vm, [[maybe_unused]] const std::vector<std::string>& ap) const
 {
 	if (!vm.count("cn")) {
-		Log(LogCritical, "cli", "Common name (--cn) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Common name (--cn) must be specified.");
 		return 1;
 	}
 
@@ -48,7 +48,7 @@ int PKITicketCommand::Run(const boost::program_options::variables_map& vm, [[may
 		salt = vm["salt"].as<std::string>();
 
 	if (salt.IsEmpty()) {
-		Log(LogCritical, "cli", "Ticket salt (--salt) must be specified.");
+		Log(LogCritical, "cli", nullptr, "Ticket salt (--salt) must be specified.");
 		return 1;
 	}
 

--- a/lib/cli/pkiverifycommand.cpp
+++ b/lib/cli/pkiverifycommand.cpp
@@ -68,13 +68,13 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		try {
 			cert = GetX509Certificate(certFile);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot read certificate file '" << certFile << "'. Please ensure that it exists and is readable.";
 
 			return ServiceCritical;
 		}
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Verifying common name (CN) '" << cn << " in certificate '" << certFile << "'.";
 
 		std::cout << PkiUtility::GetCertificateInformation(cert) << "\n";
@@ -82,12 +82,12 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		String certCN = GetCertificateCN(cert);
 
 		if (cn == certCN) {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "OK: CN '" << cn << "' matches certificate CN '" << certCN << "'.";
 
 			return ServiceOK;
 		} else {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "CRITICAL: CN '" << cn << "' does NOT match certificate CN '" << certCN << "'.";
 
 			return ServiceCritical;
@@ -100,7 +100,7 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		try {
 			cert = GetX509Certificate(certFile);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot read certificate file '" << certFile << "'. Please ensure that it exists and is readable.";
 
 			return ServiceCritical;
@@ -110,18 +110,18 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		try {
 			cacert = GetX509Certificate(caCertFile);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot read CA certificate file '" << caCertFile << "'. Please ensure that it exists and is readable.";
 
 			return ServiceCritical;
 		}
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Verifying certificate '" << certFile << "'";
 
 		std::cout << PkiUtility::GetCertificateInformation(cert) << "\n";
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< " with CA certificate '" << caCertFile << "'.";
 
 		std::cout << PkiUtility::GetCertificateInformation(cacert) << "\n";
@@ -133,7 +133,7 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		try {
 			signedByCA = VerifyCertificate(cacert, cert, crlFile);
 		} catch (const std::exception& ex) {
-			Log logmsg (LogCritical, "cli");
+			Log logmsg (LogCritical, "cli", nullptr);
 			logmsg << "CRITICAL: Certificate with CN '" << certCN << "' is NOT signed by CA: ";
 			if (const unsigned long *openssl_code = boost::get_error_info<errinfo_openssl_error>(ex)) {
 				logmsg << X509_verify_cert_error_string(*openssl_code) << " (code " << *openssl_code << ")";
@@ -145,12 +145,12 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		}
 
 		if (signedByCA) {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "OK: Certificate with CN '" << certCN << "' is signed by CA.";
 
 			return ServiceOK;
 		} else {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "CRITICAL: Certificate with CN '" << certCN << "' is NOT signed by CA.";
 
 			return ServiceCritical;
@@ -164,24 +164,24 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		try {
 			cacert = GetX509Certificate(caCertFile);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot read CA certificate file '" << caCertFile << "'. Please ensure that it exists and is readable.";
 
 			return ServiceCritical;
 		}
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Checking whether certificate '" << caCertFile << "' is a valid CA certificate.";
 
 		std::cout << PkiUtility::GetCertificateInformation(cacert) << "\n";
 
 		if (IsCa(cacert)) {
-			Log(LogInformation, "cli")
+			Log(LogInformation, "cli", nullptr)
 				<< "OK: CA certificate file '" << caCertFile << "' was verified successfully.\n";
 
 			return ServiceOK;
 		} else {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "CRITICAL: The file '" << caCertFile << "' does not seem to be a CA certificate file.\n";
 
 			return ServiceCritical;
@@ -194,13 +194,13 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 		try {
 			cert = GetX509Certificate(certFile);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Cannot read certificate file '" << certFile << "'. Please ensure that it exists and is readable.";
 
 			return ServiceCritical;
 		}
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Printing certificate '" << certFile << "'";
 
 		std::cout << PkiUtility::GetCertificateInformation(cert) << "\n";
@@ -210,14 +210,14 @@ int PKIVerifyCommand::Run(const boost::program_options::variables_map& vm, [[may
 
 	/* Error handling. */
 	if (!cn.IsEmpty() && certFile.IsEmpty()) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "The '--cn' parameter requires the '--cert' parameter.";
 
 		return ServiceCritical;
 	}
 
 	if (cn.IsEmpty() && certFile.IsEmpty() && caCertFile.IsEmpty()) {
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Please add the '--help' parameter to see all available options.";
 
 		return ServiceOK;

--- a/lib/cli/variablegetcommand.cpp
+++ b/lib/cli/variablegetcommand.cpp
@@ -62,9 +62,9 @@ int VariableGetCommand::Run(const boost::program_options::variables_map& vm, con
 	String varsfile = Configuration::VarsPath;
 
 	if (!Utility::PathExists(varsfile)) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot open variables file '" << varsfile << "'.";
-		Log(LogCritical, "cli", "Run 'icinga2 daemon -C' to validate config and generate the cache file.");
+		Log(LogCritical, "cli", nullptr, "Run 'icinga2 daemon -C' to validate config and generate the cache file.");
 		return 1;
 	}
 

--- a/lib/cli/variablelistcommand.cpp
+++ b/lib/cli/variablelistcommand.cpp
@@ -40,9 +40,9 @@ int VariableListCommand::Run(const boost::program_options::variables_map&, [[may
 	String varsfile = Configuration::VarsPath;
 
 	if (!Utility::PathExists(varsfile)) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot open variables file '" << varsfile << "'.";
-		Log(LogCritical, "cli", "Run 'icinga2 daemon -C' to validate config and generate the cache file.");
+		Log(LogCritical, "cli", nullptr, "Run 'icinga2 daemon -C' to validate config and generate the cache file.");
 		return 1;
 	}
 

--- a/lib/cli/variableutility.cpp
+++ b/lib/cli/variableutility.cpp
@@ -72,6 +72,6 @@ void VariableUtility::PrintVariables(std::ostream& outfp)
 	sfp->Close();
 	fp.close();
 
-	Log(LogNotice, "cli")
+	Log(LogNotice, "cli", nullptr)
 		<< "Parsed " << variables_count << " variables.";
 }

--- a/lib/compat/compatlogger.cpp
+++ b/lib/compat/compatlogger.cpp
@@ -41,7 +41,7 @@ void CompatLogger::OnAllConfigLoaded()
 {
 	ObjectImpl<CompatLogger>::OnAllConfigLoaded();
 
-	Log(LogWarning, "CompatLogger")
+	Log(LogWarning, "CompatLogger", this)
 		<< "This feature is DEPRECATED and will be removed in v2.18.";
 }
 
@@ -52,7 +52,7 @@ void CompatLogger::Start(bool runtimeCreated)
 {
 	ObjectImpl<CompatLogger>::Start(runtimeCreated);
 
-	Log(LogInformation, "CompatLogger")
+	Log(LogInformation, "CompatLogger", this)
 		<< "'" << GetName() << "' started.";
 
 	Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
@@ -90,7 +90,7 @@ void CompatLogger::Stop(bool runtimeRemoved)
 {
 	m_RotationTimer->Stop(true);
 
-	Log(LogInformation, "CompatLogger")
+	Log(LogInformation, "CompatLogger", this)
 		<< "'" << GetName() << "' stopped.";
 
 	ObjectImpl<CompatLogger>::Stop(runtimeRemoved);
@@ -481,7 +481,7 @@ void CompatLogger::ReopenFile(bool rotate)
 		if (rotate) {
 			String archiveFile = GetLogDir() + "/archives/icinga-" + Utility::FormatDateTime("%m-%d-%Y-%H", Utility::GetTime()) + ".log";
 
-			Log(LogNotice, "CompatLogger")
+			Log(LogNotice, "CompatLogger", this)
 				<< "Rotating compat log file '" << tempFile << "' -> '" << archiveFile << "'";
 
 			(void) rename(tempFile.CStr(), archiveFile.CStr());
@@ -491,7 +491,7 @@ void CompatLogger::ReopenFile(bool rotate)
 	m_OutputFile.open(tempFile.CStr(), std::ofstream::app);
 
 	if (!m_OutputFile) {
-		Log(LogWarning, "CompatLogger")
+		Log(LogWarning, "CompatLogger", this)
 			<< "Could not open compat log file '" << tempFile << "' for writing. Log output will be lost.";
 
 		return;
@@ -586,7 +586,7 @@ void CompatLogger::ScheduleNextRotation()
 
 	time_t ts = mktime(&tmthen);
 
-	Log(LogNotice, "CompatLogger")
+	Log(LogNotice, "CompatLogger", this)
 		<< "Rescheduling rotation timer for compat log '"
 		<< GetName() << "' to '" << Utility::FormatDateTime("%Y/%m/%d %H:%M:%S %z", ts) << "'";
 

--- a/lib/compat/externalcommandlistener.cpp
+++ b/lib/compat/externalcommandlistener.cpp
@@ -31,7 +31,7 @@ void ExternalCommandListener::OnAllConfigLoaded()
 {
 	ObjectImpl<ExternalCommandListener>::OnAllConfigLoaded();
 
-	Log(LogWarning, "ExternalCommandListener")
+	Log(LogWarning, "ExternalCommandListener", this)
 		<< "This feature is DEPRECATED and will be removed in v2.18.";
 }
 
@@ -42,7 +42,7 @@ void ExternalCommandListener::Start(bool runtimeCreated)
 {
 	ObjectImpl<ExternalCommandListener>::Start(runtimeCreated);
 
-	Log(LogInformation, "ExternalCommandListener")
+	Log(LogInformation, "ExternalCommandListener", this)
 		<< "'" << GetName() << "' started.";
 
 #ifndef _WIN32
@@ -59,7 +59,7 @@ void ExternalCommandListener::Stop(bool runtimeRemoved)
 {
 	m_WaitGroup->Join();
 
-	Log(LogInformation, "ExternalCommandListener")
+	Log(LogInformation, "ExternalCommandListener", this)
 		<< "'" << GetName() << "' stopped.";
 
 	ObjectImpl<ExternalCommandListener>::Stop(runtimeRemoved);
@@ -84,7 +84,7 @@ void ExternalCommandListener::CommandPipeThread(const String& commandPath)
 	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
 
 	if (!fifo_ok && mkfifo(commandPath.CStr(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP) < 0) {
-		Log(LogCritical, "ExternalCommandListener")
+		Log(LogCritical, "ExternalCommandListener", this)
 			<< "mkfifo() for fifo path '" << commandPath << "' failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 		return;
 	}
@@ -92,7 +92,7 @@ void ExternalCommandListener::CommandPipeThread(const String& commandPath)
 	/* mkfifo() uses umask to mask off some bits, which means we need to chmod() the
 	 * fifo to get the right mask. */
 	if (chmod(commandPath.CStr(), mode) < 0) {
-		Log(LogCritical, "ExternalCommandListener")
+		Log(LogCritical, "ExternalCommandListener", this)
 			<< "chmod() on fifo '" << commandPath << "' failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 		return;
 	}
@@ -101,7 +101,7 @@ void ExternalCommandListener::CommandPipeThread(const String& commandPath)
 		int fd = open(commandPath.CStr(), O_RDWR | O_NONBLOCK);
 
 		if (fd < 0) {
-			Log(LogCritical, "ExternalCommandListener")
+			Log(LogCritical, "ExternalCommandListener", this)
 				<< "open() for fifo path '" << commandPath << "' failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 			return;
 		}
@@ -123,7 +123,7 @@ void ExternalCommandListener::CommandPipeThread(const String& commandPath)
 				if (errno == EAGAIN)
 					continue;
 
-				Log(LogWarning, "ExternalCommandListener")
+				Log(LogWarning, "ExternalCommandListener", this)
 					<< "Cannot read from command pipe." << DiagnosticInformation(ex);
 				break;
 			}
@@ -142,14 +142,14 @@ void ExternalCommandListener::CommandPipeThread(const String& commandPath)
 					break;
 
 				try {
-					Log(LogInformation, "ExternalCommandListener")
+					Log(LogInformation, "ExternalCommandListener", this)
 						<< "Executing external command: " << command;
 
 					ExternalCommandProcessor::Execute(m_WaitGroup, command);
 				} catch (const std::exception& ex) {
-					Log(LogWarning, "ExternalCommandListener")
+					Log(LogWarning, "ExternalCommandListener", this)
 						<< "External command failed: " << DiagnosticInformation(ex, false);
-					Log(LogNotice, "ExternalCommandListener")
+					Log(LogNotice, "ExternalCommandListener", this)
 						<< "External command failed: " << DiagnosticInformation(ex, true);
 				}
 			}

--- a/lib/config/applyrule.cpp
+++ b/lib/config/applyrule.cpp
@@ -183,7 +183,7 @@ void ApplyRule::CheckMatches(bool silent)
 void ApplyRule::CheckMatches(const ApplyRule::Ptr& rule, Type* sourceType, bool silent)
 {
 	if (!rule->HasMatches() && !silent) {
-		Log(LogWarning, "ApplyRule")
+		Log(LogWarning, "ApplyRule", nullptr)
 			<< "Apply rule '" << rule->GetName() << "' (" << rule->GetDebugInfo() << ") for type '"
 			<< sourceType->GetName() << "' does not match anywhere!";
 	}

--- a/lib/config/configcompiler.cpp
+++ b/lib/config/configcompiler.cpp
@@ -99,7 +99,7 @@ void ConfigCompiler::CollectIncludes(std::vector<std::unique_ptr<Expression> >& 
 	try {
 		expressions.emplace_back(CompileFile(file, zone, package));
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "ConfigCompiler")
+		Log(LogWarning, "ConfigCompiler", nullptr)
 			<< "Cannot compile file '"
 			<< file << "': " << DiagnosticInformation(ex);
 	}
@@ -270,7 +270,7 @@ std::unique_ptr<Expression> ConfigCompiler::CompileFile(const String& path, cons
 			<< boost::errinfo_errno(errno)
 			<< boost::errinfo_file_name(path));
 
-	Log(LogNotice, "ConfigCompiler")
+	Log(LogNotice, "ConfigCompiler", nullptr)
 		<< "Compiling config file: " << path;
 
 	return CompileStream(path, &stream, zone, package);
@@ -297,7 +297,7 @@ std::unique_ptr<Expression> ConfigCompiler::CompileText(const String& path, cons
  */
 void ConfigCompiler::AddIncludeSearchDir(const String& dir)
 {
-	Log(LogInformation, "ConfigCompiler")
+	Log(LogInformation, "ConfigCompiler", nullptr)
 		<< "Adding include search dir: " << dir;
 
 	m_IncludeSearchDirs.push_back(dir);
@@ -337,7 +337,7 @@ bool ConfigCompiler::HasZoneConfigAuthority(const String& zoneName)
 			paths.push_back(zf.Path);
 		}
 
-		Log(LogNotice, "ConfigCompiler")
+		Log(LogNotice, "ConfigCompiler", nullptr)
 			<< "Registered authoritative config directories for zone '" << zoneName << "': " << Utility::NaturalJoin(paths);
 	}
 

--- a/lib/config/configcompilercontext.cpp
+++ b/lib/config/configcompilercontext.cpp
@@ -21,7 +21,7 @@ void ConfigCompilerContext::OpenObjectsFile(const String& filename)
 	try {
 		m_ObjectsFP = std::make_unique<AtomicFile>(filename, 0600);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli", "Could not create temporary objects file: " + DiagnosticInformation(ex, false));
+		Log(LogCritical, "cli", nullptr, "Could not create temporary objects file: " + DiagnosticInformation(ex, false));
 		Application::Exit(1);
 	}
 }

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -167,7 +167,7 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 	Type::Ptr type = GetType();
 
 #ifdef I2_DEBUG
-	Log(LogDebug, "ConfigItem")
+	Log(LogDebug, "ConfigItem", nullptr)
 		<< "Commit called for ConfigItem Type=" << type->GetName() << ", Name=" << GetName();
 #endif /* I2_DEBUG */
 
@@ -194,7 +194,7 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 		m_Expression->Evaluate(frame, &debugHints);
 	} catch (const std::exception& ex) {
 		if (m_IgnoreOnError) {
-			Log(LogNotice, "ConfigObject")
+			Log(LogNotice, "ConfigObject", dobj)
 				<< "Ignoring config object '" << m_Name << "' of type '" << type->GetName() << "' due to errors: " << DiagnosticInformation(ex);
 
 			{
@@ -246,7 +246,7 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 		dobj->Validate(FAConfig, utils);
 	} catch (ValidationError& ex) {
 		if (m_IgnoreOnError) {
-			Log(LogNotice, "ConfigObject")
+			Log(LogNotice, "ConfigObject", dobj)
 				<< "Ignoring config object '" << m_Name << "' of type '" << type->GetName() << "' due to errors: " << DiagnosticInformation(ex);
 
 			{
@@ -265,7 +265,7 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 		dobj->OnConfigLoaded();
 	} catch (const std::exception& ex) {
 		if (m_IgnoreOnError) {
-			Log(LogNotice, "ConfigObject")
+			Log(LogNotice, "ConfigObject", dobj)
 				<< "Ignoring config object '" << m_Name << "' of type '" << m_Type->GetName() << "' due to errors: " << DiagnosticInformation(ex);
 
 			{
@@ -441,7 +441,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 		return true;
 
 #ifdef I2_DEBUG
-	Log(LogDebug, "configitem")
+	Log(LogDebug, "configitem", nullptr)
 		<< "Committing " << total << " new items.";
 #endif /* I2_DEBUG */
 
@@ -482,7 +482,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 		itemsCount += committed_items;
 
 		if (committed_items > 0)
-			Log(LogDebug, "configitem")
+			Log(LogDebug, "configitem", nullptr)
 				<< "Committed " << committed_items << " items of type '" << type->GetName() << "'.";
 #endif /* I2_DEBUG */
 
@@ -491,7 +491,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	}
 
 #ifdef I2_DEBUG
-	Log(LogDebug, "configitem")
+	Log(LogDebug, "configitem", nullptr)
 		<< "Committed " << itemsCount << " items.";
 #endif /* I2_DEBUG */
 
@@ -532,7 +532,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 						if (!item->m_IgnoreOnError)
 							throw;
 
-						Log(LogNotice, "ConfigObject")
+						Log(LogNotice, "ConfigObject", item->m_Object)
 							<< "Ignoring config object '" << item->m_Name << "' of type '" << item->m_Type->GetName() << "' due to errors: " << DiagnosticInformation(ex);
 
 						item->Unregister();
@@ -554,7 +554,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 
 #ifdef I2_DEBUG
 		if (notified_items > 0)
-			Log(LogDebug, "configitem")
+			Log(LogDebug, "configitem", nullptr)
 				<< "Sent OnAllConfigLoaded to " << notified_items << " items of type '" << type->GetName() << "'.";
 #endif /* I2_DEBUG */
 
@@ -580,7 +580,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 
 #ifdef I2_DEBUG
 		if (notified_items > 0)
-			Log(LogDebug, "configitem")
+			Log(LogDebug, "configitem", nullptr)
 				<< "Sent CreateChildObjects to " << notified_items << " items of type '" << type->GetName() << "'.";
 #endif /* I2_DEBUG */
 
@@ -598,7 +598,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent)
 {
 	if (!silent)
-		Log(LogInformation, "ConfigItem", "Committing config item(s).");
+		Log(LogInformation, "ConfigItem", nullptr, "Committing config item(s).");
 
 	if (!CommitNewItems(context, upq, newItems)) {
 		upq.ReportExceptions("config");
@@ -624,7 +624,7 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 		}
 
 		for (const ItemCountMap::value_type& kv : itemCounts) {
-			Log(LogInformation, "ConfigItem")
+			Log(LogInformation, "ConfigItem", nullptr)
 				<< "Instantiated " << kv.second << " " << (kv.second != 1 ? kv.first->GetPluralName() : kv.first->GetName()) << ".";
 		}
 	}
@@ -655,7 +655,7 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 					ScriptFrame frame(true);
 					expression->Evaluate(frame);
 				} catch (const std::exception& ex) {
-					Log(LogCritical, "config", DiagnosticInformation(ex));
+					Log(LogCritical, "config", nullptr, DiagnosticInformation(ex));
 				}
 			}
 		}
@@ -671,7 +671,7 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 			continue;
 
 #ifdef I2_DEBUG
-		Log(LogDebug, "ConfigItem")
+		Log(LogDebug, "ConfigItem", object)
 			<< "Setting 'active' to true for object '" << object->GetName() << "' of type '" << object->GetReflectionType()->GetName() << "'";
 #endif /* I2_DEBUG */
 
@@ -679,7 +679,7 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 	}
 
 	if (mainConfigActivation)
-		Log(LogInformation, "ConfigItem", "Triggering Start signal for config items");
+		Log(LogInformation, "ConfigItem", nullptr, "Triggering Start signal for config items");
 
 	/* Activate objects in priority order. */
 	std::vector<Type::Ptr> types = Type::GetAllTypes();
@@ -710,7 +710,7 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 				continue;
 
 #ifdef I2_DEBUG
-			Log(LogDebug, "ConfigItem")
+			Log(LogDebug, "ConfigItem", object)
 				<< "Activating object '" << object->GetName() << "' of type '"
 				<< objectType->GetName() << "' with priority "
 				<< objectType->GetActivationPriority();
@@ -726,7 +726,7 @@ bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, boo
 	}
 
 	if (mainConfigActivation)
-		Log(LogInformation, "ConfigItem", "Activated all objects.");
+		Log(LogInformation, "ConfigItem", nullptr, "Activated all objects.");
 
 	return true;
 }
@@ -802,7 +802,7 @@ void ConfigItem::RemoveIgnoredItems(const String& allowedConfigPath)
 		if (path.Find(allowedConfigPath) == String::NPos)
 			continue;
 
-		Log(LogNotice, "ConfigItem")
+		Log(LogNotice, "ConfigItem", nullptr)
 			<< "Removing ignored item path '" << path << "'.";
 
 		(void) unlink(path.CStr());

--- a/lib/config/configitembuilder.cpp
+++ b/lib/config/configitembuilder.cpp
@@ -92,7 +92,7 @@ ConfigItem::Ptr ConfigItemBuilder::Compile()
 		std::ostringstream oss;
 		ShowCodeLocation(oss, m_DebugInfo, false);
 
-		Log(LogWarning, "config")
+		Log(LogWarning, "config", nullptr)
 			<< "Object name of type '" << m_Type->GetName() << "' contains leading/trailing whitespace.\n" << oss.str();
 	}
 
@@ -100,7 +100,7 @@ ConfigItem::Ptr ConfigItemBuilder::Compile()
 		std::ostringstream oss;
 		ShowCodeLocation(oss, m_DebugInfo, false);
 
-		Log(LogWarning, "config")
+		Log(LogWarning, "config", nullptr)
 			<< "Object name of type '" << m_Type->GetName() << "' is too long (length: " << m_Name.GetLength()
 			<< ", max: 255).\n" << oss.str();
 	}
@@ -109,7 +109,7 @@ ConfigItem::Ptr ConfigItemBuilder::Compile()
 		std::ostringstream oss;
 		ShowCodeLocation(oss, m_DebugInfo, false);
 
-		Log(LogWarning, "config")
+		Log(LogWarning, "config", nullptr)
 			<< "Object name of type '" << m_Type->GetName()
 			<< "' contains ctrl or newline characters, which may cause problems in some contexts.\n" << oss.str();
 	}

--- a/lib/config/expression.cpp
+++ b/lib/config/expression.cpp
@@ -43,7 +43,7 @@ ExpressionResult Expression::Evaluate(ScriptFrame& frame, DebugHint *dhint) cons
 #ifdef I2_DEBUG
 /*		std::ostringstream msgbuf;
 		ShowCodeLocation(msgbuf, GetDebugInfo(), false);
-		Log(LogDebug, "Expression")
+		Log(LogDebug, "Expression", nullptr)
 			<< "Executing:\n" << msgbuf.str();*/
 #endif /* I2_DEBUG */
 
@@ -603,7 +603,7 @@ void WarnOnImplicitlySetGlobalVar(const std::unique_ptr<Expression>& setLhs, con
 
 			auto varName (var->GetVariable());
 
-			Log(LogWarning, "config")
+			Log(LogWarning, "config", nullptr)
 				<< "Global variable '" << varName << "' has been set implicitly via '" << varName << ' ' << opStr << " ...' " << debug << "."
 				" Please set it explicitly via 'globals." << varName << ' ' << opStr << " ...' instead.";
 		}
@@ -925,7 +925,7 @@ ExpressionResult NamespaceExpression::DoEvaluate(ScriptFrame&, DebugHint*) const
 	std::ostringstream oss;
 	ShowCodeLocation(oss, adjustedDI, false);
 
-	Log(LogWarning, "config")
+	Log(LogWarning, "config", nullptr)
 		<< "User-defined namespaces are deprecated and will be removed in v2.18:\n"
 		<< oss.str();
 
@@ -979,7 +979,7 @@ ExpressionResult LibraryExpression::DoEvaluate(ScriptFrame& frame, DebugHint *dh
 	ExpressionResult libres = m_Operand->Evaluate(frame, dhint);
 	CHECK_RESULT(libres);
 
-	Log(LogNotice, "config")
+	Log(LogNotice, "config", nullptr)
 		<< "Ignoring explicit load request for library \"" << libres << "\".";
 
 	return Empty;

--- a/lib/db_ido/dbconnection.cpp
+++ b/lib/db_ido/dbconnection.cpp
@@ -30,7 +30,7 @@ void DbConnection::OnConfigLoaded()
 	SetCategoryFilter(FilterArrayToInt(categories, DbQuery::GetCategoryFilterMap(), DbCatEverything));
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "DbConnection")
+		Log(LogDebug, "DbConnection", this)
 			<< "HA functionality disabled. Won't pause IDO connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -43,7 +43,7 @@ void DbConnection::Start(bool runtimeCreated)
 {
 	ObjectImpl<DbConnection>::Start(runtimeCreated);
 
-	Log(LogInformation, "DbConnection")
+	Log(LogInformation, "DbConnection", this)
 		<< "'" << GetName() << "' started.";
 
 	auto onQuery = [this](const DbQuery& query) { ExecuteQuery(query); };
@@ -63,7 +63,7 @@ void DbConnection::Start(bool runtimeCreated)
 
 void DbConnection::Stop(bool runtimeRemoved)
 {
-	Log(LogInformation, "DbConnection")
+	Log(LogInformation, "DbConnection", this)
 		<< "'" << GetName() << "' stopped.";
 
 	ObjectImpl<DbConnection>::Stop(runtimeRemoved);
@@ -81,7 +81,7 @@ void DbConnection::Resume()
 {
 	ConfigObject::Resume();
 
-	Log(LogInformation, "DbConnection")
+	Log(LogInformation, "DbConnection", this)
 		<< "Resuming IDO connection: " << GetName();
 
 	m_CleanUpTimer = Timer::Create();
@@ -99,7 +99,7 @@ void DbConnection::Resume()
 
 void DbConnection::Pause()
 {
-	Log(LogInformation, "DbConnection")
+	Log(LogInformation, "DbConnection", this)
 		<< "Pausing IDO connection: " << GetName();
 
 	m_LogStatsTimer->Stop(true);
@@ -164,7 +164,7 @@ void DbConnection::UpdateProgramStatus()
 	if (!icingaApplication)
 		return;
 
-	Log(LogNotice, "DbConnection")
+	Log(LogNotice, "DbConnection", nullptr)
 		<< "Updating programstatus table.";
 
 	std::vector<DbQuery> queries;
@@ -259,7 +259,7 @@ void DbConnection::CleanUpHandler()
 			continue;
 
 		CleanUpExecuteQuery(table.name, table.time_column, now - max_age);
-		Log(LogNotice, "DbConnection")
+		Log(LogNotice, "DbConnection", this)
 			<< "Cleanup (" << table.name << "): " << max_age
 			<< " now: " << now
 			<< " old: " << now - max_age;
@@ -289,7 +289,7 @@ void DbConnection::LogStatsHandler()
 
 	auto input = round(m_InputQueries.CalculateRate(now, 10));
 
-	Log(LogInformation, GetReflectionType()->GetName())
+	Log(LogInformation, GetReflectionType()->GetName(), this)
 		<< "Pending queries: " << pending << " (Input: " << input
 		<< "/s; Output: " << output << "/s)";
 

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -1014,7 +1014,7 @@ void DbEvents::AddCheckResultLogHistory(const Checkable::Ptr& checkable, const C
 				type = LogEntryTypeServiceCritical;
 				break;
 			default:
-				Log(LogCritical, "DbEvents")
+				Log(LogCritical, "DbEvents", service)
 					<< "Unknown service state: " << service->GetState();
 				return;
 		}
@@ -1035,7 +1035,7 @@ void DbEvents::AddCheckResultLogHistory(const Checkable::Ptr& checkable, const C
 				type = LogEntryTypeHostDown;
 				break;
 			default:
-				Log(LogCritical, "DbEvents")
+				Log(LogCritical, "DbEvents", host)
 					<< "Unknown host state: " << host->GetState();
 				return;
 		}

--- a/lib/db_ido/endpointdbobject.cpp
+++ b/lib/db_ido/endpointdbobject.cpp
@@ -44,7 +44,7 @@ Dictionary::Ptr EndpointDbObject::GetStatusFields() const
 	Endpoint::Ptr endpoint = static_pointer_cast<Endpoint>(GetObject());
 
 
-	Log(LogDebug, "EndpointDbObject")
+	Log(LogDebug, "EndpointDbObject", endpoint)
 		<< "update status for endpoint '" << endpoint->GetName() << "'";
 
 	return new Dictionary({
@@ -59,7 +59,7 @@ void EndpointDbObject::UpdateConnectedStatus(const Endpoint::Ptr& endpoint)
 {
 	bool connected = EndpointIsConnected(endpoint);
 
-	Log(LogDebug, "EndpointDbObject")
+	Log(LogDebug, "EndpointDbObject", endpoint)
 		<< "update is_connected=" << connected << " for endpoint '" << endpoint->GetName() << "'";
 
 	DbQuery query1;

--- a/lib/db_ido/hostdbobject.cpp
+++ b/lib/db_ido/hostdbobject.cpp
@@ -203,7 +203,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 		if (!parent)
 			continue;
 
-		Log(LogDebug, "HostDbObject")
+		Log(LogDebug, "HostDbObject", parent)
 			<< "host parents: " << parent->GetName();
 
 		/* parents: host_id, parent_host_object_id */
@@ -222,7 +222,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	DbObject::OnMultipleQueries(queries);
 
 	/* host dependencies */
-	Log(LogDebug, "HostDbObject")
+	Log(LogDebug, "HostDbObject", host)
 		<< "host dependencies for '" << host->GetName() << "'";
 
 	queries.clear();
@@ -240,14 +240,14 @@ void HostDbObject::OnConfigUpdateHeavy()
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent) {
-			Log(LogDebug, "HostDbObject")
+			Log(LogDebug, "HostDbObject", dep)
 				<< "Missing parent for dependency '" << dep->GetName() << "'.";
 			continue;
 		}
 
 		int stateFilter = dep->GetStateFilter();
 
-		Log(LogDebug, "HostDbObject")
+		Log(LogDebug, "HostDbObject", parent)
 			<< "parent host: " << parent->GetName();
 
 		DbQuery query2;
@@ -268,7 +268,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 
 	DbObject::OnMultipleQueries(queries);
 
-	Log(LogDebug, "HostDbObject")
+	Log(LogDebug, "HostDbObject", host)
 		<< "host contacts: " << host->GetName();
 
 	queries.clear();
@@ -283,7 +283,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	queries.emplace_back(std::move(query4));
 
 	for (const User::Ptr& user : CompatUtility::GetCheckableNotificationUsers(host)) {
-		Log(LogDebug, "HostDbObject")
+		Log(LogDebug, "HostDbObject", user)
 			<< "host contacts: " << user->GetName();
 
 		DbQuery query_contact;
@@ -300,7 +300,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 
 	DbObject::OnMultipleQueries(queries);
 
-	Log(LogDebug, "HostDbObject")
+	Log(LogDebug, "HostDbObject", host)
 		<< "host contactgroups: " << host->GetName();
 
 	queries.clear();
@@ -315,7 +315,7 @@ void HostDbObject::OnConfigUpdateHeavy()
 	queries.emplace_back(std::move(query5));
 
 	for (const UserGroup::Ptr& usergroup : CompatUtility::GetCheckableNotificationUserGroups(host)) {
-		Log(LogDebug, "HostDbObject")
+		Log(LogDebug, "HostDbObject", usergroup)
 			<< "host contactgroups: " << usergroup->GetName();
 
 		DbQuery query_contact;

--- a/lib/db_ido/servicedbobject.cpp
+++ b/lib/db_ido/servicedbobject.cpp
@@ -199,12 +199,12 @@ void ServiceDbObject::OnConfigUpdateHeavy()
 		Checkable::Ptr parent = dep->GetParent();
 
 		if (!parent) {
-			Log(LogDebug, "ServiceDbObject")
+			Log(LogDebug, "ServiceDbObject", dep)
 				<< "Missing parent for dependency '" << dep->GetName() << "'.";
 			continue;
 		}
 
-		Log(LogDebug, "ServiceDbObject")
+		Log(LogDebug, "ServiceDbObject", parent)
 			<< "service parents: " << parent->GetName();
 
 		int stateFilter = dep->GetStateFilter();

--- a/lib/db_ido/zonedbobject.cpp
+++ b/lib/db_ido/zonedbobject.cpp
@@ -30,7 +30,7 @@ Dictionary::Ptr ZoneDbObject::GetStatusFields() const
 {
 	Zone::Ptr zone = static_pointer_cast<Zone>(GetObject());
 
-	Log(LogDebug, "ZoneDbObject")
+	Log(LogDebug, "ZoneDbObject", zone)
 		<< "update status for zone '" << zone->GetName() << "'";
 
 	return new Dictionary({

--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -51,7 +51,7 @@ void IdoMysqlConnection::OnAllConfigLoaded()
 {
 	ObjectImpl<IdoMysqlConnection>::OnAllConfigLoaded();
 
-	Log(LogWarning, "IdoMysqlConnection")
+	Log(LogWarning, "IdoMysqlConnection", this)
 		<< "This feature is DEPRECATED and will be removed in v2.18.";
 }
 
@@ -84,7 +84,7 @@ void IdoMysqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 
 void IdoMysqlConnection::Resume()
 {
-	Log(LogInformation, "IdoMysqlConnection")
+	Log(LogInformation, "IdoMysqlConnection", this)
 		<< "'" << GetName() << "' resumed.";
 
 	SetConnected(false);
@@ -112,7 +112,7 @@ void IdoMysqlConnection::Resume()
 
 void IdoMysqlConnection::Pause()
 {
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Attempting to pause '" << GetName() << "'.";
 
 	DbConnection::Pause();
@@ -121,20 +121,20 @@ void IdoMysqlConnection::Pause()
 	m_TxTimer->Stop(true);
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Rescheduling disconnect task.";
 #endif /* I2_DEBUG */
 
-	Log(LogInformation, "IdoMysqlConnection")
+	Log(LogInformation, "IdoMysqlConnection", this)
 		<< "'" << GetName() << "' paused.";
 
 }
 
 void IdoMysqlConnection::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogCritical, "IdoMysqlConnection", "Exception during database operation: Verify that your database is operational!");
+	Log(LogCritical, "IdoMysqlConnection", this, "Exception during database operation: Verify that your database is operational!");
 
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Exception during database operation: " << DiagnosticInformation(std::move(exp));
 
 	if (GetConnected()) {
@@ -161,7 +161,7 @@ void IdoMysqlConnection::Disconnect()
 
 	SetConnected(false);
 
-	Log(LogInformation, "IdoMysqlConnection")
+	Log(LogInformation, "IdoMysqlConnection", this)
 		<< "Disconnected from '" << GetName() << "' database '" << GetDatabase() << "'.";
 }
 
@@ -171,7 +171,7 @@ void IdoMysqlConnection::NewTransaction()
 		return;
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Scheduling new transaction and finishing async queries.";
 #endif /* I2_DEBUG */
 
@@ -196,7 +196,7 @@ void IdoMysqlConnection::InternalNewTransaction()
 void IdoMysqlConnection::ReconnectTimerHandler()
 {
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Scheduling reconnect task.";
 #endif /* I2_DEBUG */
 
@@ -230,7 +230,7 @@ void IdoMysqlConnection::Reconnect()
 		reconnect = true;
 	}
 
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Reconnect: Clearing ID cache.";
 
 	ClearIDCache();
@@ -270,7 +270,7 @@ void IdoMysqlConnection::Reconnect()
 
 	/* connection */
 	if (!m_Mysql->init(&m_Connection)) {
-		Log(LogCritical, "IdoMysqlConnection")
+		Log(LogCritical, "IdoMysqlConnection", this)
 			<< "mysql_init() failed: out of memory";
 
 		BOOST_THROW_EXCEPTION(std::bad_alloc());
@@ -285,14 +285,14 @@ void IdoMysqlConnection::Reconnect()
 		m_Mysql->ssl_set(&m_Connection, sslKey, sslCert, sslCa, sslCaPath, sslCipher);
 
 	if (!m_Mysql->real_connect(&m_Connection, host, user, passwd, db, port, socket_path, CLIENT_FOUND_ROWS | CLIENT_MULTI_STATEMENTS)) {
-		Log(LogCritical, "IdoMysqlConnection")
+		Log(LogCritical, "IdoMysqlConnection", this)
 			<< "Connection to database '" << db << "' with user '" << user << "' on '" << host << ":" << port
 			<< "' " << (enableSsl ? "(SSL enabled) " : "") << "failed: \"" << m_Mysql->error(&m_Connection) << "\"";
 
 		BOOST_THROW_EXCEPTION(std::runtime_error(m_Mysql->error(&m_Connection)));
 	}
 
-	Log(LogNotice, "IdoMysqlConnection")
+	Log(LogNotice, "IdoMysqlConnection", this)
 		<< "Reconnect: '" << GetName() << "' is now connected to database '" << GetDatabase() << "'.";
 
 	SetConnected(true);
@@ -317,7 +317,7 @@ void IdoMysqlConnection::Reconnect()
 		m_Mysql->close(&m_Connection);
 		SetConnected(false);
 
-		Log(LogCritical, "IdoMysqlConnection", "Schema does not provide any valid version! Verify your schema installation.");
+		Log(LogCritical, "IdoMysqlConnection", this, "Schema does not provide any valid version! Verify your schema installation.");
 
 		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid schema."));
 	}
@@ -332,7 +332,7 @@ void IdoMysqlConnection::Reconnect()
 		m_Mysql->close(&m_Connection);
 		SetConnected(false);
 
-		Log(LogCritical, "IdoMysqlConnection")
+		Log(LogCritical, "IdoMysqlConnection", this)
 			<< "Schema version '" << version << "' does not match the required version '"
 			<< GetCompatSchemaVersion() << "' (or newer)! Please check the upgrade documentation at "
 			<< "https://icinga.com/docs/icinga2/latest/doc/16-upgrading-icinga-2/#upgrading-mysql-db";
@@ -369,7 +369,7 @@ void IdoMysqlConnection::Reconnect()
 		if (row)
 			endpoint_name = row->Get("endpoint_name");
 		else
-			Log(LogNotice, "IdoMysqlConnection", "Empty program status table");
+			Log(LogNotice, "IdoMysqlConnection", this, "Empty program status table");
 
 		/* if we did not write into the database earlier, another instance is active */
 		if (endpoint_name != my_endpoint->GetName()) {
@@ -386,7 +386,7 @@ void IdoMysqlConnection::Reconnect()
 			double failoverTimeout = GetFailoverTimeout();
 
 			if (status_update_age < failoverTimeout) {
-				Log(LogInformation, "IdoMysqlConnection")
+				Log(LogInformation, "IdoMysqlConnection", this)
 					<< "Last update by endpoint '" << endpoint_name << "' was "
 					<< status_update_age << "s ago (< failover timeout of " << failoverTimeout << "s). Retrying.";
 
@@ -399,7 +399,7 @@ void IdoMysqlConnection::Reconnect()
 
 			/* activate the IDO only, if we're authoritative in this zone */
 			if (IsPaused()) {
-				Log(LogNotice, "IdoMysqlConnection")
+				Log(LogNotice, "IdoMysqlConnection", this)
 					<< "Local endpoint '" << my_endpoint->GetName() << "' is not authoritative, bailing out.";
 
 				m_Mysql->close(&m_Connection);
@@ -410,15 +410,15 @@ void IdoMysqlConnection::Reconnect()
 
 			SetLastFailover(now);
 
-			Log(LogInformation, "IdoMysqlConnection")
+			Log(LogInformation, "IdoMysqlConnection", this)
 				<< "Last update by endpoint '" << endpoint_name << "' was "
 				<< status_update_age << "s ago. Taking over '" << GetName() << "' in HA zone '" << Zone::GetLocalZone()->GetName() << "'.";
 		}
 
-		Log(LogNotice, "IdoMysqlConnection", "Enabling IDO connection in HA zone.");
+		Log(LogNotice, "IdoMysqlConnection", this, "Enabling IDO connection in HA zone.");
 	}
 
-	Log(LogInformation, "IdoMysqlConnection")
+	Log(LogInformation, "IdoMysqlConnection", this)
 		<< "MySQL IDO instance id: " << static_cast<long>(m_InstanceID) << " (schema version: '" + version + "')";
 
 	/* set session time zone to utc */
@@ -469,7 +469,7 @@ void IdoMysqlConnection::Reconnect()
 		if (dbobj->GetObject())
 			continue;
 
-		Log(LogNotice, "IdoMysqlConnection")
+		Log(LogNotice, "IdoMysqlConnection", this)
 			<< "Deactivate deleted object name1: '" << dbobj->GetName1()
 			<< "' name2: '" << dbobj->GetName2() + "'.";
 		DeactivateObject(dbobj);
@@ -478,7 +478,7 @@ void IdoMysqlConnection::Reconnect()
 	UpdateAllObjects();
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Scheduling session table clear and finish connect task.";
 #endif /* I2_DEBUG */
 
@@ -496,7 +496,7 @@ void IdoMysqlConnection::FinishConnect(double startTime)
 
 	FinishAsyncQueries();
 
-	Log(LogInformation, "IdoMysqlConnection")
+	Log(LogInformation, "IdoMysqlConnection", this)
 		<< "Finished reconnecting to '" << GetName() << "' database '" << GetDatabase() << "' in "
 		<< std::setw(2) << Utility::GetTime() - startTime << " second(s).";
 
@@ -576,7 +576,7 @@ void IdoMysqlConnection::FinishAsyncQueries()
 			IncreaseQueryCount();
 			count++;
 
-			Log(LogDebug, "IdoMysqlConnection")
+			Log(LogDebug, "IdoMysqlConnection", this)
 				<< "Query: " << aq.Query;
 
 			querybuf << aq.Query;
@@ -589,7 +589,7 @@ void IdoMysqlConnection::FinishAsyncQueries()
 			std::ostringstream msgbuf;
 			String message = m_Mysql->error(&m_Connection);
 			msgbuf << "Error \"" << message << "\" when executing query \"" << query << "\"";
-			Log(LogCritical, "IdoMysqlConnection", msgbuf.str());
+			Log(LogCritical, "IdoMysqlConnection", this, msgbuf.str());
 
 			BOOST_THROW_EXCEPTION(
 				database_error()
@@ -612,7 +612,7 @@ void IdoMysqlConnection::FinishAsyncQueries()
 					std::ostringstream msgbuf;
 					String message = m_Mysql->error(&m_Connection);
 					msgbuf << "Error \"" << message << "\" when executing query \"" << aq.Query << "\"";
-					Log(LogCritical, "IdoMysqlConnection", msgbuf.str());
+					Log(LogCritical, "IdoMysqlConnection", this, msgbuf.str());
 
 					BOOST_THROW_EXCEPTION(
 						database_error()
@@ -630,7 +630,7 @@ void IdoMysqlConnection::FinishAsyncQueries()
 				std::ostringstream msgbuf;
 				String message = m_Mysql->error(&m_Connection);
 				msgbuf << "Error \"" << message << "\" when executing query \"" << query << "\"";
-				Log(LogCritical, "IdoMysqlConnection", msgbuf.str());
+				Log(LogCritical, "IdoMysqlConnection", this, msgbuf.str());
 
 				BOOST_THROW_EXCEPTION(
 					database_error()
@@ -659,7 +659,7 @@ IdoMysqlResult IdoMysqlConnection::Query(const String& query)
 	/* finish all async queries to maintain the right order for queries */
 	FinishAsyncQueries();
 
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Query: " << query;
 
 	IncreaseQueryCount();
@@ -668,7 +668,7 @@ IdoMysqlResult IdoMysqlConnection::Query(const String& query)
 		std::ostringstream msgbuf;
 		String message = m_Mysql->error(&m_Connection);
 		msgbuf << "Error \"" << message << "\" when executing query \"" << query << "\"";
-		Log(LogCritical, "IdoMysqlConnection", msgbuf.str());
+		Log(LogCritical, "IdoMysqlConnection", this, msgbuf.str());
 
 		BOOST_THROW_EXCEPTION(
 			database_error()
@@ -686,7 +686,7 @@ IdoMysqlResult IdoMysqlConnection::Query(const String& query)
 			std::ostringstream msgbuf;
 			String message = m_Mysql->error(&m_Connection);
 			msgbuf << "Error \"" << message << "\" when executing query \"" << query << "\"";
-			Log(LogCritical, "IdoMysqlConnection", msgbuf.str());
+			Log(LogCritical, "IdoMysqlConnection", this, msgbuf.str());
 
 			BOOST_THROW_EXCEPTION(
 				database_error()
@@ -774,7 +774,7 @@ void IdoMysqlConnection::ActivateObject(const DbObject::Ptr& dbobj)
 		return;
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", dbobj->GetObject())
 		<< "Scheduling object activation task for '" << dbobj->GetName1() << "!" << dbobj->GetName2() << "'.";
 #endif /* I2_DEBUG */
 
@@ -820,7 +820,7 @@ void IdoMysqlConnection::DeactivateObject(const DbObject::Ptr& dbobj)
 		return;
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", dbobj->GetObject())
 		<< "Scheduling object deactivation task for '" << dbobj->GetName1() << "!" << dbobj->GetName2() << "'.";
 #endif /* I2_DEBUG */
 
@@ -938,7 +938,7 @@ void IdoMysqlConnection::ExecuteQuery(const DbQuery& query)
 	ASSERT(query.Category != DbCatInvalid);
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Scheduling execute query task, type " << query.Type << ", table '" << query.Table << "'.";
 #endif /* I2_DEBUG */
 
@@ -955,7 +955,7 @@ void IdoMysqlConnection::ExecuteMultipleQueries(const std::vector<DbQuery>& quer
 		return;
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "IdoMysqlConnection")
+	Log(LogDebug, "IdoMysqlConnection", this)
 		<< "Scheduling multiple execute query task, type " << queries[0].Type << ", table '" << queries[0].Table << "'.";
 #endif /* I2_DEBUG */
 
@@ -1013,7 +1013,7 @@ void IdoMysqlConnection::InternalExecuteMultipleQueries(const std::vector<DbQuer
 		if (!CanExecuteQuery(query)) {
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-			Log(LogDebug, "IdoMysqlConnection")
+			Log(LogDebug, "IdoMysqlConnection", this)
 				<< "Scheduling multiple execute query task again: Cannot execute query now. Type '"
 				<< query.Type << "', table '" << query.Table << "', queue size: '" << GetPendingQueryCount() << "'.";
 #endif /* I2_DEBUG */
@@ -1063,7 +1063,7 @@ void IdoMysqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 	if (!CanExecuteQuery(query)) {
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-		Log(LogDebug, "IdoMysqlConnection")
+		Log(LogDebug, "IdoMysqlConnection", this)
 			<< "Scheduling execute query task again: Cannot execute query now. Type '"
 			<< typeOverride << "', table '" << query.Table << "', queue size: '" << GetPendingQueryCount() << "'.";
 #endif /* I2_DEBUG */
@@ -1086,7 +1086,7 @@ void IdoMysqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 			if (!FieldToEscapedString(kv.first, kv.second, &value)) {
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-				Log(LogDebug, "IdoMysqlConnection")
+				Log(LogDebug, "IdoMysqlConnection", this)
 					<< "Scheduling execute query task again: Cannot execute query now. Type '"
 					<< typeOverride << "', table '" << query.Table << "', queue size: '" << GetPendingQueryCount() << "'.";
 #endif /* I2_DEBUG */
@@ -1163,7 +1163,7 @@ void IdoMysqlConnection::InternalExecuteQuery(const DbQuery& query, int typeOver
 			if (!FieldToEscapedString(kv.first, kv.second, &value)) {
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-				Log(LogDebug, "IdoMysqlConnection")
+				Log(LogDebug, "IdoMysqlConnection", this)
 					<< "Scheduling execute query task again: Cannot extract required INSERT/UPDATE fields, key '"
 					<< kv.first << "', val '" << kv.second << "', type " << typeOverride << ", table '" << query.Table << "'.";
 #endif /* I2_DEBUG */
@@ -1206,7 +1206,7 @@ void IdoMysqlConnection::FinishExecuteQuery(const DbQuery& query, int type, bool
 	if (upsert && GetAffectedRows() == 0) {
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-		Log(LogDebug, "IdoMysqlConnection")
+		Log(LogDebug, "IdoMysqlConnection", this)
 			<< "Rescheduling DELETE/INSERT query: Upsert UPDATE did not affect rows, type " << type << ", table '" << query.Table << "'.";
 #endif /* I2_DEBUG */
 
@@ -1234,7 +1234,7 @@ void IdoMysqlConnection::CleanUpExecuteQuery(const String& table, const String& 
 		return;
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-		Log(LogDebug, "IdoMysqlConnection")
+		Log(LogDebug, "IdoMysqlConnection", this)
 			<< "Rescheduling cleanup query for table '" << table << "' and column '"
 			<< time_column << "'. max_age is set to '" << max_age << "'.";
 #endif /* I2_DEBUG */

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -59,7 +59,7 @@ void IdoPgsqlConnection::OnAllConfigLoaded()
 {
 	ObjectImpl<IdoPgsqlConnection>::OnAllConfigLoaded();
 
-	Log(LogWarning, "IdoPgsqlConnection")
+	Log(LogWarning, "IdoPgsqlConnection", this)
 		<< "This feature is DEPRECATED and will be removed in v2.18.";
 }
 
@@ -92,7 +92,7 @@ void IdoPgsqlConnection::StatsFunc(const Dictionary::Ptr& status, const Array::P
 
 void IdoPgsqlConnection::Resume()
 {
-	Log(LogInformation, "IdoPgsqlConnection")
+	Log(LogInformation, "IdoPgsqlConnection", this)
 		<< "'" << GetName() << "' resumed.";
 
 	SetConnected(false);
@@ -125,15 +125,15 @@ void IdoPgsqlConnection::Pause()
 	m_ReconnectTimer->Stop(true);
 	m_TxTimer->Stop(true);
 
-	Log(LogInformation, "IdoPgsqlConnection")
+	Log(LogInformation, "IdoPgsqlConnection", this)
 		<< "'" << GetName() << "' paused.";
 }
 
 void IdoPgsqlConnection::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogWarning, "IdoPgsqlConnection", "Exception during database operation: Verify that your database is operational!");
+	Log(LogWarning, "IdoPgsqlConnection", this, "Exception during database operation: Verify that your database is operational!");
 
-	Log(LogDebug, "IdoPgsqlConnection")
+	Log(LogDebug, "IdoPgsqlConnection", this)
 		<< "Exception during database operation: " << DiagnosticInformation(std::move(exp));
 
 	if (GetConnected()) {
@@ -160,7 +160,7 @@ void IdoPgsqlConnection::Disconnect()
 	m_Pgsql->finish(m_Connection);
 	SetConnected(false);
 
-	Log(LogInformation, "IdoPgsqlConnection")
+	Log(LogInformation, "IdoPgsqlConnection", this)
 		<< "Disconnected from '" << GetName() << "' database '" << GetDatabase() << "'.";
 }
 
@@ -261,7 +261,7 @@ void IdoPgsqlConnection::Reconnect()
 		m_Pgsql->finish(m_Connection);
 		SetConnected(false);
 
-		Log(LogCritical, "IdoPgsqlConnection")
+		Log(LogCritical, "IdoPgsqlConnection", this)
 			<< "Connection to database '" << database << "' with user '" << user << "' on '" << host << ":" << port
 			<< "' failed: \"" << message << "\"";
 
@@ -282,7 +282,7 @@ void IdoPgsqlConnection::Reconnect()
 		m_Pgsql->finish(m_Connection);
 		SetConnected(false);
 
-		Log(LogCritical, "IdoPgsqlConnection", "Schema does not provide any valid version! Verify your schema installation.");
+		Log(LogCritical, "IdoPgsqlConnection", this, "Schema does not provide any valid version! Verify your schema installation.");
 
 		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid schema."));
 	}
@@ -295,7 +295,7 @@ void IdoPgsqlConnection::Reconnect()
 		m_Pgsql->finish(m_Connection);
 		SetConnected(false);
 
-		Log(LogCritical, "IdoPgsqlConnection")
+		Log(LogCritical, "IdoPgsqlConnection", this)
 			<< "Schema version '" << version << "' does not match the required version '"
 			<< GetCompatSchemaVersion() << "' (or newer)! Please check the upgrade documentation at "
 			<< "https://icinga.com/docs/icinga2/latest/doc/16-upgrading-icinga-2/#upgrading-postgresql-db";
@@ -332,7 +332,7 @@ void IdoPgsqlConnection::Reconnect()
 		if (row)
 			endpoint_name = row->Get("endpoint_name");
 		else
-			Log(LogNotice, "IdoPgsqlConnection", "Empty program status table");
+			Log(LogNotice, "IdoPgsqlConnection", this, "Empty program status table");
 
 		/* if we did not write into the database earlier, another instance is active */
 		if (endpoint_name != my_endpoint->GetName()) {
@@ -349,7 +349,7 @@ void IdoPgsqlConnection::Reconnect()
 			double failoverTimeout = GetFailoverTimeout();
 
 			if (status_update_age < GetFailoverTimeout()) {
-				Log(LogInformation, "IdoPgsqlConnection")
+				Log(LogInformation, "IdoPgsqlConnection", this)
 					<< "Last update by endpoint '" << endpoint_name << "' was "
 					<< status_update_age << "s ago (< failover timeout of " << failoverTimeout << "s). Retrying.";
 
@@ -362,7 +362,7 @@ void IdoPgsqlConnection::Reconnect()
 
 			/* activate the IDO only, if we're authoritative in this zone */
 			if (IsPaused()) {
-				Log(LogNotice, "IdoPgsqlConnection")
+				Log(LogNotice, "IdoPgsqlConnection", this)
 					<< "Local endpoint '" << my_endpoint->GetName() << "' is not authoritative, bailing out.";
 
 				m_Pgsql->finish(m_Connection);
@@ -373,15 +373,15 @@ void IdoPgsqlConnection::Reconnect()
 
 			SetLastFailover(now);
 
-			Log(LogInformation, "IdoPgsqlConnection")
+			Log(LogInformation, "IdoPgsqlConnection", this)
 				<< "Last update by endpoint '" << endpoint_name << "' was "
 				<< status_update_age << "s ago. Taking over '" << GetName() << "' in HA zone '" << Zone::GetLocalZone()->GetName() << "'.";
 		}
 
-		Log(LogNotice, "IdoPgsqlConnection", "Enabling IDO connection.");
+		Log(LogNotice, "IdoPgsqlConnection", this, "Enabling IDO connection.");
 	}
 
-	Log(LogInformation, "IdoPgsqlConnection")
+	Log(LogInformation, "IdoPgsqlConnection", this)
 		<< "PGSQL IDO instance id: " << static_cast<long>(m_InstanceID) << " (schema version: '" + version + "')"
 		<< (!sslMode.IsEmpty() ? ", sslmode='" + sslMode + "'" : "");
 
@@ -434,7 +434,7 @@ void IdoPgsqlConnection::Reconnect()
 		if (dbobj->GetObject())
 			continue;
 
-		Log(LogNotice, "IdoPgsqlConnection")
+		Log(LogNotice, "IdoPgsqlConnection", this)
 			<< "Deactivate deleted object name1: '" << dbobj->GetName1()
 			<< "' name2: '" << dbobj->GetName2() + "'.";
 		DeactivateObject(dbobj);
@@ -454,7 +454,7 @@ void IdoPgsqlConnection::FinishConnect(double startTime)
 	if (!GetConnected())
 		return;
 
-	Log(LogInformation, "IdoPgsqlConnection")
+	Log(LogInformation, "IdoPgsqlConnection", this)
 		<< "Finished reconnecting to '" << GetName() << "' database '" << GetDatabase() << "' in "
 		<< std::setw(2) << Utility::GetTime() - startTime << " second(s).";
 
@@ -484,7 +484,7 @@ IdoPgsqlResult IdoPgsqlConnection::Query(const String& query)
 
 	Defer decreaseQueries ([this]() { DecreasePendingQueries(1); });
 
-	Log(LogDebug, "IdoPgsqlConnection")
+	Log(LogDebug, "IdoPgsqlConnection", this)
 		<< "Query: " << query;
 
 	IncreaseQueryCount();
@@ -493,7 +493,7 @@ IdoPgsqlResult IdoPgsqlConnection::Query(const String& query)
 
 	if (!result) {
 		String message = m_Pgsql->errorMessage(m_Connection);
-		Log(LogCritical, "IdoPgsqlConnection")
+		Log(LogCritical, "IdoPgsqlConnection", this)
 			<< "Error \"" << message << "\" when executing query \"" << query << "\"";
 
 		BOOST_THROW_EXCEPTION(
@@ -515,7 +515,7 @@ IdoPgsqlResult IdoPgsqlConnection::Query(const String& query)
 		String message = m_Pgsql->resultErrorMessage(result);
 		m_Pgsql->clear(result);
 
-		Log(LogCritical, "IdoPgsqlConnection")
+		Log(LogCritical, "IdoPgsqlConnection", this)
 			<< "Error \"" << message << "\" when executing query \"" << query << "\"";
 
 		BOOST_THROW_EXCEPTION(
@@ -539,7 +539,7 @@ DbReference IdoPgsqlConnection::GetSequenceValue(const String& table, const Stri
 
 	ASSERT(row);
 
-	Log(LogDebug, "IdoPgsqlConnection")
+	Log(LogDebug, "IdoPgsqlConnection", this)
 		<< "Sequence Value: " << row->Get("id");
 
 	return {Convert::ToLong(row->Get("id"))};

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -472,7 +472,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(
 		ArrayData serviceDowntimes;
 
 		for (const Service::Ptr& hostService : host->GetServices()) {
-			Log(LogNotice, "ApiActions")
+			Log(LogNotice, "ApiActions", hostService)
 				<< "Creating downtime for service " << hostService->GetName() << " on host " << host->GetName();
 
 			Downtime::Ptr serviceDowntime = Downtime::AddDowntime(hostService, author, comment, startTime, endTime,
@@ -497,7 +497,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(
 			trigger = downtime;
 		}
 
-		Log(LogNotice, "ApiActions")
+		Log(LogNotice, "ApiActions", downtime)
 			<< "Processing child options " << childOptions << " for downtime " << downtimeName;
 
 		ArrayData childDowntimes;
@@ -517,14 +517,14 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(
 				continue;
 			}
 
-			Log(LogNotice, "ApiActions")
+			Log(LogNotice, "ApiActions", child)
 				<< "Scheduling downtime for child object " << child->GetName();
 
 			Downtime::Ptr childDowntime = Downtime::AddDowntime(child, author, comment, startTime, endTime,
 				fixed, trigger, duration, String(), String(), downtimeName);
 			String childDowntimeName = childDowntime->GetName();
 
-			Log(LogNotice, "ApiActions")
+			Log(LogNotice, "ApiActions", childDowntime)
 				<< "Add child downtime '" << childDowntimeName << "'.";
 
 			Dictionary::Ptr childAdditional = new Dictionary({
@@ -537,7 +537,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(
 				ArrayData childServiceDowntimes;
 
 				for (const Service::Ptr& childService : childHost->GetServices()) {
-					Log(LogNotice, "ApiActions")
+					Log(LogNotice, "ApiActions", childService)
 						<< "Creating downtime for service " << childService->GetName() << " on child host " << childHost->GetName();
 
 					Downtime::Ptr serviceDowntime = Downtime::AddDowntime(childService, author, comment, startTime, endTime,
@@ -589,7 +589,7 @@ Dictionary::Ptr ApiActions::RemoveDowntime(
 			try {
 				Downtime::RemoveDowntime(downtime->GetName(), true, DowntimeRemovedByUser, author);
 			} catch (const invalid_downtime_removal_error& error) {
-				Log(LogWarning, "ApiActions") << error.what();
+				Log(LogWarning, "ApiActions", downtime) << error.what();
 
 				return ApiActions::CreateResult(400, error.what());
 			}
@@ -613,7 +613,7 @@ Dictionary::Ptr ApiActions::RemoveDowntime(
 		return ApiActions::CreateResult(200, "Successfully removed downtime '" + downtimeName +
 			"' and " + std::to_string(childCount) + " child downtimes.");
 	} catch (const invalid_downtime_removal_error& error) {
-		Log(LogWarning, "ApiActions") << error.what();
+		Log(LogWarning, "ApiActions", downtime) << error.what();
 
 		return ApiActions::CreateResult(400, error.what());
 	}
@@ -679,7 +679,7 @@ Value ApiActions::GetSingleObjectByNameUsingPermissions(const String& type, cons
 	try {
 		objs = FilterUtility::GetFilterTargets(qd, queryParams, user);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "ApiActions") << DiagnosticInformation(ex);
+		Log(LogWarning, "ApiActions", nullptr) << DiagnosticInformation(ex);
 		return nullptr;
 	}
 

--- a/lib/icinga/apievents.cpp
+++ b/lib/icinga/apievents.cpp
@@ -42,7 +42,7 @@ void ApiEvents::CheckResultHandler(const Checkable::Ptr& checkable, const CheckR
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'CheckResult'.");
+	Log(LogDebug, "ApiEvents", checkable, "Processing event type 'CheckResult'.");
 
 	Dictionary::Ptr result = new Dictionary();
 	result->Set("type", "CheckResult");
@@ -71,7 +71,7 @@ void ApiEvents::StateChangeHandler(const Checkable::Ptr& checkable, const CheckR
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'StateChange'.");
+	Log(LogDebug, "ApiEvents", checkable, "Processing event type 'StateChange'.");
 
 	Dictionary::Ptr result = new Dictionary();
 	result->Set("type", "StateChange");
@@ -104,7 +104,7 @@ void ApiEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& notif
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'Notification'.");
+	Log(LogDebug, "ApiEvents", notification, "Processing event type 'Notification'.");
 
 	Dictionary::Ptr result = new Dictionary();
 	result->Set("type", "Notification");
@@ -145,7 +145,7 @@ void ApiEvents::FlappingChangedHandler(const Checkable::Ptr& checkable, const Me
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'Flapping'.");
+	Log(LogDebug, "ApiEvents", checkable, "Processing event type 'Flapping'.");
 
 	Dictionary::Ptr result = new Dictionary();
 	result->Set("type", "Flapping");
@@ -178,7 +178,7 @@ void ApiEvents::AcknowledgementSetHandler(const Checkable::Ptr& checkable,
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'AcknowledgementSet'.");
+	Log(LogDebug, "ApiEvents", checkable, "Processing event type 'AcknowledgementSet'.");
 
 	Dictionary::Ptr result = new Dictionary();
 	result->Set("type", "AcknowledgementSet");
@@ -212,7 +212,7 @@ void ApiEvents::AcknowledgementClearedHandler(const Checkable::Ptr& checkable, [
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'AcknowledgementCleared'.");
+	Log(LogDebug, "ApiEvents", checkable, "Processing event type 'AcknowledgementCleared'.");
 
 	Dictionary::Ptr result = new Dictionary();
 	result->Set("type", "AcknowledgementCleared");
@@ -240,7 +240,7 @@ void ApiEvents::CommentAddedHandler(const Comment::Ptr& comment)
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'CommentAdded'.");
+	Log(LogDebug, "ApiEvents", comment, "Processing event type 'CommentAdded'.");
 
 	Dictionary::Ptr result = new Dictionary({
 		{ "type", "CommentAdded" },
@@ -258,7 +258,7 @@ void ApiEvents::CommentRemovedHandler(const Comment::Ptr& comment)
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'CommentRemoved'.");
+	Log(LogDebug, "ApiEvents", comment, "Processing event type 'CommentRemoved'.");
 
 	Dictionary::Ptr result = new Dictionary({
 		{ "type", "CommentRemoved" },
@@ -276,7 +276,7 @@ void ApiEvents::DowntimeAddedHandler(const Downtime::Ptr& downtime)
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeAdded'.");
+	Log(LogDebug, "ApiEvents", downtime, "Processing event type 'DowntimeAdded'.");
 
 	Dictionary::Ptr result = new Dictionary({
 		{ "type", "DowntimeAdded" },
@@ -294,7 +294,7 @@ void ApiEvents::DowntimeRemovedHandler(const Downtime::Ptr& downtime)
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeRemoved'.");
+	Log(LogDebug, "ApiEvents", downtime, "Processing event type 'DowntimeRemoved'.");
 
 	Dictionary::Ptr result = new Dictionary({
 		{ "type", "DowntimeRemoved" },
@@ -312,7 +312,7 @@ void ApiEvents::DowntimeStartedHandler(const Downtime::Ptr& downtime)
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeStarted'.");
+	Log(LogDebug, "ApiEvents", downtime, "Processing event type 'DowntimeStarted'.");
 
 	Dictionary::Ptr result = new Dictionary({
 		{ "type", "DowntimeStarted" },
@@ -330,7 +330,7 @@ void ApiEvents::DowntimeTriggeredHandler(const Downtime::Ptr& downtime)
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeTriggered'.");
+	Log(LogDebug, "ApiEvents", downtime, "Processing event type 'DowntimeTriggered'.");
 
 	Dictionary::Ptr result = new Dictionary({
 		{ "type", "DowntimeTriggered" },
@@ -361,7 +361,7 @@ void ApiEvents::SendObjectChangeEvent(const ConfigObject::Ptr& object, const Eve
 	if (!inboxes)
 		return;
 
-	Log(LogDebug, "ApiEvents") << "Processing event type '" + eventQueue + "'.";
+	Log(LogDebug, "ApiEvents", object) << "Processing event type '" + eventQueue + "'.";
 
 	Dictionary::Ptr result = new Dictionary ({
 		{"type", eventQueue},

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -72,7 +72,7 @@ void Checkable::UpdateNextCheck(const MessageOrigin::Ptr& origin)
 	double nextCheck = now - adj + interval;
 	double lastCheck = GetLastCheck();
 
-	Log(LogDebug, "Checkable")
+	Log(LogDebug, "Checkable", this)
 		<< std::fixed << std::setprecision(0)
 		<< "Update checkable '" << GetName() << "' with check interval '" << GetCheckInterval()
 		<< "' from last check time at " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", (lastCheck < 0 ? 0 : lastCheck))
@@ -185,7 +185,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 		/* Our current timestamp may be from the future (wrong server time adjusted again). Allow overrides here. */
 		if (currentCRTimestamp > now) {
 			/* our current CR is from the future, let the new CR override it. */
-			Log(LogDebug, "Checkable")
+			Log(LogDebug, "Checkable", this)
 				<< std::fixed << std::setprecision(6) << "Processing check result for checkable '" << GetName() << "' from "
 				<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", newCRTimestamp) << " (" << newCRTimestamp
 				<< "). Overriding since ours is from the future at "
@@ -193,7 +193,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 		} else {
 			/* Current timestamp is from the past, but the new timestamp is even more in the past. Skip it. */
 			if (newCRTimestamp < currentCRTimestamp) {
-				Log(LogDebug, "Checkable")
+				Log(LogDebug, "Checkable", this)
 					<< std::fixed << std::setprecision(6) << "Skipping check result for checkable '" << GetName() << "' from "
 					<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", newCRTimestamp) << " (" << newCRTimestamp
 					<< "). It is in the past compared to ours at "
@@ -391,7 +391,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	}
 
 #ifdef I2_DEBUG /* I2_DEBUG */
-	Log(LogDebug, "Checkable")
+	Log(LogDebug, "Checkable", this)
 		<< "Flapping: Checkable " << GetName()
 		<< " was: " << was_flapping
 		<< " is: " << is_flapping
@@ -411,13 +411,13 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	/* Whether a hard state change or a volatile state change except OK -> OK happened. */
 	if (hardChange || (is_volatile && !(IsStateOK(old_state) && IsStateOK(new_state)))) {
 		OnStateChange(this, cr, StateTypeHard, origin);
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "State Change: Checkable '" << GetName() << "' hard state change from " << old_state_str << " to " << new_state_str << " detected." << (is_volatile ? " Checkable is volatile." : "");
 	}
 	/* Whether a state change happened or the state type is SOFT (must be logged too). */
 	else if (stateChange || GetStateType() == StateTypeSoft) {
 		OnStateChange(this, cr, StateTypeSoft, origin);
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "State Change: Checkable '" << GetName() << "' soft state change from " << old_state_str << " to " << new_state_str << " detected.";
 	}
 
@@ -438,7 +438,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 			}
 		}
 
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "Flapping Start: Checkable '" << GetName() << "' started flapping (Current flapping value "
 			<< GetFlappingCurrent() << "% > high threshold " << GetFlappingThresholdHigh() << "%).";
 
@@ -453,7 +453,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 			}
 		}
 
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "Flapping Stop: Checkable '" << GetName() << "' stopped flapping (Current flapping value "
 			<< GetFlappingCurrent() << "% < low threshold " << GetFlappingThresholdLow() << "%).";
 
@@ -692,7 +692,7 @@ void Checkable::UpdateStatistics(const CheckResult::Ptr& cr, CheckableType type)
 		else
 			CIB::UpdatePassiveServiceChecksStatistics(ts, 1);
 	} else {
-		Log(LogWarning, "Checkable", "Unknown checkable type for statistic update.");
+		Log(LogWarning, "Checkable", nullptr, "Unknown checkable type for statistic update.");
 	}
 }
 

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -280,7 +280,7 @@ std::set<Checkable::Ptr> Checkable::GetAllChildren() const
 void Checkable::GetAllChildrenInternal(std::set<Checkable::Ptr>& seenChildren, int level) const
 {
 	if (level > Dependency::MaxDependencyRecursionLevel) {
-		Log(LogWarning, "Checkable")
+		Log(LogWarning, "Checkable", this)
 			<< "Too many nested dependencies (>" << Dependency::MaxDependencyRecursionLevel << ") for checkable '"
 			<< GetName() << "': aborting traversal.";
 		return;

--- a/lib/icinga/checkable-event.cpp
+++ b/lib/icinga/checkable-event.cpp
@@ -27,7 +27,7 @@ void Checkable::ExecuteEventHandler(const Dictionary::Ptr& resolvedMacros, bool 
 
 	/* HA enabled zones. */
 	if (IsActive() && IsPaused()) {
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "Skipping event handler for HA-paused checkable '" << GetName() << "'";
 		return;
 	}
@@ -37,7 +37,7 @@ void Checkable::ExecuteEventHandler(const Dictionary::Ptr& resolvedMacros, bool 
 	if (!ec)
 		return;
 
-	Log(LogNotice, "Checkable")
+	Log(LogNotice, "Checkable", this)
 		<< "Executing event handler '" << ec->GetName() << "' for checkable '" << GetName() << "'";
 
 	Dictionary::Ptr macros;

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -43,7 +43,7 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 
 	if (!IcingaApplication::GetInstance()->GetEnableNotifications() || !GetEnableNotifications()) {
 		if (!force) {
-			Log(LogInformation, "Checkable")
+			Log(LogInformation, "Checkable", this)
 				<< "Notifications are disabled for checkable '" << checkableName << "'.";
 			return;
 		}
@@ -55,12 +55,12 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 
 	// Bail early if there are no notifications.
 	if (notifications.empty()) {
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "Skipping checkable '" << checkableName << "' which doesn't have any notification objects configured.";
 		return;
 	}
 
-	Log(LogInformation, "Checkable")
+	Log(LogInformation, "Checkable", this)
 		<< "Checkable '" << checkableName << "' has " << notifications.size()
 		<< " notification(s). Checking filters for type '" << notificationTypeName << "', sends will be logged.";
 
@@ -72,7 +72,7 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 					auto stashedNotifications (notification->GetStashedNotifications());
 
 					if (stashedNotifications->GetLength()) {
-						Log(LogNotice, "Notification")
+						Log(LogNotice, "Notification", notification)
 							<< "Notification '" << notification->GetName() << "': there are some stashed notifications. Stashing notification to preserve order.";
 
 						stashedNotifications->Add(new Dictionary({
@@ -87,17 +87,17 @@ void Checkable::SendNotifications(NotificationType type, const CheckResult::Ptr&
 						notification->BeginExecuteNotification(type, cr, force, false, author, text);
 					}
 				} else {
-					Log(LogNotice, "Notification")
+					Log(LogNotice, "Notification", notification)
 						<< "Notification '" << notification->GetName() << "': HA cluster active, this endpoint does not have the authority (paused=true). Skipping.";
 				}
 			} catch (const std::exception& ex) {
-				Log(LogWarning, "Checkable")
+				Log(LogWarning, "Checkable", notification)
 					<< "Exception occurred during notification '" << notification->GetName() << "' for checkable '"
 					<< GetName() << "': " << DiagnosticInformation(ex, false);
 			}
 		} else {
 			// Cold startup phase. Stash notification for later.
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", notification)
 				<< "Notification '" << notification->GetName() << "': object authority hasn't been updated, yet. Stashing notification.";
 
 			notification->GetStashedNotifications()->Add(new Dictionary({

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -87,7 +87,7 @@ void Checkable::OnAllConfigLoaded()
 		auto [_, inserted] = alreadyWarned.emplace(*it);
 		lock.unlock();
 		if (inserted) {
-			Log(LogWarning, "Checkable")
+			Log(LogWarning, "Checkable", this)
 				<< "CheckCommand '" << GetCheckCommandRaw() << "' used by '" << GetName() << "' (" << GetDebugInfo()
 				<< ") is DEPRECATED and will be removed in v2.18. Further uses of this check command won't be logged.";
 		}
@@ -199,7 +199,7 @@ void Checkable::AcknowledgeProblem(const String& author, const String& comment, 
 	if (notify && !IsPaused())
 		OnNotificationsRequested(this, NotificationAcknowledgement, GetLastCheckResult(), author, comment, nullptr);
 
-	Log(LogInformation, "Checkable")
+	Log(LogInformation, "Checkable", this)
 		<< "Acknowledgement set for checkable '" << GetName() << "'.";
 
 	OnAcknowledgementSet(this, author, comment, type, notify, persistent, changeTime, expiry, origin);
@@ -216,7 +216,7 @@ void Checkable::ClearAcknowledgement(const String& removedBy, double changeTime,
 	SetAcknowledgementRaw(AcknowledgementNone);
 	SetAcknowledgementExpiry(0);
 
-	Log(LogInformation, "Checkable")
+	Log(LogInformation, "Checkable", this)
 		<< "Acknowledgement cleared for checkable '" << GetName() << "'.";
 
 	if (wasAcked) {

--- a/lib/icinga/clusterevents-check.cpp
+++ b/lib/icinga/clusterevents-check.cpp
@@ -116,7 +116,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 	}
 
 	if (!sourceEndpoint || (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone))) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", sourceEndpoint)
 			<< "Discarding 'execute command' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return;
 	}
@@ -124,7 +124,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 
 	if (!listener) {
-		Log(LogCritical, "ApiListener") << "No instance available.";
+		Log(LogCritical, "ApiListener", nullptr) << "No instance available.";
 		return;
 	}
 
@@ -144,7 +144,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 		double deadline = params->Get("deadline");
 
 		if (Utility::GetTime() > deadline) {
-			Log(LogNotice, "ApiListener")
+			Log(LogNotice, "ApiListener", sourceEndpoint)
 				<< "Discarding 'ExecuteCheckFromQueue' event for checkable '" << checkableName
 				<< "' from '" << origin->FromClient->GetIdentity() << "': Deadline has expired.";
 			return;
@@ -158,7 +158,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 
 			if (pr.ExitStatus > 3) {
 				Process::Arguments parguments = Process::PrepareCommand(commandLine);
-				Log(LogWarning, "ApiListener")
+				Log(LogWarning, "ApiListener", sourceEndpoint)
 					<< "Command for object '" << checkableName << "' (PID: " << pr.PID
 					<< ", arguments: " << Process::PrettyPrintArguments(parguments) << ") terminated with exit code "
 					<< pr.ExitStatus << ", output: " << pr.Output;
@@ -170,7 +170,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 	}
 
 	if (!listener->GetAcceptCommands() && !origin->IsLocal()) {
-		Log(LogWarning, "ApiListener")
+		Log(LogWarning, "ApiListener", sourceEndpoint)
 			<< "Ignoring command. '" << listener->GetName() << "' does not accept commands.";
 
 		String output = "Endpoint '" + Endpoint::GetLocalEndpoint()->GetName() + "' does not accept commands.";
@@ -246,7 +246,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 	} else if (command_type == "event_command") {
 		if (!EventCommand::GetByName(command)) {
 			String output = "Event command '" + command + "' does not exist.";
-			Log(LogWarning, "ClusterEvents") << output;
+			Log(LogWarning, "ClusterEvents", sourceEndpoint) << output;
 
 			if (params->Contains("source")) {
 				double now = Utility::GetTime();
@@ -258,7 +258,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 	} else if (command_type == "notification_command") {
 		if (!NotificationCommand::GetByName(command)) {
 			String output = "Notification command '" + command + "' does not exist.";
-			Log(LogWarning, "ClusterEvents") << output;
+			Log(LogWarning, "ClusterEvents", sourceEndpoint) << output;
 
 			if (params->Contains("source")) {
 				double now = Utility::GetTime();
@@ -301,7 +301,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 				listener->SyncSendMessage(sourceEndpoint, message);
 			}
 
-			Log(LogCritical, "checker", output);
+			Log(LogCritical, "checker", sourceEndpoint, output);
 		}
 	} else if (command_type == "event_command") {
 		try {
@@ -360,7 +360,7 @@ int ClusterEvents::GetCheckRequestQueueSize()
 
 void ClusterEvents::LogRemoteCheckQueueInformation() {
 	if (m_ChecksDroppedDuringInterval > 0) {
-		Log(LogCritical, "ClusterEvents")
+		Log(LogCritical, "ClusterEvents", nullptr)
 			<< "Remote check queue ran out of slots. "
 			<< m_ChecksDroppedDuringInterval << " checks dropped.";
 		m_ChecksDroppedDuringInterval = 0;
@@ -369,7 +369,7 @@ void ClusterEvents::LogRemoteCheckQueueInformation() {
 	if (m_ChecksExecutedDuringInterval == 0)
 		return;
 
-	Log(LogInformation, "RemoteCheckQueue")
+	Log(LogInformation, "RemoteCheckQueue", nullptr)
 		<< "items: " << m_CheckRequestQueue.size()
 		<< ", rate: " << m_ChecksExecutedDuringInterval / 10 << "/s "
 		<< "(" << m_ChecksExecutedDuringInterval * 6 << "/min "

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -111,7 +111,7 @@ Value ClusterEvents::CheckResultAPIHandler(const MessageOrigin::Ptr& origin, con
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'check result' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -170,7 +170,7 @@ Value ClusterEvents::CheckResultAPIHandler(const MessageOrigin::Ptr& origin, con
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable) && endpoint != checkable->GetCommandEndpoint()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'check result' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -214,7 +214,7 @@ Value ClusterEvents::NextCheckChangedAPIHandler(const MessageOrigin::Ptr& origin
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'next check changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -235,7 +235,7 @@ Value ClusterEvents::NextCheckChangedAPIHandler(const MessageOrigin::Ptr& origin
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'next check changed' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -281,7 +281,7 @@ Value ClusterEvents::LastCheckStartedChangedAPIHandler(const MessageOrigin::Ptr&
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'last_check_started changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -302,7 +302,7 @@ Value ClusterEvents::LastCheckStartedChangedAPIHandler(const MessageOrigin::Ptr&
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'last_check_started changed' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -343,7 +343,7 @@ Value ClusterEvents::StateBeforeSuppressionChangedAPIHandler(const MessageOrigin
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'state before suppression changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -364,7 +364,7 @@ Value ClusterEvents::StateBeforeSuppressionChangedAPIHandler(const MessageOrigin
 		return Empty;
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'state before suppression changed' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -405,7 +405,7 @@ Value ClusterEvents::SuppressedNotificationsChangedAPIHandler(const MessageOrigi
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'suppressed notifications changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -426,7 +426,7 @@ Value ClusterEvents::SuppressedNotificationsChangedAPIHandler(const MessageOrigi
 		return Empty;
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'suppressed notifications changed' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -461,7 +461,7 @@ Value ClusterEvents::SuppressedNotificationTypesChangedAPIHandler(const MessageO
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'suppressed notifications changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -472,7 +472,7 @@ Value ClusterEvents::SuppressedNotificationTypesChangedAPIHandler(const MessageO
 		return Empty;
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", notification)
 			<< "Discarding 'suppressed notification types changed' message for notification '" << notification->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -507,7 +507,7 @@ Value ClusterEvents::NextNotificationChangedAPIHandler(const MessageOrigin::Ptr&
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'next notification changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -518,7 +518,7 @@ Value ClusterEvents::NextNotificationChangedAPIHandler(const MessageOrigin::Ptr&
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(notification)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", notification)
 			<< "Discarding 'next notification changed' message for notification '" << notification->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -560,14 +560,14 @@ Value ClusterEvents::LastNotifiedStatePerUserUpdatedAPIHandler(const MessageOrig
 	auto endpoint (origin->FromClient->GetEndpoint());
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'last notified state of user updated' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 
 		return Empty;
 	}
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", endpoint)
 			<< "Discarding 'last notified state of user updated' message from '"
 			<< origin->FromClient->GetIdentity() << "': Unauthorized access.";
 
@@ -616,7 +616,7 @@ Value ClusterEvents::LastNotifiedStatePerUserClearedAPIHandler(const MessageOrig
 	auto endpoint (origin->FromClient->GetEndpoint());
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'last notified state of user cleared' message from '"
 			<< origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 
@@ -624,7 +624,7 @@ Value ClusterEvents::LastNotifiedStatePerUserClearedAPIHandler(const MessageOrig
 	}
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", endpoint)
 			<< "Discarding 'last notified state of user cleared' message from '"
 			<< origin->FromClient->GetIdentity() << "': Unauthorized access.";
 
@@ -673,7 +673,7 @@ Value ClusterEvents::ForceNextCheckChangedAPIHandler(const MessageOrigin::Ptr& o
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'force next check changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -694,7 +694,7 @@ Value ClusterEvents::ForceNextCheckChangedAPIHandler(const MessageOrigin::Ptr& o
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'force next check' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -735,7 +735,7 @@ Value ClusterEvents::ForceNextNotificationChangedAPIHandler(const MessageOrigin:
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'force next notification changed' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -756,7 +756,7 @@ Value ClusterEvents::ForceNextNotificationChangedAPIHandler(const MessageOrigin:
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'force next notification' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -805,7 +805,7 @@ Value ClusterEvents::AcknowledgementSetAPIHandler(const MessageOrigin::Ptr& orig
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'acknowledgement set' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -826,7 +826,7 @@ Value ClusterEvents::AcknowledgementSetAPIHandler(const MessageOrigin::Ptr& orig
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'acknowledgement set' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -835,7 +835,7 @@ Value ClusterEvents::AcknowledgementSetAPIHandler(const MessageOrigin::Ptr& orig
 	ObjectLock oLock (checkable);
 
 	if (checkable->IsAcknowledged()) {
-		Log(LogWarning, "ClusterEvents")
+		Log(LogWarning, "ClusterEvents", checkable)
 			<< "Discarding 'acknowledgement set' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Checkable is already acknowledged.";
 		return Empty;
@@ -879,7 +879,7 @@ Value ClusterEvents::AcknowledgementClearedAPIHandler(const MessageOrigin::Ptr& 
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'acknowledgement cleared' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -900,7 +900,7 @@ Value ClusterEvents::AcknowledgementClearedAPIHandler(const MessageOrigin::Ptr& 
 		return Empty;
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'acknowledgement cleared' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -923,7 +923,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 
 		/* Discard messages from anonymous clients */
 		if (!endpoint) {
-			Log(LogNotice, "ClusterEvents") << "Discarding 'execute command' message from '"
+			Log(LogNotice, "ClusterEvents", nullptr) << "Discarding 'execute command' message from '"
 				<< origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 			return Empty;
 		}
@@ -937,7 +937,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 		bool fromParentZone = parentZone && originZone == parentZone;
 
 		if (!fromLocalZone && !fromParentZone) {
-			Log(LogNotice, "ClusterEvents") << "Discarding 'execute command' message from '"
+			Log(LogNotice, "ClusterEvents", endpoint) << "Discarding 'execute command' message from '"
 				<< origin->FromClient->GetIdentity() << "': Unauthorized access.";
 			return Empty;
 		}
@@ -949,7 +949,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 		Endpoint::Ptr execEndpoint = Endpoint::GetByName(params->Get("endpoint"));
 
 		if (!execEndpoint) {
-			Log(LogWarning, "ClusterEvents")
+			Log(LogWarning, "ClusterEvents", nullptr)
 				<< "Discarding 'execute command' message " << executionUuid
 				<< ": Endpoint " << params->Get("endpoint") << " does not exist";
 			return Empty;
@@ -998,7 +998,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 					Checkable::Ptr checkable;
 					Host::Ptr host = Host::GetByName(params->Get("host"));
 					if (!host) {
-						Log(LogWarning, "ClusterEvents")
+						Log(LogWarning, "ClusterEvents", nullptr)
 							<< "Discarding 'execute command' message " << executionUuid
 							<< ": host " << params->Get("host") << " does not exist";
 						return Empty;
@@ -1014,7 +1014,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 						if (params->Contains("service"))
 							checkableName += "!" + params->Get("service");
 
-						Log(LogWarning, "ClusterEvents")
+						Log(LogWarning, "ClusterEvents", nullptr)
 							<< "Discarding 'execute command' message " << executionUuid
 							<< ": " << checkableName << " does not exist";
 						return Empty;
@@ -1092,7 +1092,7 @@ Value ClusterEvents::SendNotificationsAPIHandler(const MessageOrigin::Ptr& origi
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'send notification' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -1113,7 +1113,7 @@ Value ClusterEvents::SendNotificationsAPIHandler(const MessageOrigin::Ptr& origi
 		return Empty;
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'send custom notification' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -1183,7 +1183,7 @@ Value ClusterEvents::NotificationSentUserAPIHandler(const MessageOrigin::Ptr& or
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'sent notification to user' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -1204,7 +1204,7 @@ Value ClusterEvents::NotificationSentUserAPIHandler(const MessageOrigin::Ptr& or
 		return Empty;
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'send notification to user' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -1297,7 +1297,7 @@ Value ClusterEvents::NotificationSentToAllUsersAPIHandler(const MessageOrigin::P
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'sent notification to all users' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -1318,7 +1318,7 @@ Value ClusterEvents::NotificationSentToAllUsersAPIHandler(const MessageOrigin::P
 		return Empty;
 
 	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'sent notification to all users' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -1407,7 +1407,7 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 	}
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'update executions API handler' message from '" << origin->FromClient->GetIdentity()
 			<< "': Invalid endpoint origin (client not allowed).";
 
@@ -1432,7 +1432,7 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 	ObjectLock oLock (checkable);
 
 	if (!params->Contains("execution")) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Execution UUID missing.";
 		return Empty;
@@ -1443,7 +1443,7 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 	Dictionary::Ptr executions = checkable->GetExecutions();
 
 	if (!executions) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Execution '" << uuid << "' missing.";
 		return Empty;
@@ -1452,7 +1452,7 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 	Dictionary::Ptr execution = executions->Get(uuid);
 
 	if (!execution) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Execution '" << uuid << "' missing.";
 		return Empty;
@@ -1460,7 +1460,7 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 
 	Endpoint::Ptr command_endpoint = Endpoint::GetByName(execution->Get("endpoint"));
 	if (!command_endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'update executions API handler' message from '" << origin->FromClient->GetIdentity()
 			<< "': Command endpoint does not exists.";
 
@@ -1468,7 +1468,7 @@ Value ClusterEvents::ExecutedCommandAPIHandler(const MessageOrigin::Ptr& origin,
 	}
 
 	if (origin->FromZone && !command_endpoint->GetZone()->IsChildOf(origin->FromZone)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -1514,7 +1514,7 @@ Value ClusterEvents::UpdateExecutionsAPIHandler(const MessageOrigin::Ptr& origin
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", nullptr)
 			<< "Discarding 'update executions API handler' message from '" << origin->FromClient->GetIdentity()
 			<< "': Invalid endpoint origin (client not allowed).";
 
@@ -1539,7 +1539,7 @@ Value ClusterEvents::UpdateExecutionsAPIHandler(const MessageOrigin::Ptr& origin
 	ObjectLock oLock (checkable);
 
 	if (origin->FromZone && !origin->FromZone->CanAccessObject(checkable)) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", checkable)
 			<< "Discarding 'update executions API handler' message for checkable '" << checkable->GetName()
 			<< "' from '" << origin->FromClient->GetIdentity() << "': Unauthorized access.";
 		return Empty;
@@ -1596,7 +1596,7 @@ Value ClusterEvents::SetRemovalInfoAPIHandler(const MessageOrigin::Ptr& origin, 
 	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
 
 	if (!endpoint || (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone))) {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", endpoint)
 			<< "Discarding 'set removal info' message from '" << origin->FromClient->GetIdentity()
 			<< "': Invalid endpoint origin (client not allowed).";
 		return Empty;
@@ -1620,7 +1620,7 @@ Value ClusterEvents::SetRemovalInfoAPIHandler(const MessageOrigin::Ptr& origin, 
 			downtime->SetRemovalInfo(removedBy, removeTime, origin);
 		}
 	} else {
-		Log(LogNotice, "ClusterEvents")
+		Log(LogNotice, "ClusterEvents", endpoint)
 			<< "Discarding 'set removal info' message from '" << origin->FromClient->GetIdentity()
 			<< "': Unknown object type.";
 	}

--- a/lib/icinga/comment.cpp
+++ b/lib/icinga/comment.cpp
@@ -171,7 +171,7 @@ Comment::Ptr Comment::AddComment(const Checkable::Ptr& checkable, CommentType en
 	if (!ConfigObjectUtility::CreateObject(Comment::TypeInstance, fullName, config, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (String error : errors) {
-			Log(LogCritical, "Comment", error);
+			Log(LogCritical, "Comment", checkable, error);
 		}
 
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not create comment."));
@@ -182,7 +182,7 @@ Comment::Ptr Comment::AddComment(const Checkable::Ptr& checkable, CommentType en
 	if (!comment)
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not create comment."));
 
-	Log(LogNotice, "Comment")
+	Log(LogNotice, "Comment", comment)
 		<< "Added comment '" << comment->GetName() << "'.";
 
 	return comment;
@@ -195,7 +195,7 @@ void Comment::RemoveComment(const String& id, bool removedManually, const String
 	if (!comment || comment->GetPackage() != "_api")
 		return;
 
-	Log(LogNotice, "Comment")
+	Log(LogNotice, "Comment", comment)
 		<< "Removed comment '" << comment->GetName() << "' from object '" << comment->GetCheckable()->GetName() << "'.";
 
 	if (removedManually) {
@@ -207,7 +207,7 @@ void Comment::RemoveComment(const String& id, bool removedManually, const String
 	if (!ConfigObjectUtility::DeleteObject(comment, false, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (String error : errors) {
-			Log(LogCritical, "Comment", error);
+			Log(LogCritical, "Comment", comment, error);
 		}
 
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not remove comment."));

--- a/lib/icinga/comment.ti
+++ b/lib/icinga/comment.ti
@@ -35,12 +35,12 @@ class Comment : ConfigObject < CommentNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, no_user_modify, protected, required, navigation(host)] name(Host) host_name {
+	[config, no_user_modify, protected, required, navigation(host), parent_affecting_logging] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, no_user_modify, protected, navigation(service)] String service_name {
+	[config, no_user_modify, protected, navigation(service), parent_affecting_logging] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/dependency-state.cpp
+++ b/lib/icinga/dependency-state.cpp
@@ -35,7 +35,7 @@ bool DependencyStateChecker::IsReachable(Checkable::ConstPtr checkable, int rsta
 	}
 
 	if (rstack > Dependency::MaxDependencyRecursionLevel) {
-		Log(LogWarning, "Checkable")
+		Log(LogWarning, "Checkable", checkable)
 			<< "Too many nested dependencies (>" << Dependency::MaxDependencyRecursionLevel << ") for checkable '"
 			<< checkable->GetName() << "': Dependency failed.";
 
@@ -54,7 +54,7 @@ bool DependencyStateChecker::IsReachable(Checkable::ConstPtr checkable, int rsta
 
 	for (auto& dependencyGroup : checkable->GetDependencyGroups()) {
 		if (auto state(GetState(dependencyGroup, checkable.get(), rstack + 1)); state != DependencyGroup::State::Ok) {
-			Log(LogDebug, "Checkable")
+			Log(LogDebug, "Checkable", checkable)
 				<< "Dependency group '" << dependencyGroup->GetRedundancyGroupName() << "' have failed for checkable '"
 				<< checkable->GetName() << "': Marking as unreachable.";
 

--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -302,14 +302,14 @@ bool Dependency::IsAvailable(DependencyType dt) const
 
 	/* ignore if it's the same checkable object */
 	if (parent == GetChild()) {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' passed: Parent and child " << (parentService ? "service" : "host") << " are identical.";
 		return true;
 	}
 
 	/* ignore pending  */
 	if (!parent->GetLastCheckResult()) {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' passed: Parent " << (parentService ? "service" : "host") << " '" << parent->GetName() << "' hasn't been checked yet.";
 		return true;
 	}
@@ -317,12 +317,12 @@ bool Dependency::IsAvailable(DependencyType dt) const
 	if (GetIgnoreSoftStates()) {
 		/* ignore soft states */
 		if (parent->GetStateType() == StateTypeSoft) {
-			Log(LogNotice, "Dependency")
+			Log(LogNotice, "Dependency", this)
 				<< "Dependency '" << GetName() << "' passed: Parent " << (parentService ? "service" : "host") << " '" << parent->GetName() << "' is in a soft state.";
 			return true;
 		}
 	} else {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' failed: Parent " << (parentService ? "service" : "host") << " '" << parent->GetName() << "' is in a soft state.";
 	}
 
@@ -335,7 +335,7 @@ bool Dependency::IsAvailable(DependencyType dt) const
 
 	/* check state */
 	if (state & GetStateFilter()) {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' passed: Parent " << (parentService ? "service" : "host") << " '" << parent->GetName() << "' matches state filter.";
 		return true;
 	}
@@ -343,22 +343,22 @@ bool Dependency::IsAvailable(DependencyType dt) const
 	/* ignore if not in time period */
 	TimePeriod::Ptr tp = GetPeriod();
 	if (tp && !tp->IsInside(Utility::GetTime())) {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' passed: Outside time period.";
 		return true;
 	}
 
 	if (dt == DependencyCheckExecution && !GetDisableChecks()) {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' passed: Checks are not disabled.";
 		return true;
 	} else if (dt == DependencyNotification && !GetDisableNotifications()) {
-		Log(LogNotice, "Dependency")
+		Log(LogNotice, "Dependency", this)
 			<< "Dependency '" << GetName() << "' passed: Notifications are not disabled";
 		return true;
 	}
 
-	Log(LogNotice, "Dependency")
+	Log(LogNotice, "Dependency", this)
 		<< "Dependency '" << GetName() << "' failed. Parent "
 		<< (parentService ? "service" : "host") << " '" << parent->GetName() << "' is "
 		<< (parentService ? Service::StateToString(parentService->GetState()) : Host::StateToString(parentHost->GetState()));

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -26,13 +26,13 @@ class Dependency : CustomVarObject < DependencyNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, no_user_modify, required, navigation(child_host)] name(Host) child_host_name {
+	[config, no_user_modify, required, navigation(child_host), parent_affecting_logging] name(Host) child_host_name {
 		navigate {{{
 			return Host::GetByName(GetChildHostName());
 		}}}
 	};
 
-	[config, no_user_modify, navigation(child_service)] String child_service_name {
+	[config, no_user_modify, navigation(child_service), parent_affecting_logging] String child_service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetChildHostName(), oldValue);

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -55,13 +55,13 @@ class Dependency : CustomVarObject < DependencyNameComposer
 		}}}
 	};
 
-	[config, no_user_modify, required, navigation(parent_host)] name(Host) parent_host_name {
+	[config, no_user_modify, required, navigation(parent_host), parent_affecting_logging] name(Host) parent_host_name {
 		navigate {{{
 			return Host::GetByName(GetParentHostName());
 		}}}
 	};
 
-	[config, no_user_modify, navigation(parent_service)] String parent_service_name {
+	[config, no_user_modify, navigation(parent_service), parent_affecting_logging] String parent_service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetParentHostName(), oldValue);

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -168,6 +168,17 @@ void Downtime::Stop(bool runtimeRemoved)
 	ObjectImpl<Downtime>::Stop(runtimeRemoved);
 }
 
+void Downtime::GetParentsAffectingLogging(std::vector<ConfigObject::Ptr>& output) const
+{
+	ObjectImpl<Downtime>::GetParentsAffectingLogging(output);
+
+	auto object (ConfigObject::GetObject<ScheduledDowntime>(GetConfigOwner()));
+
+	if (object) {
+		output.emplace_back(std::move(object));
+	}
+}
+
 void Downtime::Pause()
 {
 	if (m_CleanupTimer) {

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -131,7 +131,7 @@ void Downtime::Start(bool runtimeCreated)
 	 * for DB IDO, etc.)
 	 */
 	if (!GetFixed() && !checkable->IsStateOK(checkable->GetStateRaw())) {
-		Log(LogNotice, "Downtime")
+		Log(LogNotice, "Downtime", this)
 			<< "Checkable '" << checkable->GetName() << "' already in a NOT-OK state."
 			<< " Triggering downtime now.";
 
@@ -343,7 +343,7 @@ Downtime::Ptr Downtime::AddDowntime(const Checkable::Ptr& checkable, const Strin
 	if (!ConfigObjectUtility::CreateObject(Downtime::TypeInstance, fullName, config, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (String error : errors) {
-			Log(LogCritical, "Downtime", error);
+			Log(LogCritical, "Downtime", checkable, error);
 		}
 
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not create downtime."));
@@ -362,7 +362,7 @@ Downtime::Ptr Downtime::AddDowntime(const Checkable::Ptr& checkable, const Strin
 	if (!downtime)
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not create downtime object."));
 
-	Log(LogInformation, "Downtime")
+	Log(LogInformation, "Downtime", downtime)
 		<< "Added downtime '" << downtime->GetName()
 		<< "' between '" << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S", startTime)
 		<< "' and '" << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S", endTime) << "', author: '"
@@ -401,7 +401,7 @@ void Downtime::RemoveDowntime(const String& id, bool includeChildren, DowntimeRe
 	if (!ConfigObjectUtility::DeleteObject(downtime, false, errors, nullptr)) {
 		ObjectLock olock(errors);
 		for (String error : errors) {
-			Log(LogCritical, "Downtime", error);
+			Log(LogCritical, "Downtime", downtime, error);
 		}
 
 		BOOST_THROW_EXCEPTION(std::runtime_error("Could not remove downtime."));
@@ -423,7 +423,7 @@ void Downtime::RemoveDowntime(const String& id, bool includeChildren, DowntimeRe
 			break;
 	}
 
-	Log msg (LogInformation, "Downtime");
+	Log msg (LogInformation, "Downtime", downtime);
 
 	msg << "Removed downtime '" << downtime->GetName() << "' from checkable";
 
@@ -501,7 +501,7 @@ void Downtime::TriggerDowntime(double triggerTime)
 
 	Checkable::Ptr checkable = GetCheckable();
 
-	Log(LogInformation, "Downtime")
+	Log(LogInformation, "Downtime", this)
 		<< "Triggering downtime '" << GetName() << "' for checkable '" << checkable->GetName() << "'.";
 
 	if (GetTriggerTime() == 0) {

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -78,6 +78,7 @@ public:
 protected:
 	void Start(bool runtimeCreated) override;
 	void Stop(bool runtimeRemoved) override;
+	void GetParentsAffectingLogging(std::vector<ConfigObject::Ptr>& output) const override;
 
 	void Pause() override;
 	void Resume() override;

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -26,12 +26,12 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, no_user_modify, required, navigation(host)] name(Host) host_name {
+	[config, no_user_modify, required, navigation(host), parent_affecting_logging] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, no_user_modify, navigation(service)] String service_name {
+	[config, no_user_modify, navigation(service), parent_affecting_logging] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -75,7 +75,7 @@ class Downtime : ConfigObject < DowntimeNameComposer
 	[no_storage] bool was_cancelled {
 		get {{{ return GetRemoveTime() > 0; }}}
 	};
-	[config] String config_owner;
+	[config, no_user_modify] String config_owner;
 	[config] String config_owner_hash;
 	[config] String authoritative_zone;
 

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -277,7 +277,7 @@ void ExternalCommandProcessor::ExecuteFromFile(const WaitGroup::Ptr& producer, c
 	std::vector<String> argvExtra(argv.begin() + 1, argv.end());
 
 	if (argv[0] == "PROCESS_FILE") {
-		Log(LogDebug, "ExternalCommandProcessor")
+		Log(LogDebug, "ExternalCommandProcessor", nullptr)
 			<< "Enqueing external command file " << argvExtra[0];
 		file_queue.push_back(argvExtra);
 	} else {
@@ -296,7 +296,7 @@ void ExternalCommandProcessor::ProcessHostCheckResult(const WaitGroup::Ptr& prod
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Got passive check result for host '" + arguments[0] + "' which has passive checks disabled."));
 
 	if (!host->IsReachable(DependencyCheckExecution)) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Ignoring passive check result for unreachable host '" << arguments[0] << "'";
 		return;
 	}
@@ -326,7 +326,7 @@ void ExternalCommandProcessor::ProcessHostCheckResult(const WaitGroup::Ptr& prod
 	/* Mark this check result as passive. */
 	result->SetActive(false);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Processing passive check result for host '" << arguments[0] << "'";
 
 	host->ProcessCheckResult(result, producer);
@@ -343,7 +343,7 @@ void ExternalCommandProcessor::ProcessServiceCheckResult(const WaitGroup::Ptr& p
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Got passive check result for service '" + arguments[1] + "' which has passive checks disabled."));
 
 	if (!service->IsReachable(DependencyCheckExecution)) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Ignoring passive check result for unreachable service '" << arguments[1] << "'";
 		return;
 	}
@@ -364,7 +364,7 @@ void ExternalCommandProcessor::ProcessServiceCheckResult(const WaitGroup::Ptr& p
 	/* Mark this check result as passive. */
 	result->SetActive(false);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Processing passive check result for service '" << arguments[1] << "'";
 
 	service->ProcessCheckResult(result, producer);
@@ -380,13 +380,13 @@ void ExternalCommandProcessor::ScheduleHostCheck(double, const std::vector<Strin
 	double planned_check = Convert::ToDouble(arguments[1]);
 
 	if (planned_check > host->GetNextCheck()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Ignoring reschedule request for host '"
 			<< arguments[0] << "' (next check is already sooner than requested check time)";
 		return;
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Rescheduling next check for host '" << arguments[0] << "'";
 
 	if (planned_check < Utility::GetTime())
@@ -405,7 +405,7 @@ void ExternalCommandProcessor::ScheduleForcedHostCheck(double, const std::vector
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot reschedule forced host check for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Rescheduling next check for host '" << arguments[0] << "'";
 
 	host->SetForceNextCheck(true);
@@ -425,13 +425,13 @@ void ExternalCommandProcessor::ScheduleSvcCheck(double, const std::vector<String
 	double planned_check = Convert::ToDouble(arguments[2]);
 
 	if (planned_check > service->GetNextCheck()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Ignoring reschedule request for service '"
 			<< arguments[1] << "' (next check is already sooner than requested check time)";
 		return;
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Rescheduling next check for service '" << arguments[1] << "'";
 
 	if (planned_check < Utility::GetTime())
@@ -450,7 +450,7 @@ void ExternalCommandProcessor::ScheduleForcedSvcCheck(double, const std::vector<
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot reschedule forced service check for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Rescheduling next check for service '" << arguments[1] << "'";
 
 	service->SetForceNextCheck(true);
@@ -467,7 +467,7 @@ void ExternalCommandProcessor::EnableHostCheck(double, const std::vector<String>
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host checks for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Enabling active checks for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_active_checks", true);
@@ -480,7 +480,7 @@ void ExternalCommandProcessor::DisableHostCheck(double, const std::vector<String
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host check non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Disabling active checks for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_active_checks", false);
@@ -493,7 +493,7 @@ void ExternalCommandProcessor::EnableSvcCheck(double, const std::vector<String>&
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service check for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Enabling active checks for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_active_checks", true);
@@ -506,7 +506,7 @@ void ExternalCommandProcessor::DisableSvcCheck(double, const std::vector<String>
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service check for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Disabling active checks for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_active_checks", false);
@@ -514,13 +514,13 @@ void ExternalCommandProcessor::DisableSvcCheck(double, const std::vector<String>
 
 void ExternalCommandProcessor::ShutdownProcess(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Shutting down Icinga via external command.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Shutting down Icinga via external command.");
 	Application::RequestShutdown();
 }
 
 void ExternalCommandProcessor::RestartProcess(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Restarting Icinga via external command.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Restarting Icinga via external command.");
 	Application::RequestRestart();
 }
 
@@ -534,7 +534,7 @@ void ExternalCommandProcessor::ScheduleForcedHostSvcChecks(double, const std::ve
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot reschedule forced host service checks for non-existent host '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : host->GetServices()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Rescheduling next check for service '" << service->GetName() << "'";
 
 		service->SetNextCheck(planned_check);
@@ -559,13 +559,13 @@ void ExternalCommandProcessor::ScheduleHostSvcChecks(double, const std::vector<S
 
 	for (const Service::Ptr& service : host->GetServices()) {
 		if (planned_check > service->GetNextCheck()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Ignoring reschedule request for service '"
 				<< service->GetName() << "' (next check is already sooner than requested check time)";
 			continue;
 		}
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Rescheduling next check for service '" << service->GetName() << "'";
 
 		service->SetNextCheck(planned_check);
@@ -583,7 +583,7 @@ void ExternalCommandProcessor::EnableHostSvcChecks(double, const std::vector<Str
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host service checks for non-existent host '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : host->GetServices()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Enabling active checks for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_active_checks", true);
@@ -598,7 +598,7 @@ void ExternalCommandProcessor::DisableHostSvcChecks(double, const std::vector<St
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host service checks for non-existent host '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : host->GetServices()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Disabling active checks for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_active_checks", false);
@@ -624,7 +624,7 @@ void ExternalCommandProcessor::AcknowledgeSvcProblem(double, const std::vector<S
 		BOOST_THROW_EXCEPTION(std::invalid_argument("The service '" + arguments[1] + "' is already acknowledged."));
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Setting acknowledgement for service '" << service->GetName() << "'" << (notify ? "" : ". Disabled notification");
 
 	Comment::AddComment(service, CommentAcknowledgement, arguments[5], arguments[6], persistent, 0, sticky);
@@ -654,7 +654,7 @@ void ExternalCommandProcessor::AcknowledgeSvcProblemExpire(double, const std::ve
 		BOOST_THROW_EXCEPTION(std::invalid_argument("The service '" + arguments[1] + "' is already acknowledged."));
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Setting timed acknowledgement for service '" << service->GetName() << "'" << (notify ? "" : ". Disabled notification");
 
 	Comment::AddComment(service, CommentAcknowledgement, arguments[6], arguments[7], persistent, timestamp, sticky);
@@ -668,7 +668,7 @@ void ExternalCommandProcessor::RemoveSvcAcknowledgement(double, const std::vecto
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot remove service acknowledgement for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Removing acknowledgement for service '" << service->GetName() << "'";
 
 	{
@@ -691,7 +691,7 @@ void ExternalCommandProcessor::AcknowledgeHostProblem(double, const std::vector<
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot acknowledge host problem for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Setting acknowledgement for host '" << host->GetName() << "'" << (notify ? "" : ". Disabled notification");
 
 	if (host->GetState() == HostUp)
@@ -718,7 +718,7 @@ void ExternalCommandProcessor::AcknowledgeHostProblemExpire(double, const std::v
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot acknowledge host problem with expire time for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Setting timed acknowledgement for host '" << host->GetName() << "'" << (notify ? "" : ". Disabled notification");
 
 	if (host->GetState() == HostUp)
@@ -742,7 +742,7 @@ void ExternalCommandProcessor::RemoveHostAcknowledgement(double, const std::vect
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot remove acknowledgement for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Removing acknowledgement for host '" << host->GetName() << "'";
 
 	{
@@ -761,7 +761,7 @@ void ExternalCommandProcessor::EnableHostgroupSvcChecks(double, const std::vecto
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
 		for (const Service::Ptr& service : host->GetServices()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Enabling active checks for service '" << service->GetName() << "'";
 
 			service->ModifyAttribute("enable_active_checks", true);
@@ -778,7 +778,7 @@ void ExternalCommandProcessor::DisableHostgroupSvcChecks(double, const std::vect
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
 		for (const Service::Ptr& service : host->GetServices()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Disabling active checks for service '" << service->GetName() << "'";
 
 			service->ModifyAttribute("enable_active_checks", false);
@@ -794,7 +794,7 @@ void ExternalCommandProcessor::EnableServicegroupSvcChecks(double, const std::ve
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable servicegroup service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Enabling active checks for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_active_checks", true);
@@ -809,7 +809,7 @@ void ExternalCommandProcessor::DisableServicegroupSvcChecks(double, const std::v
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable servicegroup service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Disabling active checks for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_active_checks", false);
@@ -823,7 +823,7 @@ void ExternalCommandProcessor::EnablePassiveHostChecks(double, const std::vector
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable passive host checks for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Enabling passive checks for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_passive_checks", true);
@@ -836,7 +836,7 @@ void ExternalCommandProcessor::DisablePassiveHostChecks(double, const std::vecto
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable passive host checks for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Disabling passive checks for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_passive_checks", false);
@@ -849,7 +849,7 @@ void ExternalCommandProcessor::EnablePassiveSvcChecks(double, const std::vector<
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service checks for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Enabling passive checks for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_passive_checks", true);
@@ -862,7 +862,7 @@ void ExternalCommandProcessor::DisablePassiveSvcChecks(double, const std::vector
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service checks for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Disabling passive checks for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_passive_checks", false);
@@ -876,7 +876,7 @@ void ExternalCommandProcessor::EnableServicegroupPassiveSvcChecks(double, const 
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable servicegroup passive service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Enabling passive checks for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_passive_checks", true);
@@ -891,7 +891,7 @@ void ExternalCommandProcessor::DisableServicegroupPassiveSvcChecks(double, const
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable servicegroup passive service checks for non-existent servicegroup '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Disabling passive checks for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_passive_checks", false);
@@ -907,7 +907,7 @@ void ExternalCommandProcessor::EnableHostgroupPassiveSvcChecks(double, const std
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
 		for (const Service::Ptr& service : host->GetServices()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Enabling passive checks for service '" << service->GetName() << "'";
 
 			service->ModifyAttribute("enable_passive_checks", true);
@@ -924,7 +924,7 @@ void ExternalCommandProcessor::DisableHostgroupPassiveSvcChecks(double, const st
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
 		for (const Service::Ptr& service : host->GetServices()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Disabling passive checks for service '" << service->GetName() << "'";
 
 			service->ModifyAttribute("enable_passive_checks", false);
@@ -954,12 +954,12 @@ void ExternalCommandProcessor::ProcessFile(const WaitGroup::Ptr& producer, doubl
 			std::getline(ifp, line);
 
 			try {
-				Log(LogNotice, "compat")
+				Log(LogNotice, "compat", nullptr)
 					<< "Executing external command: " << line;
 
 				ExecuteFromFile(producer, line, file_queue);
 			} catch (const std::exception& ex) {
-				Log(LogWarning, "ExternalCommandProcessor")
+				Log(LogWarning, "ExternalCommandProcessor", nullptr)
 					<< "External command failed: " << DiagnosticInformation(ex);
 			}
 		}
@@ -986,7 +986,7 @@ void ExternalCommandProcessor::ScheduleSvcDowntime(double, const std::vector<Str
 		triggeredBy = Downtime::GetDowntimeFromLegacyID(triggeredByLegacy);
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Creating downtime for service " << service->GetName();
 	(void) Downtime::AddDowntime(service, arguments[7], arguments[8],
 		Convert::ToDouble(arguments[2]), Convert::ToDouble(arguments[3]),
@@ -1006,10 +1006,10 @@ void ExternalCommandProcessor::DelSvcDowntime(double, const std::vector<String>&
 	try {
 		Downtime::RemoveDowntime(rid, false, DowntimeRemovedByUser);
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", dt)
 			<< "Removed downtime ID " << arguments[0];
 	} catch (const invalid_downtime_removal_error& error) {
-		Log(LogWarning, "ExternalCommandProcessor") << error.what();
+		Log(LogWarning, "ExternalCommandProcessor", dt) << error.what();
 	}
 }
 
@@ -1028,7 +1028,7 @@ void ExternalCommandProcessor::ScheduleHostDowntime(double, const std::vector<St
 		triggeredBy = Downtime::GetDowntimeFromLegacyID(triggeredByLegacy);
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Creating downtime for host " << host->GetName();
 
 	(void) Downtime::AddDowntime(host, arguments[6], arguments[7],
@@ -1051,7 +1051,7 @@ void ExternalCommandProcessor::ScheduleAndPropagateHostDowntime(double, const st
 		triggeredBy = Downtime::GetDowntimeFromLegacyID(triggeredByLegacy);
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Creating downtime for host " << host->GetName();
 
 	(void) Downtime::AddDowntime(host, arguments[6], arguments[7],
@@ -1089,7 +1089,7 @@ void ExternalCommandProcessor::ScheduleAndPropagateTriggeredHostDowntime(double,
 		triggeredBy = Downtime::GetDowntimeFromLegacyID(triggeredByLegacy);
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Creating downtime for host " << host->GetName();
 
 	Downtime::Ptr parentDowntime = Downtime::AddDowntime(host, arguments[6], arguments[7],
@@ -1125,10 +1125,10 @@ void ExternalCommandProcessor::DelHostDowntime(double, const std::vector<String>
 	try {
 		Downtime::RemoveDowntime(rid, false, DowntimeRemovedByUser);
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", dt)
 			<< "Removed downtime ID " << arguments[0];
 	} catch (const invalid_downtime_removal_error& error) {
-		Log(LogWarning, "ExternalCommandProcessor") << error.what();
+		Log(LogWarning, "ExternalCommandProcessor", dt) << error.what();
 	}
 }
 
@@ -1152,7 +1152,7 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 		commentString = arguments[3];
 
 	if (arguments.size() > 5)
-		Log(LogWarning, "ExternalCommandProcessor")
+		Log(LogWarning, "ExternalCommandProcessor", host)
 			<< ("Ignoring additional parameters for host '" + arguments[0] + "' downtime deletion.");
 
 	for (const Downtime::Ptr& downtime : host->GetDowntimes()) {
@@ -1160,10 +1160,10 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 			String downtimeName = downtime->GetName();
 			Downtime::RemoveDowntime(downtimeName, false, DowntimeRemovedByUser);
 
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", downtime)
 				<< "Removed downtime '" << downtimeName << "'.";
 		} catch (const invalid_downtime_removal_error& error) {
-			Log(LogWarning, "ExternalCommandProcessor") << error.what();
+			Log(LogWarning, "ExternalCommandProcessor", downtime) << error.what();
 		}
 	}
 
@@ -1182,10 +1182,10 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 				String downtimeName = downtime->GetName();
 				Downtime::RemoveDowntime(downtimeName, false, DowntimeRemovedByUser);
 
-				Log(LogNotice, "ExternalCommandProcessor")
+				Log(LogNotice, "ExternalCommandProcessor", downtime)
 					<< "Removed downtime '" << downtimeName << "'.";
 			} catch (const invalid_downtime_removal_error& error) {
-				Log(LogWarning, "ExternalCommandProcessor") << error.what();
+				Log(LogWarning, "ExternalCommandProcessor", downtime) << error.what();
 			}
 		}
 	}
@@ -1206,7 +1206,7 @@ void ExternalCommandProcessor::ScheduleHostSvcDowntime(double, const std::vector
 		triggeredBy = Downtime::GetDowntimeFromLegacyID(triggeredByLegacy);
 	}
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Creating downtime for host " << host->GetName();
 
 	(void) Downtime::AddDowntime(host, arguments[6], arguments[7],
@@ -1214,7 +1214,7 @@ void ExternalCommandProcessor::ScheduleHostSvcDowntime(double, const std::vector
 		Convert::ToBool(is_fixed), triggeredBy, Convert::ToDouble(arguments[5]));
 
 	for (const Service::Ptr& service : host->GetServices()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Creating downtime for service " << service->GetName();
 		(void) Downtime::AddDowntime(service, arguments[6], arguments[7],
 			Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
@@ -1238,7 +1238,7 @@ void ExternalCommandProcessor::ScheduleHostgroupHostDowntime(double, const std::
 	}
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<<  "Creating downtime for host " << host->GetName();
 
 		(void) Downtime::AddDowntime(host, arguments[6], arguments[7],
@@ -1275,7 +1275,7 @@ void ExternalCommandProcessor::ScheduleHostgroupSvcDowntime(double, const std::v
 	}
 
 	for (const Service::Ptr& service : services) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Creating downtime for service " << service->GetName();
 		(void) Downtime::AddDowntime(service, arguments[6], arguments[7],
 			Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
@@ -1310,7 +1310,7 @@ void ExternalCommandProcessor::ScheduleServicegroupHostDowntime(double, const st
 	}
 
 	for (const Host::Ptr& host : hosts) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Creating downtime for host " << host->GetName();
 		(void) Downtime::AddDowntime(host, arguments[6], arguments[7],
 			Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
@@ -1334,7 +1334,7 @@ void ExternalCommandProcessor::ScheduleServicegroupSvcDowntime(double, const std
 	}
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Creating downtime for service " << service->GetName();
 		(void) Downtime::AddDowntime(service, arguments[6], arguments[7],
 			Convert::ToDouble(arguments[1]), Convert::ToDouble(arguments[2]),
@@ -1352,7 +1352,7 @@ void ExternalCommandProcessor::AddHostComment(double, const std::vector<String>&
 	if (arguments[2].IsEmpty() || arguments[3].IsEmpty())
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Author and comment must not be empty"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Creating comment for host " << host->GetName();
 	(void) Comment::AddComment(host, CommentUser, arguments[2], arguments[3], false, 0);
 }
@@ -1360,7 +1360,7 @@ void ExternalCommandProcessor::AddHostComment(double, const std::vector<String>&
 void ExternalCommandProcessor::DelHostComment(double, const std::vector<String>& arguments)
 {
 	int id = Convert::ToLong(arguments[0]);
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", nullptr)
 		<< "Removing comment ID " << arguments[0];
 	String rid = Comment::GetCommentIDFromLegacyID(id);
 	Comment::RemoveComment(rid);
@@ -1376,7 +1376,7 @@ void ExternalCommandProcessor::AddSvcComment(double, const std::vector<String>& 
 	if (arguments[3].IsEmpty() || arguments[4].IsEmpty())
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Author and comment must not be empty"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Creating comment for service " << service->GetName();
 	(void) Comment::AddComment(service, CommentUser, arguments[3], arguments[4], false, 0);
 }
@@ -1384,7 +1384,7 @@ void ExternalCommandProcessor::AddSvcComment(double, const std::vector<String>& 
 void ExternalCommandProcessor::DelSvcComment(double, const std::vector<String>& arguments)
 {
 	int id = Convert::ToLong(arguments[0]);
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", nullptr)
 		<< "Removing comment ID " << arguments[0];
 
 	String rid = Comment::GetCommentIDFromLegacyID(id);
@@ -1398,7 +1398,7 @@ void ExternalCommandProcessor::DelAllHostComments(double, const std::vector<Stri
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot delete all host comments for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Removing all comments for host " << host->GetName();
 	host->RemoveAllComments();
 }
@@ -1410,7 +1410,7 @@ void ExternalCommandProcessor::DelAllSvcComments(double, const std::vector<Strin
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot delete all service comments for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Removing all comments for service " << service->GetName();
 	service->RemoveAllComments();
 }
@@ -1424,7 +1424,7 @@ void ExternalCommandProcessor::SendCustomHostNotification(double, const std::vec
 
 	int options = Convert::ToLong(arguments[1]);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Sending custom notification for host " << host->GetName();
 	if (options & 2) {
 		host->SetForceNextNotification(true);
@@ -1443,7 +1443,7 @@ void ExternalCommandProcessor::SendCustomSvcNotification(double, const std::vect
 
 	int options = Convert::ToLong(arguments[2]);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Sending custom notification for service " << service->GetName();
 
 	if (options & 2) {
@@ -1461,7 +1461,7 @@ void ExternalCommandProcessor::DelayHostNotification(double, const std::vector<S
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot delay host notification for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Delaying notifications for host '" << host->GetName() << "'";
 
 	for (const Notification::Ptr& notification : host->GetNotifications()) {
@@ -1476,7 +1476,7 @@ void ExternalCommandProcessor::DelaySvcNotification(double, const std::vector<St
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot delay service notification for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Delaying notifications for service " << service->GetName();
 
 	for (const Notification::Ptr& notification : service->GetNotifications()) {
@@ -1491,7 +1491,7 @@ void ExternalCommandProcessor::EnableHostNotifications(double, const std::vector
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host notifications for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Enabling notifications for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_notifications", true);
@@ -1504,7 +1504,7 @@ void ExternalCommandProcessor::DisableHostNotifications(double, const std::vecto
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host notifications for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Disabling notifications for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_notifications", false);
@@ -1517,7 +1517,7 @@ void ExternalCommandProcessor::EnableSvcNotifications(double, const std::vector<
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service notifications for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Enabling notifications for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_notifications", true);
@@ -1530,7 +1530,7 @@ void ExternalCommandProcessor::DisableSvcNotifications(double, const std::vector
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service notifications for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Disabling notifications for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_notifications", false);
@@ -1543,11 +1543,11 @@ void ExternalCommandProcessor::EnableHostSvcNotifications(double, const std::vec
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable notifications for all services for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Enabling notifications for all services on host '" << arguments[0] << "'";
 
 	for (const Service::Ptr& service : host->GetServices()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Enabling notifications for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_notifications", true);
@@ -1561,11 +1561,11 @@ void ExternalCommandProcessor::DisableHostSvcNotifications(double, const std::ve
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable notifications for all services  for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Disabling notifications for all services on host '" << arguments[0] << "'";
 
 	for (const Service::Ptr& service : host->GetServices()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Disabling notifications for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_notifications", false);
@@ -1580,7 +1580,7 @@ void ExternalCommandProcessor::DisableHostgroupHostChecks(double, const std::vec
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable hostgroup host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Disabling active checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_active_checks", false);
@@ -1595,7 +1595,7 @@ void ExternalCommandProcessor::DisableHostgroupPassiveHostChecks(double, const s
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable hostgroup passive host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Disabling passive checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_passive_checks", false);
@@ -1612,7 +1612,7 @@ void ExternalCommandProcessor::DisableServicegroupHostChecks(double, const std::
 	for (const Service::Ptr& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Disabling active checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_active_checks", false);
@@ -1629,7 +1629,7 @@ void ExternalCommandProcessor::DisableServicegroupPassiveHostChecks(double, cons
 	for (const Service::Ptr& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Disabling passive checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_passive_checks", false);
@@ -1644,7 +1644,7 @@ void ExternalCommandProcessor::EnableHostgroupHostChecks(double, const std::vect
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable hostgroup host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Enabling active checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_active_checks", true);
@@ -1659,7 +1659,7 @@ void ExternalCommandProcessor::EnableHostgroupPassiveHostChecks(double, const st
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable hostgroup passive host checks for non-existent hostgroup '" + arguments[0] + "'"));
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Enabling passive checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_passive_checks", true);
@@ -1676,7 +1676,7 @@ void ExternalCommandProcessor::EnableServicegroupHostChecks(double, const std::v
 	for (const Service::Ptr& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Enabling active checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_active_checks", true);
@@ -1693,7 +1693,7 @@ void ExternalCommandProcessor::EnableServicegroupPassiveHostChecks(double, const
 	for (const Service::Ptr& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Enabling passive checks for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_passive_checks", true);
@@ -1707,7 +1707,7 @@ void ExternalCommandProcessor::EnableHostFlapping(double, const std::vector<Stri
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host flapping for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Enabling flapping detection for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_flapping", true);
@@ -1720,7 +1720,7 @@ void ExternalCommandProcessor::DisableHostFlapping(double, const std::vector<Str
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host flapping for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Disabling flapping detection for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_flapping", false);
@@ -1733,7 +1733,7 @@ void ExternalCommandProcessor::EnableSvcFlapping(double, const std::vector<Strin
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service flapping for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Enabling flapping detection for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_flapping", true);
@@ -1746,7 +1746,7 @@ void ExternalCommandProcessor::DisableSvcFlapping(double, const std::vector<Stri
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service flapping for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Disabling flapping detection for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_flapping", false);
@@ -1754,84 +1754,84 @@ void ExternalCommandProcessor::DisableSvcFlapping(double, const std::vector<Stri
 
 void ExternalCommandProcessor::EnableNotifications(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally enabling notifications.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally enabling notifications.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_notifications", true);
 }
 
 void ExternalCommandProcessor::DisableNotifications(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally disabling notifications.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally disabling notifications.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_notifications", false);
 }
 
 void ExternalCommandProcessor::EnableFlapDetection(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally enabling flap detection.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally enabling flap detection.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_flapping", true);
 }
 
 void ExternalCommandProcessor::DisableFlapDetection(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally disabling flap detection.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally disabling flap detection.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_flapping", false);
 }
 
 void ExternalCommandProcessor::EnableEventHandlers(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally enabling event handlers.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally enabling event handlers.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_event_handlers", true);
 }
 
 void ExternalCommandProcessor::DisableEventHandlers(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally disabling event handlers.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally disabling event handlers.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_event_handlers", false);
 }
 
 void ExternalCommandProcessor::EnablePerformanceData(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally enabling performance data processing.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally enabling performance data processing.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_perfdata", true);
 }
 
 void ExternalCommandProcessor::DisablePerformanceData(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally disabling performance data processing.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally disabling performance data processing.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_perfdata", false);
 }
 
 void ExternalCommandProcessor::StartExecutingSvcChecks(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally enabling service checks.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally enabling service checks.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_service_checks", true);
 }
 
 void ExternalCommandProcessor::StopExecutingSvcChecks(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally disabling service checks.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally disabling service checks.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_service_checks", false);
 }
 
 void ExternalCommandProcessor::StartExecutingHostChecks(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally enabling host checks.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally enabling host checks.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_host_checks", true);
 }
 
 void ExternalCommandProcessor::StopExecutingHostChecks(double, const std::vector<String>&)
 {
-	Log(LogNotice, "ExternalCommandProcessor", "Globally disabling host checks.");
+	Log(LogNotice, "ExternalCommandProcessor", nullptr, "Globally disabling host checks.");
 
 	IcingaApplication::GetInstance()->ModifyAttribute("enable_host_checks", false);
 }
@@ -1845,7 +1845,7 @@ void ExternalCommandProcessor::ChangeNormalSvcCheckInterval(double, const std::v
 
 	double interval = Convert::ToDouble(arguments[2]);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Updating check interval for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("check_interval", interval * 60);
@@ -1858,7 +1858,7 @@ void ExternalCommandProcessor::ChangeNormalHostCheckInterval(double, const std::
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot update check interval for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Updating check interval for host '" << arguments[0] << "'";
 
 	double interval = Convert::ToDouble(arguments[1]);
@@ -1875,7 +1875,7 @@ void ExternalCommandProcessor::ChangeRetrySvcCheckInterval(double, const std::ve
 
 	double interval = Convert::ToDouble(arguments[2]);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Updating retry interval for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("retry_interval", interval * 60);
@@ -1888,7 +1888,7 @@ void ExternalCommandProcessor::ChangeRetryHostCheckInterval(double, const std::v
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot update retry interval for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Updating retry interval for host '" << arguments[0] << "'";
 
 	double interval = Convert::ToDouble(arguments[1]);
@@ -1903,7 +1903,7 @@ void ExternalCommandProcessor::EnableHostEventHandler(double, const std::vector<
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable event handler for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Enabling event handler for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_event_handler", true);
@@ -1916,7 +1916,7 @@ void ExternalCommandProcessor::DisableHostEventHandler(double, const std::vector
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable event handler for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Disabling event handler for host '" << arguments[0] << "'";
 
 	host->ModifyAttribute("enable_event_handler", false);
@@ -1929,7 +1929,7 @@ void ExternalCommandProcessor::EnableSvcEventHandler(double, const std::vector<S
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable event handler for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Enabling event handler for service '" << arguments[1] << "'";
 
 	service->ModifyAttribute("enable_event_handler", true);
@@ -1942,7 +1942,7 @@ void ExternalCommandProcessor::DisableSvcEventHandler(double, const std::vector<
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable event handler for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Disabling event handler for service '" << arguments[1] + "'";
 
 	service->ModifyAttribute("enable_event_handler", false);
@@ -1956,7 +1956,7 @@ void ExternalCommandProcessor::ChangeHostEventHandler(double, const std::vector<
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot change event handler for non-existent host '" + arguments[0] + "'"));
 
 	if (arguments[1].IsEmpty()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Unsetting event handler for host '" << arguments[0] << "'";
 
 		host->ModifyAttribute("event_command", "");
@@ -1966,7 +1966,7 @@ void ExternalCommandProcessor::ChangeHostEventHandler(double, const std::vector<
 		if (!command)
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Event command '" + arguments[1] + "' does not exist."));
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Changing event handler for host '" << arguments[0] << "' to '" << arguments[1] << "'";
 
 		host->ModifyAttribute("event_command", command->GetName());
@@ -1981,7 +1981,7 @@ void ExternalCommandProcessor::ChangeSvcEventHandler(double, const std::vector<S
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot change event handler for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
 	if (arguments[2].IsEmpty()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Unsetting event handler for service '" << arguments[1] << "'";
 
 		service->ModifyAttribute("event_command", "");
@@ -1991,7 +1991,7 @@ void ExternalCommandProcessor::ChangeSvcEventHandler(double, const std::vector<S
 		if (!command)
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Event command '" + arguments[2] + "' does not exist."));
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Changing event handler for service '" << arguments[1] << "' to '" << arguments[2] << "'";
 
 		service->ModifyAttribute("event_command", command->GetName());
@@ -2010,7 +2010,7 @@ void ExternalCommandProcessor::ChangeHostCheckCommand(double, const std::vector<
 	if (!command)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Check command '" + arguments[1] + "' does not exist."));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Changing check command for host '" << arguments[0] << "' to '" << arguments[1] << "'";
 
 	host->ModifyAttribute("check_command", command->GetName());
@@ -2028,7 +2028,7 @@ void ExternalCommandProcessor::ChangeSvcCheckCommand(double, const std::vector<S
 	if (!command)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Check command '" + arguments[2] + "' does not exist."));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Changing check command for service '" << arguments[1] << "' to '" << arguments[2] << "'";
 
 	service->ModifyAttribute("check_command", command->GetName());
@@ -2043,7 +2043,7 @@ void ExternalCommandProcessor::ChangeMaxHostCheckAttempts(double, const std::vec
 
 	int attempts = Convert::ToLong(arguments[1]);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Changing max check attempts for host '" << arguments[0] << "' to '" << arguments[1] << "'";
 
 	host->ModifyAttribute("max_check_attempts", attempts);
@@ -2058,7 +2058,7 @@ void ExternalCommandProcessor::ChangeMaxSvcCheckAttempts(double, const std::vect
 
 	int attempts = Convert::ToLong(arguments[2]);
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Changing max check attempts for service '" << arguments[1] << "' to '" << arguments[2] << "'";
 
 	service->ModifyAttribute("max_check_attempts", attempts);
@@ -2076,7 +2076,7 @@ void ExternalCommandProcessor::ChangeHostCheckTimeperiod(double, const std::vect
 	if (!tp)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Time period '" + arguments[1] + "' does not exist."));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Changing check period for host '" << arguments[0] << "' to '" << arguments[1] << "'";
 
 	host->ModifyAttribute("check_period", tp->GetName());
@@ -2094,7 +2094,7 @@ void ExternalCommandProcessor::ChangeSvcCheckTimeperiod(double, const std::vecto
 	if (!tp)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Time period '" + arguments[2] + "' does not exist."));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Changing check period for service '" << arguments[1] << "' to '" << arguments[2] << "'";
 
 	service->ModifyAttribute("check_period", tp->GetName());
@@ -2107,7 +2107,7 @@ void ExternalCommandProcessor::ChangeCustomHostVar(double, const std::vector<Str
 	if (!host)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot change custom var for non-existent host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", host)
 		<< "Changing custom var '" << arguments[1] << "' for host '" << arguments[0] << "' to value '" << arguments[2] << "'";
 
 	host->ModifyAttribute("vars." + arguments[1], arguments[2]);
@@ -2120,7 +2120,7 @@ void ExternalCommandProcessor::ChangeCustomSvcVar(double, const std::vector<Stri
 	if (!service)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot change custom var for non-existent service '" + arguments[1] + "' on host '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", service)
 		<< "Changing custom var '" << arguments[2] << "' for service '" << arguments[1] << "' on host '"
 		<< arguments[0] << "' to value '" << arguments[3] << "'";
 
@@ -2134,7 +2134,7 @@ void ExternalCommandProcessor::ChangeCustomUserVar(double, const std::vector<Str
 	if (!user)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot change custom var for non-existent user '" + arguments[0] + "'"));
 
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", user)
 		<< "Changing custom var '" << arguments[1] << "' for user '" << arguments[0] << "' to value '" << arguments[2] << "'";
 
 	user->ModifyAttribute("vars." + arguments[1], arguments[2]);
@@ -2172,7 +2172,7 @@ void ExternalCommandProcessor::ChangeCustomNotificationcommandVar(double, const 
 
 void ExternalCommandProcessor::ChangeCustomCommandVarInternal(const Command::Ptr& command, const String& name, const Value& value)
 {
-	Log(LogNotice, "ExternalCommandProcessor")
+	Log(LogNotice, "ExternalCommandProcessor", command)
 		<< "Changing custom var '" << name << "' for command '" << command->GetName() << "' to value '" << value << "'";
 
 	command->ModifyAttribute("vars." + name, value);
@@ -2186,7 +2186,7 @@ void ExternalCommandProcessor::EnableHostgroupHostNotifications(double, const st
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable host notifications for non-existent hostgroup '" + arguments[0] + "'"));
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Enabling notifications for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_notifications", true);
@@ -2202,7 +2202,7 @@ void ExternalCommandProcessor::EnableHostgroupSvcNotifications(double, const std
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
 		for (const Service::Ptr& service : host->GetServices()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Enabling notifications for service '" << service->GetName() << "'";
 
 			service->ModifyAttribute("enable_notifications", true);
@@ -2218,7 +2218,7 @@ void ExternalCommandProcessor::DisableHostgroupHostNotifications(double, const s
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable host notifications for non-existent hostgroup '" + arguments[0] + "'"));
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Disabling notifications for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_notifications", false);
@@ -2234,7 +2234,7 @@ void ExternalCommandProcessor::DisableHostgroupSvcNotifications(double, const st
 
 	for (const Host::Ptr& host : hg->GetMembers()) {
 		for (const Service::Ptr& service : host->GetServices()) {
-			Log(LogNotice, "ExternalCommandProcessor")
+			Log(LogNotice, "ExternalCommandProcessor", service)
 				<< "Disabling notifications for service '" << service->GetName() << "'";
 
 			service->ModifyAttribute("enable_notifications", false);
@@ -2252,7 +2252,7 @@ void ExternalCommandProcessor::EnableServicegroupHostNotifications(double, const
 	for (const Service::Ptr& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Enabling notifications for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_notifications", true);
@@ -2267,7 +2267,7 @@ void ExternalCommandProcessor::EnableServicegroupSvcNotifications(double, const 
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot enable service notifications for non-existent servicegroup '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Enabling notifications for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_notifications", true);
@@ -2284,7 +2284,7 @@ void ExternalCommandProcessor::DisableServicegroupHostNotifications(double, cons
 	for (const Service::Ptr& service : sg->GetMembers()) {
 		Host::Ptr host = service->GetHost();
 
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", host)
 			<< "Disabling notifications for host '" << host->GetName() << "'";
 
 		host->ModifyAttribute("enable_notifications", false);
@@ -2299,7 +2299,7 @@ void ExternalCommandProcessor::DisableServicegroupSvcNotifications(double, const
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Cannot disable service notifications for non-existent servicegroup '" + arguments[0] + "'"));
 
 	for (const Service::Ptr& service : sg->GetMembers()) {
-		Log(LogNotice, "ExternalCommandProcessor")
+		Log(LogNotice, "ExternalCommandProcessor", service)
 			<< "Disabling notifications for service '" << service->GetName() << "'";
 
 		service->ModifyAttribute("enable_notifications", false);

--- a/lib/icinga/host.ti
+++ b/lib/icinga/host.ti
@@ -16,7 +16,7 @@ class Host : Checkable
 	load_after Endpoint;
 	load_after Zone;
 
-	[config, no_user_modify, required, signal_with_old_value] array(name(HostGroup)) groups {
+	[config, no_user_modify, required, signal_with_old_value, parent_affecting_logging] array(name(HostGroup)) groups {
 		default {{{ return new Array(); }}}
 	};
 

--- a/lib/icinga/hostgroup.cpp
+++ b/lib/icinga/hostgroup.cpp
@@ -33,7 +33,7 @@ bool HostGroup::EvaluateObjectRule(const Host::Ptr& host, const ConfigItem::Ptr&
 	if (!group->GetFilter()->Evaluate(frame).GetValue().ToBool())
 		return false;
 
-	Log(LogDebug, "HostGroup")
+	Log(LogDebug, "HostGroup", host)
 		<< "Assigning membership for group '" << groupName << "' to host '" << host->GetName() << "'";
 
 	Array::Ptr groups = host->GetGroups();
@@ -80,7 +80,7 @@ void HostGroup::RemoveMember(const Host::Ptr& host)
 bool HostGroup::ResolveGroupMembership(const Host::Ptr& host, bool add, int rstack) {
 
 	if (add && rstack > 20) {
-		Log(LogWarning, "HostGroup")
+		Log(LogWarning, "HostGroup", host)
 			<< "Too many nested groups for group '" << GetName() << "': Host '"
 			<< host->GetName() << "' membership assignment failed.";
 

--- a/lib/icinga/hostgroup.ti
+++ b/lib/icinga/hostgroup.ti
@@ -20,7 +20,7 @@ class HostGroup : CustomVarObject
 		}}}
 	};
 
-	[config, no_user_modify] array(name(HostGroup)) groups;
+	[config, no_user_modify, parent_affecting_logging] array(name(HostGroup)) groups;
 	[config] String notes;
 	[config] String notes_url;
 	[config] String action_url;

--- a/lib/icinga/icingaapplication.cpp
+++ b/lib/icinga/icingaapplication.cpp
@@ -38,11 +38,11 @@ void IcingaApplication::StaticInitialize()
 	String node_name = Utility::GetFQDN();
 
 	if (node_name.IsEmpty()) {
-		Log(LogNotice, "IcingaApplication", "No FQDN available. Trying Hostname.");
+		Log(LogNotice, "IcingaApplication", nullptr, "No FQDN available. Trying Hostname.");
 		node_name = Utility::GetHostName();
 
 		if (node_name.IsEmpty()) {
-			Log(LogWarning, "IcingaApplication", "No FQDN nor Hostname available. Setting Nodename to 'localhost'.");
+			Log(LogWarning, "IcingaApplication", nullptr, "No FQDN nor Hostname available. Setting Nodename to 'localhost'.");
 			node_name = "localhost";
 		}
 	}
@@ -102,7 +102,7 @@ void IcingaApplication::StatsFunc(const Dictionary::Ptr& status, [[maybe_unused]
  */
 int IcingaApplication::Main()
 {
-	Log(LogDebug, "IcingaApplication", "In IcingaApplication::Main()");
+	Log(LogDebug, "IcingaApplication", this, "In IcingaApplication::Main()");
 
 	/* periodically dump the program state */
 	l_RetentionTimer = Timer::Create();
@@ -112,7 +112,7 @@ int IcingaApplication::Main()
 
 	RunEventLoop();
 
-	Log(LogInformation, "IcingaApplication", "Icinga has shut down.");
+	Log(LogInformation, "IcingaApplication", this, "Icinga has shut down.");
 
 	return EXIT_SUCCESS;
 }
@@ -173,7 +173,7 @@ void IcingaApplication::DumpModifiedAttributes()
 	try {
 		Utility::Glob(path + ".tmp.*", &Utility::Remove, GlobFile);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "IcingaApplication") << DiagnosticInformation(ex);
+		Log(LogWarning, "IcingaApplication", this) << DiagnosticInformation(ex);
 	}
 
 	AtomicFile fp (path, 0644);

--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -387,7 +387,7 @@ bool LegacyTimePeriod::IsInDayDefinition(const String& daydef, const tm *referen
 
 	ParseTimeRange(daydef, &begin, &end, &stride, reference);
 
-	Log(LogDebug, "LegacyTimePeriod")
+	Log(LogDebug, "LegacyTimePeriod", nullptr)
 		<< "ParseTimeRange: '" << daydef << "' => " << Utility::TmToTimestamp(&begin)
 		<< " -> " << Utility::TmToTimestamp(&end) << ", stride: " << stride;
 
@@ -606,7 +606,7 @@ Array::Ptr LegacyTimePeriod::ScriptFunc(const TimePeriod::Ptr& tp, double begin,
 		for (tm reference = tm_begin; Utility::TmToTimestamp(&reference) <= end; advance_to_next_day(&reference)) {
 
 #ifdef I2_DEBUG
-			Log(LogDebug, "LegacyTimePeriod")
+			Log(LogDebug, "LegacyTimePeriod", tp)
 				<< "Checking reference time " << Utility::TmToTimestamp(&reference);
 #endif /* I2_DEBUG */
 
@@ -614,14 +614,14 @@ Array::Ptr LegacyTimePeriod::ScriptFunc(const TimePeriod::Ptr& tp, double begin,
 			for (const Dictionary::Pair& kv : ranges) {
 				if (!IsInDayDefinition(kv.first, &reference)) {
 #ifdef I2_DEBUG
-					Log(LogDebug, "LegacyTimePeriod")
+					Log(LogDebug, "LegacyTimePeriod", tp)
 						<< "Not in day definition '" << kv.first << "'.";
 #endif /* I2_DEBUG */
 					continue;
 				}
 
 #ifdef I2_DEBUG
-				Log(LogDebug, "LegacyTimePeriod")
+				Log(LogDebug, "LegacyTimePeriod", tp)
 					<< "In day definition '" << kv.first << "'.";
 #endif /* I2_DEBUG */
 
@@ -630,7 +630,7 @@ Array::Ptr LegacyTimePeriod::ScriptFunc(const TimePeriod::Ptr& tp, double begin,
 		}
 	}
 
-	Log(LogDebug, "LegacyTimePeriod")
+	Log(LogDebug, "LegacyTimePeriod", tp)
 		<< "Legacy timeperiod update returned " << segments->GetLength() << " segments.";
 
 	return segments;

--- a/lib/icinga/macroprocessor.cpp
+++ b/lib/icinga/macroprocessor.cpp
@@ -280,7 +280,7 @@ Value MacroProcessor::InternalResolveMacros(const String& str, const ResolverLis
 
 		if (!found) {
 			if (!missingMacro)
-				Log(LogWarning, "MacroProcessor")
+				Log(LogWarning, "MacroProcessor", nullptr)
 					<< "Macro '" << name << "' is not defined.";
 			else
 				*missingMacro = name;
@@ -518,7 +518,7 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 							value = Convert::ToLong(set_if_resolved);
 						} catch (const std::exception& ex) {
 							/* tried to convert a string */
-							Log(LogWarning, "PluginUtility")
+							Log(LogWarning, "PluginUtility", nullptr)
 								<< "Error evaluating set_if value '" << set_if_resolved
 								<< "' used in argument '" << arg.Key << "': " << ex.what();
 							continue;
@@ -558,7 +558,7 @@ Value MacroProcessor::ResolveArguments(const Value& command, const Dictionary::P
 		for (const CommandArgument& arg : args) {
 
 			if (arg.AValue.IsObjectType<Dictionary>()) {
-				Log(LogWarning, "PluginUtility")
+				Log(LogWarning, "PluginUtility", nullptr)
 					<< "Tried to use dictionary in argument '" << arg.Key << "'.";
 				continue;
 			} else if (arg.AValue.IsObjectType<Array>()) {

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -254,7 +254,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 	String notificationName = GetName();
 	String notificationTypeName = NotificationTypeToString(type);
 
-	Log(LogNotice, "Notification")
+	Log(LogNotice, "Notification", this)
 		<< "Attempting to send " << (reminder ? "reminder " : "")
 		<< "notifications of type '" << notificationTypeName
 		<< "' for notification object '" << notificationName << "'.";
@@ -275,7 +275,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 		TimePeriod::Ptr tp = GetPeriod();
 
 		if (tp && !tp->IsInside(Utility::GetTime())) {
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", this)
 				<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '" << notificationName
 				<< "': not in timeperiod '" << tp->GetName() << "'";
 
@@ -322,7 +322,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			Value timesEnd = times->Get("end");
 
 			if (timesBegin != Empty && timesBegin >= 0 && now < checkable->GetLastHardStateChange() + timesBegin) {
-				Log(LogNotice, "Notification")
+				Log(LogNotice, "Notification", this)
 					<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '"
 					<< notificationName << "': before specified begin time (" << Utility::FormatDuration(timesBegin) << ")";
 
@@ -341,7 +341,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			}
 
 			if (timesEnd != Empty && timesEnd >= 0 && now > checkable->GetLastHardStateChange() + timesEnd) {
-				Log(LogNotice, "Notification")
+				Log(LogNotice, "Notification", this)
 					<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '"
 					<< notificationName << "': after specified end time (" << Utility::FormatDuration(timesEnd) << ")";
 				return;
@@ -350,13 +350,13 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		unsigned long ftype = type;
 
-		Log(LogDebug, "Notification")
+		Log(LogDebug, "Notification", this)
 			<< "Type '" << NotificationTypeToString(type)
 			<< "', TypeFilter: " << NotificationFilterToString(GetTypeFilter(), GetTypeFilterMap())
 			<< " (FType=" << ftype << ", TypeFilter=" << GetTypeFilter() << ")";
 
 		if (!(ftype & GetTypeFilter())) {
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", this)
 				<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '"
 				<< notificationName << "': type '"
 				<< NotificationTypeToString(type) << "' does not match type filter: "
@@ -391,12 +391,12 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 				stateStr = NotificationHostStateToString(host->GetState());
 			}
 
-			Log(LogDebug, "Notification")
+			Log(LogDebug, "Notification", this)
 				<< "State '" << stateStr << "', StateFilter: " << NotificationFilterToString(GetStateFilter(), GetStateFilterMap())
 				<< " (FState=" << fstate << ", StateFilter=" << GetStateFilter() << ")";
 
 			if (!(fstate & GetStateFilter())) {
-				Log(LogNotice, "Notification")
+				Log(LogNotice, "Notification", this)
 					<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '"
 					<< notificationName << "': state '" << stateStr
 					<< "' does not match state filter: " << NotificationFilterToString(GetStateFilter(), GetStateFilterMap()) << ".";
@@ -404,7 +404,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			}
 		}
 	} else {
-		Log(LogNotice, "Notification")
+		Log(LogNotice, "Notification", this)
 			<< "Not checking " << (reminder ? "reminder " : "") << "notification filters for notification object '"
 			<< notificationName << "': Notification was forced.";
 	}
@@ -445,14 +445,14 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 		String userName = user->GetName();
 
 		if (!user->GetEnableNotifications()) {
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", this)
 				<< "Notification object '" << notificationName << "': Disabled notifications for user '"
 				<< userName << "'. Not sending notification.";
 			continue;
 		}
 
 		if (!CheckNotificationUserFilters(type, user, force, reminder)) {
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", this)
 				<< "Notification object '" << notificationName << "': Filters for user '" << userName << "' not matched. Not sending notification.";
 			continue;
 		}
@@ -464,7 +464,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			// ones, or this Notification instance isn't allowed to send problem notifications (doesn't contain
 			// the 'Problem' type filter).
 			if (!notifiedProblemUsers->Contains(userName) && NotificationProblem & user->GetTypeFilter() & GetTypeFilter()) {
-				Log(LogNotice, "Notification")
+				Log(LogNotice, "Notification", this)
 					<< "Notification object '" << notificationName << "': We did not notify user '" << userName
 					<< "' (Problem types enabled) for a problem before. Not sending "
 					<< (type == NotificationRecovery ? "Recovery" : "acknowledgement") << " notification.";
@@ -480,7 +480,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			if (state == (uint_fast8_t)GetLastNotifiedStatePerUser()->Get(userName)) {
 				auto stateStr (service ? NotificationServiceStateToString(service->GetState()) : NotificationHostStateToString(host->GetState()));
 
-				Log(LogNotice, "Notification")
+				Log(LogNotice, "Notification", this)
 					<< "Notification object '" << notificationName << "': We already notified user '" << userName << "' for a " << stateStr
 					<< " problem. Likely after that another state change notification was filtered out by config. Not sending duplicate '"
 					<< stateStr << "' notification.";
@@ -489,7 +489,7 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			}
 		}
 
-		Log(LogInformation, "Notification")
+		Log(LogInformation, "Notification", this)
 			<< "Sending " << (reminder ? "reminder " : "") << "'" << NotificationTypeToString(type) << "' notification '"
 			<< notificationName << "' for user '" << userName << "'";
 
@@ -535,7 +535,7 @@ bool Notification::CheckNotificationUserFilters(NotificationType type, const Use
 		TimePeriod::Ptr tp = user->GetPeriod();
 
 		if (tp && !tp->IsInside(Utility::GetTime())) {
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", this)
 				<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '"
 				<< notificationName << " and user '" << userName
 				<< "': user period not in timeperiod '" << tp->GetName() << "'";
@@ -544,7 +544,7 @@ bool Notification::CheckNotificationUserFilters(NotificationType type, const Use
 
 		unsigned long ftype = type;
 
-		Log(LogDebug, "Notification")
+		Log(LogDebug, "Notification", this)
 			<< "User '" << userName << "' notification '" << notificationName
 			<< "', Type '" << NotificationTypeToString(type)
 			<< "', TypeFilter: " << NotificationFilterToString(user->GetTypeFilter(), GetTypeFilterMap())
@@ -552,7 +552,7 @@ bool Notification::CheckNotificationUserFilters(NotificationType type, const Use
 
 
 		if (!(ftype & user->GetTypeFilter())) {
-			Log(LogNotice, "Notification")
+			Log(LogNotice, "Notification", this)
 				<< "Not sending " << (reminder ? "reminder " : "") << "notifications for notification object '"
 				<< notificationName << " and user '" << userName << "': type '"
 				<< NotificationTypeToString(type) << "' does not match type filter: "
@@ -578,14 +578,14 @@ bool Notification::CheckNotificationUserFilters(NotificationType type, const Use
 				stateStr = NotificationHostStateToString(host->GetState());
 			}
 
-			Log(LogDebug, "Notification")
+			Log(LogDebug, "Notification", this)
 				<< "User '" << userName << "' notification '" << notificationName
 				<< "', State '" << stateStr << "', StateFilter: "
 				<< NotificationFilterToString(user->GetStateFilter(), GetStateFilterMap())
 				<< " (FState=" << fstate << ", StateFilter=" << user->GetStateFilter() << ")";
 
 			if (!(fstate & user->GetStateFilter())) {
-				Log(LogNotice, "Notification")
+				Log(LogNotice, "Notification", this)
 					<< "Not " << (reminder ? "reminder " : "") << "sending notifications for notification object '"
 					<< notificationName << " and user '" << userName << "': state '" << stateStr
 					<< "' does not match state filter: " << NotificationFilterToString(user->GetStateFilter(), GetStateFilterMap()) << ".";
@@ -593,7 +593,7 @@ bool Notification::CheckNotificationUserFilters(NotificationType type, const Use
 			}
 		}
 	} else {
-		Log(LogNotice, "Notification")
+		Log(LogNotice, "Notification", this)
 			<< "Not checking " << (reminder ? "reminder " : "") << "notification filters for notification object '"
 			<< notificationName << "' and user '" << userName << "': Notification was forced.";
 	}
@@ -610,7 +610,7 @@ void Notification::ExecuteNotificationHelper(NotificationType type, const User::
 	NotificationCommand::Ptr command = GetCommand();
 
 	if (!command) {
-		Log(LogDebug, "Notification")
+		Log(LogDebug, "Notification", this)
 			<< "No command found for notification '" << notificationName << "'. Skipping execution.";
 		return;
 	}
@@ -623,13 +623,13 @@ void Notification::ExecuteNotificationHelper(NotificationType type, const User::
 		/* required by compatlogger */
 		Service::OnNotificationSentToUser(this, GetCheckable(), user, type, cr, author, text, commandName, nullptr);
 
-		Log(LogInformation, "Notification")
+		Log(LogInformation, "Notification", this)
 			<< "Completed sending '" << NotificationTypeToString(type)
 			<< "' notification '" << notificationName
 			<< "' for checkable '" << checkableName
 			<< "' and user '" << userName << "' using command '" << commandName << "'.";
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "Notification")
+		Log(LogWarning, "Notification", this)
 			<< "Exception occurred during notification '" << notificationName
 			<< "' for checkable '" << checkableName
 			<< "' and user '" << userName << "' using command '" << commandName << "': "

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -52,12 +52,12 @@ class Notification : CustomVarObject < NotificationNameComposer
 		set;
 	};
 	[no_user_view, no_user_modify] int state_filter_real (StateFilter);
-	[config, no_user_modify, protected, required, navigation(host)] name(Host) host_name {
+	[config, no_user_modify, protected, required, navigation(host), parent_affecting_logging] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, protected, no_user_modify, navigation(service)] String service_name {
+	[config, protected, no_user_modify, navigation(service), parent_affecting_logging] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -30,7 +30,7 @@ void PluginUtility::ExecuteCommand(const Command::Ptr& commandObj,
 	} catch (const std::exception& ex) {
 		String message = DiagnosticInformation(ex);
 
-		Log(LogWarning, "PluginUtility", message);
+		Log(LogWarning, "PluginUtility", commandObj, message);
 
 		if (callback) {
 			ProcessResult pr;
@@ -61,7 +61,7 @@ void PluginUtility::ExecuteCommand(const Command::Ptr& commandObj,
 
 #ifdef I2_DEBUG
 			if (!missingMacro.IsEmpty())
-				Log(LogDebug, "PluginUtility")
+				Log(LogDebug, "PluginUtility", commandObj)
 					<< "Macro '" << name << "' is not defined.";
 #endif /* I2_DEBUG */
 
@@ -200,7 +200,7 @@ String PluginUtility::FormatPerfdata(const Array::Ptr& perfdata, bool normalize)
 			try {
 				normalized = PerfdataValue::Parse(pdv);
 			} catch (const std::invalid_argument& ex) {
-				Log(LogDebug, "PerfdataValue") << ex.what();
+				Log(LogDebug, "PerfdataValue", nullptr) << ex.what();
 			}
 
 			if (normalized) {

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -96,7 +96,7 @@ void ScheduledDowntime::TimerProc()
 			try {
 				sd->CreateNextDowntime();
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "ScheduledDowntime")
+				Log(LogCritical, "ScheduledDowntime", sd)
 					<< "Exception occurred during creation of next downtime for scheduled downtime '"
 					<< sd->GetName() << "': " << DiagnosticInformation(ex, false);
 				continue;
@@ -105,7 +105,7 @@ void ScheduledDowntime::TimerProc()
 			try {
 				sd->RemoveObsoleteDowntimes();
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "ScheduledDowntime")
+				Log(LogCritical, "ScheduledDowntime", sd)
 					<< "Exception occurred during removal of obsolete downtime for scheduled downtime '"
 					<< sd->GetName() << "': " << DiagnosticInformation(ex, false);
 			}
@@ -128,7 +128,7 @@ std::pair<double, double> ScheduledDowntime::FindRunningSegment(double minEnd)
 	time_t refts = Utility::GetTime();
 	tm reference = Utility::LocalTime(refts);
 
-	Log(LogDebug, "ScheduledDowntime")
+	Log(LogDebug, "ScheduledDowntime", this)
 	    << "Finding running scheduled downtime segment for time " << refts
 	    << " (minEnd " << (minEnd > 0 ? Utility::FormatDateTime("%c", minEnd) : "-") << ")";
 
@@ -147,7 +147,7 @@ std::pair<double, double> ScheduledDowntime::FindRunningSegment(double minEnd)
 
 	/* Find the longest lasting (and longer than minEnd, if given) segment that's already running */  
 	for (const Dictionary::Pair& kv : ranges) {
-		Log(LogDebug, "ScheduledDowntime")
+		Log(LogDebug, "ScheduledDowntime", this)
 		    << "Evaluating (running?) segment: " << kv.first << ": " << kv.second;
 
 		Dictionary::Ptr segment = LegacyTimePeriod::FindRunningSegment(kv.first, kv.second, &reference);
@@ -158,20 +158,20 @@ std::pair<double, double> ScheduledDowntime::FindRunningSegment(double minEnd)
 		double begin = segment->Get("begin");
 		double end = segment->Get("end");
 
-		Log(LogDebug, "ScheduledDowntime")
+		Log(LogDebug, "ScheduledDowntime", this)
 		    << "Considering (running?) segment: " << Utility::FormatDateTime("%c", begin) << " -> " << Utility::FormatDateTime("%c", end);
 
 		if (begin >= now || end < now) {
-			Log(LogDebug, "ScheduledDowntime") << "not running.";
+			Log(LogDebug, "ScheduledDowntime", this) << "not running.";
 			continue;
 		}
 		if (minEnd && end <= minEnd) {
-			Log(LogDebug, "ScheduledDowntime") << "ending too early.";
+			Log(LogDebug, "ScheduledDowntime", this) << "ending too early.";
 			continue;
 		}
 
 		if (!bestSegment || end > bestEnd) {
-			Log(LogDebug, "ScheduledDowntime") << "(best match yet)";
+			Log(LogDebug, "ScheduledDowntime", this) << "(best match yet)";
 			bestSegment = segment;
 			bestBegin = begin;
 			bestEnd = end;
@@ -189,7 +189,7 @@ std::pair<double, double> ScheduledDowntime::FindNextSegment()
 	time_t refts = Utility::GetTime();
 	tm reference = Utility::LocalTime(refts);
 
-	Log(LogDebug, "ScheduledDowntime")
+	Log(LogDebug, "ScheduledDowntime", this)
 		<< "Finding next scheduled downtime segment for time " << refts;
 
 	Dictionary::Ptr ranges = GetRanges();
@@ -207,7 +207,7 @@ std::pair<double, double> ScheduledDowntime::FindNextSegment()
 
 	/* Find the segment starting earliest */
 	for (const Dictionary::Pair& kv : ranges) {
-		Log(LogDebug, "ScheduledDowntime")
+		Log(LogDebug, "ScheduledDowntime", this)
 			<< "Evaluating segment: " << kv.first << ": " << kv.second;
 
 		Dictionary::Ptr segment = LegacyTimePeriod::FindNextSegment(kv.first, kv.second, &reference);
@@ -218,16 +218,16 @@ std::pair<double, double> ScheduledDowntime::FindNextSegment()
 		double begin = segment->Get("begin");
 		double end = segment->Get("end");
 
-		Log(LogDebug, "ScheduledDowntime")
+		Log(LogDebug, "ScheduledDowntime", this)
 			<< "Considering segment: " << Utility::FormatDateTime("%c", begin) << " -> " << Utility::FormatDateTime("%c", end);
 
 		if (begin < now) {
-			Log(LogDebug, "ScheduledDowntime") << "already running.";
+			Log(LogDebug, "ScheduledDowntime", this) << "already running.";
 			continue;
 		}
 
 		if (!bestSegment || begin < bestBegin) {
-			Log(LogDebug, "ScheduledDowntime") << "(best match yet)";
+			Log(LogDebug, "ScheduledDowntime", this) << "(best match yet)";
 			bestSegment = segment;
 			bestBegin = begin;
 			bestEnd = end;
@@ -244,7 +244,7 @@ void ScheduledDowntime::CreateNextDowntime()
 {
 	/* HA enabled zones. */
 	if (IsActive() && IsPaused()) {
-		Log(LogNotice, "Checkable")
+		Log(LogNotice, "Checkable", this)
 			<< "Skipping downtime creation for HA-paused Scheduled Downtime object '" << GetName() << "'";
 		return;
 	}
@@ -271,7 +271,7 @@ void ScheduledDowntime::CreateNextDowntime()
 		return;
 	}
 
-	Log(LogDebug, "ScheduledDowntime")
+	Log(LogDebug, "ScheduledDowntime", this)
 		<< "Creating new Downtime for ScheduledDowntime \"" << GetName() << "\"";
 
 	std::pair<double, double> segment = FindRunningSegment(minEnd);
@@ -295,17 +295,17 @@ void ScheduledDowntime::CreateNextDowntime()
 		if (childOptions == 1)
 			trigger = downtime;
 
-		Log(LogNotice, "ScheduledDowntime")
+		Log(LogNotice, "ScheduledDowntime", downtime)
 				<< "Processing child options " << childOptions << " for downtime " << downtimeName;
 
 		for (const Checkable::Ptr& child : GetCheckable()->GetAllChildren()) {
-			Log(LogNotice, "ScheduledDowntime")
+			Log(LogNotice, "ScheduledDowntime", child)
 				<< "Scheduling downtime for child object " << child->GetName();
 
 			Downtime::Ptr childDowntime = Downtime::AddDowntime(child, GetAuthor(), GetComment(),
 				segment.first, segment.second, GetFixed(), trigger, GetDuration(), GetName(), GetName());
 
-			Log(LogNotice, "ScheduledDowntime")
+			Log(LogNotice, "ScheduledDowntime", childDowntime)
 				<< "Add child downtime '" << childDowntime->GetName() << "'.";
 		}
 	}

--- a/lib/icinga/scheduleddowntime.ti
+++ b/lib/icinga/scheduleddowntime.ti
@@ -27,12 +27,12 @@ class ScheduledDowntime : CustomVarObject < ScheduledDowntimeNameComposer
 	load_after Host;
 	load_after Service;
 
-	[config, protected, no_user_modify, required, navigation(host)] name(Host) host_name {
+	[config, protected, no_user_modify, required, navigation(host), parent_affecting_logging] name(Host) host_name {
 		navigate {{{
 			return Host::GetByName(GetHostName());
 		}}}
 	};
-	[config, protected, no_user_modify, navigation(service)] String service_name {
+	[config, protected, no_user_modify, navigation(service), parent_affecting_logging] String service_name {
 		track {{{
 			if (!oldValue.IsEmpty()) {
 				Service::Ptr service = Service::GetByNamePair(GetHostName(), oldValue);

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -28,7 +28,7 @@ class Service : Checkable < ServiceNameComposer
 	load_after Host;
 	load_after Zone;
 
-	[config, no_user_modify, required, signal_with_old_value] array(name(ServiceGroup)) groups {
+	[config, no_user_modify, required, signal_with_old_value, parent_affecting_logging] array(name(ServiceGroup)) groups {
 		default {{{ return new Array(); }}}
 	};
 

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -41,7 +41,7 @@ class Service : Checkable < ServiceNameComposer
 				return displayName;
 		}}}
 	};
-	[config, no_user_modify, required] name(Host) host_name;
+	[config, no_user_modify, required, parent_affecting_logging] name(Host) host_name;
 	[no_storage, navigation] Host::Ptr host {
 		get;
 		navigate {{{

--- a/lib/icinga/servicegroup.cpp
+++ b/lib/icinga/servicegroup.cpp
@@ -36,7 +36,7 @@ bool ServiceGroup::EvaluateObjectRule(const Service::Ptr& service, const ConfigI
 	if (!group->GetFilter()->Evaluate(frame).GetValue().ToBool())
 		return false;
 
-	Log(LogDebug, "ServiceGroup")
+	Log(LogDebug, "ServiceGroup", service)
 		<< "Assigning membership for group '" << groupName << "' to service '" << service->GetName() << "'";
 
 	Array::Ptr groups = service->GetGroups();
@@ -83,7 +83,7 @@ void ServiceGroup::RemoveMember(const Service::Ptr& service)
 bool ServiceGroup::ResolveGroupMembership(const Service::Ptr& service, bool add, int rstack) {
 
 	if (add && rstack > 20) {
-		Log(LogWarning, "ServiceGroup")
+		Log(LogWarning, "ServiceGroup", service)
 			<< "Too many nested groups for group '" << GetName() << "': Service '"
 			<< service->GetName() << "' membership assignment failed.";
 

--- a/lib/icinga/servicegroup.ti
+++ b/lib/icinga/servicegroup.ti
@@ -20,7 +20,7 @@ class ServiceGroup : CustomVarObject
 		}}}
 	};
 
-	[config, no_user_modify] array(name(ServiceGroup)) groups;
+	[config, no_user_modify, parent_affecting_logging] array(name(ServiceGroup)) groups;
 	[config] String notes;
 	[config] String notes_url;
 	[config] String action_url;

--- a/lib/icinga/timeperiod.cpp
+++ b/lib/icinga/timeperiod.cpp
@@ -43,7 +43,7 @@ void TimePeriod::AddSegment(double begin, double end)
 {
 	ASSERT(OwnsLock());
 
-	Log(LogDebug, "TimePeriod")
+	Log(LogDebug, "TimePeriod", this)
 		<< "Adding segment '" << Utility::FormatDateTime("%c", begin) << "' <-> '"
 		<< Utility::FormatDateTime("%c", end) << "' to TimePeriod '" << GetName() << "'";
 
@@ -104,7 +104,7 @@ void TimePeriod::RemoveSegment(double begin, double end)
 {
 	ASSERT(OwnsLock());
 
-	Log(LogDebug, "TimePeriod")
+	Log(LogDebug, "TimePeriod", this)
 		<< "Removing segment '" << Utility::FormatDateTime("%c", begin) << "' <-> '"
 		<< Utility::FormatDateTime("%c", end) << "' from TimePeriod '" << GetName() << "'";
 
@@ -176,7 +176,7 @@ void TimePeriod::PurgeSegments(double end)
 {
 	ASSERT(OwnsLock());
 
-	Log(LogDebug, "TimePeriod")
+	Log(LogDebug, "TimePeriod", this)
 		<< "Purging segments older than '" << Utility::FormatDateTime("%c", end)
 		<< "' from TimePeriod '" << GetName() << "'";
 
@@ -204,7 +204,7 @@ void TimePeriod::PurgeSegments(double end)
 
 void TimePeriod::Merge(const TimePeriod::Ptr& timeperiod, bool include)
 {
-	Log(LogDebug, "TimePeriod")
+	Log(LogDebug, "TimePeriod", this)
 		<< "Merge TimePeriod '" << GetName() << "' with '" << timeperiod->GetName() << "' "
 		<< "Method: " << (include ? "include" : "exclude");
 
@@ -352,23 +352,23 @@ void TimePeriod::Dump()
 
 	Array::Ptr segments = GetSegments();
 
-	Log(LogDebug, "TimePeriod")
+	Log(LogDebug, "TimePeriod", this)
 		<< "Dumping TimePeriod '" << GetName() << "'";
 
-	Log(LogDebug, "TimePeriod")
+	Log(LogDebug, "TimePeriod", this)
 		<< "Valid from '" << Utility::FormatDateTime("%c", GetValidBegin())
 		<< "' until '" << Utility::FormatDateTime("%c", GetValidEnd());
 
 	if (segments) {
 		ObjectLock dlock(segments);
 		for (Dictionary::Ptr segment : segments) {
-			Log(LogDebug, "TimePeriod")
+			Log(LogDebug, "TimePeriod", this)
 				<< "Segment: " << Utility::FormatDateTime("%c", segment->Get("begin")) << " <-> "
 				<< Utility::FormatDateTime("%c", segment->Get("end"));
 		}
 	}
 
-	Log(LogDebug, "TimePeriod", "---");
+	Log(LogDebug, "TimePeriod", this, "---");
 }
 
 void TimePeriod::ValidateRanges(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils)

--- a/lib/icinga/user.ti
+++ b/lib/icinga/user.ti
@@ -21,7 +21,7 @@ class User : CustomVarObject
 				return displayName;
 		}}}
 	};
-	[config, no_user_modify, required, signal_with_old_value] array(name(UserGroup)) groups {
+	[config, no_user_modify, required, signal_with_old_value, parent_affecting_logging] array(name(UserGroup)) groups {
 		default {{{ return new Array(); }}}
 	};
 	[config, navigation] name(TimePeriod) period (PeriodRaw) {

--- a/lib/icinga/usergroup.cpp
+++ b/lib/icinga/usergroup.cpp
@@ -34,7 +34,7 @@ bool UserGroup::EvaluateObjectRule(const User::Ptr& user, const ConfigItem::Ptr&
 	if (!group->GetFilter()->Evaluate(frame).GetValue().ToBool())
 		return false;
 
-	Log(LogDebug, "UserGroup")
+	Log(LogDebug, "UserGroup", user)
 		<< "Assigning membership for group '" << groupName << "' to user '" << user->GetName() << "'";
 
 	Array::Ptr groups = user->GetGroups();
@@ -99,7 +99,7 @@ void UserGroup::RemoveNotification(const Notification::Ptr& notification)
 bool UserGroup::ResolveGroupMembership(const User::Ptr& user, bool add, int rstack) {
 
 	if (add && rstack > 20) {
-		Log(LogWarning, "UserGroup")
+		Log(LogWarning, "UserGroup", user)
 			<< "Too many nested groups for group '" << GetName() << "': User '"
 			<< user->GetName() << "' membership assignment failed.";
 

--- a/lib/icinga/usergroup.ti
+++ b/lib/icinga/usergroup.ti
@@ -20,7 +20,7 @@ class UserGroup : CustomVarObject
 		}}}
 	};
 
-	[config, no_user_modify] array(name(UserGroup)) groups;
+	[config, no_user_modify, parent_affecting_logging] array(name(UserGroup)) groups;
 };
 
 }

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -219,7 +219,7 @@ void IcingaDB::UpdateAllConfigObjects()
 	// previously enqueued queries on m_RconWorker that we need to wait for. So, no Sync() call is necessary here.
 	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:schema", "MAXLEN", "1", "*", "version", "6"}, {}, true);
 
-	Log(LogInformation, "IcingaDB") << "Starting initial config/status dump";
+	Log(LogInformation, "IcingaDB", this) << "Starting initial config/status dump";
 	double startTime = Utility::GetTime();
 
 	SetOngoingDumpStart(startTime);
@@ -367,7 +367,7 @@ void IcingaDB::UpdateAllConfigObjects()
 
 			ExecuteRedisTransaction(rcon, hMSets, {});
 
-			Log(LogNotice, "IcingaDB")
+			Log(LogNotice, "IcingaDB", this)
 				<< "Dumped " << bulkCounter << " objects of " << type->ToString();
 		});
 
@@ -552,7 +552,7 @@ void IcingaDB::UpdateAllConfigObjects()
 	SetLastdumpTook(took);
 	SetLastdumpEnd(endTime);
 
-	Log(LogInformation, "IcingaDB")
+	Log(LogInformation, "IcingaDB", this)
 		<< "Initial config/status dump finished in " << took << " seconds.";
 }
 
@@ -2583,7 +2583,7 @@ void IcingaDB::ForwardHistoryEntries()
 
 			auto size (m_HistoryBulker.Size());
 
-			Log(size > m_HistoryBulker.GetBulkSize() ? LogInformation : LogNotice, "IcingaDB")
+			Log(size > m_HistoryBulker.GetBulkSize() ? LogInformation : LogNotice, "IcingaDB", this)
 				<< "Pending history queries: " << size;
 		}
 	});
@@ -2603,8 +2603,8 @@ void IcingaDB::ForwardHistoryEntries()
 
 		uintmax_t attempts = 0;
 
-		auto logFailure ([&haystack, &attempts](const char* err = nullptr) {
-			Log msg (LogNotice, "IcingaDB");
+		auto logFailure ([this, &haystack, &attempts](const char* err = nullptr) {
+			Log msg (LogNotice, "IcingaDB", this);
 
 			msg << "history: " << haystack.size() << " queries failed temporarily (attempt #" << ++attempts << ")";
 
@@ -2630,7 +2630,7 @@ void IcingaDB::ForwardHistoryEntries()
 			}
 
 			if (!GetActive()) {
-				Log(LogCritical, "IcingaDB") << "history: " << haystack.size() << " queries failed (attempt #" << attempts
+				Log(LogCritical, "IcingaDB", this) << "history: " << haystack.size() << " queries failed (attempt #" << attempts
 					<< ") while we're about to shut down. Giving up and discarding additional "
 					<< m_HistoryBulker.Size() << " queued history queries.";
 
@@ -3168,7 +3168,7 @@ void IcingaDB::CustomVarsChangedHandler(const ConfigObject::Ptr& object, const D
 }
 
 void IcingaDB::DeleteRelationship(const String& id, RedisConnection::QueryArg redisObjKey, RedisConnection::QueryArg redisChecksumKey) {
-	Log(LogNotice, "IcingaDB")
+	Log(LogNotice, "IcingaDB", this)
 		<< "Deleting relationship '" << static_cast<std::string_view>(redisObjKey) << " -> '" << id << "'";
 
 	RedisConnection::Queries queries;
@@ -3188,7 +3188,7 @@ void IcingaDB::DeleteRelationship(const String& id, RedisConnection::QueryArg re
 
 void IcingaDB::DeleteState(const String& id, RedisConnection::QueryArg redisObjKey, RedisConnection::QueryArg redisChecksumKey) const
 {
-	Log(LogNotice, "IcingaDB")
+	Log(LogNotice, "IcingaDB", this)
 		<< "Deleting state '" << static_cast<std::string_view>(redisObjKey) << "' -> " << std::quoted(id.CStr());
 
 	RedisConnection::Queries hdels = {{"HDEL", std::move(redisObjKey), id}};

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -69,7 +69,7 @@ void IcingaDB::PendingItemsThreadProc()
 		// make the user aware of the situation as that's usually an indication of something being wrong.
 		if (elapsed >= logInterval || (laggingBehind && elapsed >= heavyLoadLogInterval)) {
 			lastLogTime = now;
-			Log log(laggingBehind ? LogWarning : LogInformation, "IcingaDB");
+			Log log (laggingBehind ? LogWarning : LogInformation, "IcingaDB", this);
 			log << "Pending config and state updates: " << seqView.size() << " (Redis queries: "
 				<< (m_RconWorker ? m_RconWorker->GetPendingQueryCount() : 0);
 			if (!seqView.empty()) {
@@ -96,7 +96,7 @@ void IcingaDB::PendingItemsThreadProc()
 					try {
 						ProcessQueueItem(item);
 					} catch (const std::exception& ex) {
-						Log(LogCritical, "IcingaDB")
+						Log(LogCritical, "IcingaDB", this)
 							<< "Exception while processing pending item of type '" << typeid(decltype(item)).name()
 							<< "': " << DiagnosticInformation(ex, GetActive());
 					}

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -70,7 +70,7 @@ void IcingaDB::Start(bool runtimeCreated)
 	VERIFY(!m_EnvironmentId.IsEmpty());
 	PersistEnvironmentId();
 
-	Log(LogInformation, "IcingaDB")
+	Log(LogInformation, "IcingaDB", this)
 		<< "'" << GetName() << "' started.";
 
 	m_ConfigDumpInProgress = false;
@@ -107,7 +107,7 @@ void IcingaDB::Start(bool runtimeCreated)
 			});
 
 			auto pending = --*pendingConns;
-			Log(LogDebug, "IcingaDB") << pending << " pending child connections remaining";
+			Log(LogDebug, "IcingaDB", this) << pending << " pending child connections remaining";
 			if (pending == 0) {
 				m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
 			}
@@ -138,9 +138,9 @@ void IcingaDB::Start(bool runtimeCreated)
 
 void IcingaDB::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogCritical, "IcingaDB", "Exception during redis query. Verify that Redis is operational.");
+	Log(LogCritical, "IcingaDB", this, "Exception during redis query. Verify that Redis is operational.");
 
-	Log(LogDebug, "IcingaDB")
+	Log(LogDebug, "IcingaDB", this)
 		<< "Exception during redis operation: " << DiagnosticInformation(exp);
 }
 
@@ -160,7 +160,7 @@ void IcingaDB::OnConnectedHandler()
 			UpdateAllConfigObjects();
 			break;
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "IcingaDB") << "Exception during ConfigDump: " << ex.what();
+			Log(LogCritical, "IcingaDB", this) << "Exception during ConfigDump: " << ex.what();
 		}
 		Utility::Sleep(10);
 	}
@@ -202,13 +202,13 @@ void IcingaDB::PublishStats()
 
 void IcingaDB::Stop(bool runtimeRemoved)
 {
-	Log(LogInformation, "IcingaDB")
+	Log(LogInformation, "IcingaDB", this)
 		<< "Flushing history data buffer to Redis.";
 
 	m_PendingItemsCV.notify_all(); // Wake up the pending items worker to let it exit cleanly.
 
 	if (m_HistoryThread.wait_for(std::chrono::minutes(1)) == std::future_status::timeout) {
-		Log(LogCritical, "IcingaDB")
+		Log(LogCritical, "IcingaDB", this)
 			<< "Flushing takes more than one minute (while we're about to shut down). Giving up and discarding "
 			<< m_HistoryBulker.Size() << " queued history queries.";
 	}
@@ -216,7 +216,7 @@ void IcingaDB::Stop(bool runtimeRemoved)
 	m_StatsTimer->Stop(true);
 	m_PendingItemsThread.join();
 
-	Log(LogInformation, "IcingaDB")
+	Log(LogInformation, "IcingaDB", this)
 		<< "'" << GetName() << "' stopped.";
 
 	ObjectImpl<IcingaDB>::Stop(runtimeRemoved);

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -132,7 +132,7 @@ void LogQuery(RedisConnection::Query& query, Log& msg)
 void RedisConnection::FireAndForgetQuery(Query query, QueryAffects affects, bool highPriority)
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
-		Log msg (LogDebug, "IcingaDB", "Firing and forgetting query:");
+		Log msg (LogDebug, "IcingaDB", nullptr, "Firing and forgetting query:");
 		LogQuery(query, msg);
 	}
 
@@ -154,7 +154,7 @@ void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, Que
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
 		for (auto& query : queries) {
-			Log msg(LogDebug, "IcingaDB", "Firing and forgetting query:");
+			Log msg (LogDebug, "IcingaDB", nullptr, "Firing and forgetting query:");
 			LogQuery(query, msg);
 		}
 	}
@@ -178,7 +178,7 @@ void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, Que
 RedisConnection::Reply RedisConnection::GetResultOfQuery(RedisConnection::Query query, QueryAffects affects)
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
-		Log msg (LogDebug, "IcingaDB", "Executing query:");
+		Log msg (LogDebug, "IcingaDB", nullptr, "Executing query:");
 		LogQuery(query, msg);
 	}
 
@@ -208,7 +208,7 @@ RedisConnection::Replies RedisConnection::GetResultsOfQueries(Queries queries, Q
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
 		for (auto& query : queries) {
-			Log msg(LogDebug, "IcingaDB", "Executing query:");
+			Log msg (LogDebug, "IcingaDB", nullptr, "Executing query:");
 			LogQuery(query, msg);
 		}
 	}
@@ -291,7 +291,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 		try {
 			if (m_ConnInfo->Path.IsEmpty()) {
 				if (m_TLSContext) {
-					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB")
+					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB", nullptr)
 						<< "Trying to connect to Redis server (async, TLS) on host '" << m_ConnInfo->Host << ":" << m_ConnInfo->Port << "'";
 
 					auto conn (Shared<AsioTlsStream>::Make(m_Strand.context(), *m_TLSContext, m_ConnInfo->Host));
@@ -321,7 +321,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					m_QueuedReads.WaitForClear(yc);
 					m_TlsConn = std::move(conn);
 				} else {
-					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB")
+					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB", nullptr)
 						<< "Trying to connect to Redis server (async) on host '" << m_ConnInfo->Host << ":" << m_ConnInfo->Port << "'";
 
 					auto conn (Shared<TcpConn>::Make(m_Strand.context()));
@@ -333,7 +333,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					m_TcpConn = std::move(conn);
 				}
 			} else {
-				Log(LogInformation, "IcingaDB")
+				Log(LogInformation, "IcingaDB", nullptr)
 					<< "Trying to connect to Redis server (async) on unix socket path '" << m_ConnInfo->Path << "'";
 
 				auto conn (Shared<UnixConn>::Make(m_Strand.context()));
@@ -347,7 +347,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 
 			m_Connected.store(true);
 
-			Log(m_Parent ? LogNotice : LogInformation, "IcingaDB", "Connected to Redis server");
+			Log(m_Parent ? LogNotice : LogInformation, "IcingaDB", nullptr, "Connected to Redis server");
 
 			// Operate on a copy so that the callback can set a new callback without destroying itself while running.
 			auto callback (m_ConnectedCallback);
@@ -357,7 +357,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 
 			break;
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "IcingaDB")
+			Log(LogCritical, "IcingaDB", nullptr)
 				<< "Cannot connect to Redis server ('"
 				<< (m_ConnInfo->Path.IsEmpty() ? m_ConnInfo->Host+":"+Convert::ToString(m_ConnInfo->Port) : m_ConnInfo->Path)
 				<< "'): " << ex.what();
@@ -388,7 +388,7 @@ void RedisConnection::ReadLoop(asio::yield_context& yc)
 							ReadOne(yc);
 						}
 					} catch (const std::exception& ex) {
-						Log(LogCritical, "IcingaDB")
+						Log(LogCritical, "IcingaDB", nullptr)
 							<< "Error during receiving the response to a query which has been fired and forgotten: " << ex.what();
 
 						continue;
@@ -496,7 +496,7 @@ void RedisConnection::LogStats(asio::yield_context& yc)
 		if (m_PendingQueries < output * 5 && !timeoutReached)
 			continue;
 
-		Log(LogInformation, "IcingaDB")
+		Log(LogInformation, "IcingaDB", nullptr)
 			<< "Pending queries: " << m_PendingQueries << " (Input: "
 			<< round(m_InputQueries.CalculateRate(now, 10)) << "/s; Output: " << output << "/s)";
 
@@ -518,7 +518,7 @@ bool RedisConnection::WriteItem(const FireAndForgetQ& item, boost::asio::yield_c
 	try {
 		WriteOne(*item, yc);
 	} catch (const std::exception& ex) {
-		Log msg (LogCritical, "IcingaDB", "Error during sending query");
+		Log msg (LogCritical, "IcingaDB", nullptr, "Error during sending query");
 		LogQuery(*item, msg);
 		msg << " which has been fired and forgotten: " << ex.what();
 
@@ -554,7 +554,7 @@ bool RedisConnection::WriteItem(const FireAndForgetQs& item, boost::asio::yield_
 			++i;
 		}
 	} catch (const std::exception& ex) {
-		Log msg (LogCritical, "IcingaDB", "Error during sending query");
+		Log msg (LogCritical, "IcingaDB", nullptr, "Error during sending query");
 		LogQuery((*item)[i], msg);
 		msg << " which has been fired and forgotten: " << ex.what();
 

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -541,7 +541,7 @@ void RedisConnection::Handshake(StreamPtr& strm, boost::asio::yield_context& yc)
 				boost::smatch what;
 
 				if (boost::regex_search(authErr, what, m_ErrAuth)) {
-					Log(LogWarning, "IcingaDB") << authErr;
+					Log(LogWarning, "IcingaDB", nullptr) << authErr;
 				} else {
 					// Likely WRONGPASS
 					BOOST_THROW_EXCEPTION(std::runtime_error(authErr));

--- a/lib/livestatus/attributefilter.cpp
+++ b/lib/livestatus/attributefilter.cpp
@@ -53,7 +53,7 @@ bool AttributeFilter::Apply(const Table::Ptr& table, const Value& row)
 				boost::smatch what;
 				ret = boost::regex_search(operand.GetData(), what, expr);
 			} catch (boost::exception&) {
-				Log(LogWarning, "AttributeFilter")
+				Log(LogWarning, "AttributeFilter", nullptr)
 					<< "Regex '" << m_Operand << " " << m_Operator << " " << value << "' error.";
 				ret = false;
 			}
@@ -69,7 +69,7 @@ bool AttributeFilter::Apply(const Table::Ptr& table, const Value& row)
 				String operand = value;
 				ret = boost::iequals(operand, m_Operand.GetData());
 			} catch (boost::exception&) {
-				Log(LogWarning, "AttributeFilter")
+				Log(LogWarning, "AttributeFilter", nullptr)
 					<< "Case-insensitive equality '" << m_Operand << " " << m_Operator << " " << value << "' error.";
 				ret = false;
 			}
@@ -83,7 +83,7 @@ bool AttributeFilter::Apply(const Table::Ptr& table, const Value& row)
 				boost::smatch what;
 				ret = boost::regex_search(operand.GetData(), what, expr);
 			} catch (boost::exception&) {
-				Log(LogWarning, "AttributeFilter")
+				Log(LogWarning, "AttributeFilter", nullptr)
 					<< "Regex '" << m_Operand << " " << m_Operator << " " << value << "' error.";
 				ret = false;
 			}

--- a/lib/livestatus/hoststable.cpp
+++ b/lib/livestatus/hoststable.cpp
@@ -151,7 +151,7 @@ void HostsTable::AddColumns(Table *table, const String& prefix,
 	/* add additional group by values received through the object accessor */
 	if (table->GetGroupByType() == LivestatusGroupByHostGroup) {
 		/* _1 = row, _2 = groupByType, _3 = groupByObject */
-		Log(LogDebug, "Livestatus")
+		Log(LogDebug, "Livestatus", nullptr)
 			<< "Processing hosts group by hostgroup table.";
 		HostGroupsTable::AddColumns(table, "hostgroup_", [](const Value&, LivestatusGroupByType groupByType, const Object::Ptr& groupByObject) -> Value {
 			return HostGroupAccessor(groupByType, groupByObject);

--- a/lib/livestatus/livestatuslistener.cpp
+++ b/lib/livestatus/livestatuslistener.cpp
@@ -46,7 +46,7 @@ void LivestatusListener::OnAllConfigLoaded()
 {
 	ObjectImpl<LivestatusListener>::OnAllConfigLoaded();
 
-	Log(LogWarning, "LivestatusListener")
+	Log(LogWarning, "LivestatusListener", this)
 		<< "This feature is DEPRECATED and will be removed in v2.18.";
 }
 
@@ -57,7 +57,7 @@ void LivestatusListener::Start(bool runtimeCreated)
 {
 	ObjectImpl<LivestatusListener>::Start(runtimeCreated);
 
-	Log(LogInformation, "LivestatusListener")
+	Log(LogInformation, "LivestatusListener", this)
 		<< "'" << GetName() << "' started.";
 
 	if (GetSocketType() == "tcp") {
@@ -66,7 +66,7 @@ void LivestatusListener::Start(bool runtimeCreated)
 		try {
 			socket->Bind(GetBindHost(), GetBindPort(), AF_UNSPEC);
 		} catch (std::exception&) {
-			Log(LogCritical, "LivestatusListener")
+			Log(LogCritical, "LivestatusListener", this)
 				<< "Cannot bind TCP socket on host '" << GetBindHost() << "' port '" << GetBindPort() << "'.";
 			return;
 		}
@@ -75,7 +75,7 @@ void LivestatusListener::Start(bool runtimeCreated)
 
 		m_Thread = std::thread([this]() { ServerThreadProc(); });
 
-		Log(LogInformation, "LivestatusListener")
+		Log(LogInformation, "LivestatusListener", this)
 			<< "Created TCP socket listening on host '" << GetBindHost() << "' port '" << GetBindPort() << "'.";
 	}
 	else if (GetSocketType() == "unix") {
@@ -85,7 +85,7 @@ void LivestatusListener::Start(bool runtimeCreated)
 		try {
 			socket->Bind(GetSocketPath());
 		} catch (std::exception&) {
-			Log(LogCritical, "LivestatusListener")
+			Log(LogCritical, "LivestatusListener", this)
 				<< "Cannot bind UNIX socket to '" << GetSocketPath() << "'.";
 			return;
 		}
@@ -94,7 +94,7 @@ void LivestatusListener::Start(bool runtimeCreated)
 		mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
 
 		if (chmod(GetSocketPath().CStr(), mode) < 0) {
-			Log(LogCritical, "LivestatusListener")
+			Log(LogCritical, "LivestatusListener", this)
 				<< "chmod() on unix socket '" << GetSocketPath() << "' failed with error code " << errno << ", \"" << Utility::FormatErrorNumber(errno) << "\"";
 			return;
 		}
@@ -103,11 +103,11 @@ void LivestatusListener::Start(bool runtimeCreated)
 
 		m_Thread = std::thread([this]() { ServerThreadProc(); });
 
-		Log(LogInformation, "LivestatusListener")
+		Log(LogInformation, "LivestatusListener", this)
 			<< "Created UNIX socket in '" << GetSocketPath() << "'.";
 #else
 		/* no UNIX sockets on windows */
-		Log(LogCritical, "LivestatusListener", "Unix sockets are not supported on Windows.");
+		Log(LogCritical, "LivestatusListener", this, "Unix sockets are not supported on Windows.");
 		return;
 #endif
 	}
@@ -117,7 +117,7 @@ void LivestatusListener::Stop(bool runtimeRemoved)
 {
 	ObjectImpl<LivestatusListener>::Stop(runtimeRemoved);
 
-	Log(LogInformation, "LivestatusListener")
+	Log(LogInformation, "LivestatusListener", this)
 		<< "'" << GetName() << "' stopped.";
 
 	m_Listener->Close();
@@ -151,7 +151,7 @@ void LivestatusListener::ServerThreadProc()
 
 			if (m_Listener->Poll(true, false, &tv)) {
 				Socket::Ptr client = m_Listener->Accept();
-				Log(LogNotice, "LivestatusListener", "Client connected");
+				Log(LogNotice, "LivestatusListener", this, "Client connected");
 				Utility::QueueAsyncCallback([this, client]() { ClientHandler(client); }, LowLatencyScheduler);
 			}
 
@@ -159,7 +159,7 @@ void LivestatusListener::ServerThreadProc()
 				break;
 		}
 	} catch (std::exception&) {
-		Log(LogCritical, "LivestatusListener", "Cannot accept new connection.");
+		Log(LogCritical, "LivestatusListener", this, "Cannot accept new connection.");
 	}
 
 	m_Listener->Close();

--- a/lib/livestatus/livestatuslogutility.cpp
+++ b/lib/livestatus/livestatuslogutility.cpp
@@ -48,7 +48,7 @@ void LivestatusLogUtility::CreateLogIndexFileHandler(const String& path, std::ma
 
 	stream.close();
 
-	Log(LogDebug, "LivestatusLogUtility")
+	Log(LogDebug, "LivestatusLogUtility", nullptr)
 		<< "Indexing log file: '" << path << "' with timestamp start: '" << ts_start << "'.";
 
 	index[ts_start] = path;
@@ -85,7 +85,7 @@ void LivestatusLogUtility::CreateLogCache(std::map<time_t, String> index, Histor
 
 			/* no attributes available - invalid log line */
 			if (!log_entry_attrs) {
-				Log(LogDebug, "LivestatusLogUtility")
+				Log(LogDebug, "LivestatusLogUtility", nullptr)
 					<< "Skipping invalid log line: '" << line << "'.";
 				continue;
 			}
@@ -108,7 +108,7 @@ Dictionary::Ptr LivestatusLogUtility::GetAttributes(const String& text)
 	 */
 	unsigned long time = atoi(text.SubStr(1, 11).CStr());
 
-	Log(LogDebug, "LivestatusLogUtility")
+	Log(LogDebug, "LivestatusLogUtility", nullptr)
 		<< "Processing log line: '" << text << "'.";
 	bag->Set("time", time);
 

--- a/lib/livestatus/livestatusquery.cpp
+++ b/lib/livestatus/livestatusquery.cpp
@@ -48,7 +48,7 @@ LivestatusQuery::LivestatusQuery(const std::vector<String>& lines, const String&
 	for (const String& line : lines) {
 		msg += line + "\n";
 	}
-	Log(LogDebug, "LivestatusQuery", msg);
+	Log(LogDebug, "LivestatusQuery", nullptr, msg);
 
 	m_CompatLogPath = compat_log_path;
 
@@ -189,11 +189,11 @@ LivestatusQuery::LivestatusQuery(const std::vector<String>& lines, const String&
 
 			if (header == "Or" || header == "StatsOr") {
 				filter = new OrFilter();
-				Log(LogDebug, "LivestatusQuery")
+				Log(LogDebug, "LivestatusQuery", nullptr)
 					<< "Add OR filter for " << params << " column(s). " << deq.size() << " filters available.";
 			} else {
 				filter = new AndFilter();
-				Log(LogDebug, "LivestatusQuery")
+				Log(LogDebug, "LivestatusQuery", nullptr)
 					<< "Add AND filter for " << params << " column(s). " << deq.size() << " filters available.";
 			}
 
@@ -206,7 +206,7 @@ LivestatusQuery::LivestatusQuery(const std::vector<String>& lines, const String&
 
 			while (num > 0 && num--) {
 				filter->AddSubFilter(deq.back());
-				Log(LogDebug, "LivestatusQuery")
+				Log(LogDebug, "LivestatusQuery", nullptr)
 					<< "Add " << num << " filter.";
 				deq.pop_back();
 				if (&deq == &stats)
@@ -335,7 +335,7 @@ Filter::Ptr LivestatusQuery::ParseFilter(const String& params, unsigned long& fr
 		}
 	}
 
-	Log(LogDebug, "LivestatusQuery")
+	Log(LogDebug, "LivestatusQuery", nullptr)
 		<< "Parsed filter with attr: '" << attr << "' op: '" << op << "' val: '" << val << "'.";
 
 	return filter;
@@ -438,7 +438,7 @@ String LivestatusQuery::QuoteStringPython(const String& str) {
 
 void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 {
-	Log(LogNotice, "LivestatusQuery")
+	Log(LogNotice, "LivestatusQuery", nullptr)
 		<< "Table: " << m_Table;
 
 	Table::Ptr table = Table::GetByName(m_Table, m_CompatLogPath, m_LogTimeFrom, m_LogTimeUntil);
@@ -579,7 +579,7 @@ void LivestatusQuery::ExecuteCommandHelper(const WaitGroup::Ptr& producer, const
 		l_ExternalCommands++;
 	}
 
-	Log(LogNotice, "LivestatusQuery")
+	Log(LogNotice, "LivestatusQuery", nullptr)
 		<< "Executing command: " << m_Command;
 	ExternalCommandProcessor::Execute(producer, m_Command);
 	SendResponse(stream, LivestatusErrorOK, "");
@@ -587,7 +587,7 @@ void LivestatusQuery::ExecuteCommandHelper(const WaitGroup::Ptr& producer, const
 
 void LivestatusQuery::ExecuteErrorHelper(const Stream::Ptr& stream)
 {
-	Log(LogDebug, "LivestatusQuery")
+	Log(LogDebug, "LivestatusQuery", nullptr)
 		<< "ERROR: Code: '" << m_ErrorCode << "' Message: '" << m_ErrorMessage << "'.";
 	SendResponse(stream, m_ErrorCode, m_ErrorMessage);
 }
@@ -601,7 +601,7 @@ void LivestatusQuery::SendResponse(const Stream::Ptr& stream, int code, const St
 		try {
 			stream->Write(data.CStr(), data.GetLength());
 		} catch (const std::exception&) {
-			Log(LogCritical, "LivestatusQuery", "Cannot write query response to socket.");
+			Log(LogCritical, "LivestatusQuery", nullptr, "Cannot write query response to socket.");
 		}
 	}
 }
@@ -618,14 +618,14 @@ void LivestatusQuery::PrintFixed16(const Stream::Ptr& stream, int code, const St
 	try {
 		stream->Write(header.CStr(), header.GetLength());
 	} catch (const std::exception&) {
-		Log(LogCritical, "LivestatusQuery", "Cannot write to TCP socket.");
+		Log(LogCritical, "LivestatusQuery", nullptr, "Cannot write to TCP socket.");
 	}
 }
 
 bool LivestatusQuery::Execute(const WaitGroup::Ptr& producer, const Stream::Ptr& stream)
 {
 	try {
-		Log(LogNotice, "LivestatusQuery")
+		Log(LogNotice, "LivestatusQuery", nullptr)
 			<< "Executing livestatus query: " << m_Verb;
 
 		if (m_Verb == "GET")

--- a/lib/livestatus/logtable.cpp
+++ b/lib/livestatus/logtable.cpp
@@ -82,7 +82,7 @@ String LogTable::GetPrefix() const
 
 void LogTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	Log(LogDebug, "LogTable")
+	Log(LogDebug, "LogTable", nullptr)
 		<< "Pre-selecting log file from " << m_TimeFrom << " until " << m_TimeUntil;
 
 	/* create log file index */

--- a/lib/livestatus/servicestable.cpp
+++ b/lib/livestatus/servicestable.cpp
@@ -128,14 +128,14 @@ void ServicesTable::AddColumns(Table *table, const String& prefix,
 	/* add additional group by values received through the object accessor */
 	if (table->GetGroupByType() == LivestatusGroupByServiceGroup) {
 		/* _1 = row, _2 = groupByType, _3 = groupByObject */
-		Log(LogDebug, "Livestatus")
+		Log(LogDebug, "Livestatus", nullptr)
 			<< "Processing services group by servicegroup table.";
 		ServiceGroupsTable::AddColumns(table, "servicegroup_", [](const Value&, LivestatusGroupByType groupByType, const Object::Ptr& groupByObject) -> Value {
 			return ServiceGroupAccessor(groupByType, groupByObject);
 		});
 	} else if (table->GetGroupByType() == LivestatusGroupByHostGroup) {
 		/* _1 = row, _2 = groupByType, _3 = groupByObject */
-		Log(LogDebug, "Livestatus")
+		Log(LogDebug, "Livestatus", nullptr)
 			<< "Processing services group by hostgroup table.";
 		HostGroupsTable::AddColumns(table, "hostgroup_", [](const Value&, LivestatusGroupByType groupByType, const Object::Ptr& groupByObject) -> Value {
 			return HostGroupAccessor(groupByType, groupByObject);

--- a/lib/livestatus/statehisttable.cpp
+++ b/lib/livestatus/statehisttable.cpp
@@ -96,7 +96,7 @@ void StateHistTable::UpdateLogEntries(const Dictionary::Ptr& log_entry_attrs, in
 
 		state_hist_service_states->Add(state_hist_bag);
 
-		Log(LogDebug, "StateHistTable")
+		Log(LogDebug, "StateHistTable", checkable)
 			<< "statehist: Adding new object '" << checkable->GetName() << "' to services cache.";
 	} else {
 		state_hist_service_states = m_CheckablesCache[checkable];
@@ -153,7 +153,7 @@ void StateHistTable::UpdateLogEntries(const Dictionary::Ptr& log_entry_attrs, in
 
 					state_hist_service_states->Add(state_hist_bag_new);
 
-					Log(LogDebug, "StateHistTable")
+					Log(LogDebug, "StateHistTable", checkable)
 						<< "statehist: State change detected for object '" << checkable->GetName() << "' in '" << log_line << "'.";
 				}
 				break;
@@ -241,7 +241,7 @@ String StateHistTable::GetPrefix() const
 
 void StateHistTable::FetchRows(const AddRowFunction& addRowFn)
 {
-	Log(LogDebug, "StateHistTable")
+	Log(LogDebug, "StateHistTable", nullptr)
 		<< "Pre-selecting log file from " << m_TimeFrom << " until " << m_TimeUntil;
 
 	/* create log file index */

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -457,7 +457,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		[strand, checkable, cr, psCommand, psHost, expectedSan, psPort, conn, req, checkTimeout, reportResult = std::move(reportResult)](asio::yield_context yc) {
 			Timeout timeout (*strand, checkTimeout,
 				[&conn, &checkable] {
-					Log(LogNotice, "IfwApiCheckTask")
+					Log(LogNotice, "IfwApiCheckTask", checkable)
 						<< "Timeout while checking " << checkable->GetReflectionType()->GetName()
 						<< " '" << checkable->GetName() << "', cancelling attempt";
 

--- a/lib/methods/pluginchecktask.cpp
+++ b/lib/methods/pluginchecktask.cpp
@@ -73,7 +73,7 @@ void PluginCheckTask::ProcessFinishedHandler(const Checkable::Ptr& checkable, co
 
 	if (pr.ExitStatus > 3) {
 		Process::Arguments parguments = Process::PrepareCommand(commandLine);
-		Log(LogWarning, "PluginCheckTask")
+		Log(LogWarning, "PluginCheckTask", checkable)
 			<< "Check command for object '" << checkable->GetName() << "' (PID: " << pr.PID
 			<< ", arguments: " << Process::PrettyPrintArguments(parguments) << ") terminated with exit code "
 			<< pr.ExitStatus << ", output: " << pr.Output;

--- a/lib/methods/plugineventtask.cpp
+++ b/lib/methods/plugineventtask.cpp
@@ -54,7 +54,7 @@ void PluginEventTask::ProcessFinishedHandler(const Checkable::Ptr& checkable, co
 {
 	if (pr.ExitStatus != 0) {
 		Process::Arguments parguments = Process::PrepareCommand(commandLine);
-		Log(LogWarning, "PluginEventTask")
+		Log(LogWarning, "PluginEventTask", checkable)
 			<< "Event command for object '" << checkable->GetName() << "' (PID: " << pr.PID
 			<< ", arguments: " << Process::PrettyPrintArguments(parguments) << ") terminated with exit code "
 			<< pr.ExitStatus << ", output: " << pr.Output;

--- a/lib/methods/pluginnotificationtask.cpp
+++ b/lib/methods/pluginnotificationtask.cpp
@@ -116,7 +116,7 @@ void PluginNotificationTask::ProcessFinishedHandler(const Checkable::Ptr& checka
 {
 	if (pr.ExitStatus != 0) {
 		Process::Arguments parguments = Process::PrepareCommand(commandLine);
-		Log(LogWarning, "PluginNotificationTask")
+		Log(LogWarning, "PluginNotificationTask", checkable)
 			<< "Notification command for object '" << checkable->GetName() << "' (PID: " << pr.PID
 			<< ", arguments: " << Process::PrettyPrintArguments(parguments) << ") terminated with exit code "
 			<< pr.ExitStatus << ", output: " << pr.Output;

--- a/lib/notification/notificationcomponent.cpp
+++ b/lib/notification/notificationcomponent.cpp
@@ -37,7 +37,7 @@ void NotificationComponent::Start(bool runtimeCreated)
 {
 	ObjectImpl<NotificationComponent>::Start(runtimeCreated);
 
-	Log(LogInformation, "NotificationComponent")
+	Log(LogInformation, "NotificationComponent", this)
 		<< "'" << GetName() << "' started.";
 
 	Checkable::OnNotificationsRequested.connect([this](const Checkable::Ptr& checkable, NotificationType type, const CheckResult::Ptr& cr,
@@ -55,7 +55,7 @@ void NotificationComponent::Stop(bool runtimeRemoved)
 {
 	m_NotificationTimer->Stop(true);
 
-	Log(LogInformation, "NotificationComponent")
+	Log(LogInformation, "NotificationComponent", this)
 		<< "'" << GetName() << "' stopped.";
 
 	ObjectImpl<NotificationComponent>::Stop(runtimeRemoved);
@@ -99,7 +99,7 @@ void FireSuppressedNotifications(const Notification::Ptr& notification)
 
 			auto notificationName (notification->GetName());
 
-			Log(LogNotice, "NotificationComponent")
+			Log(LogNotice, "NotificationComponent", notification)
 				<< "Attempting to re-send previously suppressed notification '" << notificationName << "'.";
 
 			subtract |= type;
@@ -109,7 +109,7 @@ void FireSuppressedNotifications(const Notification::Ptr& notification)
 			try {
 				notification->BeginExecuteNotification(type, checkable->GetLastCheckResult(), false, false);
 			} catch (const std::exception& ex) {
-				Log(LogWarning, "NotificationComponent")
+				Log(LogWarning, "NotificationComponent", notification)
 					<< "Exception occurred during notification for object '"
 					<< notificationName << "': " << DiagnosticInformation(ex, false);
 			}
@@ -147,7 +147,7 @@ void NotificationComponent::NotificationTimerHandler()
 				ObjectLock olock(stashedNotifications);
 
 				if (stashedNotifications->GetLength()) {
-					Log(LogNotice, "NotificationComponent")
+					Log(LogNotice, "NotificationComponent", notification)
 						<< "Notification '" << notificationName << "': HA cluster active, this endpoint does not have the authority. Dropping all stashed notifications.";
 
 					stashedNotifications->Clear();
@@ -155,7 +155,7 @@ void NotificationComponent::NotificationTimerHandler()
 			}
 
 			if (myEndpoint && GetEnableHA()) {
-				Log(LogNotice, "NotificationComponent")
+				Log(LogNotice, "NotificationComponent", notification)
 					<< "Reminder notification '" << notificationName << "': HA cluster active, this endpoint does not have the authority (paused=true). Skipping.";
 				continue;
 			}
@@ -188,7 +188,7 @@ void NotificationComponent::NotificationTimerHandler()
 						continue;
 
 					try {
-						Log(LogNotice, "NotificationComponent")
+						Log(LogNotice, "NotificationComponent", notification)
 							<< "Attempting to send stashed notification '" << notificationName << "'.";
 
 						notification->BeginExecuteNotification(
@@ -200,7 +200,7 @@ void NotificationComponent::NotificationTimerHandler()
 							(String)unstashedNotification->Get("text")
 						);
 					} catch (const std::exception& ex) {
-						Log(LogWarning, "NotificationComponent")
+						Log(LogWarning, "NotificationComponent", notification)
 							<< "Exception occurred during notification for object '"
 							<< notificationName << "': " << DiagnosticInformation(ex, false);
 					}
@@ -211,7 +211,7 @@ void NotificationComponent::NotificationTimerHandler()
 		}
 
 		if (notification->GetInterval() <= 0 && notification->GetNoMoreNotifications()) {
-			Log(LogNotice, "NotificationComponent")
+			Log(LogNotice, "NotificationComponent", notification)
 				<< "Reminder notification '" << notificationName << "': Notification was sent out once and interval=0 disables reminder notifications.";
 			continue;
 		}
@@ -246,12 +246,12 @@ void NotificationComponent::NotificationTimerHandler()
 		}
 
 		try {
-			Log(LogNotice, "NotificationComponent")
+			Log(LogNotice, "NotificationComponent", notification)
 				<< "Attempting to send reminder notification '" << notificationName << "'.";
 
 			notification->BeginExecuteNotification(NotificationProblem, checkable->GetLastCheckResult(), false, true);
 		} catch (const std::exception& ex) {
-			Log(LogWarning, "NotificationComponent")
+			Log(LogWarning, "NotificationComponent", notification)
 				<< "Exception occurred during notification for object '"
 				<< notificationName << "': " << DiagnosticInformation(ex, false);
 		}

--- a/lib/otel/otel.cpp
+++ b/lib/otel/otel.cpp
@@ -133,7 +133,7 @@ void OTel::Stop()
 			}
 		}
 
-		Log(LogInformation, "OTelExporter")
+		Log(LogInformation, "OTelExporter", nullptr)
 			<< "Disconnected from OpenTelemetry backend.";
 
 		m_Stream.reset();
@@ -155,7 +155,7 @@ void OTel::Export(std::unique_ptr<MetricsRequest>&& request)
 {
 	std::unique_lock lock(m_Mutex);
 	if (m_Exporting) {
-		Log(LogWarning, "OTelExporter")
+		Log(LogWarning, "OTelExporter", nullptr)
 			<< "Received export request while previous export is still in progress. Waiting for it to complete.";
 
 		m_ExportCV.wait(lock, [this] { return m_Stopped || !m_Exporting; });
@@ -234,7 +234,7 @@ void OTel::PopulateResourceAttrs(const std::unique_ptr<v1_metrics::ResourceMetri
  */
 void OTel::Connect(boost::asio::yield_context& yc)
 {
-	Log(LogInformation, "OTelExporter")
+	Log(LogInformation, "OTelExporter", nullptr)
 		<< "Connecting to OpenTelemetry backend on host '" << m_ConnInfo.Host << ":" << m_ConnInfo.Port << "'.";
 
 	for (uint64_t attempt = 1; !m_Stopped; ++attempt) {
@@ -247,7 +247,7 @@ void OTel::Connect(boost::asio::yield_context& yc)
 			}
 
 			Timeout timeout{m_Strand, 10s, [this, stream] {
-				Log(LogCritical, "OTelExporter")
+				Log(LogCritical, "OTelExporter", nullptr)
 					<< "Timeout while connecting to OpenTelemetry backend '" << m_ConnInfo.Host << ":" << m_ConnInfo.Port << "', cancelling attempt.";
 
 				boost::system::error_code ec;
@@ -270,11 +270,11 @@ void OTel::Connect(boost::asio::yield_context& yc)
 
 			m_Stream = std::move(stream);
 
-			Log(LogInformation, "OTelExporter")
+			Log(LogInformation, "OTelExporter", nullptr)
 				<< "Successfully connected to OpenTelemetry backend.";
 			return;
 		} catch (const std::exception& ex) {
-			Log(m_Stopped ? LogDebug : LogCritical, "OTelExporter")
+			Log(m_Stopped ? LogDebug : LogCritical, "OTelExporter", nullptr)
 				<< "Cannot connect to OpenTelemetry backend '" << m_ConnInfo.Host << ":" << m_ConnInfo.Port
 				<< "' (attempt #" << attempt << "): " << ex.what();
 
@@ -339,7 +339,7 @@ void OTel::ExportLoop(boost::asio::yield_context& yc)
 					retryAfter = Backoff(attempt);
 				}
 
-				Log(LogWarning, "OTelExporter")
+				Log(LogWarning, "OTelExporter", nullptr)
 					<< "Failed to export metrics to OpenTelemetry backend (attempt #" << attempt << "). Retrying in "
 					<< retryAfter.count() << "ms.";
 
@@ -356,7 +356,7 @@ void OTel::ExportLoop(boost::asio::yield_context& yc)
 				if (m_Stopped || (ser && (ser->code() == http::error::end_of_stream || ser->code() == boost::asio::error::broken_pipe))) {
 					severity = LogDebug;
 				}
-				Log{severity, "OTelExporter", DiagnosticInformation(ex, false)};
+				Log{severity, "OTelExporter", nullptr, DiagnosticInformation(ex, false)};
 				m_Stream.reset(); // Force reconnect on next export attempt.
 			}
 		}
@@ -382,7 +382,7 @@ void OTel::ExportImpl(boost::asio::yield_context& yc) const
 			// but without the expected Protobuf content type. So, don't do anything here since the request succeeded.
 			return;
 		}
-		Log(LogWarning, "OTelExporter")
+		Log(LogWarning, "OTelExporter", nullptr)
 			<< "Unexpected Content-Type from OpenTelemetry backend '" << ct << "' (" << responseMsg.reason() << "):\n"
 			<< responseMsg.body();
 	} else if (responseMsg.result_int() >= 200 && responseMsg.result_int() <= 299) {
@@ -397,7 +397,7 @@ void OTel::ExportImpl(boost::asio::yield_context& yc) const
 			const auto& ps = response->partial_success();
 			const auto& msg = ps.error_message();
 			if (ps.rejected_data_points() > 0 || !msg.empty()) {
-				Log(LogWarning, "OTelExporter")
+				Log(LogWarning, "OTelExporter", nullptr)
 					<< "OpenTelemetry backend reported partial success: " << (msg.empty() ? "<none>" : msg)
 					<< " (" << ps.rejected_data_points() << " metric data points rejected).";
 			}
@@ -408,13 +408,13 @@ void OTel::ExportImpl(boost::asio::yield_context& yc) const
 			try {
 				throttleSeconds = boost::lexical_cast<uint64_t>(throttle);
 			} catch (const std::exception& ex) {
-				Log(LogWarning, "OTelExporter")
+				Log(LogWarning, "OTelExporter", nullptr)
 					<< "Failed to parse 'Retry-After' header from OpenTelemetry backend response: " << ex.what();
 			}
 		}
 		BOOST_THROW_EXCEPTION(RetryableExportError{throttleSeconds});
 	} else {
-		Log(LogWarning, "OTelExporter")
+		Log(LogWarning, "OTelExporter", nullptr)
 			<< "OpenTelemetry backend responded with non-success and non-retryable status code "
 			<< responseMsg.result_int() << " (" << responseMsg.reason() << ").\n" << responseMsg.body();
 	}

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -34,7 +34,7 @@ void ElasticsearchWriter::OnConfigLoaded()
 	m_WorkQueue.SetName("ElasticsearchWriter, " + GetName());
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "ElasticsearchWriter")
+		Log(LogDebug, "ElasticsearchWriter", this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -47,7 +47,7 @@ void ElasticsearchWriter::OnAllConfigLoaded()
 {
 	ObjectImpl<ElasticsearchWriter>::OnAllConfigLoaded();
 
-	Log(LogWarning, "ElasticsearchWriter")
+	Log(LogWarning, "ElasticsearchWriter", this)
 		<< "This feature is DEPRECATED and will be removed in v2.18.";
 }
 
@@ -79,7 +79,7 @@ void ElasticsearchWriter::Start(bool runtimeCreated)
 		try {
 			m_SslContext = MakeAsioSslContext(GetCertPath(), GetKeyPath(), GetCaPath());
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "ElasticsearchWriter")
+			Log(LogCritical, "ElasticsearchWriter", this)
 				<< "Unable to create SSL context: " << ex.what();
 			throw;
 		}
@@ -90,7 +90,7 @@ void ElasticsearchWriter::Resume()
 {
 	ObjectImpl<ElasticsearchWriter>::Resume();
 
-	Log(LogInformation, "ElasticsearchWriter")
+	Log(LogInformation, "ElasticsearchWriter", this)
 		<< "'" << GetName() << "' resumed.";
 
 	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
@@ -140,7 +140,7 @@ void ElasticsearchWriter::Pause()
 
 	m_WorkQueue.Join();
 
-	Log(LogInformation, "ElasticsearchWriter")
+	Log(LogInformation, "ElasticsearchWriter", this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<ElasticsearchWriter>::Pause();
@@ -211,7 +211,7 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 				try {
 					pdv = PerfdataValue::Parse(val);
 				} catch (const std::exception&) {
-					Log(LogWarning, "ElasticsearchWriter")
+					Log(LogWarning, "ElasticsearchWriter", checkable)
 						<< "Ignoring invalid perfdata for checkable '"
 						<< checkable->GetName() << "' and command '"
 						<< checkCommand->GetName() << "' with value: " << val;
@@ -384,7 +384,7 @@ void ElasticsearchWriter::NotificationSentToAllUsersHandler(const Checkable::Ptr
 
 		CONTEXT("Elasticwriter processing notification to all users '" << checkable->GetName() << "'");
 
-		Log(LogDebug, "ElasticsearchWriter")
+		Log(LogDebug, "ElasticsearchWriter", checkable)
 			<< "Processing notification for '" << checkable->GetName() << "'";
 
 		double ts = Utility::GetTime();
@@ -414,14 +414,14 @@ void ElasticsearchWriter::Enqueue(const Checkable::Ptr& checkable, const String&
 	String indexBody = "{\"index\": {} }\n";
 	String fieldsBody = JsonEncode(fields);
 
-	Log(LogDebug, "ElasticsearchWriter")
+	Log(LogDebug, "ElasticsearchWriter", checkable)
 		<< "Checkable '" << checkable->GetName() << "' adds to metric list: '" << fieldsBody << "'.";
 
 	m_DataBuffer.emplace_back(indexBody + fieldsBody);
 
 	/* Flush if we've buffered too much to prevent excessive memory use. */
 	if (static_cast<int>(m_DataBuffer.size()) >= GetFlushThreshold()) {
-		Log(LogDebug, "ElasticsearchWriter")
+		Log(LogDebug, "ElasticsearchWriter", this)
 			<< "Data buffer overflow writing " << m_DataBuffer.size() << " data points";
 		Flush();
 	}
@@ -512,7 +512,7 @@ void ElasticsearchWriter::SendRequest(const String& body)
 	request.content_length(request.body().size());
 
 	/* Don't log the request body to debug log, this is already done above. */
-	Log(LogDebug, "ElasticsearchWriter")
+	Log(LogDebug, "ElasticsearchWriter", this)
 		<< "Sending " << request.method_string() << " request" << ((!username.IsEmpty() && !password.IsEmpty()) ? " with basic auth" : "" )
 		<< " to '" << url->Format() << "'.";
 
@@ -520,7 +520,7 @@ void ElasticsearchWriter::SendRequest(const String& body)
 	try {
 		response = m_Connection->Send(request);
 	} catch (const PerfdataWriterConnection::Stopped& ex) {
-		Log(LogDebug, "ElasticsearchWriter") << ex.what();
+		Log(LogDebug, "ElasticsearchWriter", this) << ex.what();
 		return;
 	}
 
@@ -528,11 +528,11 @@ void ElasticsearchWriter::SendRequest(const String& body)
 		if (response.result() == http::status::unauthorized) {
 			/* More verbose error logging with Elasticsearch is hidden behind a proxy. */
 			if (!username.IsEmpty() && !password.IsEmpty()) {
-				Log(LogCritical, "ElasticsearchWriter")
+				Log(LogCritical, "ElasticsearchWriter", this)
 					<< "401 Unauthorized. Please ensure that the user '" << username
 					<< "' is able to authenticate against the HTTP API/Proxy.";
 			} else {
-				Log(LogCritical, "ElasticsearchWriter")
+				Log(LogCritical, "ElasticsearchWriter", this)
 					<< "401 Unauthorized. The HTTP API requires authentication but no username/password has been configured.";
 			}
 
@@ -559,14 +559,14 @@ void ElasticsearchWriter::SendRequest(const String& body)
 		try {
 			jsonResponse = JsonDecode(body);
 		} catch (...) {
-			Log(LogWarning, "ElasticsearchWriter")
+			Log(LogWarning, "ElasticsearchWriter", this)
 				<< "Unable to parse JSON response:\n" << body;
 			return;
 		}
 
 		String error = jsonResponse->Get("error");
 
-		Log(LogCritical, "ElasticsearchWriter")
+		Log(LogCritical, "ElasticsearchWriter", this)
 			<< "Error: '" << error << "'. " << msgbuf.str();
 	}
 }
@@ -578,9 +578,9 @@ void ElasticsearchWriter::AssertOnWorkQueue()
 
 void ElasticsearchWriter::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogCritical, "ElasticsearchWriter", "Exception during Elastic operation: Verify that your backend is operational!");
+	Log(LogCritical, "ElasticsearchWriter", this, "Exception during Elastic operation: Verify that your backend is operational!");
 
-	Log(LogDebug, "ElasticsearchWriter")
+	Log(LogDebug, "ElasticsearchWriter", this)
 		<< "Exception during Elasticsearch operation: " << DiagnosticInformation(std::move(exp));
 }
 

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -33,7 +33,7 @@ void GelfWriter::OnConfigLoaded()
 	m_WorkQueue.SetName("GelfWriter, " + GetName());
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "GelfWriter")
+		Log(LogDebug, "GelfWriter", this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -74,7 +74,7 @@ void GelfWriter::Start(bool runtimeCreated)
 		try {
 			m_SslContext = MakeAsioSslContext(GetCertPath(), GetKeyPath(), GetCaPath());
 		} catch (const std::exception& ex) {
-			Log(LogWarning, "GelfWriter")
+			Log(LogWarning, "GelfWriter", this)
 				<< "Unable to create SSL context.";
 			throw;
 		}
@@ -85,7 +85,7 @@ void GelfWriter::Resume()
 {
 	ObjectImpl<GelfWriter>::Resume();
 
-	Log(LogInformation, "GelfWriter")
+	Log(LogInformation, "GelfWriter", this)
 		<< "'" << GetName() << "' resumed.";
 
 	/* Register exception handler for WQ tasks. */
@@ -128,7 +128,7 @@ void GelfWriter::Pause()
 
 	m_WorkQueue.Join();
 
-	Log(LogInformation, "GelfWriter")
+	Log(LogInformation, "GelfWriter", this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<GelfWriter>::Pause();
@@ -141,8 +141,8 @@ void GelfWriter::AssertOnWorkQueue()
 
 void GelfWriter::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogCritical, "GelfWriter") << "Exception during Graylog Gelf operation: " << DiagnosticInformation(exp, false);
-	Log(LogDebug, "GelfWriter") << "Exception during Graylog Gelf operation: " << DiagnosticInformation(exp, true);
+	Log(LogCritical, "GelfWriter", this) << "Exception during Graylog Gelf operation: " << DiagnosticInformation(exp, false);
+	Log(LogDebug, "GelfWriter", this) << "Exception during Graylog Gelf operation: " << DiagnosticInformation(exp, true);
 }
 
 void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
@@ -185,7 +185,7 @@ void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const Check
 
 		CONTEXT("GELF Processing check result for '" << checkable->GetName() << "'");
 
-		Log(LogDebug, "GelfWriter")
+		Log(LogDebug, "GelfWriter", checkable)
 			<< "Processing check result for '" << checkable->GetName() << "'";
 
 		fields->Set("_latency", cr->CalculateLatency());
@@ -207,7 +207,7 @@ void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const Check
 						try {
 							pdv = PerfdataValue::Parse(val);
 						} catch (const std::exception&) {
-							Log(LogWarning, "GelfWriter")
+							Log(LogWarning, "GelfWriter", checkable)
 								<< "Ignoring invalid perfdata for checkable '"
 								<< checkable->GetName() << "' and command '"
 								<< checkable->GetCheckCommand()->GetName() << "' with value: " << val;
@@ -295,7 +295,7 @@ void GelfWriter::NotificationToUserHandler(const Checkable::Ptr& checkable, Noti
 
 		CONTEXT("GELF Processing notification to all users '" << checkable->GetName() << "'");
 
-		Log(LogDebug, "GelfWriter")
+		Log(LogDebug, "GelfWriter", checkable)
 			<< "Processing notification for '" << checkable->GetName() << "'";
 
 		SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), ts));
@@ -341,7 +341,7 @@ void GelfWriter::StateChangeHandler(const Checkable::Ptr& checkable, const Check
 
 		CONTEXT("GELF Processing state change '" << checkable->GetName() << "'");
 
-		Log(LogDebug, "GelfWriter")
+		Log(LogDebug, "GelfWriter", checkable)
 			<< "Processing state change for '" << checkable->GetName() << "'";
 
 		SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), ts));
@@ -368,12 +368,12 @@ void GelfWriter::SendLogMessage(const Checkable::Ptr& checkable, const String& g
 	auto log = msgbuf.str();
 
 	try {
-		Log(LogDebug, "GelfWriter")
+		Log(LogDebug, "GelfWriter", checkable)
 			<< "Checkable '" << checkable->GetName() << "' sending message '" << log << "'.";
 
 		m_Connection->Send(boost::asio::const_buffer{log.data(), log.length()});
 	} catch (const PerfdataWriterConnection::Stopped& ex) {
-		Log(LogDebug, "GelfWriter") << ex.what();
+		Log(LogDebug, "GelfWriter", checkable) << ex.what();
 		return;
 	}
 }

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -36,7 +36,7 @@ void GraphiteWriter::OnConfigLoaded()
 	m_WorkQueue.SetName("GraphiteWriter, " + GetName());
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "GraphiteWriter")
+		Log(LogDebug, "GraphiteWriter", this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -80,7 +80,7 @@ void GraphiteWriter::Resume()
 {
 	ObjectImpl<GraphiteWriter>::Resume();
 
-	Log(LogInformation, "GraphiteWriter")
+	Log(LogInformation, "GraphiteWriter", this)
 		<< "'" << GetName() << "' resumed.";
 
 	/* Register exception handler for WQ tasks. */
@@ -114,7 +114,7 @@ void GraphiteWriter::Pause()
 
 	m_WorkQueue.Join();
 
-	Log(LogInformation, "GraphiteWriter")
+	Log(LogInformation, "GraphiteWriter", this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<GraphiteWriter>::Pause();
@@ -137,9 +137,9 @@ void GraphiteWriter::AssertOnWorkQueue()
  */
 void GraphiteWriter::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogCritical, "GraphiteWriter", "Exception during Graphite operation: Verify that your backend is operational!");
+	Log(LogCritical, "GraphiteWriter", this, "Exception during Graphite operation: Verify that your backend is operational!");
 
-	Log(LogDebug, "GraphiteWriter")
+	Log(LogDebug, "GraphiteWriter", this)
 		<< "Exception during Graphite operation: " << DiagnosticInformation(std::move(exp));
 }
 
@@ -235,7 +235,7 @@ void GraphiteWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 			try {
 				pdv = PerfdataValue::Parse(val);
 			} catch (const std::exception&) {
-				Log(LogWarning, "GraphiteWriter")
+				Log(LogWarning, "GraphiteWriter", checkable)
 					<< "Ignoring invalid perfdata for checkable '"
 					<< checkable->GetName() << "' and command '"
 					<< checkCommand->GetName() << "' with value: " << val;
@@ -279,7 +279,7 @@ void GraphiteWriter::SendMetric(const Checkable::Ptr& checkable, const String& p
 	std::ostringstream msgbuf;
 	msgbuf << prefix << "." << name << " " << Convert::ToString(value) << " " << static_cast<long>(ts);
 
-	Log(LogDebug, "GraphiteWriter")
+	Log(LogDebug, "GraphiteWriter", checkable)
 		<< "Checkable '" << checkable->GetName() << "' adds to metric list: '" << msgbuf.str() << "'.";
 
 	// do not send \n to debug log
@@ -288,7 +288,7 @@ void GraphiteWriter::SendMetric(const Checkable::Ptr& checkable, const String& p
 	try {
 		m_Connection->Send(asio::buffer(msgbuf.str()));
 	} catch (const PerfdataWriterConnection::Stopped& ex) {
-		Log(LogDebug, "GraphiteWriter") << ex.what();
+		Log(LogDebug, "GraphiteWriter", checkable) << ex.what();
 		return;
 	}
 }

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -51,7 +51,7 @@ void InfluxdbCommonWriter::OnConfigLoaded()
 	m_WorkQueue.SetName(GetReflectionType()->GetName() + ", " + GetName());
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, GetReflectionType()->GetName())
+		Log(LogDebug, GetReflectionType()->GetName(), this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -68,7 +68,7 @@ void InfluxdbCommonWriter::Start(bool runtimeCreated)
 		try {
 			m_SslContext = MakeAsioSslContext(GetSslCert(), GetSslKey(), GetSslCaCert());
 		} catch (const std::exception& ex) {
-			Log(LogCritical, GetReflectionType()->GetName())
+			Log(LogCritical, GetReflectionType()->GetName(), this)
 				<< "Unable to create SSL context: " << ex.what();
 			throw;
 		}
@@ -79,7 +79,7 @@ void InfluxdbCommonWriter::Resume()
 {
 	ObjectImpl<InfluxdbCommonWriter>::Resume();
 
-	Log(LogInformation, GetReflectionType()->GetName())
+	Log(LogInformation, GetReflectionType()->GetName(), this)
 		<< "'" << GetName() << "' resumed.";
 
 	/* Register exception handler for WQ tasks. */
@@ -107,7 +107,7 @@ void InfluxdbCommonWriter::Pause()
 	m_HandleCheckResults.disconnect();
 
 	/* Force a flush. */
-	Log(LogDebug, GetReflectionType()->GetName())
+	Log(LogDebug, GetReflectionType()->GetName(), this)
 		<< "Processing pending tasks and flushing data buffers.";
 
 	m_FlushTimer->Stop(true);
@@ -124,7 +124,7 @@ void InfluxdbCommonWriter::Pause()
 	/* Wait for the flush to complete, implicitly waits for all WQ tasks enqueued prior to pausing. */
 	m_WorkQueue.Join();
 
-	Log(LogInformation, GetReflectionType()->GetName())
+	Log(LogInformation, GetReflectionType()->GetName(), this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<InfluxdbCommonWriter>::Pause();
@@ -137,9 +137,9 @@ void InfluxdbCommonWriter::AssertOnWorkQueue()
 
 void InfluxdbCommonWriter::ExceptionHandler(std::exception_ptr exp)
 {
-	Log(LogCritical, GetReflectionType()->GetName(), "Exception during InfluxDB operation: Verify that your backend is operational!");
+	Log(LogCritical, GetReflectionType()->GetName(), this, "Exception during InfluxDB operation: Verify that your backend is operational!");
 
-	Log(LogDebug, GetReflectionType()->GetName())
+	Log(LogDebug, GetReflectionType()->GetName(), this)
 		<< "Exception during InfluxDB operation: " << DiagnosticInformation(std::move(exp));
 }
 
@@ -222,7 +222,7 @@ void InfluxdbCommonWriter::CheckResultHandler(const Checkable::Ptr& checkable, c
 					try {
 						pdv = PerfdataValue::Parse(val);
 					} catch (const std::exception&) {
-						Log(LogWarning, GetReflectionType()->GetName())
+						Log(LogWarning, GetReflectionType()->GetName(), checkable)
 							<< "Ignoring invalid perfdata for checkable '"
 							<< checkable->GetName() << "' and command '"
 							<< checkable->GetCheckCommand()->GetName() << "' with value: " << val;
@@ -337,7 +337,7 @@ void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dic
 
 	msgbuf << " " <<  static_cast<unsigned long>(ts);
 
-	Log(LogDebug, GetReflectionType()->GetName())
+	Log(LogDebug, GetReflectionType()->GetName(), checkable)
 		<< "Checkable '" << checkable->GetName() << "' adds to metric list:'" << msgbuf.str() << "'.";
 
 	// Buffer the data point
@@ -346,7 +346,7 @@ void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dic
 
 	// Flush if we've buffered too much to prevent excessive memory use
 	if (static_cast<int>(m_DataBuffer.size()) >= GetFlushThreshold()) {
-		Log(LogDebug, GetReflectionType()->GetName())
+		Log(LogDebug, GetReflectionType()->GetName(), this)
 			<< "Data buffer overflow writing " << m_DataBuffer.size() << " data points";
 
 		try {
@@ -383,7 +383,7 @@ void InfluxdbCommonWriter::FlushWQ()
 	if (m_DataBuffer.empty())
 		return;
 
-	Log(LogDebug, GetReflectionType()->GetName())
+	Log(LogDebug, GetReflectionType()->GetName(), this)
 		<< "Flushing data buffer to InfluxDB.";
 
 	String body = boost::algorithm::join(m_DataBuffer, "\n");
@@ -396,12 +396,12 @@ void InfluxdbCommonWriter::FlushWQ()
 	try {
 		response = m_Connection->Send(request);
 	} catch (const PerfdataWriterConnection::Stopped& ex) {
-		Log(LogDebug, GetReflectionType()->GetName()) << ex.what();
+		Log(LogDebug, GetReflectionType()->GetName(), this) << ex.what();
 		return;
 	}
 
 	if (response.result() != http::status::no_content) {
-		Log(LogCritical, GetReflectionType()->GetName())
+		Log(LogCritical, GetReflectionType()->GetName(), this)
 			<< "Unexpected response code: " << response.result() << ", InfluxDB error message:\n" << response.body();
 	}
 }

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -34,7 +34,7 @@ void OpenTsdbWriter::OnConfigLoaded()
 	m_WorkQueue.SetName("OpenTsdbWriter, " + GetName());
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "OpenTsdbWriter")
+		Log(LogDebug, "OpenTsdbWriter", this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -81,11 +81,11 @@ void OpenTsdbWriter::Resume()
 {
 	ObjectImpl<OpenTsdbWriter>::Resume();
 
-	Log(LogInformation, "OpentsdbWriter")
+	Log(LogInformation, "OpentsdbWriter", this)
 		<< "'" << GetName() << "' resumed.";
 
-	m_WorkQueue.SetExceptionCallback([](const std::exception_ptr& exp) {
-		Log(LogDebug, "OpenTsdbWriter")
+	m_WorkQueue.SetExceptionCallback([this](const std::exception_ptr& exp) {
+		Log(LogDebug, "OpenTsdbWriter", this)
 			<< "Exception during OpenTsdb operation: " << DiagnosticInformation(exp);
 	});
 
@@ -117,7 +117,7 @@ void OpenTsdbWriter::Pause()
 
 	m_WorkQueue.Join();
 
-	Log(LogInformation, "OpentsdbWriter")
+	Log(LogInformation, "OpentsdbWriter", this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<OpenTsdbWriter>::Pause();
@@ -183,7 +183,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 				Value value = MacroProcessor::ResolveMacros(pair.second, resolvers, cr, &missing_macro);
 				
 				if (!missing_macro.IsEmpty()) {
-					Log(LogDebug, "OpenTsdbWriter")
+					Log(LogDebug, "OpenTsdbWriter", checkable)
 						<< "Unable to resolve macro '" << missing_macro 
 						<< "' for checkable '" << checkable->GetName() << "'.";
 					
@@ -191,7 +191,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 				}
 
 				if (value.IsEmpty()) {
-					Log(LogDebug, "OpenTsdbWriter")
+					Log(LogDebug, "OpenTsdbWriter", checkable)
 						<< "Resolved macro '" << pair.second
 						<< "' for checkable '" << checkable->GetName() << "' to '', skipping.";
 
@@ -211,7 +211,7 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 			Value value = MacroProcessor::ResolveMacros(config_tmpl_metric, resolvers, cr, &missing_macro);
 			
 			if (!missing_macro.IsEmpty()) {
-				Log(LogDebug, "OpenTsdbWriter")
+				Log(LogDebug, "OpenTsdbWriter", checkable)
 					<< "Unable to resolve macro '" << missing_macro 
 					<< "' for checkable '" << checkable->GetName() << "'.";
 				
@@ -319,7 +319,7 @@ void OpenTsdbWriter::AddPerfdata(const Checkable::Ptr& checkable, const String& 
 			try {
 				pdv = PerfdataValue::Parse(val);
 			} catch (const std::exception&) {
-				Log(LogWarning, "OpenTsdbWriter")
+				Log(LogWarning, "OpenTsdbWriter", checkable)
 					<< "Ignoring invalid perfdata for checkable '"
 					<< checkable->GetName() << "' and command '"
 					<< checkCommand->GetName() << "' with value: " << val;
@@ -383,7 +383,7 @@ void OpenTsdbWriter::AddMetric(const Checkable::Ptr& checkable, const String& me
 	 */
 	msgbuf << "put " << metric << " " << static_cast<long>(ts) << " " << Convert::ToString(value) << tags_string;
 
-	Log(LogDebug, "OpenTsdbWriter")
+	Log(LogDebug, "OpenTsdbWriter", checkable)
 		<< "Checkable '" << checkable->GetName() << "' adds to metric list: '" << msgbuf.str() << "'.";
 
 	/* do not send \n to debug log */
@@ -395,13 +395,13 @@ void OpenTsdbWriter::SendMsgBuffer()
 {
 	ASSERT(m_WorkQueue.IsWorkerThread());
 
-	Log(LogDebug, "OpenTsdbWriter")
+	Log(LogDebug, "OpenTsdbWriter", this)
 		<< "Flushing data buffer to OpenTsdb.";
 
 	try {
 		m_Connection->Send(boost::asio::buffer(std::exchange(m_MsgBuf, std::string{})));
 	} catch (const PerfdataWriterConnection::Stopped& ex) {
-		Log(LogDebug, "OpenTsdbWriter") << ex.what();
+		Log(LogDebug, "OpenTsdbWriter", this) << ex.what();
 		return;
 	}
 }
@@ -455,20 +455,20 @@ void OpenTsdbWriter::ReadConfigTemplate()
 	m_ServiceConfigTemplate = GetServiceTemplate();
 
 	if (!m_ServiceConfigTemplate) {
-		Log(LogDebug, "OpenTsdbWriter")
+		Log(LogDebug, "OpenTsdbWriter", this)
 			<< "Unable to locate service template configuration.";
 	} else if (m_ServiceConfigTemplate->GetLength() == 0) {
-		Log(LogDebug, "OpenTsdbWriter")
+		Log(LogDebug, "OpenTsdbWriter", this)
 			<< "The service template configuration is empty.";
 	}
 
 	m_HostConfigTemplate = GetHostTemplate();
 
 	if (!m_HostConfigTemplate) {
-		Log(LogDebug, "OpenTsdbWriter")
+		Log(LogDebug, "OpenTsdbWriter", this)
 			<< "Unable to locate host template configuration.";
 	} else if (m_HostConfigTemplate->GetLength() == 0) {
-		Log(LogDebug, "OpenTsdbWriter")
+		Log(LogDebug, "OpenTsdbWriter", this)
 			<< "The host template configuration is empty.";
 	}
 

--- a/lib/perfdata/otlpmetricswriter.cpp
+++ b/lib/perfdata/otlpmetricswriter.cpp
@@ -63,7 +63,7 @@ void OTLPMetricsWriter::OnConfigLoaded()
 	m_WorkQueue.SetName("OTLPMetricsWriter, " + GetName());
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "OTLPMetricsWriter")
+		Log(LogDebug, "OTLPMetricsWriter", this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -96,11 +96,11 @@ void OTLPMetricsWriter::Resume()
 {
 	ObjectImpl::Resume();
 
-	Log(LogInformation, "OTLPMetricsWriter")
+	Log(LogInformation, "OTLPMetricsWriter", this)
 		<< "'" << GetName() << "' resumed.";
 
-	m_WorkQueue.SetExceptionCallback([](std::exception_ptr exp) {
-		Log(LogCritical, "OTLPMetricsWriter")
+	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) {
+		Log(LogCritical, "OTLPMetricsWriter", this)
 			<< "Exception while producing OTel metric: " << DiagnosticInformation(exp);
 	});
 
@@ -150,7 +150,7 @@ void OTLPMetricsWriter::Pause()
 	}, PriorityLow);
 
 	if (auto status = future.wait_for(std::chrono::seconds(GetDisconnectTimeout())); status != std::future_status::ready) {
-		Log(LogWarning, "OTLPMetricsWriter")
+		Log(LogWarning, "OTLPMetricsWriter", this)
 			<< "Disconnect timeout reached while flushing OTel metrics, discarding '" << m_DataPointsCount
 			<< "' data points ('" << m_RecordedBytes << "' bytes).";
 	}
@@ -159,7 +159,7 @@ void OTLPMetricsWriter::Pause()
 
 	m_Metrics.clear();
 
-	Log(LogInformation, "OTLPMetricsWriter")
+	Log(LogInformation, "OTLPMetricsWriter", this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl::Pause();
@@ -189,7 +189,7 @@ void OTLPMetricsWriter::CheckResultHandler(const Checkable::Ptr& checkable, cons
 				try {
 					pdv = PerfdataValue::Parse(val);
 				} catch (const std::exception&) {
-					Log(LogWarning, "OTLPMetricsWriter")
+					Log(LogWarning, "OTLPMetricsWriter", checkable)
 						<< "Ignoring invalid perfdata for checkable '" << checkable->GetName() << "' and command '"
 						<< checkable->GetCheckCommand()->GetName() << "' with value: " << val;
 					continue;
@@ -242,7 +242,7 @@ void OTLPMetricsWriter::Flush(bool fromTimer)
 		return;
 	}
 
-	Log(LogDebug, "OTLPMetricsWriter")
+	Log(LogDebug, "OTLPMetricsWriter", this)
 		<< "Flushing OTel metrics to OpenTelemetry backend" << (fromTimer ? " (timer expired)." : ".");
 
 	auto request = std::make_unique<OTel::MetricsRequest>();
@@ -252,7 +252,7 @@ void OTLPMetricsWriter::Flush(bool fromTimer)
 		}
 	}
 	if (request->resource_metrics_size() == 0) {
-		Log(LogDebug, "OTLPMetricsWriter")
+		Log(LogDebug, "OTLPMetricsWriter", this)
 			<< "Not flushing OTel metrics: No data points recorded.";
 		return;
 	}
@@ -265,7 +265,7 @@ void OTLPMetricsWriter::AddBytesAndFlushIfNeeded(std::size_t newBytes)
 {
 	auto existingBytes = m_RecordedBytes.fetch_add(newBytes, std::memory_order_relaxed);
 	if (auto bytes{existingBytes + newBytes}; bytes >= static_cast<uint64_t>(GetFlushThreshold())) {
-		Log(LogDebug, "OTLPMetricsWriter")
+		Log(LogDebug, "OTLPMetricsWriter", this)
 			<< "Flush threshold reached, flushing '" << bytes << "' bytes of OTel metrics.";
 		Flush();
 	}
@@ -346,7 +346,7 @@ std::size_t OTLPMetricsWriter::Record(
 					try {
 						OTel::SetAttribute(*attr, "icinga2.custom." + pair.first, resolvedVal);
 					} catch (const std::exception& ex) {
-						Log(LogWarning, "OTLPMetricsWriter")
+						Log(LogWarning, "OTLPMetricsWriter", checkable)
 							<< "Ignoring invalid resource attribute '" << pair.first << "' for checkable '"
 							<< checkable->GetName() << "': " << ex.what();
 						 // Remove the last attribute from the list which is the one we just attempted to set.

--- a/lib/perfdata/perfdatawriter.cpp
+++ b/lib/perfdata/perfdatawriter.cpp
@@ -27,7 +27,7 @@ void PerfdataWriter::OnConfigLoaded()
 	ObjectImpl<PerfdataWriter>::OnConfigLoaded();
 
 	if (!GetEnableHa()) {
-		Log(LogDebug, "PerfdataWriter")
+		Log(LogDebug, "PerfdataWriter", this)
 			<< "HA functionality disabled. Won't pause connection: " << GetName();
 
 		SetHAMode(HARunEverywhere);
@@ -51,7 +51,7 @@ void PerfdataWriter::Resume()
 {
 	ObjectImpl<PerfdataWriter>::Resume();
 
-	Log(LogInformation, "PerfdataWriter")
+	Log(LogInformation, "PerfdataWriter", this)
 		<< "'" << GetName() << "' resumed.";
 
 	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,
@@ -81,7 +81,7 @@ void PerfdataWriter::Pause()
 	/* Force a rotation closing the file stream. */
 	RotateAllFiles();
 
-	Log(LogInformation, "PerfdataWriter")
+	Log(LogInformation, "PerfdataWriter", this)
 		<< "'" << GetName() << "' paused.";
 
 	ObjectImpl<PerfdataWriter>::Pause();
@@ -145,7 +145,7 @@ void PerfdataWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 
 void PerfdataWriter::RotateFile(std::ofstream& output, const String& temp_path, const String& perfdata_path)
 {
-	Log(LogDebug, "PerfdataWriter")
+	Log(LogDebug, "PerfdataWriter", this)
 		<< "Rotating perfdata files.";
 
 	std::unique_lock<std::mutex> lock(m_StreamMutex);
@@ -156,7 +156,7 @@ void PerfdataWriter::RotateFile(std::ofstream& output, const String& temp_path, 
 		if (Utility::PathExists(temp_path)) {
 			String finalFile = perfdata_path + "." + Convert::ToString((long)Utility::GetTime());
 
-			Log(LogDebug, "PerfdataWriter")
+			Log(LogDebug, "PerfdataWriter", this)
 				<< "Closed output file and renaming into '" << finalFile << "'.";
 
 			Utility::RenameFile(temp_path, finalFile);
@@ -166,7 +166,7 @@ void PerfdataWriter::RotateFile(std::ofstream& output, const String& temp_path, 
 	output.open(temp_path.CStr());
 
 	if (!output.good()) {
-		Log(LogWarning, "PerfdataWriter")
+		Log(LogWarning, "PerfdataWriter", this)
 			<< "Could not open perfdata file '" << temp_path << "' for writing. Perfdata will be lost.";
 	}
 }

--- a/lib/perfdata/perfdatawriterconnection.hpp
+++ b/lib/perfdata/perfdatawriterconnection.hpp
@@ -88,7 +88,7 @@ public:
 						return;
 					}
 
-					Log(LogCritical, m_LogFacility)
+					Log(LogCritical, m_LogFacility, nullptr)
 						<< "Error while " << (m_Connected ? "sending" : "connecting") << " to '" << m_Host << ":"
 						<< m_Port << "' for '" << m_ParentName << "': " << ex.what();
 

--- a/lib/remote/actionshandler.cpp
+++ b/lib/remote/actionshandler.cpp
@@ -74,7 +74,7 @@ bool ActionsHandler::HandleRequest(
 
 	ArrayData results;
 
-	Log(LogNotice, "ApiActionHandler")
+	Log(LogNotice, "ApiActionHandler", nullptr)
 		<< "Running action " << actionName;
 
 	bool verbose = false;

--- a/lib/remote/apilistener-authority.cpp
+++ b/lib/remote/apilistener-authority.cpp
@@ -15,10 +15,10 @@ void ApiListener::UpdateObjectAuthority()
 {
 	/* Always run this, even if there is no 'api' feature enabled. */
 	if (auto listener = ApiListener::GetInstance()) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", listener)
 			<< "Updating object authority for objects at endpoint '" << listener->GetIdentity() << "'.";
 	} else {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", nullptr)
 			<< "Updating object authority for local objects.";
 	}
 

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -57,7 +57,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	/* discard messages if the client is not configured on this node */
 	if (!endpoint) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", listener)
 			<< "Discarding 'config update object' message from '" << identity << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -66,7 +66,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	/* discard messages if the sender is in a child zone */
 	if (!Zone::GetLocalZone()->IsChildOf(endpointZone)) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", endpoint)
 			<< "Discarding 'config update object' message"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << objName << "' of type '" << objType << "'. Sender is in a child zone.";
@@ -76,7 +76,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 	String objZone = params->Get("zone");
 
 	if (!objZone.IsEmpty() && !Zone::GetByName(objZone)) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", endpoint)
 			<< "Discarding 'config update object' message"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << objName << "' of type '" << objType << "'. Objects zone '" << objZone << "' isn't known locally.";
@@ -85,7 +85,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	/* ignore messages if the endpoint does not accept config */
 	if (!listener->GetAcceptConfig()) {
-		Log(LogWarning, "ApiListener")
+		Log(LogWarning, "ApiListener", endpoint)
 			<< "Ignoring config update"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << objName << "' of type '" << objType << "'. '" << listener->GetName() << "' does not accept config.";
@@ -97,7 +97,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	auto deletedVersion = listener->GetRuntimeObjectDeletionTs(objType, objName);
 	if (deletedVersion >= objVersion) {
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Ignoring config update for deleted object '" << objName << "' of type '" << objType << "' from '"
 			<< identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName()
 			<< "'): Object version " << std::fixed << objVersion << " is less recent than the deleted version "
@@ -105,7 +105,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 		return Empty;
 	}
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", endpoint)
 		<< "Received config update for object '" << objName << "' of type " << objType
 		<< ", version: " << std::fixed << objVersion;
 
@@ -114,7 +114,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	if (!ctype) {
 		// This never happens with icinga cluster endpoints, only with development errors.
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", endpoint)
 			<< "Config type '" << objType << "' does not exist.";
 		return Empty;
 	}
@@ -141,12 +141,12 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 		 * IMPORTANT: Pass the origin to prevent cluster sync loops.
 		 */
 		if (!ConfigObjectUtility::CreateObject(ptype, objName, config, errors, nullptr, origin)) {
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", endpoint)
 				<< "Could not create object '" << objName << "':";
 
 			ObjectLock olock(errors);
 			for (auto& error : errors) {
-				Log(LogCritical, "ApiListener", error);
+				Log(LogCritical, "ApiListener", endpoint, error);
 			}
 
 			return Empty;
@@ -166,7 +166,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	/* update object attributes if version was changed or if this is a new object */
 	if (newObject || objVersion <= object->GetVersion()) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", object)
 			<< "Discarding config update"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << object->GetName()
@@ -176,7 +176,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 		return Empty;
 	}
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", object)
 		<< "Processing config update"
 		<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 		<< " for object '" << object->GetName()
@@ -226,7 +226,7 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", m_Instance)
 		<< "Received config delete for object: " << JsonEncode(params);
 
 	/* check permissions */
@@ -243,7 +243,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 	String identity = origin->FromClient->GetIdentity();
 
 	if (!endpoint) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", listener)
 			<< "Discarding 'config delete object' message from '" << identity << "': Invalid endpoint origin (client not allowed).";
 		return Empty;
 	}
@@ -252,7 +252,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	/* discard messages if the sender is in a child zone */
 	if (!Zone::GetLocalZone()->IsChildOf(endpointZone)) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", endpoint)
 			<< "Discarding 'config delete object' message"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << objName << "' of type '" << objType << "'. Sender is in a child zone.";
@@ -260,7 +260,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 	}
 
 	if (!listener->GetAcceptConfig()) {
-		Log(LogWarning, "ApiListener")
+		Log(LogWarning, "ApiListener", endpoint)
 			<< "Ignoring config delete"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << objName << "' of type '" << objType << "'. '" << listener->GetName() << "' does not accept config.";
@@ -273,7 +273,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	if (!ctype) {
 		// This never happens with icinga cluster endpoints, only with development errors.
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", endpoint)
 			<< "Config type '" << objType << "' does not exist.";
 		return Empty;
 	}
@@ -288,7 +288,7 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 	// Check if the deletion is for an older object version
 	double objVersion = params->Get("version");
 	if (object && objVersion < object->GetVersion()) {
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", object)
 			<< "Ignoring 'config delete object' message"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << object->GetName()
@@ -304,18 +304,18 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 	listener->UpdateRuntimeObjectDeletionTs(objType, objName, objVersion);
 
 	if (!object) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", endpoint)
 			<< "Could not delete non-existent object '" << objName << "' with type '" << params->Get("type") << "'.";
 		return Empty;
 	}
 
 	if (object->GetPackage() != "_api") {
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", object)
 			<< "Could not delete object '" << objName << "': Not created by the API.";
 		return Empty;
 	}
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", object)
 		<< "Processing config delete"
 		<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 		<< " for object '" << object->GetName() << "'.";
@@ -327,11 +327,11 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 	 * IMPORTANT: Pass the origin to prevent cluster sync loops.
 	 */
 	if (!ConfigObjectUtility::DeleteObject(object, true, errors, nullptr, origin)) {
-		Log(LogCritical, "ApiListener", "Could not delete object:");
+		Log(LogCritical, "ApiListener", object, "Could not delete object:");
 
 		ObjectLock olock(errors);
 		for (auto& error : errors) {
-			Log(LogCritical, "ApiListener", error);
+			Log(LogCritical, "ApiListener", object, error);
 		}
 	}
 
@@ -346,7 +346,7 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 		Zone::Ptr target_zone = client->GetEndpoint()->GetZone();
 
 		if (target_zone && !target_zone->CanAccessObject(object)) {
-			Log(LogDebug, "ApiListener")
+			Log(LogDebug, "ApiListener", object)
 				<< "Not sending 'update config' message to unauthorized zone '" << target_zone->GetName() << "'"
 				<< " for object: '" << object->GetName() << "'.";
 
@@ -409,7 +409,7 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 	params->Set("original_attributes", new Array(std::move(newOriginalAttributes)));
 
 #ifdef I2_DEBUG
-	Log(LogDebug, "ApiListener")
+	Log(LogDebug, "ApiListener", object)
 		<< "Sent update for object '" << object->GetName() << "': " << JsonEncode(params);
 #endif /* I2_DEBUG */
 
@@ -489,7 +489,7 @@ void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const Mess
 		Zone::Ptr target_zone = client->GetEndpoint()->GetZone();
 
 		if (target_zone && !target_zone->CanAccessObject(object)) {
-			Log(LogDebug, "ApiListener")
+			Log(LogDebug, "ApiListener", object)
 				<< "Not sending 'delete config' message to unauthorized zone '" << target_zone->GetName() << "'"
 				<< " for object: '" << object->GetName() << "'.";
 
@@ -511,7 +511,7 @@ void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const Mess
 
 
 #ifdef I2_DEBUG
-	Log(LogDebug, "ApiListener")
+	Log(LogDebug, "ApiListener", object)
 		<< "Sent delete for object '" << object->GetName() << "': " << JsonEncode(params);
 #endif /* I2_DEBUG */
 
@@ -535,7 +535,7 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 
 	Zone::Ptr azone = endpoint->GetZone();
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", endpoint)
 		<< "Syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
 
 	std::unordered_set<ConfigObject*> syncedObjects;
@@ -552,7 +552,7 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 		}
 	}
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", endpoint)
 		<< "Finished syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
 }
 

--- a/lib/remote/apilistener-filesync.cpp
+++ b/lib/remote/apilistener-filesync.cpp
@@ -96,7 +96,7 @@ void ApiListener::SyncLocalZoneDir(const Zone::Ptr& zone) const
 
 	String productionZonesDir = GetApiZonesDir() + zoneName;
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", zone)
 		<< "Copying " << sumUpdates << " zone configuration files for zone '" << zoneName << "' to '" << productionZonesDir << "'.";
 
 	// Purge files to allow deletion via zones.d.
@@ -120,7 +120,7 @@ void ApiListener::SyncLocalZoneDir(const Zone::Ptr& zone) const
 
 			Utility::MkDirP(Utility::DirName(dst), 0755);
 
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", zone)
 				<< "Updating configuration file: " << dst;
 
 			String content = kv.second;
@@ -160,7 +160,7 @@ void ApiListener::SyncLocalZoneDir(const Zone::Ptr& zone) const
 	fp << std::fixed << JsonEncode(newConfigInfo.Checksums);
 	fp.close();
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", zone)
 		<< "Updated meta data for cluster config sync. Checksum: '" << checksumsPath
 		<< "', timestamp: '" << tsPath << "', auth: '" << authPath << "'.";
 }
@@ -203,7 +203,7 @@ void ApiListener::SendConfigUpdate(const JsonRpcConnection::Ptr& aclient)
 		if (!Utility::PathExists(zoneDir))
 			continue;
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", zone)
 			<< "Syncing configuration files for " << (zone->IsGlobal() ? "global " : "")
 			<< "zone '" << zoneName << "' to endpoint '" << endpoint->GetName() << "'.";
 
@@ -250,7 +250,7 @@ static bool CompareTimestampsConfigChange(const Dictionary::Ptr& productionConfi
 	// Skip update if our configuration files are more recent.
 	if (productionTimestamp >= receivedTimestamp) {
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", nullptr)
 			<< "Our production configuration is more recent than the received configuration update."
 			<< " Ignoring configuration file update for path '" << stageConfigZoneDir << "'. Current timestamp '"
 			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", productionTimestamp) << "' ("
@@ -291,30 +291,32 @@ static bool CompareTimestampsConfigChange(const Dictionary::Ptr& productionConfi
  */
 Value ApiListener::ConfigUpdateHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
+	Endpoint::Ptr endpoint = origin->FromClient->GetEndpoint();
+
 	// Verify permissions and trust relationship.
-	if (!origin->FromClient->GetEndpoint() || (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone)))
+	if (!endpoint || (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone)))
 		return Empty;
 
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 
 	if (!listener) {
-		Log(LogCritical, "ApiListener", "No instance available.");
+		Log(LogCritical, "ApiListener", nullptr, "No instance available.");
 		return Empty;
 	}
 
 	if (!listener->GetAcceptConfig()) {
-		Log(LogWarning, "ApiListener")
+		Log(LogWarning, "ApiListener", endpoint)
 			<< "Ignoring config update. '" << listener->GetName() << "' does not accept config.";
 		return Empty;
 	}
 
-	std::thread([origin, params, listener]() {
+	std::thread([origin, params, listener, endpoint]() {
 		try {
 			listener->HandleConfigUpdate(origin, params);
 		} catch (const std::exception& ex) {
 			auto msg ("Exception during config sync: " + DiagnosticInformation(ex));
 
-			Log(LogCritical, "ApiListener") << msg;
+			Log(LogCritical, "ApiListener", endpoint) << msg;
 			listener->UpdateLastFailedZonesStageValidation(msg);
 		}
 	}).detach();
@@ -332,7 +334,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 	String fromEndpointName = origin->FromClient->GetEndpoint()->GetName();
 	String fromZoneName = GetFromZoneName(origin->FromZone);
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "Applying config update from endpoint '" << fromEndpointName
 		<< "' of zone '" << fromZoneName << "'.";
 
@@ -375,7 +377,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 		Zone::Ptr zone = Zone::GetByName(zoneName);
 
 		if (!zone) {
-			Log(LogWarning, "ApiListener")
+			Log(LogWarning, "ApiListener", this)
 				<< "Ignoring config update from endpoint '" << fromEndpointName
 				<< "' for unknown zone '" << zoneName << "'.";
 
@@ -384,7 +386,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 
 		// Ignore updates where we have an authoritive copy in etc/zones.d, packages, etc.
 		if (ConfigCompiler::HasZoneConfigAuthority(zoneName)) {
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", zone)
 				<< "Ignoring config update from endpoint '" << fromEndpointName
 				<< "' for zone '" << zoneName << "' because we have an authoritative version of the zone's config.";
 
@@ -427,7 +429,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 		 * Otherwise do the old timestamp dance for versions < 2.11.
 		 */
 		if (checksums) {
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", zone)
 				<< "Received configuration for zone '" << zoneName << "' from endpoint '"
 				<< fromEndpointName << "'. Comparing the timestamp and checksums.";
 
@@ -444,7 +446,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 			 * TODO: Deprecate and remove this behaviour in 2.13+.
 			 */
 
-			Log(LogWarning, "ApiListener")
+			Log(LogWarning, "ApiListener", zone)
 				<< "Received configuration update without checksums from parent endpoint "
 				<< fromEndpointName << ". This behaviour is deprecated. Please upgrade the parent endpoint to 2.11+";
 
@@ -483,7 +485,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 				String path = stageConfigZoneDir + "/" + kv.first;
 
 				if (Utility::Match("*.conf", path)) {
-					Log(LogInformation, "ApiListener")
+					Log(LogInformation, "ApiListener", zone)
 						<< "Stage: Updating received configuration file '" << path << "' for zone '" << zoneName << "'.";
 				}
 
@@ -506,7 +508,7 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 			}
 		}
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", zone)
 			<< "Applying configuration file update for path '" << stageConfigZoneDir << "' ("
 			<< numBytes << " Bytes).";
 
@@ -537,12 +539,12 @@ void ApiListener::HandleConfigUpdate(const MessageOrigin::Ptr& origin, const Dic
 	 * A successful validation also triggers the final restart.
 	 */
 	if (configChange) {
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", this)
 			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
 			<< "' are different to production, triggering validation and reload.";
 		TryActivateZonesStage(relativePaths);
 	} else {
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", this)
 			<< "Received configuration updates (" << count << ") from endpoint '" << fromEndpointName
 			<< "' are equal to production, skipping validation and reload.";
 		ClearLastFailedZonesStageValidation();
@@ -604,7 +606,7 @@ void ApiListener::TryActivateZonesStage(const std::vector<String>& relativePaths
 
 	// Validation went fine, copy stage and reload.
 	if (pr.ExitStatus == 0) {
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", m_Instance)
 			<< "Config validation for stage '" << apiZonesStageDir << "' was OK, replacing into '" << apiZonesDir << "' and triggering reload.";
 
 		// Purge production before copying stage.
@@ -618,7 +620,7 @@ void ApiListener::TryActivateZonesStage(const std::vector<String>& relativePaths
 			if (!Utility::PathExists(apiZonesStageDir + path))
 				continue;
 
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", m_Instance)
 				<< "Copying file '" << path << "' from config sync staging to production zones directory.";
 
 			String stagePath = apiZonesStageDir + path;
@@ -647,7 +649,7 @@ void ApiListener::TryActivateZonesStage(const std::vector<String>& relativePaths
 	fpFailedLog.close();
 
 	// Error case.
-	Log(LogCritical, "ApiListener")
+	Log(LogCritical, "ApiListener", m_Instance)
 		<< "Config validation failed for staged cluster config sync in '" << apiZonesStageDir
 		<< "'. Aborting. Logs: '" << failedLogFile << "'";
 
@@ -699,7 +701,7 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 	Dictionary::Ptr newChecksums = newConfig.Checksums;
 
 	// TODO: Figure out whether normal users need this for debugging.
-	Log(LogDebug, "ApiListener")
+	Log(LogDebug, "ApiListener", m_Instance)
 		<< "Checking for config change between stage and production. Old (" << oldChecksums->GetLength() << "): '"
 		<< JsonEncode(oldChecksums)
 		<< "' vs. new (" << newChecksums->GetLength() << "): '"
@@ -719,19 +721,19 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			 * If we don't, this results in "always change" restart loops.
 			 */
 			if (Utility::Match("/.*", path)) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", m_Instance)
 					<< "Ignoring old internal file '" << path << "'.";
 
 				continue;
 			}
 
-			Log(LogDebug, "ApiListener")
+			Log(LogDebug, "ApiListener", m_Instance)
 				<< "Checking " << path << " for old checksum: " << oldChecksum << ".";
 
 			// Check if key exists first for more verbose logging.
 			// Note: Don't do this later on.
 			if (!newChecksums->Contains(path)) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", m_Instance)
 					<< "File '" << path << "' was deleted by remote.";
 
 				return true;
@@ -740,7 +742,7 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			String newChecksum = newChecksums->Get(path);
 
 			if (newChecksum != kv.second) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", m_Instance)
 					<< "Path '" << path << "' doesn't match old checksum '"
 					<< oldChecksum << "' with new checksum '" << newChecksum << "'.";
 
@@ -760,18 +762,18 @@ bool ApiListener::CheckConfigChange(const ConfigDirInformation& oldConfig, const
 			 * If we don't, this results in "always change" restart loops.
 			 */
 			if (Utility::Match("/.*", path)) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", m_Instance)
 					<< "Ignoring new internal file '" << path << "'.";
 
 				continue;
 			}
 
-			Log(LogDebug, "ApiListener")
+			Log(LogDebug, "ApiListener", m_Instance)
 				<< "Checking " << path << " for new checksum: " << newChecksum << ".";
 
 			// Check if the checksum exists, checksums in both sets have already been compared
 			if (!oldChecksums->Contains(path)) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", m_Instance)
 					<< "File '" << path << "' was added by remote.";
 
 				return true;
@@ -815,7 +817,7 @@ void ApiListener::ConfigGlobHandler(ConfigDirInformation& config, const String& 
 
 	CONTEXT("Creating config update for file '" << file << "'");
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", m_Instance)
 		<< "Creating config update for file '" << file << "'.";
 
 	std::ifstream fp(file.CStr(), std::ifstream::binary);
@@ -848,7 +850,7 @@ void ApiListener::ConfigGlobHandler(ConfigDirInformation& config, const String& 
 		 * Rationale: https://github.com/Icinga/icinga2/issues/7382
 		 */
 		if (content != sanitizedContent) {
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", m_Instance)
 				<< "Ignoring file '" << file << "' for cluster config sync: Does not contain valid UTF8. Binary files are not supported.";
 			return;
 		}

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -123,7 +123,7 @@ void ApiListener::CopyCertificateFile(const String& oldCertPath, const String& n
 	struct stat st1, st2;
 
 	if (!oldCertPath.IsEmpty() && stat(oldCertPath.CStr(), &st1) >= 0 && (stat(newCertPath.CStr(), &st2) < 0 || st1.st_mtime > st2.st_mtime)) {
-		Log(LogWarning, "ApiListener")
+		Log(LogWarning, "ApiListener", m_Instance)
 			<< "Copying '" << oldCertPath << "' certificate file to '" << newCertPath << "'";
 
 		Utility::MkDirP(Utility::DirName(newCertPath), 0700);
@@ -152,7 +152,7 @@ void ApiListener::OnConfigLoaded()
 	CopyCertificateFile(oldCaPath, defaultCaPath);
 
 	if (!oldCertPath.IsEmpty() && !oldKeyPath.IsEmpty() && !oldCaPath.IsEmpty()) {
-		Log(LogWarning, "ApiListener", "Please read the upgrading documentation for v2.8: https://icinga.com/docs/icinga2/latest/doc/16-upgrading-icinga-2/");
+		Log(LogWarning, "ApiListener", this, "Please read the upgrading documentation for v2.8: https://icinga.com/docs/icinga2/latest/doc/16-upgrading-icinga-2/");
 	}
 
 	/* Create the internal API object storage. */
@@ -177,7 +177,7 @@ void ApiListener::OnConfigLoaded()
 			+ defaultCertPath + "'.", GetDebugInfo()));
 	}
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "My API identity: " << GetIdentity();
 
 	UpdateSSLContext();
@@ -196,7 +196,7 @@ std::shared_ptr<X509> ApiListener::RenewCert(const std::shared_ptr<X509>& cert, 
 	 * a certificate it wouldn't be able to use to connect to us anyway) */
 	try {
 		if (!VerifyCertificate(cacert, newcert, GetCrlPath())) {
-			Log(LogWarning, "ApiListener")
+			Log(LogWarning, "ApiListener", this)
 				<< "The CA in '" << GetDefaultCaPath() << "' does not match the CA which Icinga uses "
 				<< "for its own cluster connections. This is most likely a configuration problem.";
 
@@ -236,7 +236,7 @@ void ApiListener::OnAllConfigLoaded()
 		BOOST_THROW_EXCEPTION(ScriptError("Endpoint object for '" + GetIdentity() + "' is missing.", GetDebugInfo()));
 
 	if (!GetEnforceFilterExpressionPermission()) {
-		Log(LogWarning, "ApiListener") << "Security notice:\n"
+		Log(LogWarning, "ApiListener", this) << "Security notice:\n"
 			"    Currently, all ApiUsers are allowed to use Icinga 2 DSL filter expressions\n"
 			"    in API queries because enforce_filter_expression_permission is set to false.\n"
 			"    This can pose a security risk as filters are evaluated within the Icinga 2\n"
@@ -253,7 +253,7 @@ void ApiListener::OnAllConfigLoaded()
  */
 void ApiListener::Start(bool runtimeCreated)
 {
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "'" << GetName() << "' started.";
 
 	SyncLocalZoneDirs();
@@ -286,7 +286,7 @@ void ApiListener::Start(bool runtimeCreated)
 
 	/* create the primary JSON-RPC listener */
 	if (!AddListener(GetBindHost(), GetBindPort())) {
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", this)
 			<< "Cannot add listener on host '" << GetBindHost() << "' for port '" << GetBindPort() << "'.";
 		Application::Exit(EXIT_FAILURE);
 	}
@@ -341,7 +341,7 @@ void ApiListener::RenewOwnCert()
 		return;
 	}
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "Our certificate will expire soon, but we own the CA. Renewing.";
 
 	cert = RenewCert(cert);
@@ -363,7 +363,7 @@ void ApiListener::RenewCA()
 		return;
 	}
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "Our CA will expire soon, but we own it. Renewing.";
 
 	cert = RenewCert(cert, true);
@@ -397,7 +397,7 @@ void ApiListener::Stop(bool runtimeDeleted)
 
 	ObjectImpl<ApiListener>::Stop(runtimeDeleted);
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "'" << GetName() << "' stopped.";
 
 	{
@@ -457,7 +457,7 @@ bool ApiListener::AddListener(const String& node, const String& service)
 	ObjectLock olock(this);
 
 	if (!m_SSLContext) {
-		Log(LogCritical, "ApiListener", "SSL context is required for AddListener()");
+		Log(LogCritical, "ApiListener", this, "SSL context is required for AddListener()");
 		return false;
 	}
 
@@ -500,7 +500,7 @@ bool ApiListener::AddListener(const String& node, const String& service)
 			}
 		}
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", this)
 			<< "Cannot bind TCP socket for host '" << node << "' on port '" << service << "': " << ex.what();
 		return false;
 	}
@@ -509,17 +509,17 @@ bool ApiListener::AddListener(const String& node, const String& service)
 
 	auto localEndpoint (acceptor->local_endpoint());
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", this)
 		<< "Started new listener on '[" << localEndpoint.address() << "]:" << localEndpoint.port() << "'";
 
 	auto strand = Shared<asio::io_context::strand>::Make(io);
 
-	boost::signals2::scoped_connection closeSignal = m_OnListenerShutdown.connect([strand, acceptor]() {
-		boost::asio::post(*strand, [acceptor] {
+	boost::signals2::scoped_connection closeSignal = m_OnListenerShutdown.connect([this, strand, acceptor]() {
+		boost::asio::post(*strand, [this, acceptor] {
 			try {
 				acceptor->close();
 			} catch (const std::exception& ex) {
-				Log(LogCritical, "ApiListener")
+				Log(LogCritical, "ApiListener", this)
 					<< "Failed to close acceptor socket: " << ex.what();
 			}
 		});
@@ -559,7 +559,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 
 	std::shared_lock wgLock(*m_ListenerWaitGroup, std::try_to_lock);
 	if (!wgLock) {
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", this)
 			<< "Could not lock the listener wait group.";
 		return;
 	}
@@ -592,8 +592,8 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
 				Timeout timeout (*strand, std::chrono::duration<double>{GetConnectTimeout()},
-					[sslConn, remoteEndpoint] {
-						Log(LogWarning, "ApiListener")
+					[this, sslConn, remoteEndpoint] {
+						Log(LogWarning, "ApiListener", this)
 							<< "Timeout while processing incoming connection from " << remoteEndpoint;
 
 						boost::system::error_code ec;
@@ -610,7 +610,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 				return;
 			}
 
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", this)
 				<< "Cannot accept new connection: " << ex.what();
 		}
 	}
@@ -627,7 +627,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 	using asio::ip::tcp;
 
 	if (!m_SSLContext) {
-		Log(LogCritical, "ApiListener", "SSL context is required for AddConnection()");
+		Log(LogCritical, "ApiListener", this, "SSL context is required for AddConnection()");
 		return;
 	}
 
@@ -638,7 +638,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 		String host = endpoint->GetHost();
 		String port = endpoint->GetPort();
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host << "' and port '" << port << "'";
 
 		try {
@@ -649,7 +649,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 
 			Timeout timeout (*strand, std::chrono::duration<double>{GetConnectTimeout()},
 				[sslConn, endpoint, host, port] {
-					Log(LogCritical, "ApiListener")
+					Log(LogCritical, "ApiListener", endpoint)
 						<< "Timeout while reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host
 						<< "' and port '" << port << "', cancelling attempt";
 
@@ -663,12 +663,12 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 			NewClientHandler(yc, strand, sslConn, endpoint->GetName(), RoleClient);
 
 			endpoint->SetConnecting(false);
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", endpoint)
 				<< "Finished reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host << "' and port '" << port << "'";
 		} catch (const std::exception& ex) {
 			endpoint->SetConnecting(false);
 
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", endpoint)
 				<< "Cannot connect to host '" << host << "' on port '" << port << "': " << ex.what();
 		}
 	});
@@ -682,10 +682,10 @@ void ApiListener::NewClientHandler(
 	try {
 		NewClientHandlerInternal(yc, strand, client, hostname, role);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", this)
 			<< "Exception while handling new API client connection: " << DiagnosticInformation(ex, false);
 
-		Log(LogDebug, "ApiListener")
+		Log(LogDebug, "ApiListener", this)
 			<< "Exception while handling new API client connection: " << DiagnosticInformation(ex);
 	}
 }
@@ -756,12 +756,12 @@ void ApiListener::NewClientHandlerInternal(
 		// https://github.com/boostorg/beast/issues/915
 		// Google Chrome 73+ seems not close the connection properly, https://stackoverflow.com/questions/56272906/how-to-fix-certificate-unknown-error-from-chrome-v73
 		if (ec == asio::ssl::error::stream_truncated) {
-			Log(LogNotice, "ApiListener")
+			Log(LogNotice, "ApiListener", this)
 				<< "TLS stream was truncated, ignoring connection from " << conninfo;
 			return;
 		}
 
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", this)
 			<< (role == RoleClient ? "Client" : "Server")
 			<< " TLS handshake failed (" << conninfo << "): " << ec.message();
 		return;
@@ -780,19 +780,19 @@ void ApiListener::NewClientHandlerInternal(
 		try {
 			identity = GetCertificateCN(cert);
 		} catch (const std::exception&) {
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", this)
 				<< "Cannot get certificate common name from peer (" << conninfo << ") cert.";
 			return;
 		}
 
 		if (!hostname.IsEmpty()) {
 			if (identity != hostname) {
-				Log(LogWarning, "ApiListener")
+				Log(LogWarning, "ApiListener", this)
 					<< "Unexpected certificate common name while connecting to endpoint '"
 					<< hostname << "': got '" << identity << "'";
 				return;
 			} else if (!verify_ok) {
-				Log(LogWarning, "ApiListener")
+				Log(LogWarning, "ApiListener", this)
 					<< "Certificate validation failed for endpoint '" << hostname
 					<< "': " << verifyError;
 			}
@@ -802,7 +802,7 @@ void ApiListener::NewClientHandlerInternal(
 			endpoint = Endpoint::GetByName(identity);
 		}
 
-		Log log(LogInformation, "ApiListener");
+		Log log (LogInformation, "ApiListener", endpoint);
 
 		log << "New client connection for identity '" << identity << "' " << conninfo;
 
@@ -812,7 +812,7 @@ void ApiListener::NewClientHandlerInternal(
 			log << " (no Endpoint object found for identity)";
 		}
 	} else {
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", this)
 			<< "New client connection " << conninfo << " (no client certificate)";
 	}
 
@@ -837,11 +837,11 @@ void ApiListener::NewClientHandlerInternal(
 
 			if (client->async_fill(yc[ec]) == 0u) {
 				if (identity.IsEmpty()) {
-					Log(LogInformation, "ApiListener")
+					Log(LogInformation, "ApiListener", endpoint)
 						<< "No data received on new API connection " << conninfo << ": " << ec.message()
 						<< ". Ensure that the remote endpoints are properly configured in a cluster setup.";
 				} else {
-					Log(LogWarning, "ApiListener")
+					Log(LogWarning, "ApiListener", endpoint)
 						<< "No data received on new API connection " << conninfo << " for identity '" << identity << "': " << ec.message()
 						<< ". Ensure that the remote endpoints are properly configured in a cluster setup.";
 				}
@@ -884,16 +884,16 @@ void ApiListener::NewClientHandlerInternal(
 	}
 
 	if (ctype == ClientJsonRpc) {
-		Log(LogNotice, "ApiListener", "New JSON-RPC client");
+		Log(LogNotice, "ApiListener", this, "New JSON-RPC client");
 
 		if (verify_ok && !endpoint) {
-			Log(LogWarning, "ApiListener")
+			Log(LogWarning, "ApiListener", this)
 				<< "Unknown endpoint '" << identity << "' with valid certificate. Aborting JSON-RPC connection.";
 			return;
 		}
 
 		if (endpoint && endpoint->GetConnected()) {
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", endpoint)
 				<< "Ignoring JSON-RPC connection " << conninfo
 				<< ". We're already connected to Endpoint '" << endpoint->GetName()
 				<< "' (last message sent: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S", endpoint->GetLastMessageSent())
@@ -910,7 +910,7 @@ void ApiListener::NewClientHandlerInternal(
 				SyncClient(aclient, endpoint, true);
 			});
 		} else if (!AddAnonymousClient(aclient)) {
-			Log(LogNotice, "ApiListener")
+			Log(LogNotice, "ApiListener", this)
 				<< "Ignoring anonymous JSON-RPC connection " << conninfo
 				<< ". Max connections (" << GetMaxAnonymousClients() << ") exceeded.";
 
@@ -922,7 +922,7 @@ void ApiListener::NewClientHandlerInternal(
 
 		aclient->Start();
 	} else {
-		Log(LogNotice, "ApiListener", "New HTTP client");
+		Log(LogNotice, "ApiListener", endpoint, "New HTTP client");
 
 		HttpServerConnection::Ptr aclient = new HttpServerConnection(m_WaitGroup, identity, verify_ok, client);
 		AddHttpClient(aclient);
@@ -958,19 +958,19 @@ void ApiListener::SyncClient(const JsonRpcConnection::Ptr& aclient, const Endpoi
 		 * before the logs are replayed.
 		 */
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Sending config updates for endpoint '" << endpoint->GetName() << "' in zone '" << eZone->GetName() << "'.";
 
 		/* sync zone file config */
 		SendConfigUpdate(aclient);
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Finished sending config file updates for endpoint '" << endpoint->GetName() << "' in zone '" << eZone->GetName() << "'.";
 
 		/* sync runtime config */
 		SendRuntimeConfigObjects(aclient);
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Finished sending runtime config updates for endpoint '" << endpoint->GetName() << "' in zone '" << eZone->GetName() << "'.";
 
 		if (!needSync) {
@@ -979,7 +979,7 @@ void ApiListener::SyncClient(const JsonRpcConnection::Ptr& aclient, const Endpoi
 			return;
 		}
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Sending replay log for endpoint '" << endpoint->GetName() << "' in zone '" << eZone->GetName() << "'.";
 
 		ReplayLog(aclient);
@@ -987,7 +987,7 @@ void ApiListener::SyncClient(const JsonRpcConnection::Ptr& aclient, const Endpoi
 		if (eZone == Zone::GetLocalZone())
 			UpdateObjectAuthority();
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", endpoint)
 			<< "Finished sending replay log for endpoint '" << endpoint->GetName() << "' in zone '" << eZone->GetName() << "'.";
 	} catch (const std::exception& ex) {
 		{
@@ -995,14 +995,14 @@ void ApiListener::SyncClient(const JsonRpcConnection::Ptr& aclient, const Endpoi
 			endpoint->SetSyncing(false);
 		}
 
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", endpoint)
 			<< "Error while syncing endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex, false);
 
-		Log(LogDebug, "ApiListener")
+		Log(LogDebug, "ApiListener", endpoint)
 			<< "Error while syncing endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex);
 	}
 
-	Log(LogInformation, "ApiListener")
+	Log(LogInformation, "ApiListener", endpoint)
 		<< "Finished syncing endpoint '" << endpoint->GetName() << "' in zone '" << eZone->GetName() << "'.";
 }
 
@@ -1040,7 +1040,7 @@ void ApiListener::ApiTimerHandler()
 
 		if (!need) {
 			String path = GetApiDir() + "log/" + Convert::ToString(ts);
-			Log(LogNotice, "ApiListener")
+			Log(LogNotice, "ApiListener", this)
 				<< "Removing old log file: " << path;
 			(void)unlink(path.CStr());
 		}
@@ -1070,7 +1070,7 @@ void ApiListener::ApiTimerHandler()
 				maxTs = client->GetTimestamp();
 		}
 
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", endpoint)
 			<< "Setting log position for identity '" << endpoint->GetName() << "': "
 			<< Utility::FormatDateTime("%Y/%m/%d %H:%M:%S", ts);
 
@@ -1079,7 +1079,7 @@ void ApiListener::ApiTimerHandler()
 				try {
 					client->SendMessage(lmessage);
 				} catch (const std::runtime_error& ex) {
-					Log(LogNotice, "ApiListener")
+					Log(LogNotice, "ApiListener", endpoint)
 						<< "Error while setting log position for identity '" << endpoint->GetName() << "': " << DiagnosticInformation(ex, false);
 				}
 			} else {
@@ -1100,7 +1100,7 @@ void ApiListener::ApiReconnectTimerHandler()
 
 		/* only connect to endpoints in a) the same zone b) our parent zone c) immediate child zones */
 		if (my_zone != zone && my_zone != zone->GetParent() && zone != my_zone->GetParent()) {
-			Log(LogDebug, "ApiListener")
+			Log(LogDebug, "ApiListener", zone)
 				<< "Not connecting to Zone '" << zone->GetName()
 				<< "' because it's not in the same zone, a parent or a child zone.";
 			continue;
@@ -1109,14 +1109,14 @@ void ApiListener::ApiReconnectTimerHandler()
 		for (const Endpoint::Ptr& endpoint : zone->GetEndpoints()) {
 			/* don't connect to ourselves */
 			if (endpoint == GetLocalEndpoint()) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", endpoint)
 					<< "Not connecting to Endpoint '" << endpoint->GetName() << "' because that's us.";
 				continue;
 			}
 
 			/* don't try to connect to endpoints which don't have a host and port */
 			if (endpoint->GetHost().IsEmpty() || endpoint->GetPort().IsEmpty()) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", endpoint)
 					<< "Not connecting to Endpoint '" << endpoint->GetName()
 					<< "' because the host/port attributes are missing.";
 				continue;
@@ -1124,7 +1124,7 @@ void ApiListener::ApiReconnectTimerHandler()
 
 			/* don't try to connect if there's already a connection attempt */
 			if (endpoint->GetConnecting()) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", endpoint)
 					<< "Not connecting to Endpoint '" << endpoint->GetName()
 					<< "' because we're already trying to connect to it.";
 				continue;
@@ -1132,7 +1132,7 @@ void ApiListener::ApiReconnectTimerHandler()
 
 			/* don't try to connect if we're already connected */
 			if (endpoint->GetConnected()) {
-				Log(LogDebug, "ApiListener")
+				Log(LogDebug, "ApiListener", endpoint)
 					<< "Not connecting to Endpoint '" << endpoint->GetName()
 					<< "' because we're already connected to it.";
 				continue;
@@ -1148,7 +1148,7 @@ void ApiListener::ApiReconnectTimerHandler()
 	Endpoint::Ptr master = GetMaster();
 
 	if (master)
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", master)
 			<< "Current zone master: " << master->GetName();
 
 	std::vector<String> names;
@@ -1156,7 +1156,7 @@ void ApiListener::ApiReconnectTimerHandler()
 		if (endpoint->GetConnected())
 			names.emplace_back(endpoint->GetName() + " (" + Convert::ToString(endpoint->GetClients().size()) + ")");
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", this)
 		<< "Connected endpoints: " << Utility::NaturalJoin(names);
 }
 
@@ -1235,7 +1235,7 @@ void ApiListener::SyncSendMessage(const Endpoint::Ptr& endpoint, const Dictionar
 	ObjectLock olock(endpoint);
 
 	if (!endpoint->GetSyncing()) {
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", endpoint)
 			<< "Sending message '" << message->Get("method") << "' to '" << endpoint->GetName() << "'";
 
 		double maxTs = 0;
@@ -1252,7 +1252,7 @@ void ApiListener::SyncSendMessage(const Endpoint::Ptr& endpoint, const Dictionar
 			try {
 				client->SendMessage(message);
 			} catch (const std::runtime_error& ex) {
-				Log(LogNotice, "ApiListener")
+				Log(LogNotice, "ApiListener", endpoint)
 					<< "Error while sending message to endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex, false);
 			}
 		}
@@ -1361,7 +1361,7 @@ bool ApiListener::RelayMessageOne(const Zone::Ptr& targetZone, const MessageOrig
 			if (!isMaster && targetEndpoint != currentZoneMaster) {
 				if (currentTargetZone == parentZone) {
 					if (m_CurrentParentEndpoint.exchange(currentZoneMaster.get()) != currentZoneMaster.get()) {
-						Log(LogInformation, "ApiListener")
+						Log(LogInformation, "ApiListener", currentZoneMaster)
 							<< "Relaying messages for parent Zone '" << parentZone->GetName()
 							<< "' through Endpoint '" << currentZoneMaster->GetName() << "' of our own Zone";
 					}
@@ -1375,7 +1375,7 @@ bool ApiListener::RelayMessageOne(const Zone::Ptr& targetZone, const MessageOrig
 
 			if (currentTargetZone == parentZone) {
 				if (m_CurrentParentEndpoint.exchange(targetEndpoint.get()) != targetEndpoint.get()) {
-					Log(LogInformation, "ApiListener")
+					Log(LogInformation, "ApiListener", targetEndpoint)
 						<< "Relaying messages for parent Zone '" << parentZone->GetName()
 						<< "' directly to Endpoint '" << targetEndpoint->GetName() << "' of that Zone";
 				}
@@ -1405,7 +1405,7 @@ void ApiListener::SyncRelayMessage(const MessageOrigin::Ptr& origin,
 	double ts = Utility::GetTime();
 	message->Set("ts", ts);
 
-	Log(LogNotice, "ApiListener")
+	Log(LogNotice, "ApiListener", secobj)
 		<< "Relaying '" << message->Get("method") << "' message";
 
 	if (origin && origin->FromZone)
@@ -1446,7 +1446,7 @@ void ApiListener::OpenLogFile()
 	std::unique_ptr<std::fstream> fp = std::make_unique<std::fstream>(path.CStr(), std::fstream::out | std::ofstream::app);
 
 	if (!fp->good()) {
-		Log(LogWarning, "ApiListener")
+		Log(LogWarning, "ApiListener", this)
 			<< "Could not open spool file: " << path;
 		return;
 	}
@@ -1485,7 +1485,7 @@ void ApiListener::RotateLogFile()
 			// We're rotating the current log file, so reset the log message counter as well.
 			m_LogMessageCount = 0;
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", this)
 				<< "Cannot rotate replay log file from '" << oldpath << "' to '"
 				<< newpath << "': " << ex.what();
 		}
@@ -1502,7 +1502,7 @@ void ApiListener::LogGlobHandler(std::vector<std::uint64_t>& files, const String
 	try {
 		files.emplace_back(boost::lexical_cast<std::uint64_t>(name));
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "ApiListener")
+		Log(LogCritical, "ApiListener", m_Instance)
 			<< "Error converting log file name " << file << " to uint64: " << ex.what();
 		return;
 	}
@@ -1567,7 +1567,7 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		allFiles.emplace_back(static_cast<std::uint64_t>(Utility::GetTime()) + 1, GetApiDir() + "log/current");
 
 		for (auto& file : allFiles) {
-			Log(LogNotice, "ApiListener")
+			Log(LogNotice, "ApiListener", endpoint)
 				<< "Replaying log: " << file.second;
 
 			auto *fp = new std::fstream(file.second.CStr(), std::fstream::in | std::fstream::binary);
@@ -1589,7 +1589,7 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 
 					pmessage = JsonDecode(message);
 				} catch (const std::exception&) {
-					Log(LogWarning, "ApiListener")
+					Log(LogWarning, "ApiListener", endpoint)
 						<< "Unexpected end-of-file for cluster log: " << file.second;
 
 					/* Log files may be incomplete or corrupted. This is perfectly OK. */
@@ -1615,10 +1615,10 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 					client->SendRawMessage(pmessage->Get("message"));
 					count++;
 				} catch (const std::exception& ex) {
-					Log(LogWarning, "ApiListener")
+					Log(LogWarning, "ApiListener", endpoint)
 						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << ex.what();
 
-					Log(LogDebug, "ApiListener")
+					Log(LogDebug, "ApiListener", endpoint)
 						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex);
 					return;
 				}
@@ -1644,11 +1644,11 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		}
 
 		if (count > 0) {
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", endpoint)
 				<< "Replayed " << count << " messages.";
 		}
 		else {
-			Log(LogNotice, "ApiListener")
+			Log(LogNotice, "ApiListener", endpoint)
 				<< "Replayed " << count << " messages.";
 		}
 
@@ -1693,7 +1693,7 @@ std::pair<Dictionary::Ptr, Dictionary::Ptr> ApiListener::GetStatus()
 	for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
 		/* only check endpoints in a) the same zone b) our parent zone c) immediate child zones */
 		if (my_zone != zone && my_zone != zone->GetParent() && zone != my_zone->GetParent()) {
-			Log(LogDebug, "ApiListener")
+			Log(LogDebug, "ApiListener", zone)
 				<< "Not checking connection to Zone '" << zone->GetName() << "' because it's not in the same zone, a parent or a child zone.";
 			continue;
 		}
@@ -1894,7 +1894,7 @@ Value ApiListener::HelloAPIHandler(const MessageOrigin::Ptr& origin, const Dicti
 						case 1:
 							break;
 						default:
-							Log log (LogWarning, "ApiListener");
+							Log log (LogWarning, "ApiListener", endpoint);
 							log << "Unexpected Icinga version of endpoint '" << endpoint->GetName() << "': ";
 
 							LogAppVersion(nodeVersion / 100u, log);
@@ -1928,12 +1928,12 @@ void ApiListener::UpdateActivePackageStagesCache()
 		try {
 			activeStage = ConfigPackageUtility::GetActiveStageFromFile(package);
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "ApiListener")
+			Log(LogCritical, "ApiListener", this)
 				<< ex.what();
 			continue;
 		}
 
-		Log(LogNotice, "ApiListener")
+		Log(LogNotice, "ApiListener", this)
 			<< "Updating cache: Config package '" << package << "' has active stage '" << activeStage << "'.";
 
 		m_ActivePackageStages[package] = activeStage;
@@ -1957,7 +1957,7 @@ void ApiListener::CheckApiPackageIntegrity()
 
 			String activeStageCached = it->second;
 
-			Log(LogInformation, "ApiListener")
+			Log(LogInformation, "ApiListener", this)
 				<< "Repairing broken API config package '" << package
 				<< "', setting active stage '" << activeStageCached << "'.";
 

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -99,7 +99,7 @@ void ConfigObjectUtility::RepairPackage(const String& package)
 	}
 
 	if (!foundActiveStage.IsEmpty()) {
-		Log(LogInformation, "ConfigObjectUtility")
+		Log(LogInformation, "ConfigObjectUtility", nullptr)
 			<< "Repairing config package '" << package << "' with stage '" << foundActiveStage << "'.";
 
 		ConfigPackageUtility::ActivateStage(package, foundActiveStage);
@@ -116,7 +116,7 @@ void ConfigObjectUtility::CreateStorage()
 	String package = "_api";
 
 	if (!ConfigPackageUtility::PackageExists(package)) {
-		Log(LogNotice, "ConfigObjectUtility")
+		Log(LogNotice, "ConfigObjectUtility", nullptr)
 			<< "Package " << package << " doesn't exist yet, creating it.";
 
 		ConfigPackageUtility::CreatePackage(package);
@@ -232,7 +232,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		 */
 		if (!ConfigItem::CommitItems(ascope.GetContext(), upq, newItems, true)) {
 			if (errors) {
-				Log(LogNotice, "ConfigObjectUtility")
+				Log(LogNotice, "ConfigObjectUtility", nullptr)
 					<< "Failed to commit config item '" << fullName << "'. Aborting and removing config path '" << path << "'.";
 
 				for (const std::exception_ptr& ex : upq.GetExceptions()) {
@@ -253,7 +253,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		 */
 		if (!ConfigItem::ActivateItems(newItems, true, false, false, cookie)) {
 			if (errors) {
-				Log(LogNotice, "ConfigObjectUtility")
+				Log(LogNotice, "ConfigObjectUtility", nullptr)
 					<< "Failed to activate config object '" << fullName << "'. Aborting and removing config path '" << path << "'.";
 
 				for (const std::exception_ptr& ex : upq.GetExceptions()) {
@@ -282,10 +282,10 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 			// Object is successfully created and activated, so don't remove its config.
 			removeConfigPath.Cancel();
 
-			Log(LogInformation, "ConfigObjectUtility")
+			Log(LogInformation, "ConfigObjectUtility", obj)
 				<< "Created and activated object '" << fullName << "' of type '" << type->GetName() << "'.";
 		} else {
-			Log(LogNotice, "ConfigObjectUtility")
+			Log(LogNotice, "ConfigObjectUtility", nullptr)
 				<< "Object '" << fullName << "' was not created but ignored due to errors.";
 		}
 	} catch (const std::exception& ex) {
@@ -356,7 +356,7 @@ bool ConfigObjectUtility::DeleteObjectHelper(const ConfigObject::Ptr& object, bo
 		Utility::Remove(GetExistingObjectConfigPath(object));
 	}
 
-	Log(LogInformation, "ConfigObjectUtility")
+	Log(LogInformation, "ConfigObjectUtility", object)
 		<< "Deleted object '" << name << "' of type '" << type->GetName() << "'.";
 
 	return true;

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -99,7 +99,7 @@ String ConfigPackageUtility::CreateStage(const String& packageName, const Dictio
 
 			String filePath = path + "/" + kv.first;
 
-			Log(LogInformation, "ConfigPackageUtility")
+			Log(LogInformation, "ConfigPackageUtility", nullptr)
 				<< "Updating configuration file: " << filePath;
 
 			// Pass the directory and generate a dir tree, if it does not already exist
@@ -198,7 +198,7 @@ void ConfigPackageUtility::TryActivateStageCallback(const ProcessResult& pr, con
 			}
 		}
 	} else {
-		Log(LogCritical, "ConfigPackageUtility")
+		Log(LogCritical, "ConfigPackageUtility", nullptr)
 			<< "Config validation failed for package '"
 			<< packageName << "' and stage '" << stageName << "'.";
 	}

--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -124,7 +124,7 @@ bool ConsoleHandler::ExecuteScriptHelper(const HttpApiRequest& request, HttpApiR
 {
 	namespace http = boost::beast::http;
 
-	Log(LogNotice, "Console")
+	Log(LogNotice, "Console", nullptr)
 		<< "Executing expression: " << command;
 
 	EnsureFrameCleanupTimer();
@@ -205,7 +205,7 @@ bool ConsoleHandler::AutocompleteScriptHelper(const HttpApiRequest& request, Htt
 {
 	namespace http = boost::beast::http;
 
-	Log(LogInformation, "Console")
+	Log(LogInformation, "Console", nullptr)
 		<< "Auto-completing expression: " << command;
 
 	EnsureFrameCleanupTimer();

--- a/lib/remote/endpoint.cpp
+++ b/lib/remote/endpoint.cpp
@@ -37,6 +37,12 @@ void Endpoint::OnAllConfigLoaded()
 	}
 }
 
+void Endpoint::GetParentsAffectingLogging(std::vector<ConfigObject::Ptr>& output) const
+{
+	ObjectImpl<Endpoint>::GetParentsAffectingLogging(output);
+	output.emplace_back(GetZone());
+}
+
 void Endpoint::SetCachedZone(const Zone::Ptr& zone)
 {
 	if (m_Zone)

--- a/lib/remote/endpoint.cpp
+++ b/lib/remote/endpoint.cpp
@@ -31,7 +31,7 @@ void Endpoint::OnAllConfigLoaded()
 		std::ostringstream oss;
 		ShowCodeLocation(oss, GetDebugInfo(), false);
 
-		Log(LogWarning, "Endpoint")
+		Log(LogWarning, "Endpoint", this)
 			<< "Endpoint name is too long (length: " << GetName().GetLength()
 			<< ", max: 64) to be used as CN in TLS certificates. Consider using a shorter name.\n" << oss.str();
 	}
@@ -84,7 +84,7 @@ void Endpoint::RemoveClient(const JsonRpcConnection::Ptr& client)
 		std::unique_lock<std::mutex> lock(m_ClientsLock);
 		m_Clients.erase(client);
 
-		Log(LogInformation, "ApiListener")
+		Log(LogInformation, "ApiListener", this)
 			<< "Removing API client for endpoint '" << GetName() << "'. " << m_Clients.size() << " API clients left.";
 
 		SetConnecting(false);

--- a/lib/remote/endpoint.hpp
+++ b/lib/remote/endpoint.hpp
@@ -66,6 +66,7 @@ public:
 
 protected:
 	void OnAllConfigLoaded() override;
+	void GetParentsAffectingLogging(std::vector<ConfigObject::Ptr>& output) const override;
 
 private:
 	mutable std::mutex m_ClientsLock;

--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -155,7 +155,7 @@ void EventsFilter::Push(Dictionary::Ptr event)
 						inbox->Push(event);
 					}
 				} catch (const std::exception& ex) {
-					Log(LogWarning, "EventQueue")
+					Log(LogWarning, "EventQueue", inbox->GetUser())
 						<< "Error occurred while evaluating event filter for queue of user '"
 						<< inbox->GetUser()->GetName() << "': " << DiagnosticInformation(ex);
 				}

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -294,7 +294,7 @@ bool FilterUtility::HasPermission(const ApiUser::Ptr& user, const String& permis
 	if (!foundPermission && permission == ApiUser::FilterExpressionPerm) {
 		ApiListener::Ptr listener = ApiListener::GetInstance();
 		if (listener && !listener->GetEnforceFilterExpressionPermission()) {
-			Log(LogWarning, "FilterUtility") << "ApiUser '" << user->GetName()
+			Log(LogWarning, "FilterUtility", user) << "ApiUser '" << user->GetName()
 				<< "' was allowed to use a filter expression despite missing the '" << ApiUser::FilterExpressionPerm
 				<< "' permission due to ApiListener.enforce_filter_expression_permission = false.";
 
@@ -303,7 +303,7 @@ bool FilterUtility::HasPermission(const ApiUser::Ptr& user, const String& permis
 	}
 
 	if (!foundPermission) {
-		Log(LogWarning, "FilterUtility")
+		Log(LogWarning, "FilterUtility", user)
 			<< "Missing permission: " << requiredPermission;
 	}
 

--- a/lib/remote/httphandler.cpp
+++ b/lib/remote/httphandler.cpp
@@ -124,7 +124,7 @@ void HttpHandler::ProcessRequest(
 			throw;
 		}
 
-		Log(LogWarning, "HttpServerConnection")
+		Log(LogWarning, "HttpServerConnection", request.User())
 			<< "Error while processing HTTP request: " << ex.what();
 
 		processed = false;

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -84,7 +84,7 @@ void HttpServerConnection::Disconnect(boost::asio::yield_context yc)
 
 	m_ShuttingDown = true;
 
-	Log(LogInformation, "HttpServerConnection")
+	Log(LogInformation, "HttpServerConnection", m_ApiUser)
 		<< "HTTP client disconnected (from " << m_PeerAddress << ")";
 
 	m_CheckLivenessTimer.cancel();
@@ -307,7 +307,7 @@ bool EnsureAuthenticatedUser(
 	namespace http = boost::beast::http;
 
 	if (!request.User()) {
-		Log(LogWarning, "HttpServerConnection")
+		Log(LogWarning, "HttpServerConnection", nullptr)
 			<< "Unauthorized request: " << request.method_string() << ' ' << request.target();
 
 		if (request[http::field::accept] == "application/json") {
@@ -503,7 +503,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 				request.User(ApiUser::GetByAuthHeader(std::string(request[http::field::authorization])));
 			}
 
-			Log logMsg (LogInformation, "HttpServerConnection");
+			Log logMsg (LogInformation, "HttpServerConnection", request.User());
 
 			logMsg << "Request " << request.method_string() << ' ' << request.target()
 				<< " (from " << m_PeerAddress
@@ -546,7 +546,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 		}
 	} catch (const std::exception& ex) {
 		if (!m_ShuttingDown) {
-			Log(LogWarning, "HttpServerConnection")
+			Log(LogWarning, "HttpServerConnection", m_ApiUser)
 				<< "Exception while processing HTTP request from " << m_PeerAddress << ": " << ex.what();
 		}
 	}
@@ -570,7 +570,7 @@ void HttpServerConnection::CheckLiveness(boost::asio::yield_context yc)
 		}
 
 		if (m_LivenessTimeout < std::chrono::steady_clock::now() - m_Seen) {
-			Log(LogInformation, "HttpServerConnection")
+			Log(LogInformation, "HttpServerConnection", m_ApiUser)
 				<<  "No messages for HTTP connection have been received in the last "
 				<< std::chrono::duration_cast<std::chrono::seconds>(m_LivenessTimeout).count()
 				<< " seconds, disconnecting (from " << m_PeerAddress << ").";

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -17,7 +17,7 @@ Dictionary::Ptr HttpUtility::FetchRequestParameters(const Url::Ptr& url, const s
 	Dictionary::Ptr result;
 
 	if (!body.empty()) {
-		Log(LogDebug, "HttpUtility")
+		Log(LogDebug, "HttpUtility", nullptr)
 			<< "Request body: '" << body << '\'';
 
 		result = JsonDecode(body);

--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -43,7 +43,8 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 	}
 
 	if (!cert) {
-		Log(LogWarning, "JsonRpcConnection") << "No certificate or CSR received";
+		Log(LogWarning, "JsonRpcConnection", origin->FromClient->GetEndpoint())
+			<< "No certificate or CSR received";
 
 		result->Set("status_code", 1);
 		result->Set("error", "No certificate or CSR received.");
@@ -59,7 +60,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 	bool signedByCA = false;
 
 	{
-		Log logmsg(LogInformation, "JsonRpcConnection");
+		Log logmsg (LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint());
 		logmsg << "Received certificate request for CN '" << cn << "'";
 
 		try {
@@ -123,7 +124,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 		}
 
 		if (uptodate) {
-			Log(LogInformation, "JsonRpcConnection")
+			Log(LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 				<< "The certificates for CN '" << cn << "' and its root CA are valid and uptodate. Skipping automated renewal.";
 			result->Set("status_code", 1);
 			result->Set("error", "The certificates for CN '" + cn + "' and its root CA are valid and uptodate. Skipping automated renewal.");
@@ -138,7 +139,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 		result->Set("status_code", 1);
 		result->Set("error", "Could not calculate fingerprint for the X509 certificate for CN '" + cn + "'.");
 
-		Log(LogWarning, "JsonRpcConnection")
+		Log(LogWarning, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 			<< "Could not calculate fingerprint for the X509 certificate requested for CN '"
 			<< cn << "'.";
 
@@ -165,7 +166,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 		String certResponse = request->Get("cert_response");
 
 		if (!certResponse.IsEmpty()) {
-			Log(LogInformation, "JsonRpcConnection")
+			Log(LogInformation, "JsonRpcConnection", client->GetEndpoint())
 				<< "Sending certificate response for CN '" << cn
 				<< "' to endpoint '" << client->GetIdentity() << "'.";
 
@@ -182,7 +183,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 			return result;
 		}
 	} else if (Utility::PathExists(requestDir + "/" + certFingerprint + ".removed")) {
-		Log(LogInformation, "JsonRpcConnection")
+		Log(LogInformation, "JsonRpcConnection", client->GetEndpoint())
 			<< "Certificate for CN " << cn << " has been removed. Ignoring signing request.";
 		result->Set("status_code", 1);
 		result->Set("error", "Ticket for CN " + cn + " declined by administrator.");
@@ -206,7 +207,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 		// Auto-signing is disabled: Client did not include a ticket in its request.
 		if (ticket.IsEmpty()) {
-			Log(LogNotice, "JsonRpcConnection")
+			Log(LogNotice, "JsonRpcConnection", client->GetEndpoint())
 				<< "Certificate request for CN '" << cn
 				<< "': No ticket included, skipping auto-signing and waiting for on-demand signing approval.";
 
@@ -215,7 +216,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 		// Auto-signing is disabled: no TicketSalt
 		if (salt.IsEmpty()) {
-			Log(LogNotice, "JsonRpcConnection")
+			Log(LogNotice, "JsonRpcConnection", client->GetEndpoint())
 				<< "Certificate request for CN '" << cn
 				<< "': This instance is the signing master for the Icinga CA."
 				<< " The 'ticket_salt' attribute in the 'api' feature is not set."
@@ -227,7 +228,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 		String realTicket = PBKDF2_SHA1(cn, salt, 50000);
 
 		if (!Utility::ComparePasswords(ticket, realTicket)) {
-			Log(LogWarning, "JsonRpcConnection")
+			Log(LogWarning, "JsonRpcConnection", client->GetEndpoint())
 				<< "Received ticket for CN '" << cn << "' is invalid.";
 
 			result->Set("status_code", 1);
@@ -243,7 +244,7 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 	}
 
 	/* Send the signed certificate update. */
-	Log(LogInformation, "JsonRpcConnection")
+	Log(LogInformation, "JsonRpcConnection", client->GetEndpoint())
 		<< "Sending certificate response for CN '" << cn << "' to endpoint '"
 		<< client->GetIdentity() << "'" << (!ticket.IsEmpty() ? " (auto-signing ticket)" : "" ) << ".";
 
@@ -280,7 +281,7 @@ delayed_request:
 	result->Set("status_code", 2);
 	result->Set("error", "Certificate request for CN '" + cn + "' is pending. Waiting for approval from the parent Icinga instance.");
 
-	Log(LogInformation, "JsonRpcConnection")
+	Log(LogInformation, "JsonRpcConnection", client->GetEndpoint())
 		<< "Certificate request for CN '" << cn << "' is pending. Waiting for approval.";
 
 	return result;
@@ -303,7 +304,8 @@ void JsonRpcConnection::SendCertificateRequest(const JsonRpcConnection::Ptr& acl
 	/* Path is empty if this is our own request. */
 	if (path.IsEmpty()) {
 		{
-			Log msg (LogInformation, "JsonRpcConnection");
+			Endpoint::Ptr requestor = aclient ? aclient->GetEndpoint() : (origin ? origin->FromClient->GetEndpoint() : nullptr);
+			Log msg (LogInformation, "JsonRpcConnection", requestor);
 			msg << "Requesting new certificate for this Icinga instance";
 
 			if (aclient) {
@@ -341,7 +343,7 @@ void JsonRpcConnection::SendCertificateRequest(const JsonRpcConnection::Ptr& acl
 Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
 	if (!origin->FromClient->GetEndpoint() || (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone))) {
-		Log(LogWarning, "ClusterEvents")
+		Log(LogWarning, "ClusterEvents", origin->FromClient->GetEndpoint())
 			<< "Discarding 'update certificate' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 
 		return Empty;
@@ -360,7 +362,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 
 	String cn = GetCertificateCN(newCert);
 
-	Log(LogInformation, "JsonRpcConnection")
+	Log(LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 		<< "Received certificate update message for CN '" << cn << "'";
 
 	/* Check if this is a certificate update for a subordinate instance. */
@@ -375,7 +377,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 		boost::regex expr("^[0-9a-f]+$");
 
 		if (!boost::regex_match(certFingerprint.GetData(), expr)) {
-			Log(LogWarning, "JsonRpcConnection")
+			Log(LogWarning, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 				<< "Endpoint '" << origin->FromClient->GetIdentity() << "' sent an invalid certificate fingerprint: '"
 				<< certFingerprint << "' for CN '" << cn << "'.";
 			return Empty;
@@ -386,7 +388,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 
 		/* Save the received signed certificate request to disk. */
 		if (Utility::PathExists(requestPath)) {
-			Log(LogInformation, "JsonRpcConnection")
+			Log(LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 				<< "Saved certificate update for CN '" << cn << "'";
 
 			Dictionary::Ptr request = Utility::LoadJsonFile(requestPath);
@@ -400,7 +402,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 	/* Update CA certificate. */
 	String caPath = listener->GetDefaultCaPath();
 
-	Log(LogInformation, "JsonRpcConnection")
+	Log(LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 		<< "Updating CA certificate in '" << caPath << "'.";
 
 	AtomicFile::Write(caPath, 0644, ca);
@@ -408,7 +410,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 	/* Update signed certificate. */
 	String certPath = listener->GetDefaultCertPath();
 
-	Log(LogInformation, "JsonRpcConnection")
+	Log(LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 		<< "Updating client certificate for CN '" << cn << "' in '" << certPath << "'.";
 
 	AtomicFile::Write(certPath, 0644, cert);
@@ -419,7 +421,7 @@ Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionar
 	Utility::Remove(ticketPath);
 
 	/* Update the certificates at runtime and reconnect all endpoints. */
-	Log(LogInformation, "JsonRpcConnection")
+	Log(LogInformation, "JsonRpcConnection", origin->FromClient->GetEndpoint())
 		<< "Updating the client certificate for CN '" << cn << "' at runtime and reconnecting the endpoints.";
 
 	listener->UpdateSSLContext();

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -78,7 +78,7 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 				m_Stream, yc, m_Endpoint ? m_Endpoint->GetMessageReceiveSizeLimit() : 1024L * 1024
 			);
 		} catch (const std::exception& ex) {
-			Log(m_ShuttingDown ? LogDebug : LogNotice, "JsonRpcConnection")
+			Log(m_ShuttingDown ? LogDebug : LogNotice, "JsonRpcConnection", m_Endpoint)
 				<< "Error while reading JSON-RPC message for identity '" << m_Identity
 				<< "': " << DiagnosticInformation(ex);
 
@@ -105,7 +105,7 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 				message = JsonRpc::DecodeMessage(jsonString);
 			} catch (const std::exception& ex) {
 				if (m_Authenticated) {
-					Log (LogWarning, "JsonRpcConnection")
+					Log(LogWarning, "JsonRpcConnection", m_Endpoint)
 						<< "Ignoring JSON-RPC message for identity '" << m_Identity
 						<< "' that could not be parsed: " << DiagnosticInformation(ex);
 
@@ -132,7 +132,7 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 				m_Endpoint->AddMessageProcessed(total);
 			}
 
-			Log msg(total >= ch::seconds(5) ? LogWarning : LogDebug, "JsonRpcConnection");
+			Log msg (total >= ch::seconds(5) ? LogWarning : LogDebug, "JsonRpcConnection", m_Endpoint);
 			msg << "Processed JSON-RPC '" << rpcMethod << "' message for identity '" << m_Identity
 				<< "' (took total " << toMilliseconds(total) << "ms";
 
@@ -143,7 +143,7 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 		} catch (const std::exception& ex) {
 			auto total = ch::steady_clock::now() - start;
 
-			Log msg(m_ShuttingDown ? LogDebug : LogWarning, "JsonRpcConnection");
+			Log msg (m_ShuttingDown ? LogDebug : LogWarning, "JsonRpcConnection", m_Endpoint);
 			msg << "Error while processing JSON-RPC '" << rpcMethod << "' message for identity '"
 				<< m_Identity << "' (took total " << toMilliseconds(total) << "ms";
 
@@ -187,7 +187,7 @@ void JsonRpcConnection::WriteOutgoingMessages(boost::asio::yield_context yc)
 
 				m_Stream->async_flush(yc);
 			} catch (const std::exception& ex) {
-				Log(m_ShuttingDown ? LogDebug : LogWarning, "JsonRpcConnection")
+				Log(m_ShuttingDown ? LogDebug : LogWarning, "JsonRpcConnection", m_Endpoint)
 					<< "Error while sending JSON-RPC message for identity '"
 					<< m_Identity << "'\n" << DiagnosticInformation(ex);
 
@@ -275,7 +275,7 @@ void JsonRpcConnection::Disconnect()
 	if (!m_ShuttingDown.exchange(true)) {
 		JsonRpcConnection::Ptr keepAlive (this);
 
-		Log(LogNotice, "JsonRpcConnection")
+		Log(LogNotice, "JsonRpcConnection", m_Endpoint)
 			<< "Disconnecting API client for identity '" << m_Identity << "'";
 
 		IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) {
@@ -309,7 +309,7 @@ void JsonRpcConnection::Disconnect()
 				ApiListener::GetInstance()->RemoveAnonymousClient(this);
 			}
 
-			Log(LogInformation, "JsonRpcConnection")
+			Log(LogInformation, "JsonRpcConnection", m_Endpoint)
 				<< "API client disconnected for identity '" << m_Identity << "'";
 		});
 	}
@@ -361,7 +361,7 @@ void JsonRpcConnection::MessageHandler(const Dictionary::Ptr& message)
 		if (!message->Get("id", &vid))
 			return;
 
-		Log(LogWarning, "JsonRpcConnection",
+		Log(LogWarning, "JsonRpcConnection", m_Endpoint,
 			"We received a JSON-RPC response message. This should never happen because we're only ever sending notifications.");
 
 		return;
@@ -369,7 +369,7 @@ void JsonRpcConnection::MessageHandler(const Dictionary::Ptr& message)
 
 	String method = vmethod;
 
-	Log(LogNotice, "JsonRpcConnection")
+	Log(LogNotice, "JsonRpcConnection", m_Endpoint)
 		<< "Received '" << method << "' message from identity '" << m_Identity << "'.";
 
 	Dictionary::Ptr resultMessage = new Dictionary();
@@ -378,7 +378,7 @@ void JsonRpcConnection::MessageHandler(const Dictionary::Ptr& message)
 		ApiFunction::Ptr afunc = ApiFunction::GetByName(method);
 
 		if (!afunc) {
-			Log(LogNotice, "JsonRpcConnection")
+			Log(LogNotice, "JsonRpcConnection", m_Endpoint)
 				<< "Call to non-existent function '" << method << "' from endpoint '" << m_Identity << "'.";
 		} else {
 			if (m_Endpoint) {
@@ -395,7 +395,7 @@ void JsonRpcConnection::MessageHandler(const Dictionary::Ptr& message)
 		/* TODO: Add a user readable error message for the remote caller */
 		String diagInfo = DiagnosticInformation(ex);
 		resultMessage->Set("error", diagInfo);
-		Log(LogWarning, "JsonRpcConnection")
+		Log(LogWarning, "JsonRpcConnection", m_Endpoint)
 			<< "Error while processing message for identity '" << m_Identity << "'\n" << diagInfo;
 	}
 
@@ -442,7 +442,7 @@ void JsonRpcConnection::CheckLiveness(boost::asio::yield_context yc)
 
 		auto remote (m_Stream->lowest_layer().remote_endpoint());
 
-		Log(LogInformation, "JsonRpcConnection")
+		Log(LogInformation, "JsonRpcConnection", m_Endpoint)
 			<< "Closing anonymous connection [" << remote.address() << "]:" << remote.port() << " after 10 seconds.";
 
 		Disconnect();
@@ -456,7 +456,7 @@ void JsonRpcConnection::CheckLiveness(boost::asio::yield_context yc)
 			}
 
 			if (m_Seen < Utility::GetTime() - 60 && (!m_Endpoint || !m_Endpoint->GetSyncing())) {
-				Log(LogInformation, "JsonRpcConnection")
+				Log(LogInformation, "JsonRpcConnection", m_Endpoint)
 					<<  "No messages for identity '" << m_Identity << "' have been received in the last 60 seconds.";
 
 				Disconnect();

--- a/lib/remote/pkiutility.cpp
+++ b/lib/remote/pkiutility.cpp
@@ -31,7 +31,7 @@ int PkiUtility::NewCa()
 	String caKeyFile = caDir + "/ca.key";
 
 	if (Utility::PathExists(caCertFile) && Utility::PathExists(caKeyFile)) {
-		Log(LogWarning, "cli")
+		Log(LogWarning, "cli", nullptr)
 			<< "CA files '" << caCertFile << "' and '" << caKeyFile << "' already exist.";
 		return 1;
 	}
@@ -65,7 +65,7 @@ int PkiUtility::SignCsr(const String& csrfile, const String& certfile)
 
 	if (!req) {
 		ERR_error_string_n(ERR_peek_error(), errbuf, sizeof errbuf);
-		Log(LogCritical, "SSL")
+		Log(LogCritical, "SSL", nullptr)
 			<< "Could not read X509 certificate request from '" << csrfile << "': " << ERR_peek_error() << ", \"" << errbuf << "\"";
 		return 1;
 	}
@@ -89,9 +89,9 @@ std::shared_ptr<X509> PkiUtility::FetchCert(const String& host, const String& po
 	try {
 		sslContext = MakeAsioSslContext();
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "pki")
+		Log(LogCritical, "pki", nullptr)
 			<< "Cannot make SSL context.";
-		Log(LogDebug, "pki")
+		Log(LogDebug, "pki", nullptr)
 			<< "Cannot make SSL context:\n"  << DiagnosticInformation(ex);
 		return std::shared_ptr<X509>();
 	}
@@ -101,9 +101,9 @@ std::shared_ptr<X509> PkiUtility::FetchCert(const String& host, const String& po
 	try {
 		Connect(stream->lowest_layer(), host, port);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "pki")
+		Log(LogCritical, "pki", nullptr)
 			<< "Cannot connect to host '" << host << "' on port '" << port << "'";
-		Log(LogDebug, "pki")
+		Log(LogDebug, "pki", nullptr)
 			<< "Cannot connect to host '" << host << "' on port '" << port << "':\n" << DiagnosticInformation(ex);
 		return std::shared_ptr<X509>();
 	}
@@ -113,7 +113,7 @@ std::shared_ptr<X509> PkiUtility::FetchCert(const String& host, const String& po
 	try {
 		sslConn.handshake(sslConn.client);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "pki")
+		Log(LogCritical, "pki", nullptr)
 			<< "Client TLS handshake failed. (" << ex.what() << ")";
 		return std::shared_ptr<X509>();
 	}
@@ -131,12 +131,12 @@ int PkiUtility::WriteCert(const std::shared_ptr<X509>& cert, const String& trust
 	fpcert.close();
 
 	if (fpcert.fail()) {
-		Log(LogCritical, "pki")
+		Log(LogCritical, "pki", nullptr)
 			<< "Could not write certificate to file '" << trustedfile << "'.";
 		return 1;
 	}
 
-	Log(LogInformation, "pki")
+	Log(LogInformation, "pki", nullptr)
 		<< "Writing certificate to file '" << trustedfile << "'.";
 
 	return 0;
@@ -157,9 +157,9 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 	try {
 		sslContext = MakeAsioSslContext(certfile, keyfile);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot make SSL context for cert path: '" << certfile << "' key path: '" << keyfile << "' ca path: '" << cafile << "'.";
-		Log(LogDebug, "cli")
+		Log(LogDebug, "cli", nullptr)
 			<< "Cannot make SSL context for cert path: '" << certfile << "' key path: '" << keyfile << "' ca path: '" << cafile << "':\n"  << DiagnosticInformation(ex);
 		return 1;
 	}
@@ -169,9 +169,9 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 	try {
 		Connect(stream->lowest_layer(), host, port);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Cannot connect to host '" << host << "' on port '" << port << "'";
-		Log(LogDebug, "cli")
+		Log(LogDebug, "cli", nullptr)
 			<< "Cannot connect to host '" << host << "' on port '" << port << "':\n" << DiagnosticInformation(ex);
 		return 1;
 	}
@@ -181,7 +181,7 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 	try {
 		sslConn.handshake(sslConn.client);
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Client TLS handshake failed: " << DiagnosticInformation(ex, false);
 		return 1;
 	}
@@ -191,7 +191,7 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 	auto peerCert (sslConn.GetPeerCertificate());
 
 	if (X509_cmp(peerCert.get(), trustedCert.get())) {
-		Log(LogCritical, "cli", "Peer certificate does not match trusted certificate.");
+		Log(LogCritical, "cli", nullptr, "Peer certificate does not match trusted certificate.");
 		return 1;
 	}
 
@@ -219,10 +219,10 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 			response = JsonRpc::DecodeMessage(JsonRpc::ReadMessage(stream, -1));
 
 			if (response && response->Contains("error")) {
-				Log(LogCritical, "cli", "Could not fetch valid response. Please check the master log (notice or debug).");
+				Log(LogCritical, "cli", nullptr, "Could not fetch valid response. Please check the master log (notice or debug).");
 #ifdef I2_DEBUG
 				/* we shouldn't expose master errors to the user in production environments */
-				Log(LogCritical, "cli", response->Get("error"));
+				Log(LogCritical, "cli", nullptr, response->Get("error"));
 #endif /* I2_DEBUG */
 				return 1;
 			}
@@ -233,12 +233,12 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 			break;
 		}
 	} catch (...) {
-		Log(LogCritical, "cli", "Could not fetch valid response. Please check the master log.");
+		Log(LogCritical, "cli", nullptr, "Could not fetch valid response. Please check the master log.");
 		return 1;
 	}
 
 	if (!response) {
-		Log(LogCritical, "cli", "Could not fetch valid response. Please check the master log.");
+		Log(LogCritical, "cli", nullptr, "Could not fetch valid response. Please check the master log.");
 		return 1;
 	}
 
@@ -248,12 +248,12 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 		try {
 			StringToCertificate(result->Get("ca"));
 		} catch (const std::exception& ex) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Could not write CA file: " << DiagnosticInformation(ex, false);
 			return 1;
 		}
 
-		Log(LogInformation, "cli")
+		Log(LogInformation, "cli", nullptr)
 			<< "Writing CA certificate to file '" << cafile << "'.";
 
 		std::ofstream fpca;
@@ -262,7 +262,7 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 		fpca.close();
 
 		if (fpca.fail()) {
-			Log(LogCritical, "cli")
+			Log(LogCritical, "cli", nullptr)
 				<< "Could not open CA certificate file '" << cafile << "' for writing.";
 			return 1;
 		}
@@ -282,16 +282,16 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 			severity = LogCritical;
 		else {
 			severity = LogInformation;
-			Log(severity, "cli", "!!!!!!");
+			Log(severity, "cli", nullptr, "!!!!!!");
 		}
 
-		Log(severity, "cli")
+		Log(severity, "cli", nullptr)
 			<< "!!! " << result->Get("error");
 
 		if (status == 1)
 			return 1;
 		else {
-			Log(severity, "cli", "!!!!!!");
+			Log(severity, "cli", nullptr, "!!!!!!");
 			return 0;
 		}
 	}
@@ -299,12 +299,12 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 	try {
 		StringToCertificate(result->Get("cert"));
 	} catch (const std::exception& ex) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Could not write certificate file: " << DiagnosticInformation(ex, false);
 		return 1;
 	}
 
-	Log(LogInformation, "cli")
+	Log(LogInformation, "cli", nullptr)
 		<< "Writing signed certificate to file '" << certfile << "'.";
 
 	std::ofstream fpcert;
@@ -313,7 +313,7 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 	fpcert.close();
 
 	if (fpcert.fail()) {
-		Log(LogCritical, "cli")
+		Log(LogCritical, "cli", nullptr)
 			<< "Could not write certificate to file '" << certfile << "'.";
 		return 1;
 	}

--- a/lib/remote/zone.cpp
+++ b/lib/remote/zone.cpp
@@ -146,7 +146,7 @@ void Zone::ValidateEndpointsRaw(const Lazy<Array::Ptr>& lvalue, const Validation
 	ObjectImpl<Zone>::ValidateEndpointsRaw(lvalue, utils);
 
 	if (lvalue() && lvalue()->GetLength() > 2) {
-		Log(LogWarning, "Zone")
+		Log(LogWarning, "Zone", this)
 			<< "The Zone object '" << GetName() << "' has more than two endpoints."
 			<< " Due to a known issue this type of configuration is strongly"
 			<< " discouraged and may cause Icinga to use excessive amounts of CPU time.";

--- a/lib/remote/zone.ti
+++ b/lib/remote/zone.ti
@@ -16,7 +16,7 @@ class Zone : ConfigObject
 		}}}
 	};
 
-	[config] array(name(Endpoint)) endpoints (EndpointsRaw);
+	[config, no_user_modify] array(name(Endpoint)) endpoints (EndpointsRaw);
 	[config] bool global;
 	[no_user_modify, no_storage] array(Value) all_parents {
 		get;

--- a/plugins/check_nscp_api.cpp
+++ b/plugins/check_nscp_api.cpp
@@ -182,7 +182,7 @@ static Shared<AsioTlsStream>::Ptr Connect(const String& host, const String& port
 	try {
 		sslContext = MakeAsioSslContext(Empty, Empty, Empty); //TODO: Add support for cert, key, ca parameters
 	} catch(const std::exception& ex) {
-		Log(LogCritical, "DebugConsole")
+		Log(LogCritical, "DebugConsole", nullptr)
 			<< "Cannot make SSL context: " << ex.what();
 		throw;
 	}
@@ -192,7 +192,7 @@ static Shared<AsioTlsStream>::Ptr Connect(const String& host, const String& port
 	try {
 		icinga::Connect(stream->lowest_layer(), host, port);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "DebugConsole")
+		Log(LogWarning, "DebugConsole", nullptr)
 			<< "Cannot connect to REST API on host '" << host << "' port '" << port << "': " << ex.what();
 		throw;
 	}
@@ -202,7 +202,7 @@ static Shared<AsioTlsStream>::Ptr Connect(const String& host, const String& port
 	try {
 		tlsStream.handshake(tlsStream.client);
 	} catch (const std::exception& ex) {
-		Log(LogWarning, "DebugConsole")
+		Log(LogWarning, "DebugConsole", nullptr)
 			<< "TLS handshake with host '" << host << "' failed: " << ex.what();
 		throw;
 	}

--- a/tools/mkclass/class_lexer.ll
+++ b/tools/mkclass/class_lexer.ll
@@ -136,6 +136,7 @@ deprecated			{ yylval->num = FADeprecated; return T_FIELD_ATTRIBUTE; }
 get_virtual			{ yylval->num = FAGetVirtual; return T_FIELD_ATTRIBUTE; }
 set_virtual			{ yylval->num = FASetVirtual; return T_FIELD_ATTRIBUTE; }
 signal_with_old_value			{ yylval->num = FASignalWithOldValue; return T_FIELD_ATTRIBUTE; }
+parent_affecting_logging		{ yylval->num = FAParentAffectingLogging; return T_FIELD_ATTRIBUTE; }
 virtual				{ yylval->num = FAGetVirtual | FASetVirtual; return T_FIELD_ATTRIBUTE; }
 navigation			{ return T_NAVIGATION; }
 validator			{ return T_VALIDATOR; }

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -1088,6 +1088,87 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 					<< field.GetFriendlyName() << "ChangedWithOldValue;" << std::endl << std::endl;
 			}
 		}
+
+		/* override ConfigObject#GetParentsAffectingLogging() */
+
+		bool overrideGetParentsAffectingLogging = klass.Name == "ConfigObject";
+
+		if (!overrideGetParentsAffectingLogging) {
+			for (auto& field : klass.Fields) {
+				if (field.Attributes & FAParentAffectingLogging && (field.Type.IsName || field.Attributes & FANavigation)) {
+					overrideGetParentsAffectingLogging = true;
+					break;
+				}
+			}
+		}
+
+		if (overrideGetParentsAffectingLogging) {
+			m_Header << "protected:" << std::endl << "\t";
+
+			if (klass.Name == "ConfigObject") {
+				m_Header << "virtual void GetParentsAffectingLogging(std::vector<intrusive_ptr<ConfigObject>>& output) const;";
+			} else {
+				m_Header << "void GetParentsAffectingLogging(std::vector<ConfigObject::Ptr>& output) const override;";
+			}
+
+			m_Header << std::endl;
+
+			m_Impl << "void ObjectImpl<" << klass.Name
+				<< ">::GetParentsAffectingLogging(std::vector<ConfigObject::Ptr>& output) const" << std::endl
+				<< "{" << std::endl;
+
+			std::set<std::string> types;
+
+			for (auto& field : klass.Fields) {
+				if (field.Attributes & FAParentAffectingLogging && field.Type.IsName && types.emplace(field.Type.TypeName).second) {
+					m_Impl << "\t" << "static const auto type" << field.Type.TypeName
+						<< " (Type::GetByName(\"" << field.Type.TypeName << "\"));" << std::endl
+						<< "\t" << "static const auto configType" << field.Type.TypeName
+						<< " (dynamic_cast<ConfigType*>(type" << field.Type.TypeName << ".get()));" << std::endl;
+				}
+			}
+
+			if (klass.Name != "ConfigObject") {
+				m_Impl << std::endl << "\t" << klass.Parent << "::GetParentsAffectingLogging(output);" << std::endl;
+			}
+
+			for (auto& field : klass.Fields) {
+				if (field.Attributes & FAParentAffectingLogging && (field.Type.IsName || field.Attributes & FANavigation)) {
+					m_Impl << std::endl << "\t";
+
+					if (field.Type.IsName) {
+						if (field.Type.ArrayRank) {
+							m_Impl << "auto names" << field.GetFriendlyName()
+								<< " (Get" << field.GetFriendlyName() << "());" << std::endl << std::endl
+								<< "\t" << "if (names" << field.GetFriendlyName() << ") {" << std::endl
+								<< "\t\t" << "ObjectLock lock (names" << field.GetFriendlyName() << ");" << std::endl << std::endl
+								<< "\t\t" << "for (auto& name : names" << field.GetFriendlyName() << ") {" << std::endl
+								<< "\t\t\t" << "auto object (configType" << field.Type.TypeName << "->GetObject(name));" << std::endl << std::endl
+								<< "\t\t\t" << "if (object) {" << std::endl
+								<< "\t\t\t\t" << "output.emplace_back(std::move(object));" << std::endl
+								<< "\t\t\t" << "}" << std::endl
+								<< "\t\t" << "}";
+						} else {
+							m_Impl << "auto object" << field.GetFriendlyName()
+								<< " (configType" << field.Type.TypeName << "->GetObject(Get"
+								<< field.GetFriendlyName() << "()));" << std::endl << std::endl
+								<< "\t" << "if (object" << field.GetFriendlyName() << ") {" << std::endl
+								<< "\t\t" << "output.emplace_back(std::move(object" << field.GetFriendlyName() << "));";
+						}
+					} else {
+						m_Impl << "auto object" << field.GetFriendlyName()
+							<< " (static_pointer_cast<ConfigObject>(Navigate"
+							<< field.GetFriendlyName() << "()));" << std::endl << std::endl
+							<< "\t" << "if (object" << field.GetFriendlyName() << ") {" << std::endl
+							<< "\t\t" << "output.emplace_back(std::move(object" << field.GetFriendlyName() << "));";
+					}
+
+					m_Impl << std::endl << "\t" << "}" << std::endl;
+				}
+			}
+
+			m_Impl << "}" << std::endl << std::endl;
+		}
 	}
 
 	if (klass.Name == "ConfigObject")

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -506,7 +506,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			else
 				m_Impl << "\t" << "if (" << argName << "() != GetDefault" << field.GetFriendlyName() << "())" << std::endl;
 
-			m_Impl << "\t\t" << "Log(LogWarning, \"" << klass.Name << "\") << \"Attribute '" << field.Name << R"(' for object '" << dynamic_cast<ConfigObject *>(this)->GetName() << "' of type '" << dynamic_cast<ConfigObject *>(this)->GetReflectionType()->GetName() << "' is deprecated and should not be used.";)" << std::endl;
+			m_Impl << "\t\t" << "Log(LogWarning, \"" << klass.Name << "\", dynamic_cast<ConfigObject *>(this)) << \"Attribute '" << field.Name << R"(' for object '" << dynamic_cast<ConfigObject *>(this)->GetName() << "' of type '" << dynamic_cast<ConfigObject *>(this)->GetReflectionType()->GetName() << "' is deprecated and should not be used.";)" << std::endl;
 		}
 
 		if (field.Type.ArrayRank > 0) {
@@ -521,7 +521,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			m_Impl << "\t" << "if (" << valName << ".IsObjectType<Function>()) {" << std::endl
 				<< "\t\t" << "Function::Ptr func = " << valName << ";" << std::endl
 				<< "\t\t" << "if (func->IsDeprecated())" << std::endl
-				<< "\t\t\t" << "Log(LogWarning, \"" << klass.Name << "\") << \"Attribute '" << field.Name << R"(' for object '" << dynamic_cast<ConfigObject *>(this)->GetName() << "' of type '" << dynamic_cast<ConfigObject *>(this)->GetReflectionType()->GetName() << "' is set to a deprecated function: " << func->GetName();)" << std::endl
+				<< "\t\t\t" << "Log(LogWarning, \"" << klass.Name << "\", dynamic_cast<ConfigObject *>(this)) << \"Attribute '" << field.Name << R"(' for object '" << dynamic_cast<ConfigObject *>(this)->GetName() << "' of type '" << dynamic_cast<ConfigObject *>(this)->GetReflectionType()->GetName() << "' is set to a deprecated function: " << func->GetName();)" << std::endl
 				<< "\t" << "}" << std::endl << std::endl;
 		}
 

--- a/tools/mkclass/classcompiler.hpp
+++ b/tools/mkclass/classcompiler.hpp
@@ -63,6 +63,7 @@ enum FieldAttribute
 	FASetVirtual = 16384,
 	FAActivationPriority = 32768,
 	FASignalWithOldValue = 65536,
+	FAParentAffectingLogging = 131072,
 };
 
 struct FieldType


### PR DESCRIPTION
fixes #7912

### ~This is the plan~

* ~There's a filter saying which objects along with their children are affected by a logger: f59082d22 9693663e2~
* ~Apropos, too bad children (dis)appear dynamically during parent object lifetime, but parents are static per-child, so the relationship rules point from child to parent: 1ce044c60 06ea999ba 67fb214ac d98bb316e~
* ~(Well, static is relative, I had to tweak a few things: a3f8d8402 53f881ba1)~
* ~Those rules are so simple that one can even understand them by just reading the individual commits – at the cost of a little infrastructure hosting them: 7914d8e2f~
* ~Everything's cached of course: 27413d531 2a1480389~
* ~The latter makes this algorithm especially performant where filter meets family tree: 8c3bfd0f5~

# To do

* [ ] touch every single Log#Log()🪵 caller, provide involved object(s?)

# Edit

## User POV

This adds the ability to do the following with every single logger type:

```patch
 object FileLogger "main-log" {
  severity = "information"
  path = LogDir + "/icinga2.log"
+ object_filter = { "HostGroup" = [ "NETWAYS" ] }
 }
```

All config _types_ are supported, not just HostGroup.
Not existing _objects_ will trigger warnings (as not matching apply rules do).
The line inserted above would cause _main-log_ not to log messages not **referring** to the HostGroup NETWAYS.
This is useful for (runtime) creating a debug logger, but only for some config objects.

### What does "referring" mean?

A log message _refers_ (has to be done in the code) explicitly to either the specific object given in object_filter or any of its **children** as below, recursively:

* All endpoints of a zone are its children
* All objects in a zone are its children
* All groups in a group are its children
* All members of a group are its children
* Additionally:

 child type | attribute naming parent object
 ---|---
 comment | host_name
 comment | service_name
 dependency | child_host_name
 dependency | child_service_name
 dependency | parent_host_name
 dependency | parent_service_name
 downtime | host_name
 downtime | service_name
 downtime | config_owner (scheduleddowntime)
 notification | host_name
 notification | service_name
 scheduleddowntime | host_name
 scheduleddowntime | service_name
 service | host_name

### Rationale

UX, intuitivity. Even if a user doesn't know the above table, if they include _parent_ in object_filter, they likely expect all children to be logged as well.

## Dev POV

(aka `git log --oneline` with comments)

### Logger#object_filter

* f59082d22 Introduce Logger#object_filter
* 9693663e2 Logger#{OnAllConfigLoaded,SetObjectFilter}(): warn on missing objects for
* 27413d531 Cache actual Logger#object_filter objects in Logger#m_ObjectFilterCache

The first two ones should be self-explanatory.
The third one simply looks up the strings given in object_filter (initially and on change) and caches object pointers to ease comparison later.

### Relationship rules

* 7914d8e2f Introduce ObjectImpl<ConfigObject>#GetParentsAffectingLogging()

This is the base.
On its own it would only generate the exact method as named above doing nothing.
Not to be too boring it also adds a new .ti field attribute _parent_affecting_logging_ causing the type to have a own GetParentsAffectingLogging method yielding the object named by the field.
E.g. putting _parent_affecting_logging_ on Comment's host_name and service_name creates `Comment#GetParentsAffectingLogging()` which returns the comment's host and service.
Apropos:

* d98bb316e parent_affecting_logging: a config object affects everything functionally depending on it
* 67fb214ac parent_affecting_logging: a config object affects everything applied to it
* 06ea999ba parent_affecting_logging: a group affects everything in it
* 1ce044c60 parent_affecting_logging: a zone affects everything in it

These define the _What does "referring" mean?_ part from above.
The relationships point from child to parent simply because new _children_ can appear, but -as in real life- one's parents always stay the same.
Due to that fact every child can look up its parents recursively once and cache the pointers for a lifetime:

* 2a1480389 ConfigObject#OnAllConfigLoaded(): build m_AllParentsAffectingLogging cache

Just to be sure that the parents really always stay the same:

* 53f881ba1 Forbid Zone#endpoints modification
* a3f8d8402 Disallow Downtime#config_owner modification

### Putting hydrogen and oxygen together

With all the above and an object pointer in every Log🪵 instance Log#~Log() just intersects the two caches, ConfigObject#m_AllParentsAffectingLogging and Logger#m_ObjectFilterCache, and passes the message through if successful.