### PR TITLE
GHA: cancel runs on PR, but not on push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
       - published
 
 concurrency:
-  group: docker-${{ github.ref }}
+  group: docker-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
   pull_request: {}
 
 concurrency:
-  group: linux-${{ github.ref }}
+  group: linux-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -8,7 +8,7 @@ on:
   pull_request: {}
 
 concurrency:
-  group: rpm-${{ github.ref }}
+  group: rpm-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
   pull_request: {}
 
 concurrency:
-  group: windows-${{ github.ref }}
+  group: windows-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
In a PR one top commit replaces the previous one.
But the central branches are more like timelines.
It's nice to have red crosses in a such timeline
as clear indicators that something was actually broken.