### PR TITLE
Update ITL for check_http and check_ssh

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -716,6 +716,7 @@ http_warn_time                   | **Optional.** The warning threshold.
 http_critical_time               | **Optional.** The critical threshold.
 http_expect                      | **Optional.** Comma-delimited list of strings, at least one of them is expected in the first (status) line of the server response. Default: HTTP/1.
 http_certificate                 | **Optional.** Minimum number of days a certificate has to be valid. Port defaults to 443. When this option is used the URL is not checked. The first parameter defines the warning threshold (in days), the second parameter the critical threshold (in days). (Example `http_certificate = "30,20"`).
+http_continue_after_certificate  | **Optional.** Allows the HTTP check to continue after performing the certificate check. Does nothing unless -C is used.
 http_clientcert                  | **Optional.** Name of file contains the client certificate (PEM format).
 http_privatekey                  | **Optional.** Name of file contains the private key (PEM format).
 http_headerstring                | **Optional.** String to expect in the response headers.
@@ -1412,13 +1413,15 @@ connects to an SSH server at a specified host and port.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
-Name            | Description
-----------------|--------------
-ssh_address     | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-ssh_port        | **Optional.** The port that should be checked. Defaults to 22.
-ssh_timeout     | **Optional.** Seconds before connection times out. Defaults to 10.
-ssh_ipv4        | **Optional.** Use IPv4 connection. Defaults to false.
-ssh_ipv6        | **Optional.** Use IPv6 connection. Defaults to false.
+Name                | Description
+--------------------|--------------
+ssh_address         | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+ssh_port            | **Optional.** The port that should be checked. Defaults to 22.
+ssh_timeout         | **Optional.** Seconds before connection times out. Defaults to 10.
+ssh_ipv4            | **Optional.** Use IPv4 connection. Defaults to false.
+ssh_ipv6            | **Optional.** Use IPv6 connection. Defaults to false.
+ssh_remote_version  | **Optional.** Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1).
+ssh_remote_protocol | **Optional.** Alert if protocol doesn't match expected protocol version (ex: 2.0).
 
 
 ### ssl <a id="plugin-check-command-ssl"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -425,6 +425,10 @@ object CheckCommand "http" {
 			value = "$http_certificate$"
 			description = "Minimum number of days a certificate has to be valid. This parameter explicitely sets the port to 443 and ignores the URL if passed."
 		}
+		"--continue-after-certificate" = {
+			set_if = "$http_continue_after_certificate$"
+			description = "Allows the HTTP check to continue after performing the certificate check. Does nothing unless -C is used."
+		}
 		"-J" = {
 			value = "$http_clientcert$"
 			description = "Name of file contains the client certificate (PEM format)"
@@ -1334,6 +1338,14 @@ object CheckCommand "ssh" {
 		"-6" = {
 			set_if = "$ssh_ipv6$"
 			description = "Use IPv6 connection"
+		}
+		"-r" = {
+			value = "$ssh_remote_version$"
+			description = "Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
+		}
+		"-P" = {
+			value = "$ssh_remote_protocol$"
+			description = "Alert if protocol doesn't match expected protocol version (ex: 2.0)"
 		}
 	}
 


### PR DESCRIPTION
Adds parameters for check_http and check_ssh based on nagios-plugins 2.3.3 / monitoring-plugins 2.3
Fixes #9922