### PR TITLE
Next check schedule based on LastCheckScheduleStart instead of now() fo…

### DIFF
--- a/.github/renovate-file-config.js
+++ b/.github/renovate-file-config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    "autodiscover": true,
+    "hostRules": [
+        {
+            hostType: 'github',
+            matchHost: 'https://api.github.com/repos/rtbhouse-platform-engineering/renovate-scanner',
+            token: process.env.RENOVATE_CONFIG_PRESET_TOKEN,
+        },
+    ],
+};

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>rtbhouse-platform-engineering/renovate-scanner//renovate/default.json5"
+  ]
+}

--- a/.github/workflows/automated-dependency-updates.yaml
+++ b/.github/workflows/automated-dependency-updates.yaml
@@ -1,0 +1,18 @@
+name: Automated dependency updates
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: rtbhouse-platform-engineering/renovate-scanner/.github/actions/run-renovate@261480b2d6b5bb71fc7276c976a8e202f124de76 # v0.1.1
+        with:
+          gh-renovate-config-preset-app-id: ${{ vars.GH_READER_APP_ID }}
+          gh-renovate-config-preset-app-private-key: ${{ secrets.GH_READER_APP_PRIVATE_KEY }}
+          gh-renovate-app-id: ${{ vars.GH_RENOVATE_APP_ID }}
+          gh-renovate-app-private-key: ${{ secrets.GH_RENOVATE_APP_PRIVATE_KEY }}

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -104,6 +104,7 @@ public:
 	bool HasBeenChecked() const;
 	virtual bool IsStateOK(ServiceState state) const = 0;
 
+	double GetLastCheckScheduleStart() const;
 	double GetLastCheck() const final;
 
 	virtual void SaveLastState(ServiceState state, double timestamp) = 0;


### PR DESCRIPTION
…r even performance data intervals.

Hi.
  With current scheduler Icinga2 will return performance data in intervals that are depending on check duration + latency. For example graphite requires smooth interval between metric points. If You will set check_interval = 1m, retry_interval = 1m You would expect performance data every minute. But it is true only for plugins that return data instantly . If executing check plugin takes few seconds then interval between performance data points on metric system will be check_interval  + check duration + check latency .  This causes metric databases like graphite to have gaps in plots. 

Fallowing patch:
 * makes no change for scheduling if interval is less or equal 1s (frequent checks could saturate resources, hard to predict if this could be changed safly) 
 * change schedule base, instead of now() it is based on last check ScheduleStart
 * fallback to safe "now + 0.5 + adj" in case of check duration + delay is longer that interval
 * patch was tested on production satellites  ( ubuntu  xenial  icinga2=2.12.3-1.xenial , 55k service checks total each minute)

Please consider this change in master.
