### PR TITLE
GHA: complain if PR adds commits from people not yet listed in ./AUTHORS

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -9,7 +9,6 @@ assignees: ''
 
 # Release Workflow
 
-- [ ] Check that the `.mailmap` and `AUTHORS` files are up to date
 - [ ] Update `ICINGA2_VERSION`
 - [ ] Update bundled Windows dependencies
 - [ ] Harden global TLS defaults (consult https://ssl-config.mozilla.org)

--- a/.github/workflows/authors-file.yml
+++ b/.github/workflows/authors-file.yml
@@ -1,0 +1,39 @@
+name: AUTHORS file
+
+on:
+  pull_request: { }
+
+jobs:
+  authors-file:
+    name: AUTHORS file
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check whether ./AUTHORS is up-to-date
+        run: |
+          set -exo pipefail
+          sort -uo AUTHORS AUTHORS
+          git add AUTHORS
+          git log --format='format:%aN <%aE>' "$(
+            git merge-base "origin/$GITHUB_BASE_REF" "origin/$GITHUB_HEAD_REF"
+          )..origin/$GITHUB_HEAD_REF" >> AUTHORS
+          sort -uo AUTHORS AUTHORS
+          git diff AUTHORS >> AUTHORS.diff
+
+      - name: Complain if ./AUTHORS isn't up-to-date
+        run: |
+          if [ -s AUTHORS.diff ]; then
+            cat <<'EOF' >&2
+          There are the following new authors. If the commit author data is correct,
+          either add them to the AUTHORS file or update .mailmap. See gitmailmap(5) or:
+          https://git-scm.com/docs/gitmailmap
+          Don't hesitate to ask us for help if necessary.
+          EOF
+            cat AUTHORS.diff
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,12 @@ refs #1234
 You can add multiple commits during your journey to finish your patch.
 Don't worry, you can squash those changes into a single commit later on.
 
+Ensure your name and email address in the commit metadata are correct.
+In your first contribution (PR) also add them to [AUTHORS](./AUTHORS).
+If those metadata changed since your last successful contribution,
+you should update [AUTHORS](./AUTHORS) and [.mailmap](./.mailmap).
+For the latter see [gitmailmap(5)](https://git-scm.com/docs/gitmailmap).
+
 ## <a id="contributing-pull-requests"></a> Pull Requests
 
 Once you've commited your changes, please update your local master


### PR DESCRIPTION
not to have to update ./AUTHORS or .mailmap after merging.

This substitutes ProBot functionality.