### PR TITLE
Fix typo in API Doc example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,6 +208,7 @@ mocruz <mocruz@theworkshop.com>
 Muhammad Mominul Huque <nahidbinbaten1995@gmail.com>
 nemtrif <ntrifunovic@hotmail.com>
 Nicolai <nbuchwitz@users.noreply.github.com>
+Nicolas Berens <nicolas.berens@planet.com>
 Nicolas Limage <github@xephon.org>
 Nicole Lang <nicole.lang@icinga.com>
 Niflou <dubuscyr@gmail.com>

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -950,7 +950,7 @@ list the latter in the `restore_attrs` parameter. E.g.:
 ```bash
 curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
  -X POST 'https://localhost:5665/v1/objects/hosts/example.localdomain' \
- -d '{ "restore_attrs": [ "address", "vars.os" ] }, "pretty": true }'
+ -d '{ "restore_attrs": [ "address", "vars.os" ], "pretty": true }'
 ```
 
 ```json


### PR DESCRIPTION
This PR removes an extraneous extra bracket that broke an example command.

fixes #10004 