### PR TITLE
FilterUtility::GetFilterTargets(): don't run filter for specific object(s) for all objects

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -68,6 +68,20 @@ bool Dictionary::Get(const String& key, Value *result) const
 }
 
 /**
+ * Retrieves a value's address from a dictionary.
+ *
+ * @param key The key whose value's address should be retrieved.
+ * @returns nullptr if the key was not found.
+ */
+const Value * Dictionary::GetRef(const String& key) const
+{
+	std::shared_lock<std::shared_timed_mutex> lock (m_DataMutex);
+	auto it (m_Data.find(key));
+
+	return it == m_Data.end() ? nullptr : &it->second;
+}
+
+/**
  * Sets a value in the dictionary.
  *
  * @param key The key.

--- a/lib/base/dictionary.hpp
+++ b/lib/base/dictionary.hpp
@@ -42,6 +42,7 @@ public:
 
 	Value Get(const String& key) const;
 	bool Get(const String& key, Value *result) const;
+	const Value * GetRef(const String& key) const;
 	void Set(const String& key, Value value, bool overrideFrozen = false);
 	bool Contains(const String& key) const;
 

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -108,12 +108,13 @@ private:
 	static RuleMap m_Rules;
 
 	static bool AddTargetedRule(const ApplyRule::Ptr& rule, const String& targetType, PerSourceType& rules);
-	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts);
-	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services);
-	static std::pair<const String *, const String *> GetTargetService(Expression* assignFilter);
-	static const String * GetComparedName(Expression* assignFilter, const char * lcType);
-	static bool IsNameIndexer(Expression* exp, const char * lcType);
-	static const String * GetLiteralStringValue(Expression* exp);
+	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts, const Dictionary::Ptr& constants = nullptr);
+	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services, const Dictionary::Ptr& constants = nullptr);
+	static std::pair<const String *, const String *> GetTargetService(Expression* assignFilter, const Dictionary::Ptr& constants);
+	static const String * GetComparedName(Expression* assignFilter, const char * lcType, const Dictionary::Ptr& constants);
+	static bool IsNameIndexer(Expression* exp, const char * lcType, const Dictionary::Ptr& constants);
+	static const String * GetConstString(Expression* exp, const Dictionary::Ptr& constants);
+	static const Value * GetConst(Expression* exp, const Dictionary::Ptr& constants);
 
 	ApplyRule(String name, Expression::Ptr expression,
 		Expression::Ptr filter, String package, String fkvar, String fvvar, Expression::Ptr fterm,

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -82,6 +82,8 @@ public:
 	static const std::vector<ApplyRule::Ptr>& GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType);
 	static const std::set<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const String& host);
 	static const std::set<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service);
+	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts, const Dictionary::Ptr& constants = nullptr);
+	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services, const Dictionary::Ptr& constants = nullptr);
 
 	static void RegisterType(const String& sourceType, const std::vector<String>& targetTypes);
 	static bool IsValidSourceType(const String& sourceType);
@@ -108,8 +110,6 @@ private:
 	static RuleMap m_Rules;
 
 	static bool AddTargetedRule(const ApplyRule::Ptr& rule, const String& targetType, PerSourceType& rules);
-	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts, const Dictionary::Ptr& constants = nullptr);
-	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services, const Dictionary::Ptr& constants = nullptr);
 	static std::pair<const String *, const String *> GetTargetService(Expression* assignFilter, const Dictionary::Ptr& constants);
 	static const String * GetComparedName(Expression* assignFilter, const char * lcType, const Dictionary::Ptr& constants);
 	static bool IsNameIndexer(Expression* exp, const char * lcType, const Dictionary::Ptr& constants);

--- a/lib/config/expression.hpp
+++ b/lib/config/expression.hpp
@@ -622,6 +622,11 @@ public:
 
 	void MakeInline();
 
+	inline const std::vector<std::unique_ptr<Expression>>& GetExpressions() const noexcept
+	{
+		return m_Expressions;
+	}
+
 protected:
 	ExpressionResult DoEvaluate(ScriptFrame& frame, DebugHint *dhint) const override;
 

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -2,6 +2,7 @@
 
 #include "remote/filterutility.hpp"
 #include "remote/httputility.hpp"
+#include "config/applyrule.hpp"
 #include "config/configcompiler.hpp"
 #include "config/expression.hpp"
 #include "base/namespace.hpp"
@@ -271,18 +272,73 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 		if (query->Contains("filter")) {
 			String filter = HttpUtility::GetLastParameter(query, "filter");
 			std::unique_ptr<Expression> ufilter = ConfigCompiler::CompileText("<API query>", filter);
-
 			Dictionary::Ptr filter_vars = query->Get("filter_vars");
-			if (filter_vars) {
-				ObjectLock olock(filter_vars);
-				for (const Dictionary::Pair& kv : filter_vars) {
-					frameNS->Set(kv.first, kv.second);
+			bool targeted = false;
+			std::vector<ConfigObject::Ptr> targets;
+
+			if (dynamic_cast<ConfigObjectTargetProvider*>(provider.get())) {
+				auto dict (dynamic_cast<DictExpression*>(ufilter.get()));
+
+				if (dict) {
+					auto& subex (dict->GetExpressions());
+
+					if (subex.size() == 1u) {
+						if (type == "Host") {
+							std::vector<const String *> targetNames;
+
+							if (ApplyRule::GetTargetHosts(subex.at(0).get(), targetNames, filter_vars)) {
+								static const auto typeHost (Type::GetByName("Host"));
+								static const auto ctypeHost (dynamic_cast<ConfigType*>(typeHost.get()));
+								targeted = true;
+
+								for (auto name : targetNames) {
+									auto target (ctypeHost->GetObject(*name));
+
+									if (target) {
+										targets.emplace_back(target);
+									}
+								}
+							}
+						} else if (type == "Service") {
+							std::vector<std::pair<const String *, const String *>> targetNames;
+
+							if (ApplyRule::GetTargetServices(subex.at(0).get(), targetNames, filter_vars)) {
+								static const auto typeService (Type::GetByName("Service"));
+								static const auto ctypeService (dynamic_cast<ConfigType*>(typeService.get()));
+								targeted = true;
+
+								for (auto name : targetNames) {
+									auto target (ctypeService->GetObject(*name.first + "!" + *name.second));
+
+									if (target) {
+										targets.emplace_back(target);
+									}
+								}
+							}
+						}
+					}
 				}
 			}
 
-			provider->FindTargets(type, [&permissionFrame, &permissionFilter, &frame, &ufilter, &result, variableName](const Object::Ptr& target) {
-				FilteredAddTarget(permissionFrame, permissionFilter.get(), frame, &*ufilter, result, variableName, target);
-			});
+			if (targeted) {
+				for (auto& target : targets) {
+					if (FilterUtility::EvaluateFilter(permissionFrame, permissionFilter.get(), target, variableName)) {
+						result.emplace_back(std::move(target));
+					}
+				}
+			} else {
+				if (filter_vars) {
+					ObjectLock olock (filter_vars);
+
+					for (auto& kv : filter_vars) {
+						frameNS->Set(kv.first, kv.second);
+					}
+				}
+
+				provider->FindTargets(type, [&permissionFrame, &permissionFilter, &frame, &ufilter, &result, variableName](const Object::Ptr& target) {
+					FilteredAddTarget(permissionFrame, permissionFilter.get(), frame, &*ufilter, result, variableName, target);
+				});
+			}
 		} else {
 			/* Ensure to pass a nullptr as filter expression.
 			 * GCC 8.1.1 on F28 causes problems, see GH #6533.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(base_test_SOURCES
   base-type.cpp
   base-utility.cpp
   base-value.cpp
+  config-apply.cpp
   config-ops.cpp
   icinga-checkresult.cpp
   icinga-dependencies.cpp
@@ -123,6 +124,38 @@ add_boost_test(base
     base_value/scalar
     base_value/convert
     base_value/format
+    config_apply/gettargethosts_literal
+    config_apply/gettargethosts_const
+    config_apply/gettargethosts_swapped
+    config_apply/gettargethosts_two
+    config_apply/gettargethosts_three
+    config_apply/gettargethosts_mixed
+    config_apply/gettargethosts_redundant
+    config_apply/gettargethosts_badconst
+    config_apply/gettargethosts_notliteral
+    config_apply/gettargethosts_wrongop
+    config_apply/gettargethosts_wrongattr
+    config_apply/gettargethosts_wrongvar
+    config_apply/gettargethosts_noindexer
+    config_apply/gettargetservices_literal
+    config_apply/gettargetservices_const
+    config_apply/gettargetservices_swapped_outer
+    config_apply/gettargetservices_swapped_inner
+    config_apply/gettargetservices_two
+    config_apply/gettargetservices_three
+    config_apply/gettargetservices_mixed
+    config_apply/gettargetservices_redundant
+    config_apply/gettargetservices_badconst
+    config_apply/gettargetservices_notliteral
+    config_apply/gettargetservices_wrongop_outer
+    config_apply/gettargetservices_wrongop_host
+    config_apply/gettargetservices_wrongop_service
+    config_apply/gettargetservices_wrongattr_host
+    config_apply/gettargetservices_wrongattr_service
+    config_apply/gettargetservices_wrongvar_host
+    config_apply/gettargetservices_wrongvar_service
+    config_apply/gettargetservices_noindexer_host
+    config_apply/gettargetservices_noindexer_service
     config_ops/simple
     config_ops/advanced
     icinga_checkresult/host_1attempt

--- a/test/config-apply.cpp
+++ b/test/config-apply.cpp
@@ -22,6 +22,15 @@ static Expression* RequireActualExpression(const std::unique_ptr<Expression>& co
 	return sub0;
 }
 
+template<>
+struct boost::test_tools::tt_detail::print_log_value<std::pair<String, String>>
+{
+	inline void operator()(std::ostream& os, const std::pair<String, String>& hs)
+	{
+		os << hs.first << "!" << hs.second;
+	}
+};
+
 static void GetTargetHostsHelper(
 	const String& filter, const Dictionary::Ptr& constants, bool targeted, const std::vector<String>& hosts = {}
 )
@@ -64,7 +73,7 @@ static void GetTargetServicesHelper(
 			actualServiceNames.emplace_back(*s.first, *s.second);
 		}
 
-		BOOST_CHECK(actualServiceNames == services);
+		BOOST_CHECK_EQUAL_COLLECTIONS(actualServiceNames.begin(), actualServiceNames.end(), services.begin(), services.end());
 	}
 }
 

--- a/test/config-apply.cpp
+++ b/test/config-apply.cpp
@@ -1,0 +1,242 @@
+/* Icinga 2 | (c) 2023 Icinga GmbH | GPLv2+ */
+
+#include "config/applyrule.hpp"
+#include "config/configcompiler.hpp"
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+static Expression* RequireActualExpression(const std::unique_ptr<Expression>& compiledExpression)
+{
+	BOOST_REQUIRE_NE(compiledExpression.get(), nullptr);
+
+	auto dict (dynamic_cast<DictExpression*>(compiledExpression.get()));
+	BOOST_REQUIRE_NE(dict, nullptr);
+
+	auto& subex (dict->GetExpressions());
+	BOOST_REQUIRE_EQUAL(subex.size(), 1u);
+
+	auto sub0 (subex.at(0).get());
+	BOOST_REQUIRE_NE(sub0, nullptr);
+
+	return sub0;
+}
+
+static void GetTargetHostsHelper(
+	const String& filter, const Dictionary::Ptr& constants, bool targeted, const std::vector<String>& hosts = {}
+)
+{
+	auto compiled (ConfigCompiler::CompileText("<test>", filter));
+	auto expr (RequireActualExpression(compiled));
+	std::vector<const String*> actualHosts;
+
+	BOOST_CHECK_EQUAL(ApplyRule::GetTargetHosts(expr, actualHosts, constants), targeted);
+
+	if (targeted) {
+		std::vector<String> actualHostNames;
+
+		actualHostNames.reserve(actualHosts.size());
+
+		for (auto h : actualHosts) {
+			actualHostNames.emplace_back(*h);
+		}
+
+		BOOST_CHECK_EQUAL_COLLECTIONS(actualHostNames.begin(), actualHostNames.end(), hosts.begin(), hosts.end());
+	}
+}
+
+static void GetTargetServicesHelper(
+	const String& filter, const Dictionary::Ptr& constants, bool targeted, const std::vector<std::pair<String, String>>& services = {}
+)
+{
+	auto compiled (ConfigCompiler::CompileText("<test>", filter));
+	auto expr (RequireActualExpression(compiled));
+	std::vector<std::pair<const String*, const String*>> actualServices;
+
+	BOOST_CHECK_EQUAL(ApplyRule::GetTargetServices(expr, actualServices, constants), targeted);
+
+	if (targeted) {
+		std::vector<std::pair<String, String>> actualServiceNames;
+
+		actualServiceNames.reserve(actualServices.size());
+
+		for (auto s : actualServices) {
+			actualServiceNames.emplace_back(*s.first, *s.second);
+		}
+
+		BOOST_CHECK(actualServiceNames == services);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE(config_apply)
+
+BOOST_AUTO_TEST_CASE(gettargethosts_literal)
+{
+	GetTargetHostsHelper("host.name == \"foo\"", nullptr, true, {"foo"});
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_const)
+{
+	GetTargetHostsHelper("host.name == x", new Dictionary({{"x", "foo"}}), true, {"foo"});
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_swapped)
+{
+	GetTargetHostsHelper("\"foo\" == host.name", nullptr, true, {"foo"});
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_two)
+{
+	GetTargetHostsHelper("host.name == \"foo\" || host.name == \"bar\"", nullptr, true, {"foo", "bar"});
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_three)
+{
+	GetTargetHostsHelper(
+		"host.name == \"foo\" || host.name == \"bar\" || host.name == \"foobar\"",
+		nullptr, true, {"foo", "bar", "foobar"}
+	);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_mixed)
+{
+	GetTargetHostsHelper("host.name == x || \"bar\" == host.name", new Dictionary({{"x", "foo"}}), true, {"foo", "bar"});
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_redundant)
+{
+	GetTargetHostsHelper("host.name == \"foo\" && 1", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_badconst)
+{
+	GetTargetHostsHelper("host.name == NodeName", new Dictionary({{"x", "foo"}}), false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_notliteral)
+{
+	GetTargetHostsHelper("host.name == \"foo\" + \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_wrongop)
+{
+	GetTargetHostsHelper("host.name != \"foo\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_wrongattr)
+{
+	GetTargetHostsHelper("host.__name == \"foo\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_wrongvar)
+{
+	GetTargetHostsHelper("service.name == \"foo\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargethosts_noindexer)
+{
+	GetTargetHostsHelper("name == \"foo\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_literal)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && service.name == \"bar\"", nullptr, true, {{"foo", "bar"}});
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_const)
+{
+	GetTargetServicesHelper("host.name == x && service.name == y", new Dictionary({{"x", "foo"}, {"y", "bar"}}), true, {{"foo", "bar"}});
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_swapped_outer)
+{
+	GetTargetServicesHelper("service.name == \"bar\" && host.name == \"foo\"", nullptr, true, {{"foo", "bar"}});
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_swapped_inner)
+{
+	GetTargetServicesHelper("\"foo\" == host.name && \"bar\" == service.name", nullptr, true, {{"foo", "bar"}});
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_two)
+{
+	GetTargetServicesHelper(
+		"host.name == \"foo\" && service.name == \"bar\" || host.name == \"oof\" && service.name == \"rab\"",
+		nullptr, true, {{"foo", "bar"}, {"oof", "rab"}}
+	);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_three)
+{
+	GetTargetServicesHelper(
+		"host.name == \"foo\" && service.name == \"bar\" || host.name == \"oof\" && service.name == \"rab\" || host.name == \"ofo\" && service.name == \"rba\"",
+		nullptr, true, {{"foo", "bar"}, {"oof", "rab"}, {"ofo", "rba"}}
+	);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_mixed)
+{
+	GetTargetServicesHelper("\"bar\" == service.name && x == host.name", new Dictionary({{"x", "foo"}}), true, {{"foo", "bar"}});
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_redundant)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && service.name == \"bar\" && 1", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_badconst)
+{
+	GetTargetServicesHelper("host.name == NodeName && service.name == \"bar\"", new Dictionary({{"x", "foo"}}), false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_notliteral)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && service.name == \"b\" + \"ar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongop_outer)
+{
+	GetTargetServicesHelper("host.name == \"foo\" & service.name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongop_host)
+{
+	GetTargetServicesHelper("host.name != \"foo\" && service.name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongop_service)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && service.name != \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongattr_host)
+{
+	GetTargetServicesHelper("host.__name == \"foo\" && service.name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongattr_service)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && service.__name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongvar_host)
+{
+	GetTargetServicesHelper("horst.name == \"foo\" && service.name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_wrongvar_service)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && sehrvice.name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_noindexer_host)
+{
+	GetTargetServicesHelper("name == \"foo\" && service.name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_CASE(gettargetservices_noindexer_service)
+{
+	GetTargetServicesHelper("host.name == \"foo\" && name == \"bar\"", nullptr, false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backport of #9895