### PR TITLE
GetCertificateCN(): prefer DNS SAN (if one), fall back to the CN

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -15,6 +15,10 @@
 #include <openssl/ssl.h>
 #include <openssl/ssl3.h>
 #include <fstream>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
 
 namespace icinga
 {
@@ -423,14 +427,74 @@ static String GetX509NameCN(X509_NAME *name)
 }
 
 /**
- * Retrieves the common name for an X509 certificate.
+ * Retrieves the DNS SAN (if exactly one) for an X509 certificate, fall back to the common name.
  *
  * @param certificate The X509 certificate.
- * @returns The common name.
+ * @returns The DNS SAN or common name.
  */
 String GetCertificateCN(const std::shared_ptr<X509>& certificate)
 {
-	return GetX509NameCN(X509_get_subject_name(certificate.get()));
+	std::unique_ptr<GENERAL_NAMES, void(*)(GENERAL_NAMES*)> sans (
+		(GENERAL_NAMES*)X509_get_ext_d2i(certificate.get(), NID_subject_alt_name, nullptr, nullptr),
+		&GENERAL_NAMES_free
+	);
+
+	std::vector<String> dnsSans;
+
+	if (sans) {
+		int totalSans = sk_GENERAL_NAME_num(sans.get());
+
+		for (int i = 0; i < totalSans; ++i) {
+			auto gn (sk_GENERAL_NAME_value(sans.get(), i));
+
+			if (gn->type == GEN_DNS) {
+				dnsSans.emplace_back(Convert::ToString(ASN1_STRING_get0_data(gn->d.uniformResourceIdentifier)));
+			}
+		}
+	}
+
+	if (dnsSans.size() == 1u) {
+		auto& dnsSan (dnsSans.at(0));
+		std::optional<String> cn;
+
+		try {
+			cn.emplace(GetX509NameCN(X509_get_subject_name(certificate.get())));
+		} catch (const std::exception&) {
+			// No CN - no problem
+			// GetX509NameCN() logs own errors if any
+		}
+
+		if (cn && *cn != dnsSan) {
+			Log(LogWarning, "SSL") << "Certificate's DNS SAN '" << dnsSan
+				<< "' doesn't match the CN '" << *cn << "'";
+		}
+
+		return std::move(dnsSan);
+	}
+
+	Log msg (LogWarning, "SSL");
+	decltype(dnsSans.size()) loggedSans = 0;
+
+	msg << "Expected 1 DNS SAN in certificate, found " << dnsSans.size();
+
+	for (auto& dnsSan : dnsSans) {
+		if (loggedSans) {
+			msg << ", ";
+		} else {
+			msg << ": ";
+		}
+
+		msg << "'" << dnsSan << "'";
+		++loggedSans;
+	}
+
+	// If GetX509NameCN() throws, msg is logged as-is - that's fine
+	// GetX509NameCN() logs own errors if any
+	auto cn (GetX509NameCN(X509_get_subject_name(certificate.get())));
+
+	msg << ". CN: '" << cn << "'";
+
+	return cn;
 }
 
 /**


### PR DESCRIPTION
if exactly one is given and use it as CN.

Currently Icinga 2 populates both the DNS SAN and the subject CN of a newly issued certificate with the endpoint name. But the CN is limited to 64 characters. So endpoint names are. The only clean solution is omitting the CN for too long names. Icinga 2 must be able to extract the endpoint name from such certificates in the first place and exactly one DNS SAN is a legit source.

refs #9310

This effectively only changes the behaviour of GetCertificateCN() which has the de-facto monopoly for CN inquiry. There's also GetX509NameCN() which is additionally used in CreateCert(). But this construction area isn't about certificate issuance, see the plan.

## TODO

* [ ] Ask me (@Al2Klimov) anything.
* [ ] Plan OK?
* [ ] Code beautiful enough?
* [ ] Compiles on all? (GHA)
* [ ] Test final version! (@Al2Klimov)

# This is the plan

* v2.14 already rejects missing or too long CNs wherever they're about to appear
* v2.15.0 -with this PR- doesn't do anything new by itself(!), but if -hypothetically speaking- it sees a peer(!) certificate w/o CN -but with one DNS SAN- the DNS SAN counts as CN
* v2.16.0 -with additional changes- also issues certificates w/o CNs if such would exceed the limit

## Clusters with same version

obviously work. The only noteworthy are v2.16 ones as they issue new-kind certificates, but all peers already understand them since v2.15.0.

## Mixed clusters as we support them

are the interesting ones and reason this complicated plan at all.

### v2.15 master + v2.14 satellite + v2.13 agent

The masters only start to understand something which doesn't actually exist, yet.

### v2.16 master + v2.15 satellite + v2.14 agent

Every node creates a self-signed certificate before asking its parent for an actual one. This prevents -the most important- the satellite from having a new-kind certificate the agent wouldn't recognise. Due to the fact that it still populates the CN which is limited. Not to mention the agent itself.