### PR TITLE
ApiListener#Start(): auto-renew CA on its owner

### DIFF
--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -787,10 +787,10 @@ bool IsCaUptodate(X509* cert)
 	return !CertExpiresWithin(cert, LEAF_VALID_FOR);
 }
 
-String CertificateToString(const std::shared_ptr<X509>& cert)
+String CertificateToString(X509* cert)
 {
 	BIO *mem = BIO_new(BIO_s_mem());
-	PEM_write_bio_X509(mem, cert.get());
+	PEM_write_bio_X509(mem, cert);
 
 	char *data;
 	long len = BIO_get_mem_data(mem, &data);

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -760,18 +760,31 @@ std::shared_ptr<X509> CreateCertIcingaCA(const std::shared_ptr<X509>& cert)
 	return CreateCertIcingaCA(pkey.get(), X509_get_subject_name(cert.get()));
 }
 
+static inline
+bool CertExpiresWithin(X509* cert, int seconds)
+{
+	time_t renewalStart = time(nullptr) + seconds;
+
+	return X509_cmp_time(X509_get_notAfter(cert), &renewalStart) < 0;
+}
+
 bool IsCertUptodate(const std::shared_ptr<X509>& cert)
 {
-	time_t now;
-	time(&now);
+	if (CertExpiresWithin(cert.get(), RENEW_THRESHOLD)) {
+		return false;
+	}
 
 	/* auto-renew all certificates which were created before 2017 to force an update of the CA,
 	 * because Icinga versions older than 2.4 sometimes create certificates with an invalid
 	 * serial number. */
 	time_t forceRenewalEnd = 1483228800; /* January 1st, 2017 */
-	time_t renewalStart = now + RENEW_THRESHOLD;
 
-	return X509_cmp_time(X509_get_notBefore(cert.get()), &forceRenewalEnd) != -1 && X509_cmp_time(X509_get_notAfter(cert.get()), &renewalStart) != -1;
+	return X509_cmp_time(X509_get_notBefore(cert.get()), &forceRenewalEnd) >= 0;
+}
+
+bool IsCaUptodate(X509* cert)
+{
+	return !CertExpiresWithin(cert, LEAF_VALID_FOR);
 }
 
 String CertificateToString(const std::shared_ptr<X509>& cert)

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -714,7 +714,7 @@ String GetIcingaCADir()
 	return Configuration::DataDir + "/ca";
 }
 
-std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject)
+std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject, bool ca)
 {
 	char errbuf[256];
 
@@ -751,7 +751,7 @@ std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject)
 	EVP_PKEY *privkey = EVP_PKEY_new();
 	EVP_PKEY_assign_RSA(privkey, rsa);
 
-	return CreateCert(pubkey, subject, X509_get_subject_name(cacert.get()), privkey, false);
+	return CreateCert(pubkey, subject, X509_get_subject_name(cacert.get()), privkey, ca);
 }
 
 std::shared_ptr<X509> CreateCertIcingaCA(const std::shared_ptr<X509>& cert)

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -61,7 +61,7 @@ String GetIcingaCADir();
 String CertificateToString(const std::shared_ptr<X509>& cert);
 
 std::shared_ptr<X509> StringToCertificate(const String& cert);
-std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject);
+std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject, bool ca = false);
 std::shared_ptr<X509> CreateCertIcingaCA(const std::shared_ptr<X509>& cert);
 bool IsCertUptodate(const std::shared_ptr<X509>& cert);
 bool IsCaUptodate(X509* cert);

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -64,6 +64,7 @@ std::shared_ptr<X509> StringToCertificate(const String& cert);
 std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject);
 std::shared_ptr<X509> CreateCertIcingaCA(const std::shared_ptr<X509>& cert);
 bool IsCertUptodate(const std::shared_ptr<X509>& cert);
+bool IsCaUptodate(X509* cert);
 
 String PBKDF2_SHA1(const String& password, const String& salt, int iterations);
 String PBKDF2_SHA256(const String& password, const String& salt, int iterations);

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -58,7 +58,12 @@ int MakeX509CSR(const String& cn, const String& keyfile, const String& csrfile =
 std::shared_ptr<X509> CreateCert(EVP_PKEY *pubkey, X509_NAME *subject, X509_NAME *issuer, EVP_PKEY *cakey, bool ca);
 
 String GetIcingaCADir();
-String CertificateToString(const std::shared_ptr<X509>& cert);
+String CertificateToString(X509* cert);
+
+inline String CertificateToString(const std::shared_ptr<X509>& cert)
+{
+	return CertificateToString(cert.get());
+}
 
 std::shared_ptr<X509> StringToCertificate(const String& cert);
 std::shared_ptr<X509> CreateCertIcingaCA(EVP_PKEY *pubkey, X509_NAME *subject, bool ca = false);

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -181,12 +181,12 @@ void ApiListener::OnConfigLoaded()
 	UpdateSSLContext();
 }
 
