### PR TITLE
Update 02-installation.md - cannot use alias icingadb-redis

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -564,7 +564,7 @@ The `icingadb-redis` package automatically installs the necessary systemd unit f
 Please run the following command to enable and start its service:
 
 ```bash
-systemctl enable --now icingadb-redis
+systemctl enable --now icingadb-redis-server
 ```
 
 #### Enable Remote Redis Connections <a id="enable-remote-redis-connections"></a>


### PR DESCRIPTION
You can't use the icingadb-redis alias when enabling and starting the service. So you need to type in the full name: 'icingadb-redis-server'

This is the output i got:

root@icinga:~ systemctl enable --now icingadb-redis 
Failed to enable unit: Refusing to operate on alias name or linked unit file: icingadb-redis.service 
root@icinga:~ systemctl enable --now icingadb-redis-server 
Synchronizing state of icingadb-redis-server.service with SysV service script with /lib/systemd/systemd-sysv-install. Executing: /lib/systemd/systemd-sysv-install enable icingadb-redis-server