### PR TITLE
Disable TLS renegotiation

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -11,6 +11,8 @@
 #include <boost/asio/ssl/context.hpp>
 #include <openssl/opensslv.h>
 #include <openssl/crypto.h>
+#include <openssl/ssl.h>
+#include <openssl/ssl3.h>
 #include <fstream>
 
 namespace icinga
@@ -90,6 +92,16 @@ static void InitSslContext(const Shared<boost::asio::ssl::context>::Ptr& context
 	long flags = SSL_CTX_get_options(sslContext);
 
 	flags |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	SSL_CTX_set_info_callback(sslContext, [](const SSL* ssl, int where, int) {
+		if (where & SSL_CB_HANDSHAKE_DONE) {
+			ssl->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
+		}
+	});
+#else /* OPENSSL_VERSION_NUMBER < 0x10100000L */
+	flags |= SSL_OP_NO_RENEGOTIATION;
+#endif /* OPENSSL_VERSION_NUMBER < 0x10100000L */
 
 	SSL_CTX_set_options(sslContext, flags);
 


### PR DESCRIPTION
The API doesn't need it and a customer's security scanner is afraid of a potential DoS attack vector.

ref/IP/48068

## Before

```
root@e1f6d643df02:/# openssl s_client -connect 172.17.0.5:5665 -no_tls1_3
...
Server public key is 4096 bit
Secure Renegotiation IS supported
Compression: NONE
...
---
R
RENEGOTIATING
Can't use SSL_get_servername
depth=1 CN = Icinga CA
verify error:num=19:self-signed certificate in certificate chain
verify return:1
depth=1 CN = Icinga CA
verify return:1
depth=0 CN = b67953c793d9
verify return:1
```

## After

```
root@e1f6d643df02:/# openssl s_client -connect 172.17.0.5:5665 -no_tls1_3
...
Server public key is 4096 bit
Secure Renegotiation IS supported
Compression: NONE
...
---
R
RENEGOTIATING
801BF025977F0000:error:0A000153:SSL routines:ssl3_read_bytes:no renegotiation:../ssl/record/rec_layer_s3.c:1602:
```