### PR TITLE
Drop ApiListener#m_RelayQueue

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1195,7 +1195,7 @@ void ApiListener::RelayMessage(const MessageOrigin::Ptr& origin,
 	if (!IsActive())
 		return;
 
-	m_RelayQueue.Enqueue([this, origin, secobj, message, log]() { SyncRelayMessage(origin, secobj, message, log); }, PriorityNormal, true);
+	SyncRelayMessage(origin, secobj, message, log);
 }
 
 void ApiListener::PersistMessage(const Dictionary::Ptr& message, const ConfigObject::Ptr& secobj)

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -59,7 +59,6 @@ REGISTER_APIFUNCTION(Hello, icinga, &ApiListener::HelloAPIHandler);
 
 ApiListener::ApiListener()
 {
-	m_RelayQueue.SetName("ApiListener, RelayQueue");
 	m_SyncQueue.SetName("ApiListener, SyncQueue");
 }
 
@@ -1749,10 +1748,8 @@ std::pair<Dictionary::Ptr, Dictionary::Ptr> ApiListener::GetStatus()
 	size_t jsonRpcAnonymousClients = GetAnonymousClients().size();
 	size_t httpClients = GetHttpClients().size();
 	size_t syncQueueItems = m_SyncQueue.GetLength();
-	size_t relayQueueItems = m_RelayQueue.GetLength();
 	double workQueueItemRate = JsonRpcConnection::GetWorkQueueRate();
 	double syncQueueItemRate = m_SyncQueue.GetTaskCount(60) / 60.0;
-	double relayQueueItemRate = m_RelayQueue.GetTaskCount(60) / 60.0;
 
 	Dictionary::Ptr status = new Dictionary({
 		{ "identity", GetIdentity() },
@@ -1767,10 +1764,8 @@ std::pair<Dictionary::Ptr, Dictionary::Ptr> ApiListener::GetStatus()
 		{ "json_rpc", new Dictionary({
 			{ "anonymous_clients", jsonRpcAnonymousClients },
 			{ "sync_queue_items", syncQueueItems },
-			{ "relay_queue_items", relayQueueItems },
 			{ "work_queue_item_rate", workQueueItemRate },
 			{ "sync_queue_item_rate", syncQueueItemRate },
-			{ "relay_queue_item_rate", relayQueueItemRate }
 		}) },
 
 		{ "http", new Dictionary({
@@ -1786,11 +1781,9 @@ std::pair<Dictionary::Ptr, Dictionary::Ptr> ApiListener::GetStatus()
 	perfdata->Set("num_json_rpc_anonymous_clients", jsonRpcAnonymousClients);
 	perfdata->Set("num_http_clients", httpClients);
 	perfdata->Set("num_json_rpc_sync_queue_items", syncQueueItems);
-	perfdata->Set("num_json_rpc_relay_queue_items", relayQueueItems);
 
 	perfdata->Set("num_json_rpc_work_queue_item_rate", workQueueItemRate);
 	perfdata->Set("num_json_rpc_sync_queue_item_rate", syncQueueItemRate);
-	perfdata->Set("num_json_rpc_relay_queue_item_rate", relayQueueItemRate);
 
 	return std::make_pair(status, perfdata);
 }

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -223,7 +223,6 @@ private:
 	);
 	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server);
 
-	WorkQueue m_RelayQueue;
 	WorkQueue m_SyncQueue{0, 4};
 
 	std::mutex m_LogLock;


### PR DESCRIPTION
Instead run the previously enqueued function directly. The latter doesn't really do anything more than this:

* ApiListener::SyncRelayMessage
  * ApiListener::RelayMessageOne
    * ApiListener::SyncSendMessage
      * JsonRpcConnection::SendMessage
        * strand::post **<-- The enqueued function just enqueues a function here!**
  * ApiListener::PersistMessage
    * NetString::WriteStringToStream
      * StdioStream::Write
        * basic_ostream::write **<-- Will end up in user space buffer or in Linux disk cache – so strictly speaking in yet another queue.**

But this queue isn't just useless. It's also "malicious" (even if not counting useless malloc(3) and mutex locks):

* Hw specs: 56c, 256G RAM
* Icinga 2.14 config: see below

Icinga just works as long as I don't start this:

`for i in {1..30}; do (while curl -ksSo /dev/null -d '{"filter":"service.name==string('$(($RANDOM % 10))')&&host.name==string('$RANDOM')","pretty":1}' -X GET -u root:a97ccaf00cbaf91a 'https://127.0.0.1:5665/v1/objects/services'; do true; done) & done`

Then the queue dropped here just grows and grows – with the memory usage of course.
This PR fixes the memory leak.
Maybe it slows Icinga a bit down in critical situations where **I'm literally DDoSing it**, but it's better than an OOM crash.

```
for (i in range(750000)) {
	object Host i {
		check_command = "dummy"
		vars.foo1 = "foo1"
		vars.foo2 = "foo2"
		vars.foo3 = "foo3"
		vars.foo4 = "foo4"
		vars.foo5 = "foo5"
		vars.foo6 = "foo6"
		vars.foo7 = "foo7"
		vars.foo8 = "foo8"
		vars.foo9 = "foo9"
		vars.foo10 = "foo10"
		vars.foo11 = "foo11"
		vars.foo12 = "foo12"
	}
}

for (i in range(10)) {
	apply Service i {
		check_command = "dummy"
		vars.foo1 = "foo1"
		vars.foo2 = "foo2"
		vars.foo3 = "foo3"
		vars.foo4 = "foo4"
		vars.foo5 = "foo5"
		vars.foo6 = "foo6"
		vars.foo7 = "foo7"
		vars.foo8 = "foo8"
		vars.foo9 = "foo9"
		vars.foo10 = "foo10"
		vars.foo11 = "foo11"
		vars.foo12 = "foo12"
		assign where true
	}
}
```

## Behaviour in Icinga 2.10

* JsonRpcConnection::SendMessage
  * JsonRpc::SendMessage
    * NetString::WriteStringToStream
      * TlsStream::Write
        * FIFO::Write **<-- Actually yet another queue 🤷‍♂️**

## Behaviour in Icinga 2.2

Actual sync writing reasoning the relay queue:

* TlsStream::Write
  * Socket::Poll
  * SSL_write