### PR TITLE
FilterUtility::GetFilterTargets(): don't run filter for specific object(s) for all objects

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -68,6 +68,20 @@ bool Dictionary::Get(const String& key, Value *result) const
 }
 
 /**
+ * Retrieves a value's address from a dictionary.
+ *
+ * @param key The key whose value's address should be retrieved.
+ * @returns nullptr if the key was not found.
+ */
+const Value * Dictionary::GetRef(const String& key) const
+{
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
+	auto it (m_Data.find(key));
+
+	return it == m_Data.end() ? nullptr : &it->second;
+}
+
+/**
  * Sets a value in the dictionary.
  *
  * @param key The key.

--- a/lib/base/dictionary.hpp
+++ b/lib/base/dictionary.hpp
@@ -42,6 +42,7 @@ public:
 
 	Value Get(const String& key) const;
 	bool Get(const String& key, Value *result) const;
+	const Value * GetRef(const String& key) const;
 	void Set(const String& key, Value value, bool overrideFrozen = false);
 	bool Contains(const String& key) const;
 

--- a/lib/config/expression.hpp
+++ b/lib/config/expression.hpp
@@ -622,6 +622,11 @@ public:
 
 	void MakeInline();
 
+	inline const std::vector<std::unique_ptr<Expression>>& GetExpressions() const noexcept
+	{
+		return m_Expressions;
+	}
+
 protected:
 	ExpressionResult DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const override;
 

--- a/lib/remote/CMakeLists.txt
+++ b/lib/remote/CMakeLists.txt
@@ -25,7 +25,7 @@ set(remote_SOURCES
   endpoint.cpp endpoint.hpp endpoint-ti.hpp
   eventqueue.cpp eventqueue.hpp
   eventshandler.cpp eventshandler.hpp
-  filterutility.cpp filterutility.hpp
+  filterutility.cpp filterutility-targeted.cpp filterutility.hpp
   httphandler.cpp httphandler.hpp
   httpserverconnection.cpp httpserverconnection.hpp
   httputility.cpp httputility.hpp

--- a/lib/remote/filterutility-targeted.cpp
+++ b/lib/remote/filterutility-targeted.cpp
@@ -1,0 +1,183 @@
+/* Icinga 2 | (c) 2023 Icinga GmbH | GPLv2+ */
+
+#include "remote/filterutility.hpp"
+
+using namespace icinga;
+
+/**
+ * If the given assign filter is like the following, extract the host+service names ("H"+"S", "h"+"s", ...) into the vector:
+ *
+ * host.name == "H" && service.name == "S" [ || host.name == "h" && service.name == "s" ... ]
+ *
+ * The order of operands of || && == doesn't matter.
+ *
+ * @returns Whether the given assign filter is like above.
+ */
+bool FilterUtility::GetTargetServices(Expression* filter, const Dictionary::Ptr& constants, std::vector<std::pair<const String *, const String *>>& out)
+{
+	auto lor (dynamic_cast<LogicalOrExpression*>(filter));
+
+	if (lor) {
+		return GetTargetServices(lor->GetOperand1().get(), constants, out)
+			&& GetTargetServices(lor->GetOperand2().get(), constants, out);
+	}
+
+	auto service (GetTargetService(filter, constants));
+
+	if (service.first) {
+		out.emplace_back(service);
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * If the given filter is like the following, extract the host+service names ("H"+"S"):
+ *
+ * host.name == "H" && service.name == "S"
+ *
+ * The order of operands of && == doesn't matter.
+ *
+ * @returns {host, service} on success, {nullptr, nullptr} on failure.
+ */
+std::pair<const String *, const String *> FilterUtility::GetTargetService(Expression* filter, const Dictionary::Ptr& constants)
+{
+	auto land (dynamic_cast<LogicalAndExpression*>(filter));
+
+	if (!land) {
+		return {nullptr, nullptr};
+	}
+
+	auto op1 (land->GetOperand1().get());
+	auto op2 (land->GetOperand2().get());
+	auto host (GetComparedName(op1, "host", constants));
+
+	if (!host) {
+		std::swap(op1, op2);
+		host = GetComparedName(op1, "host", constants);
+	}
+
+	if (host) {
+		auto service (GetComparedName(op2, "service", constants));
+
+		if (service) {
+			return {host, service};
+		}
+	}
+
+	return {nullptr, nullptr};
+}
+
+/**
+ * If the given assign filter is like the following, extract the host names ("H", "h", ...) into the vector:
+ *
+ * host.name == "H" [ || host.name == "h" ... ]
+ *
+ * The order of operands of || == doesn't matter.
+ *
+ * @returns Whether the given assign filter is like above.
+ */
+bool FilterUtility::GetTargetHosts(Expression* filter, const Dictionary::Ptr& constants, std::vector<const String *>& out)
+{
+	auto lor (dynamic_cast<LogicalOrExpression*>(filter));
+
+	if (lor) {
+		return GetTargetHosts(lor->GetOperand1().get(), constants, out)
+			&& GetTargetHosts(lor->GetOperand2().get(), constants, out);
+	}
+
+	auto name (GetComparedName(filter, "host", constants));
+
+	if (name) {
+		out.emplace_back(name);
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * If the given filter is like the following, extract the object name ("N"):
+ *
+ * $lcType$.name == "N"
+ *
+ * The order of operands of == doesn't matter.
+ *
+ * @returns The object name on success, nullptr on failure.
+ */
+const String * FilterUtility::GetComparedName(Expression* filter, const char * lcType, const Dictionary::Ptr& constants)
+{
+	auto eq (dynamic_cast<EqualExpression*>(filter));
+
+	if (!eq) {
+		return nullptr;
+	}
+
+	auto op1 (eq->GetOperand1().get());
+	auto op2 (eq->GetOperand2().get());
+
+	if (IsNameIndexer(op1, lcType, constants)) {
+		return GetConstString(op2, constants);
+	}
+
+	if (IsNameIndexer(op2, lcType, constants)) {
+		return GetConstString(op1, constants);
+	}
+
+	return nullptr;
+}
+
+/**
+ * @returns Whether the given expression is like $lcType$.name.
+ */
+bool FilterUtility::IsNameIndexer(Expression* exp, const char * lcType, const Dictionary::Ptr& constants)
+{
+	auto ixr (dynamic_cast<IndexerExpression*>(exp));
+
+	if (!ixr) {
+		return false;
+	}
+
+	auto var (dynamic_cast<VariableExpression*>(ixr->GetOperand1().get()));
+
+	if (!var || var->GetVariable() != lcType) {
+		return false;
+	}
+
+	auto val (GetConstString(ixr->GetOperand2().get(), constants));
+
+	return val && *val == "name";
+}
+
+/**
+ * @returns If the given expression is a constant string, its address. nullptr on failure.
+ */
+const String * FilterUtility::GetConstString(Expression* exp, const Dictionary::Ptr& constants)
+{
+	auto cnst (GetConst(exp, constants));
+
+	return cnst && cnst->IsString() ? &cnst->Get<String>() : nullptr;
+}
+
+/**
+ * @returns If the given expression is a constant, its address. nullptr on failure.
+ */
+const Value * FilterUtility::GetConst(Expression* exp, const Dictionary::Ptr& constants)
+{
+	auto lit (dynamic_cast<LiteralExpression*>(exp));
+
+	if (lit) {
+		return &lit->GetValue();
+	}
+
+	if (constants) {
+		auto var (dynamic_cast<VariableExpression*>(exp));
+
+		if (var) {
+			return constants->GetRef(var->GetVariable());
+		}
+	}
+
+	return nullptr;
+}

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -271,18 +271,73 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 		if (query->Contains("filter")) {
 			String filter = HttpUtility::GetLastParameter(query, "filter");
 			std::unique_ptr<Expression> ufilter = ConfigCompiler::CompileText("<API query>", filter);
-
 			Dictionary::Ptr filter_vars = query->Get("filter_vars");
-			if (filter_vars) {
-				ObjectLock olock(filter_vars);
-				for (const Dictionary::Pair& kv : filter_vars) {
-					frameNS->Set(kv.first, kv.second);
+			bool targeted = false;
+			std::vector<ConfigObject::Ptr> targets;
+
+			if (dynamic_cast<ConfigObjectTargetProvider*>(provider.get())) {
+				auto dict (dynamic_cast<DictExpression*>(ufilter.get()));
+
+				if (dict) {
+					auto& subex (dict->GetExpressions());
+
+					if (subex.size() == 1u) {
+						if (type == "Host") {
+							std::vector<const String *> targetNames;
+
+							if (GetTargetHosts(subex.at(0).get(), filter_vars, targetNames)) {
+								static const auto typeHost (Type::GetByName("Host"));
+								static const auto ctypeHost (dynamic_cast<ConfigType*>(typeHost.get()));
+								targeted = true;
+
+								for (auto name : targetNames) {
+									auto target (ctypeHost->GetObject(*name));
+
+									if (target) {
+										targets.emplace_back(target);
+									}
+								}
+							}
+						} else if (type == "Service") {
+							std::vector<std::pair<const String *, const String *>> targetNames;
+
+							if (GetTargetServices(subex.at(0).get(), filter_vars, targetNames)) {
+								static const auto typeService (Type::GetByName("Service"));
+								static const auto ctypeService (dynamic_cast<ConfigType*>(typeService.get()));
+								targeted = true;
+
+								for (auto name : targetNames) {
+									auto target (ctypeService->GetObject(*name.first + "!" + *name.second));
+
+									if (target) {
+										targets.emplace_back(target);
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 
-			provider->FindTargets(type, [&permissionFrame, &permissionFilter, &frame, &ufilter, &result, variableName](const Object::Ptr& target) {
-				FilteredAddTarget(permissionFrame, permissionFilter.get(), frame, &*ufilter, result, variableName, target);
-			});
+			if (targeted) {
+				for (auto& target : targets) {
+					if (FilterUtility::EvaluateFilter(permissionFrame, permissionFilter.get(), target, variableName)) {
+						result.emplace_back(std::move(target));
+					}
+				}
+			} else {
+				if (filter_vars) {
+					ObjectLock olock (filter_vars);
+
+					for (auto& kv : filter_vars) {
+						frameNS->Set(kv.first, kv.second);
+					}
+				}
+
+				provider->FindTargets(type, [&permissionFrame, &permissionFilter, &frame, &ufilter, &result, variableName](const Object::Ptr& target) {
+					FilteredAddTarget(permissionFrame, permissionFilter.get(), frame, &*ufilter, result, variableName, target);
+				});
+			}
 		} else {
 			/* Ensure to pass a nullptr as filter expression.
 			 * GCC 8.1.1 on F28 causes problems, see GH #6533.

--- a/lib/remote/filterutility.hpp
+++ b/lib/remote/filterutility.hpp
@@ -9,6 +9,7 @@
 #include "base/dictionary.hpp"
 #include "base/configobject.hpp"
 #include <set>
+#include <utility>
 
 namespace icinga
 {
@@ -57,6 +58,15 @@ public:
 		const ApiUser::Ptr& user, const String& variableName = String());
 	static bool EvaluateFilter(ScriptFrame& frame, Expression *filter,
 		const Object::Ptr& target, const String& variableName = String());
+
+private:
+	static bool GetTargetServices(Expression* filter, const Dictionary::Ptr& constants, std::vector<std::pair<const String *, const String *>>& out);
+	static std::pair<const String *, const String *> GetTargetService(Expression* filter, const Dictionary::Ptr& constants);
+	static bool GetTargetHosts(Expression* filter, const Dictionary::Ptr& constants, std::vector<const String *>& out);
+	static const String * GetComparedName(Expression* filter, const char * lcType, const Dictionary::Ptr& constants);
+	static bool IsNameIndexer(Expression* exp, const char * lcType, const Dictionary::Ptr& constants);
+	static const String * GetConstString(Expression* exp, const Dictionary::Ptr& constants);
+	static const Value * GetConst(Expression* exp, const Dictionary::Ptr& constants);
 };
 
 }


### PR DESCRIPTION
This is basically the same as

* #9545

but for API filters, not for assign rules:

1. There's a filter on Hosts/Services
2. Does it unambiguously target only specific Hosts/Services?
3. If yes: fetch just them, don't run filter for all

* This is unquestionably a significant performance improvement
* If we're nice and backport it in 2.14.1, it will be -as a side effect- also conveniently available for testing regarding https://community.icinga.com/t/memory-leak-despite-2-14-upgrade-how-to-debug/12380/43