### PR TITLE
GHA: drop EOL Fedora 36

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,6 @@ jobs:
           - debian:10
           - debian:11 # and Raspbian 11
           - debian:12 # and Raspbian 12
-          - fedora:36
           - fedora:37
           - fedora:38
           - fedora:39


### PR DESCRIPTION
```
$ docker run --rm -it fedora:36
[root@000bc86eb193 /]# yum update
Fedora 36 - x86_64                               18 MB/s |  81 MB     00:04
Fedora 36 openh264 (From Cisco) - x86_64        1.9 kB/s | 2.5 kB     00:01
Fedora Modular 36 - x86_64                       91  B/s | 196  B     00:02
Errors during downloading metadata for repository 'fedora-modular':
  - Status code: 404 for http://mirror.rnet.missouri.edu/fedora/linux/releases/36/Modular/x86_64/os/repodata/repomd.xml (IP: 128.206.116.77)
  - Status code: 404 for https://d2lzkl7pfhq30w.cloudfront.net/pub/fedora/linux/releases/36/Modular/x86_64/os/repodata/repomd.xml (IP: 52.222.232.9)
  - Status code: 404 for https://dl.fedoraproject.org/pub/fedora/linux/releases/36/Modular/x86_64/os/repodata/repomd.xml (IP: 38.145.60.24)
  - Status code: 404 for http://dl.fedoraproject.org/pub/fedora/linux/releases/36/Modular/x86_64/os/repodata/repomd.xml (IP: 38.145.60.24)
  - Status code: 404 for http://ftp.tudelft.nl/download.fedora.redhat.com/linux/releases/36/Modular/x86_64/os/repodata/repomd.xml (IP: 130.161.131.20)
Error: Failed to download metadata for repo 'fedora-modular': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
[root@000bc86eb193 /]#
```