### PR TITLE
ITL - check_http - adds second http_post

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -721,6 +721,7 @@ http_privatekey                  | **Optional.** Name of file contains the priva
 http_headerstring                | **Optional.** String to expect in the response headers.
 http_string                      | **Optional.** String to expect in the content.
 http_post                        | **Optional.** URL encoded http POST data.
+http_post_pw                     | **Optional.** URL encoded http POST data, but Icingaweb2 should hide this one, as it contains a password.
 http_method                      | **Optional.** Set http method (for example: HEAD, OPTIONS, TRACE, PUT, DELETE).
 http_maxage                      | **Optional.** Warn if document is more than seconds old.
 http_contenttype                 | **Optional.** Specify Content-Type header when POSTing.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -465,6 +465,10 @@ object CheckCommand "http" {
 			value = "$http_post$"
 			description = "URL encoded http POST data"
 		}
+		"-P" = {
+			value = "$http_post_pw$"
+			description = "URL encoded http POST data, but Icingaweb2 should hide this one, as it contains a password."
+		}
 		"-j" = {
 			value = "$http_method$"
 			description = "Set http method (for example: HEAD, OPTIONS, TRACE, PUT, DELETE)"


### PR DESCRIPTION
This PR adds second http_post for payloads containing a password.
This is usefull in connection with Icingaweb2. This addition is important to us, as we need to test password-authentication this way, while in other cases the contents of "http_post" should be visible, e.g. if it contains SOAP-headers.

The variable-name http_post_pw utilises a default (`"*pw*"`) described [here](https://github.com/Icinga/icingaweb2/blob/main/modules/monitoring/doc/03-Configuration.md#security-configuration-)