### PR TITLE
Discard likely duplicate problem notifications via Notification#last_notified_state_per_user

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1550,6 +1550,40 @@ Message updates will be dropped when:
 * Notification does not exist.
 * Origin endpoint is not within the local zone.
 
+#### event::ClearLastNotifiedStatePerUser <a id="technical-concepts-json-rpc-messages-event-clearlastnotifiedstateperuser"></a>
+
+> Location: `clusterevents.cpp`
+
+##### Message Body
+
+Key       | Value
+----------|---------
+jsonrpc   | 2.0
+method    | event::ClearLastNotifiedStatePerUser
+params    | Dictionary
+
+##### Params
+
+Key          | Type   | Description
+-------------|--------|------------------
+notification | String | Notification name
+
+Used to sync the state of a notification object within the same HA zone.
+
+##### Functions
+
+Event Sender: `Notification::OnLastNotifiedStatePerUserCleared`
+Event Receiver: `LastNotifiedStatePerUserClearedAPIHandler`
+
+##### Permissions
+
+The receiver will not process messages from not configured endpoints.
+
+Message updates will be dropped when:
+
+* Notification does not exist.
+* Origin endpoint is not within the local zone.
+
 #### event::SetForceNextCheck <a id="technical-concepts-json-rpc-messages-event-setforcenextcheck"></a>
 
 > Location: `clusterevents.cpp`

--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1514,6 +1514,42 @@ Message updates will be dropped when:
 * Notification does not exist.
 * Origin endpoint's zone is not allowed to access this checkable.
 
