### PR TITLE
Disallow triggering a cancelled downtime

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -471,6 +471,8 @@ void Downtime::SetupCleanupTimer()
 
 void Downtime::TriggerDowntime(double triggerTime)
 {
+	ObjectLock oLock (this);
+
 	if (!CanBeTriggered())
 		return;
 
@@ -483,10 +485,9 @@ void Downtime::TriggerDowntime(double triggerTime)
 		SetTriggerTime(triggerTime);
 	}
 
-	{
-		ObjectLock olock (this);
-		SetupCleanupTimer();
-	}
+	SetupCleanupTimer();
+	OnDowntimeTriggered(this);
+	oLock.Unlock();
 
 	Array::Ptr triggers = GetTriggers();
 
@@ -501,8 +502,6 @@ void Downtime::TriggerDowntime(double triggerTime)
 			downtime->TriggerDowntime(triggerTime);
 		}
 	}
-
-	OnDowntimeTriggered(this);
 }
 
 void Downtime::SetRemovalInfo(const String& removedBy, double removeTime, const MessageOrigin::Ptr& origin) {

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -430,6 +430,9 @@ std::set<Downtime::Ptr> Downtime::GetChildren() const
 
 bool Downtime::CanBeTriggered()
 {
+	if (!GetActive() || GetWasCancelled())
+		return false;
+
 	if (IsInEffect() && IsTriggered())
 		return false;
 

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -40,6 +40,7 @@ public:
 	bool IsInEffect() const;
 	bool IsTriggered() const;
 	bool IsExpired() const;
+	bool CanBeTriggered();
 	bool HasValidConfigOwner() const;
 
 	static void StaticInitialize();
@@ -85,8 +86,6 @@ private:
 	mutable std::mutex m_ChildrenMutex;
 
 	Timer::Ptr m_CleanupTimer;
-
-	bool CanBeTriggered();
 
 	void SetupCleanupTimer();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(base_test_SOURCES
   config-ops.cpp
   icinga-checkresult.cpp
   icinga-dependencies.cpp
+  icinga-downtime.cpp
   icinga-legacytimeperiod.cpp
   icinga-macros.cpp
   icinga-notification.cpp
@@ -135,6 +136,13 @@ add_boost_test(base
     icinga_checkresult/service_flapping_notification
     icinga_checkresult/suppressed_notification
     icinga_dependencies/multi_parent
+    icinga_downtime/canbetriggered_fixed
+    icinga_downtime/canbetriggered_flexible
+    icinga_downtime/canbetriggered_inactive
+    icinga_downtime/canbetriggered_removed
+    icinga_downtime/canbetriggered_triggered
+    icinga_downtime/canbetriggered_expired
+    icinga_downtime/canbetriggered_tooearly
     icinga_notification/strings
     icinga_notification/state_filter
     icinga_notification/type_filter

--- a/test/icinga-downtime.cpp
+++ b/test/icinga-downtime.cpp
@@ -1,0 +1,70 @@
+/* Icinga 2 | (c) 2023 Icinga GmbH | GPLv2+ */
+
+#include "base/utility.hpp"
+#include "icinga/downtime.hpp"
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+static void CanBeTriggeredHelper(
+	bool active, bool fixed, double relStart, double relEnd, double duration, Value relTriggered, Value relRemoved, bool canBeTriggered
+)
+{
+	Downtime::Ptr dt = new Downtime();
+	auto now (Utility::GetTime());
+
+	dt->SetActive(active, true);
+	dt->SetFixed(fixed, true);
+	dt->SetStartTime(now + relStart, true);
+	dt->SetEndTime(now + relEnd, true);
+	dt->SetDuration(duration, true);
+
+	if (!relTriggered.IsEmpty()) {
+		dt->SetTriggerTime(now + relTriggered, true);
+	}
+
+	if (!relRemoved.IsEmpty()) {
+		dt->SetRemoveTime(now + relRemoved, true);
+	}
+
+	BOOST_CHECK(dt->CanBeTriggered() == canBeTriggered);
+}
+
+BOOST_AUTO_TEST_SUITE(icinga_downtime)
+
+BOOST_AUTO_TEST_CASE(canbetriggered_fixed)
+{
+	CanBeTriggeredHelper(true, true, -2, 8, 0, Empty, Empty, true);
+}
+
+BOOST_AUTO_TEST_CASE(canbetriggered_flexible)
+{
+	CanBeTriggeredHelper(true, false, -2, 8, 20, Empty, Empty, true);
+}
+
+BOOST_AUTO_TEST_CASE(canbetriggered_inactive)
+{
+	CanBeTriggeredHelper(false, true, -2, 8, 0, Empty, Empty, false);
+}
+
+BOOST_AUTO_TEST_CASE(canbetriggered_removed)
+{
+	CanBeTriggeredHelper(true, true, -2, 8, 0, Empty, -4, false);
+}
+
+BOOST_AUTO_TEST_CASE(canbetriggered_triggered)
+{
+	CanBeTriggeredHelper(true, true, -2, 8, 0, -1, Empty, false);
+}
+
+BOOST_AUTO_TEST_CASE(canbetriggered_expired)
+{
+	CanBeTriggeredHelper(true, true, -12, -2, 0, Empty, Empty, false);
+}
+
+BOOST_AUTO_TEST_CASE(canbetriggered_tooearly)
+{
+	CanBeTriggeredHelper(true, true, 2, 12, 0, Empty, Empty, false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The optional part of

* #9896

which adds some locking which isn't trivial, especially in Icinga 2. 😢