### PR TITLE
Make ObjectImpl<Logger>#GetSeverity() non-virtual

### DIFF
--- a/lib/base/logger.ti
+++ b/lib/base/logger.ti
@@ -9,7 +9,7 @@ namespace icinga
 
 abstract class Logger : ConfigObject
 {
-	[config, virtual] String severity {
+	[config, set_virtual] String severity {
 		default {{{ return "information"; }}}
 	};
 };


### PR DESCRIPTION
After all it's not overridden.