### PR TITLE
HttpServerConnection: remove duplicate ")" from a log message

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -543,7 +543,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 
 			logMsg << "Request: " << request.method_string() << ' ' << request.target()
 				<< " (from " << m_PeerAddress
-				<< "), user: " << (authenticatedUser ? authenticatedUser->GetName() : "<unauthenticated>")
+				<< ", user: " << (authenticatedUser ? authenticatedUser->GetName() : "<unauthenticated>")
 				<< ", agent: " << request[http::field::user_agent]; //operator[] - Returns the value for a field, or "" if it does not exist.
 
 			Defer addRespCode ([&response, &logMsg]() {


### PR DESCRIPTION
The commit 5c32a5a7dcd220598d36b2b47e745d14c23edb93, which introduced it, clearly shows that the other ")" already existed legitimately.