### PR TITLE
release.md: Merge docker-icinga2 dependency updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -16,6 +16,7 @@ assignees: ''
 - [ ] Create and push a signed tag for the version
 - [ ] Build and release DEB and RPM packages
 - [ ] Build and release Windows packages
+- [ ] Merge dependency updates in https://github.com/Icinga/docker-icinga2/pulls
 - [ ] Create release on GitHub
 - [ ] Update public docs
 - [ ] Announce release


### PR DESCRIPTION
so that they're included in the Docker image our release GHA will build.

Already done for v2.14.1 btw.