### PR TITLE
release.md: cherry-pick ICINGA2_VERSION and CHANGELOG.md into master

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -20,6 +20,7 @@ assignees: ''
 - [ ] Create release on GitHub
 - [ ] Update public docs
 - [ ] Announce release
+- [ ] Cherry-pick update of `ICINGA2_VERSION` and `CHANGELOG.md` into master
 
 ## Update Bundled Windows Dependencies
 


### PR DESCRIPTION
ICINGA2_VERSION to keep snapshot versions newer than others and CHANGELOG.md to keep it in sync.

This substitutes ProBot functionality.

fixes #10016