### PR TITLE
Bump Boost shipped for Windows to v1.83

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -477,18 +477,18 @@ File Type: EXECUTABLE IMAGE
 
   Image has the following dependencies:
 
-    boost_coroutine-vc142-mt-gd-x64-1_82.dll
-    boost_date_time-vc142-mt-gd-x64-1_82.dll
-    boost_filesystem-vc142-mt-gd-x64-1_82.dll
-    boost_thread-vc142-mt-gd-x64-1_82.dll
-    boost_regex-vc142-mt-gd-x64-1_82.dll
+    boost_coroutine-vc142-mt-gd-x64-1_83.dll
+    boost_date_time-vc142-mt-gd-x64-1_83.dll
+    boost_filesystem-vc142-mt-gd-x64-1_83.dll
+    boost_thread-vc142-mt-gd-x64-1_83.dll
+    boost_regex-vc142-mt-gd-x64-1_83.dll
     libssl-3_0-x64.dll
     libcrypto-3_0-x64.dll
     WS2_32.dll
     dbghelp.dll
     SHLWAPI.dll
     msi.dll
-    boost_unit_test_framework-vc142-mt-gd-x64-1_82.dll
+    boost_unit_test_framework-vc142-mt-gd-x64-1_83.dll
     KERNEL32.dll
     SHELL32.dll
     ADVAPI32.dll
@@ -1763,7 +1763,7 @@ mkdir build
 cd .\build\
 
 & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
-  -DICINGA2_UNITY_BUILD=OFF -DBoost_INCLUDE_DIR=C:\local\boost_1_82_0-Win64 `
+  -DICINGA2_UNITY_BUILD=OFF -DBoost_INCLUDE_DIR=C:\local\boost_1_83_0-Win64 `
   -DBISON_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_bison.exe `
   -DFLEX_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_flex.exe ..
 
@@ -1935,16 +1935,16 @@ Download the [boost-binaries](https://sourceforge.net/projects/boost/files/boost
 - 64 for 64 bit builds
 
 ```
-https://sourceforge.net/projects/boost/files/boost-binaries/1.82.0/boost_1_82_0-msvc-14.2-64.exe/download
+https://sourceforge.net/projects/boost/files/boost-binaries/1.82.0/boost_1_83_0-msvc-14.2-64.exe/download
 ```
 
-Run the installer and leave the default installation path in `C:\local\boost_1_82_0`.
+Run the installer and leave the default installation path in `C:\local\boost_1_83_0`.
 
 
 ##### Source & Compile
 
 In order to use the boost development header and library files you need to [download](https://www.boost.org/users/download/)
-Boost and then extract it to e.g. `C:\local\boost_1_82_0`.
+Boost and then extract it to e.g. `C:\local\boost_1_83_0`.
 
 > **Note**
 >
@@ -1952,12 +1952,12 @@ Boost and then extract it to e.g. `C:\local\boost_1_82_0`.
 > the archive contains more than 70k files.
 
 In order to integrate Boost into Visual Studio, open the `Developer Command Prompt` from the start menu,
-and navigate to `C:\local\boost_1_82_0`.
+and navigate to `C:\local\boost_1_83_0`.
 
 Execute `bootstrap.bat` first.
 
 ```
-cd C:\local\boost_1_82_0
+cd C:\local\boost_1_83_0
 bootstrap.bat
 ```
 
@@ -2040,8 +2040,8 @@ You need to specify the previously installed component paths.
 
 Variable              | Value                                                                | Description
 ----------------------|----------------------------------------------------------------------|-------------------------------------------------------
-`BOOST_ROOT`          | `C:\local\boost_1_82_0`                                                    | Root path where you've extracted and compiled Boost.
-`BOOST_LIBRARYDIR`    | Binary: `C:\local\boost_1_82_0\lib64-msvc-14.2`, Source: `C:\local\boost_1_82_0\stage` | Path to the static compiled Boost libraries, directory must contain `lib`.
+`BOOST_ROOT`          | `C:\local\boost_1_83_0`                                                    | Root path where you've extracted and compiled Boost.
+`BOOST_LIBRARYDIR`    | Binary: `C:\local\boost_1_83_0\lib64-msvc-14.2`, Source: `C:\local\boost_1_83_0\stage` | Path to the static compiled Boost libraries, directory must contain `lib`.
 `BISON_EXECUTABLE`    | `C:\ProgramData\chocolatey\lib\winflexbison\tools\win_bison.exe`     | Path to the Bison executable.
 `FLEX_EXECUTABLE`     | `C:\ProgramData\chocolatey\lib\winflexbison\tools\win_flex.exe`      | Path to the Flex executable.
 `ICINGA2_UNITY_BUILD` | OFF                                                                  | Disable unity builds for development environments.
@@ -2076,8 +2076,8 @@ $env:ICINGA2_INSTALLPATH = 'C:\Program Files\Icinga2-debug'
 $env:ICINGA2_BUILDPATH='debug'
 $env:CMAKE_BUILD_TYPE='Debug'
 $env:OPENSSL_ROOT_DIR='C:\OpenSSL-Win64'
-$env:BOOST_ROOT='C:\local\boost_1_82_0'
-$env:BOOST_LIBRARYDIR='C:\local\boost_1_82_0\lib64-msvc-14.2'
+$env:BOOST_ROOT='C:\local\boost_1_83_0'
+$env:BOOST_LIBRARYDIR='C:\local\boost_1_83_0\lib64-msvc-14.2'
 ```
 
 #### Icinga 2 in Visual Studio

--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -13,7 +13,7 @@ function ThrowOnNativeFailure {
 
 $VsVersion = 2019
 $MsvcVersion = '14.2'
-$BoostVersion = @(1, 82, 0)
+$BoostVersion = @(1, 83, 0)
 $OpensslVersion = '3_0_9'
 
 switch ($Env:BITS) {

--- a/tools/win32/configure-dev.ps1
+++ b/tools/win32/configure-dev.ps1
@@ -31,10 +31,10 @@ if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
   $env:OPENSSL_ROOT_DIR = 'c:\local\OpenSSL-Win64'
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = 'c:\local\boost_1_82_0'
+  $env:BOOST_ROOT = 'c:\local\boost_1_83_0'
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_82_0\lib64-msvc-14.2'
+  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_83_0\lib64-msvc-14.2'
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -33,10 +33,10 @@ if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
   $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_0_9-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = "c:\local\boost_1_82_0-Win${env:BITS}"
+  $env:BOOST_ROOT = "c:\local\boost_1_83_0-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_82_0-Win${env:BITS}\lib${env:BITS}-msvc-14.2"
+  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_83_0-Win${env:BITS}\lib${env:BITS}-msvc-14.2"
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'


### PR DESCRIPTION
Note: For doc/21-development.md use:

perl -pi -e 's/(boost[-\w]*?1[-_]?)82/${1}83/g' doc/21-development.md