### PR TITLE
Remove redundant @RincewindsHat from AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -235,7 +235,6 @@ pv2b <pvz@pvz.pp.se>
 Ralph Breier <ralph.breier@roedl.com>
 Reto Zeder <reto.zeder@arcade.ch>
 Ricardo Bartels <ricardo@bitchbrothers.com>
-RincewindsHat <12514511+RincewindsHat@users.noreply.github.com>
 Rinck H. Sonnenberg <r.sonnenberg@netson.nl>
 Robert Lindgren <robert.lindgren@gmail.com>
 Robert Scheck <robert@fedoraproject.org>


### PR DESCRIPTION
.mailmap already translates him to Lorenz Kästle who is included in AUTHORS as well.