### PR TITLE
Fix `/v1/actions/` deadlock & nullptr dereference

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -679,9 +679,6 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 bool ConfigItem::ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated,
 	bool mainConfigActivation, bool withModAttrs, const Value& cookie)
 {
-	static std::mutex mtx;
-	std::unique_lock<std::mutex> lock(mtx);
-
 	if (withModAttrs) {
 		/* restore modified attributes */
 		if (Utility::PathExists(Configuration::ModAttrPath)) {

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -316,11 +316,11 @@ Dictionary::Ptr ApiActions::AddComment(const ConfigObject::Ptr& object,
 		return ApiActions::CreateResult(503, "Icinga is reloading.");
 	}
 
-	String commentName = Comment::AddComment(checkable, CommentUser,
+	Comment::Ptr comment = Comment::AddComment(checkable, CommentUser,
 		HttpUtility::GetLastParameter(params, "author"),
 		HttpUtility::GetLastParameter(params, "comment"), false, timestamp);
 
-	Comment::Ptr comment = Comment::GetByName(commentName);
+	String commentName = comment->GetName();
 
 	Dictionary::Ptr additional = new Dictionary({
 		{ "name", commentName },

--- a/lib/icinga/comment.cpp
+++ b/lib/icinga/comment.cpp
@@ -130,7 +130,7 @@ int Comment::GetNextCommentID()
 	return l_NextCommentID;
 }
 
-String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryType, const String& author,
+Comment::Ptr Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryType, const String& author,
 	const String& text, bool persistent, double expireTime, bool sticky, const String& id, const MessageOrigin::Ptr& origin)
 {
 	String fullName;
@@ -184,7 +184,7 @@ String Comment::AddComment(const Checkable::Ptr& checkable, CommentType entryTyp
 	Log(LogNotice, "Comment")
 		<< "Added comment '" << comment->GetName() << "'.";
 
-	return fullName;
+	return comment;
 }
 
 void Comment::RemoveComment(const String& id, bool removedManually, const String& removedBy,

--- a/lib/icinga/comment.hpp
+++ b/lib/icinga/comment.hpp
@@ -34,7 +34,7 @@ public:
 
 	static int GetNextCommentID();
 
-	static String AddComment(const intrusive_ptr<Checkable>& checkable, CommentType entryType,
+	static Ptr AddComment(const intrusive_ptr<Checkable>& checkable, CommentType entryType,
 		const String& author, const String& text, bool persistent, double expireTime, bool sticky = false,
 		const String& id = String(), const MessageOrigin::Ptr& origin = nullptr);
 


### PR DESCRIPTION
 Object lock was introduced by 798ea5417 to refuse acking an already acked checkable.
 I think we can unlock checkable object after ack check.

fixes #9916