### PR TITLE
check_ssl_cert: integrate new option to set maximum validity

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5834,7 +5834,7 @@ ssl_cert_proxy                | **Optional.** Proxy server to use for connecting
 ssl_cert_file                 | **Optional.** Local file path. Works only if `ssl_cert_address` is set to "localhost".
 ssl_cert_warn                 | **Optional.** Minimum number of days a certificate has to be valid.
 ssl_cert_critical             | **Optional.** Minimum number of days a certificate has to be valid to issue a critical status.
-ssl_cert_maximum_validity     | **Optional.** Maximum number of days a certificate is allowed to be valid (default 397)
+ssl_cert_maximum_validity     | **Optional.** Maximum number of days a certificate is allowed to be valid (default: 397)
 ssl_cert_cn                   | **Optional.** Pattern to match the CN or AltName of the certificate.
 ssl_cert_issuer               | **Optional.** Pattern to match the issuer of the certificate.
 ssl_cert_org                  | **Optional.** Pattern to match the organization of the certificate.

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5834,6 +5834,7 @@ ssl_cert_proxy                | **Optional.** Proxy server to use for connecting
 ssl_cert_file                 | **Optional.** Local file path. Works only if `ssl_cert_address` is set to "localhost".
 ssl_cert_warn                 | **Optional.** Minimum number of days a certificate has to be valid.
 ssl_cert_critical             | **Optional.** Minimum number of days a certificate has to be valid to issue a critical status.
+ssl_cert_maximum_validity     | **Optional.** Maximum number of days a certificate is allowed to be valid (default 397)
 ssl_cert_cn                   | **Optional.** Pattern to match the CN or AltName of the certificate.
 ssl_cert_issuer               | **Optional.** Pattern to match the issuer of the certificate.
 ssl_cert_org                  | **Optional.** Pattern to match the organization of the certificate.

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -580,7 +580,7 @@ object CheckCommand "ssl_cert" {
 		}
 		"--maximum-validity" = {                                                                                                                                                                                                                                                        
 			value = "$ssl_cert_maximum_validity$"                                                                                                                                                                                                                                       
-			description = "The maximum validity of the certificate must not exceed in days (default 397)"                                                                                                                                                                                
+			description = "The maximum validity of the certificate in days (default: 397)"                                                                                                                                                                                
 		}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
 
 	}

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -578,10 +578,10 @@ object CheckCommand "ssl_cert" {
 			set_if = "$ssl_cert_ignore_tls_renegotiation$"
 			description = "Do not check for renegotiation"
 		}
-		"--maximum-validity" = {                                                                                                                                                                                                                                                        
-			value = "$ssl_cert_maximum_validity$"                                                                                                                                                                                                                                       
-			description = "The maximum validity of the certificate in days (default: 397)"                                                                                                                                                                                
-		}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+		"--maximum-validity" = {
+			value = "$ssl_cert_maximum_validity$"
+			description = "The maximum validity of the certificate in days (default: 397)"
+		}
 
 	}
 

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -578,6 +578,10 @@ object CheckCommand "ssl_cert" {
 			set_if = "$ssl_cert_ignore_tls_renegotiation$"
 			description = "Do not check for renegotiation"
 		}
+		"--maximum-validity" = {                                                                                                                                                                                                                                                        
+			value = "$ssl_cert_maximum_validity$"                                                                                                                                                                                                                                       
+			description = "The maximum validity of the certificate must not exceed 'days' (default 397)"                                                                                                                                                                                
+		}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
 
 	}
 

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -580,7 +580,7 @@ object CheckCommand "ssl_cert" {
 		}
 		"--maximum-validity" = {                                                                                                                                                                                                                                                        
 			value = "$ssl_cert_maximum_validity$"                                                                                                                                                                                                                                       
-			description = "The maximum validity of the certificate must not exceed 'days' (default 397)"                                                                                                                                                                                
+			description = "The maximum validity of the certificate must not exceed in days (default 397)"                                                                                                                                                                                
 		}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
 
 	}


### PR DESCRIPTION
check_ssl_cert has a new option with a new default: --maximum-validity. This change allows for services to use that option to override the default of 397 days. It is needed, if you have internal certificates that have a longer duration.