### PR TITLE
Provide cancel_time in Icinga DB downtime history where has_been_cancelled may be 1

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1860,6 +1860,7 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 		"scheduled_end_time", Convert::ToString(TimestampToMilliseconds(downtime->GetEndTime())),
 		"has_been_cancelled", Convert::ToString((unsigned short)downtime->GetWasCancelled()),
 		"trigger_time", Convert::ToString(TimestampToMilliseconds(downtime->GetTriggerTime())),
+		"cancel_time", Convert::ToString(TimestampToMilliseconds(downtime->GetRemoveTime())),
 		"event_id", CalcEventID("downtime_start", downtime),
 		"event_type", "downtime_start"
 	});


### PR DESCRIPTION
The table sla_history_downtime requires a downtime_end. The Go daemon takes the cancel_time if has_been_cancelled is 1. So we must supply a cancel_time whereever has_been_cancelled is 1. Otherwise the Go daemon can't process some entries.

fixes Icinga/icinga2#9942

Btw SendRemovedDowntime() does the same.

## TODO

* [ ] Concept ok?
* [x] Transfer issue here
* [x] Check "fixes" in OP
* [ ] Merge