+#### event::UpdateLastNotifiedStatePerUser <a id="technical-concepts-json-rpc-messages-event-updatelastnotifiedstateperuser"></a>
+
+> Location: `clusterevents.cpp`
+
+##### Message Body
+
+Key       | Value
+----------|---------
+jsonrpc   | 2.0
+method    | event::UpdateLastNotifiedStatePerUser
+params    | Dictionary
+
+##### Params
+
+Key          | Type   | Description
+-------------|--------|------------------
+notification | String | Notification name
+user         | String | User name
+state        | Number | Checkable state the user just got a problem notification for
+
+Used to sync the state of a notification object within the same HA zone.
+
+##### Functions
+
+Event Sender: `Notification::OnLastNotifiedStatePerUserUpdated`
+Event Receiver: `LastNotifiedStatePerUserUpdatedAPIHandler`
+
+##### Permissions
+
+The receiver will not process messages from not configured endpoints.
+
+Message updates will be dropped when:
+
+* Notification does not exist.
+* Origin endpoint is not within the local zone.
+
 #### event::SetForceNextCheck <a id="technical-concepts-json-rpc-messages-event-setforcenextcheck"></a>
 
 > Location: `clusterevents.cpp`

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -29,6 +29,7 @@ REGISTER_APIFUNCTION(SetStateBeforeSuppression, event, &ClusterEvents::StateBefo
 REGISTER_APIFUNCTION(SetSuppressedNotifications, event, &ClusterEvents::SuppressedNotificationsChangedAPIHandler);
 REGISTER_APIFUNCTION(SetSuppressedNotificationTypes, event, &ClusterEvents::SuppressedNotificationTypesChangedAPIHandler);
 REGISTER_APIFUNCTION(SetNextNotification, event, &ClusterEvents::NextNotificationChangedAPIHandler);
+REGISTER_APIFUNCTION(UpdateLastNotifiedStatePerUser, event, &ClusterEvents::LastNotifiedStatePerUserUpdatedAPIHandler);
 REGISTER_APIFUNCTION(SetForceNextCheck, event, &ClusterEvents::ForceNextCheckChangedAPIHandler);
 REGISTER_APIFUNCTION(SetForceNextNotification, event, &ClusterEvents::ForceNextNotificationChangedAPIHandler);
 REGISTER_APIFUNCTION(SetAcknowledgement, event, &ClusterEvents::AcknowledgementSetAPIHandler);
@@ -50,6 +51,7 @@ void ClusterEvents::StaticInitialize()
 	Checkable::OnSuppressedNotificationsChanged.connect(&ClusterEvents::SuppressedNotificationsChangedHandler);
 	Notification::OnSuppressedNotificationsChanged.connect(&ClusterEvents::SuppressedNotificationTypesChangedHandler);
 	Notification::OnNextNotificationChanged.connect(&ClusterEvents::NextNotificationChangedHandler);
+	Notification::OnLastNotifiedStatePerUserUpdated.connect(&ClusterEvents::LastNotifiedStatePerUserUpdatedHandler);
 	Checkable::OnForceNextCheckChanged.connect(&ClusterEvents::ForceNextCheckChangedHandler);
 	Checkable::OnForceNextNotificationChanged.connect(&ClusterEvents::ForceNextNotificationChangedHandler);
 	Checkable::OnNotificationsRequested.connect(&ClusterEvents::SendNotificationsHandler);
@@ -525,6 +527,64 @@ Value ClusterEvents::NextNotificationChangedAPIHandler(const MessageOrigin::Ptr&
 		return Empty;
 
 	notification->SetNextNotification(nextNotification, false, origin);
+
+	return Empty;
+}
+
+void ClusterEvents::LastNotifiedStatePerUserUpdatedHandler(const Notification::Ptr& notification, const String& user, uint_fast8_t state, const MessageOrigin::Ptr& origin)
+{
+	auto listener (ApiListener::GetInstance());
+
+	if (!listener) {
+		return;
+	}
+
+	Dictionary::Ptr params = new Dictionary();
+	params->Set("notification", notification->GetName());
+	params->Set("user", user);
+	params->Set("state", state);
+
+	Dictionary::Ptr message = new Dictionary();
+	message->Set("jsonrpc", "2.0");
+	message->Set("method", "event::UpdateLastNotifiedStatePerUser");
+	message->Set("params", params);
+
+	listener->RelayMessage(origin, notification, message, true);
+}
+
+Value ClusterEvents::LastNotifiedStatePerUserUpdatedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
+{
+	auto endpoint (origin->FromClient->GetEndpoint());
+
+	if (!endpoint) {
+		Log(LogNotice, "ClusterEvents")
+			<< "Discarding 'last notified state of user updated' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
+
+		return Empty;
+	}
+
+	if (origin->FromZone && origin->FromZone != Zone::GetLocalZone()) {
+		Log(LogNotice, "ClusterEvents")
+			<< "Discarding 'last notified state of user updated' message from '"
+			<< origin->FromClient->GetIdentity() << "': Unauthorized access.";
+
+		return Empty;
+	}
+
+	auto notification (Notification::GetByName(params->Get("notification")));
+
+	if (!notification) {
+		return Empty;
+	}
+
+	auto state (params->Get("state"));
+
+	if (!state.IsNumber()) {
+		return Empty;
+	}
+
+	notification->GetLastNotifiedStatePerUser()->Set(params->Get("user"), state);
+	Notification::OnLastNotifiedStatePerUserUpdated(notification, params->Get("user"), state, origin);
 
 	return Empty;
 }

--- a/lib/icinga/clusterevents.hpp
+++ b/lib/icinga/clusterevents.hpp
@@ -41,6 +41,9 @@ public:
 	static void NextNotificationChangedHandler(const Notification::Ptr& notification, const MessageOrigin::Ptr& origin);
 	static Value NextNotificationChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
+	static void LastNotifiedStatePerUserUpdatedHandler(const Notification::Ptr& notification, const String& user, uint_fast8_t state, const MessageOrigin::Ptr& origin);
+	static Value LastNotifiedStatePerUserUpdatedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
+
 	static void ForceNextCheckChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);
 	static Value ForceNextCheckChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 

--- a/lib/icinga/clusterevents.hpp
+++ b/lib/icinga/clusterevents.hpp
@@ -44,6 +44,9 @@ public:
 	static void LastNotifiedStatePerUserUpdatedHandler(const Notification::Ptr& notification, const String& user, uint_fast8_t state, const MessageOrigin::Ptr& origin);
 	static Value LastNotifiedStatePerUserUpdatedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
+	static void LastNotifiedStatePerUserClearedHandler(const Notification::Ptr& notification, const MessageOrigin::Ptr& origin);
+	static Value LastNotifiedStatePerUserClearedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
+
 	static void ForceNextCheckChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);
 	static Value ForceNextCheckChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -452,6 +452,16 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 		/* collect all notified users */
 		allNotifiedUsers.insert(user);
 
