### PR TITLE
IcingaDB#SendConfigDelete(): fix missing nullptr check before deref

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1577,6 +1577,9 @@ IcingaDB::CreateConfigUpdate(const ConfigObject::Ptr& object, const String typeN
 
 void IcingaDB::SendConfigDelete(const ConfigObject::Ptr& object)
 {
+	if (!m_Rcon || !m_Rcon->IsConnected())
+		return;
+
 	Type::Ptr type = object->GetReflectionType();
 	String typeName = type->GetName().ToLower();
 	String objectKey = GetObjectIdentifier(object);


### PR DESCRIPTION
fixes #9897

Just as in the other methods of this kind.

Luckily the issue OP provided a stack trace.