-std::shared_ptr<X509> ApiListener::RenewCert(const std::shared_ptr<X509>& cert)
+std::shared_ptr<X509> ApiListener::RenewCert(const std::shared_ptr<X509>& cert, bool ca)
 {
 	std::shared_ptr<EVP_PKEY> pubkey (X509_get_pubkey(cert.get()), EVP_PKEY_free);
 	auto subject (X509_get_subject_name(cert.get()));
 	auto cacert (GetX509Certificate(GetDefaultCaPath()));
-	auto newcert (CreateCertIcingaCA(pubkey.get(), subject));
+	auto newcert (CreateCertIcingaCA(pubkey.get(), subject, ca));
 
 	/* verify that the new cert matches the CA we're using for the ApiListener;
 	 * this ensures that the CA we have in /var/lib/icinga2/ca matches the one

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -227,6 +227,7 @@ private:
 	void SyncLocalZoneDirs() const;
 	void SyncLocalZoneDir(const Zone::Ptr& zone) const;
 	void RenewOwnCert();
+	void RenewCA();
 
 	void SendConfigUpdate(const JsonRpcConnection::Ptr& aclient);
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -91,7 +91,7 @@ public:
 	static String GetCaDir();
 	static String GetCertificateRequestsDir();
 
-	std::shared_ptr<X509> RenewCert(const std::shared_ptr<X509>& cert);
+	std::shared_ptr<X509> RenewCert(const std::shared_ptr<X509>& cert, bool ca = false);
 	void UpdateSSLContext();
 
 	static ApiListener::Ptr GetInstance();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,6 +109,11 @@ add_boost_test(base
     base_timer/invoke
     base_timer/scope
     base_tlsutility/sha1
+    base_tlsutility/iscauptodate_ok
+    base_tlsutility/iscauptodate_expiring
+    base_tlsutility/iscertuptodate_ok
+    base_tlsutility/iscertuptodate_expiring
+    base_tlsutility/iscertuptodate_old
     base_type/gettype
     base_type/assign
     base_type/byname

--- a/test/base-tlsutility.cpp
+++ b/test/base-tlsutility.cpp
@@ -2,10 +2,60 @@
 
 #include "base/tlsutility.hpp"
 #include <BoostTestTargetConfig.h>
+#include <functional>
+#include <memory>
+#include <openssl/asn1.h>
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/obj_mac.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
 #include <utility>
 #include <vector>
 
 using namespace icinga;
+
+static EVP_PKEY* GenKeypair()
+{
+	InitializeOpenSSL();
+
+	auto e (BN_new());
+	BOOST_REQUIRE(e);
+
+	auto rsa (RSA_new());
+	BOOST_REQUIRE(rsa);
+
+	auto key (EVP_PKEY_new());
+	BOOST_REQUIRE(key);
+
+	BOOST_REQUIRE(BN_set_word(e, RSA_F4));
+	BOOST_REQUIRE(RSA_generate_key_ex(rsa, 4096, e, nullptr));
+	BOOST_REQUIRE(EVP_PKEY_assign_RSA(key, rsa));
+
+	return key;
+}
+
+static std::shared_ptr<X509> MakeCert(const char* issuer, EVP_PKEY* signer, const char* subject, EVP_PKEY* pubkey, std::function<void(ASN1_TIME*, ASN1_TIME*)> setTimes)
+{
+	auto cert (X509_new());
+	BOOST_REQUIRE(cert);
+
+	auto serial (BN_new());
+	BOOST_REQUIRE(serial);
+
+	BOOST_REQUIRE(X509_set_version(cert, 0x2));
+	BOOST_REQUIRE(BN_to_ASN1_INTEGER(serial, X509_get_serialNumber(cert)));
+	BOOST_REQUIRE(X509_NAME_add_entry_by_NID(X509_get_issuer_name(cert), NID_commonName, MBSTRING_ASC, (unsigned char*)issuer, -1, -1, 0));
+	setTimes(X509_get_notBefore(cert), X509_get_notAfter(cert));
+	BOOST_REQUIRE(X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), NID_commonName, MBSTRING_ASC, (unsigned char*)subject, -1, -1, 0));
+	BOOST_REQUIRE(X509_set_pubkey(cert, pubkey));
+	BOOST_REQUIRE(X509_sign(cert, signer, EVP_sha256()));
+
+	return std::shared_ptr<X509>(cert, X509_free);
+}
+
+static const long l_2016 = 1480000000; // Thu Nov 24 15:06:40 UTC 2016
+static const long l_2017 = 1490000000; // Mon Mar 20 08:53:20 UTC 2017
 
 BOOST_AUTO_TEST_SUITE(base_tlsutility)
 
@@ -33,6 +83,53 @@ BOOST_AUTO_TEST_CASE(sha1)
 		auto output = SHA1(input);
 		BOOST_CHECK_MESSAGE(output == expected, "SHA1('" << input << "') should be " << expected << ", got " << output);
 	}
+}
+
+BOOST_AUTO_TEST_CASE(iscauptodate_ok)
+{
+	auto key (GenKeypair());
+
+	BOOST_CHECK(IsCaUptodate(MakeCert("Icinga CA", key, "Icinga CA", key, [](ASN1_TIME* notBefore, ASN1_TIME* notAfter) {
+		BOOST_REQUIRE(X509_gmtime_adj(notBefore, 0));
+		BOOST_REQUIRE(X509_gmtime_adj(notAfter, LEAF_VALID_FOR + 60 * 60));
+	}).get()));
+}
+
+BOOST_AUTO_TEST_CASE(iscauptodate_expiring)
+{
+	auto key (GenKeypair());
+
+	BOOST_CHECK(!IsCaUptodate(MakeCert("Icinga CA", key, "Icinga CA", key, [](ASN1_TIME* notBefore, ASN1_TIME* notAfter) {
+		BOOST_REQUIRE(X509_gmtime_adj(notBefore, 0));
+		BOOST_REQUIRE(X509_gmtime_adj(notAfter, LEAF_VALID_FOR - 60 * 60));
+	}).get()));
+}
+
+BOOST_AUTO_TEST_CASE(iscertuptodate_ok)
+{
+	BOOST_CHECK(IsCertUptodate(MakeCert("Icinga CA", GenKeypair(), "example.com", GenKeypair(), [](ASN1_TIME* notBefore, ASN1_TIME* notAfter) {
+		time_t epoch = 0;
+		BOOST_REQUIRE(X509_time_adj(notBefore, l_2017, &epoch));
+		BOOST_REQUIRE(X509_gmtime_adj(notAfter, RENEW_THRESHOLD + 60 * 60));
+	})));
+}
+
+BOOST_AUTO_TEST_CASE(iscertuptodate_expiring)
+{
+	BOOST_CHECK(!IsCertUptodate(MakeCert("Icinga CA", GenKeypair(), "example.com", GenKeypair(), [](ASN1_TIME* notBefore, ASN1_TIME* notAfter) {
+		time_t epoch = 0;
+		BOOST_REQUIRE(X509_time_adj(notBefore, l_2017, &epoch));
+		BOOST_REQUIRE(X509_gmtime_adj(notAfter, RENEW_THRESHOLD - 60 * 60));
+	})));
+}
+
+BOOST_AUTO_TEST_CASE(iscertuptodate_old)
+{
+	BOOST_CHECK(!IsCertUptodate(MakeCert("Icinga CA", GenKeypair(), "example.com", GenKeypair(), [](ASN1_TIME* notBefore, ASN1_TIME* notAfter) {
+		time_t epoch = 0;
+		BOOST_REQUIRE(X509_time_adj(notBefore, l_2016, &epoch));
+		BOOST_REQUIRE(X509_gmtime_adj(notAfter, RENEW_THRESHOLD + 60 * 60));
+	})));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
otherwise it would expire.

fixes #9890

With this, the Icinga 2 node owning the CA periodically renews it locally. (Pretty much like 3753f86c80e277c9764db448e5fbc2c0b3cc99c3, but for the CA this time.)

~Sooner or later~ that local CA cert will be ~(already)~ propagated through pki::UpdateCertificate.

This way the root certificate never expires on the whole cluster.

## TODO

* [x] Increase CA threshold? @Al2Klimov
* [x] Test in a mixed version cluster (with shorter thresholds of course) @Al2Klimov