### PR TITLE
GHA: drop EOL Ubuntu 22.10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,7 +37,6 @@ jobs:
           - rockylinux:9 # RHEL 9
           - ubuntu:20.04
           - ubuntu:22.04
-          - ubuntu:22.10
           - ubuntu:23.04
 
     steps:


### PR DESCRIPTION
Follow-up of https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/59