+		switch (type) {
+			case NotificationProblem:
+			case NotificationRecovery: {
+				auto [host, service] = GetHostService(checkable);
+				GetLastNotifiedStatePerUser()->Set(userName, service ? service->GetState() : host->GetState());
+			}
+			default:
+				;
+		}
+
 		/* store all notified users for later recovery checks */
 		if (type == NotificationProblem && !notifiedProblemUsers->Contains(userName))
 			notifiedProblemUsers->Add(userName);

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -24,6 +24,7 @@ std::map<String, int> Notification::m_TypeFilterMap;
 
 boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> Notification::OnNextNotificationChanged;
 boost::signals2::signal<void (const Notification::Ptr&, const String&, uint_fast8_t, const MessageOrigin::Ptr&)> Notification::OnLastNotifiedStatePerUserUpdated;
+boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> Notification::OnLastNotifiedStatePerUserCleared;
 
 String NotificationNameComposer::MakeName(const String& shortName, const Object::Ptr& context) const
 {
@@ -231,6 +232,13 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 		<< "Attempting to send " << (reminder ? "reminder " : "")
 		<< "notifications of type '" << notificationTypeName
 		<< "' for notification object '" << notificationName << "'.";
+
+	if (type == NotificationRecovery) {
+		auto states (GetLastNotifiedStatePerUser());
+
+		states->Clear();
+		OnLastNotifiedStatePerUserCleared(this, nullptr);
+	}
 
 	Checkable::Ptr checkable = GetCheckable();
 
@@ -469,19 +477,14 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 		/* collect all notified users */
 		allNotifiedUsers.insert(user);
 
-		switch (type) {
-			case NotificationProblem:
-			case NotificationRecovery: {
-				auto [host, service] = GetHostService(checkable);
-				uint_fast8_t state = service ? service->GetState() : host->GetState();
+		if (type == NotificationProblem) {
+			auto [host, service] = GetHostService(checkable);
+			uint_fast8_t state = service ? service->GetState() : host->GetState();
 
-				if (state != (uint_fast8_t)GetLastNotifiedStatePerUser()->Get(userName)) {
-					GetLastNotifiedStatePerUser()->Set(userName, state);
-					OnLastNotifiedStatePerUserUpdated(this, userName, state, nullptr);
-				}
+			if (state != (uint_fast8_t)GetLastNotifiedStatePerUser()->Get(userName)) {
+				GetLastNotifiedStatePerUser()->Set(userName, state);
+				OnLastNotifiedStatePerUserUpdated(this, userName, state, nullptr);
 			}
-			default:
-				;
 		}
 
 		/* store all notified users for later recovery checks */

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -23,6 +23,7 @@ std::map<String, int> Notification::m_StateFilterMap;
 std::map<String, int> Notification::m_TypeFilterMap;
 
 boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> Notification::OnNextNotificationChanged;
+boost::signals2::signal<void (const Notification::Ptr&, const String&, uint_fast8_t, const MessageOrigin::Ptr&)> Notification::OnLastNotifiedStatePerUserUpdated;
 
 String NotificationNameComposer::MakeName(const String& shortName, const Object::Ptr& context) const
 {
@@ -456,7 +457,12 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 			case NotificationProblem:
 			case NotificationRecovery: {
 				auto [host, service] = GetHostService(checkable);
-				GetLastNotifiedStatePerUser()->Set(userName, service ? service->GetState() : host->GetState());
+				uint_fast8_t state = service ? service->GetState() : host->GetState();
+
+				if (state != (uint_fast8_t)GetLastNotifiedStatePerUser()->Get(userName)) {
+					GetLastNotifiedStatePerUser()->Set(userName, state);
+					OnLastNotifiedStatePerUserUpdated(this, userName, state, nullptr);
+				}
 			}
 			default:
 				;

--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -13,6 +13,7 @@
 #include "remote/endpoint.hpp"
 #include "remote/messageorigin.hpp"
 #include "base/array.hpp"
+#include <cstdint>
 
 namespace icinga
 {
@@ -92,6 +93,7 @@ public:
 	static String NotificationHostStateToString(HostState state);
 
 	static boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> OnNextNotificationChanged;
+	static boost::signals2::signal<void (const Notification::Ptr&, const String&, uint_fast8_t, const MessageOrigin::Ptr&)> OnLastNotifiedStatePerUserUpdated;
 
 	void Validate(int types, const ValidationUtils& utils) override;
 

--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -94,6 +94,7 @@ public:
 
 	static boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> OnNextNotificationChanged;
 	static boost::signals2::signal<void (const Notification::Ptr&, const String&, uint_fast8_t, const MessageOrigin::Ptr&)> OnLastNotifiedStatePerUserUpdated;
+	static boost::signals2::signal<void (const Notification::Ptr&, const MessageOrigin::Ptr&)> OnLastNotifiedStatePerUserCleared;
 
 	void Validate(int types, const ValidationUtils& utils) override;
 

--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -107,7 +107,6 @@ public:
 	static const std::map<String, int>& GetStateFilterMap();
 	static const std::map<String, int>& GetTypeFilterMap();
 
-protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
 	void Start(bool runtimeCreated) override;

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -90,6 +90,10 @@ class Notification : CustomVarObject < NotificationNameComposer
 		default {{{ return 0; }}}
 	};
 
+	[state, no_user_view, no_user_modify] Dictionary::Ptr last_notified_state_per_user {
+		default {{{ return new Dictionary(); }}}
+	};
+
 	[config, navigation] name(Endpoint) command_endpoint (CommandEndpointRaw) {
 		navigate {{{
 			return Endpoint::GetByName(GetCommandEndpointRaw());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,6 +138,9 @@ add_boost_test(base
     icinga_notification/strings
     icinga_notification/state_filter
     icinga_notification/type_filter
+    icinga_notification/no_filter_problem_no_duplicate
+    icinga_notification/filter_problem_no_duplicate
+    icinga_notification/volatile_filter_problem_duplicate
     icinga_macros/simple
     icinga_legacytimeperiod/simple
     icinga_legacytimeperiod/advanced

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,6 +141,8 @@ add_boost_test(base
     icinga_notification/no_filter_problem_no_duplicate
     icinga_notification/filter_problem_no_duplicate
     icinga_notification/volatile_filter_problem_duplicate
+    icinga_notification/no_recovery_filter_no_duplicate
+    icinga_notification/recovery_filter_duplicate
     icinga_macros/simple
     icinga_legacytimeperiod/simple
     icinga_legacytimeperiod/advanced

--- a/test/icinga-notification.cpp
+++ b/test/icinga-notification.cpp
@@ -194,4 +194,22 @@ BOOST_AUTO_TEST_CASE(volatile_filter_problem_duplicate)
 	helper.SendStateNotification(ServiceCritical, true);
 }
 
+BOOST_AUTO_TEST_CASE(no_recovery_filter_no_duplicate)
+{
+	DuplicateDueToFilterHelper helper (~0, ~0);
+
+	helper.SendStateNotification(ServiceCritical, true);
+	helper.SendStateNotification(ServiceOK, true);
+	helper.SendStateNotification(ServiceCritical, true);
+}
+
+BOOST_AUTO_TEST_CASE(recovery_filter_duplicate)
+{
+	DuplicateDueToFilterHelper helper (~NotificationRecovery, ~0);
+
+	helper.SendStateNotification(ServiceCritical, true);
+	helper.SendStateNotification(ServiceOK, false);
+	helper.SendStateNotification(ServiceCritical, true);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
fixes #4503

## Commits

1. Whenever a state notification is sent: track user.name=>checkable.state in Notification#last_notified_state_by_user
2. On Notification#last_notified_state_by_user change: sync that over cluster
3. Among the other checks like is-acked, matches-filter, etc. in Notification#BeginExecuteNotification(): in case of the same non-reminder problem already notified before drop the eff. dupl. notification
4. On recovery: clear that state

## Test

Tested with https://github.com/Al2Klimov/twintowers and following config in `volumes/icinga2/master1/etc/icinga2/zones.d/master/my.conf`

```
 for (i in range(100)) {
    object Host i {
        check_command = "dummy"
        enable_active_checks = false
        #check_interval = "dummy"
        #vars.dummy_state = {{ Math.random() < 0.01 ? 2 : 0 }}
        #vars.dummy_text = "-"
    }
}

 for (i in range(10)) {
apply Service i {
        check_command = "dummy"
        enable_active_checks = false
    assign where true
}
}

object User "me" {
    states = [ OK, Critical, Unknown ]
}

object NotificationCommand "noop" {
    command = [ "true" ]
}

apply Notification "test" to Host {
    command = "noop"
    users = [ "me" ]
    assign where true
}

apply Notification "test" to Service {
    command = "noop"
    users = [ "me" ]
    assign where true
}
```

* 👍 Initial (passive) warning filtered out as configured
* 👍 Initial critical notified as configured
* 👍 Follow-up warning filtered out as configured
* 👍 Follow-up critical filtered out due to this change
* 👍 Happened while one master was down on 10/10 services, so HA works