### PR TITLE
HttpServerConnection: always log request filter if any, for debugging

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -510,13 +510,50 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 				<< ", agent: " << request[http::field::user_agent]; //operator[] - Returns the value for a field, or "" if it does not exist.
 
 			ch::steady_clock::duration cpuBoundWorkTime(0);
-			Defer addRespCode ([&response, start, &logMsg, &cpuBoundWorkTime]() {
+			Defer addRespCode ([&request, &response, start, &logMsg, &cpuBoundWorkTime]() {
 				logMsg << ", status: " << response.result() << ")";
 				if (cpuBoundWorkTime >= ch::seconds(1)) {
 					logMsg << " waited " << ch::duration_cast<ch::milliseconds>(cpuBoundWorkTime).count() << "ms on semaphore and";
 				}
 
 				logMsg << " took total " << ch::duration_cast<ch::milliseconds>(ch::steady_clock::now() - start).count() << "ms.";
+
+				if (request.User() && request.Params()) {
+					auto filter (HttpUtility::GetLastParameter(request.Params(), "filter"));
+
+					if (filter.GetType() != ValueEmpty) {
+						bool urlHasFilter = false;
+
+						if (request.Url()) {
+							for (auto& kv : request.Url()->GetQuery()) {
+								if (kv.first == "filter") {
+									urlHasFilter = true;
+									break;
+								}
+							}
+						}
+
+						if (!urlHasFilter) {
+							auto type (HttpUtility::GetLastParameter(request.Params(), "type"));
+
+							if (type.GetType() == ValueEmpty) {
+								logMsg << " Filter: ";
+							} else {
+								logMsg << ' ' << type << " filter: ";
+							}
+
+							String filterStr = filter;
+							const auto filterLimit (1024u);
+
+							if (filterStr.GetLength() > filterLimit) {
+								filterStr.erase(filterStr.Begin() + filterLimit, filterStr.End());
+								filterStr += "...";
+							}
+
+							logMsg << filterStr;
+						}
+					}
+				}
 			});
 
 			if (!HandleAccessControl(request, response, yc)) {


### PR DESCRIPTION
Even if it's in the request body.

# Tests

## No filter

`[2024-01-16 17:38:23 +0100] information/HttpServerConnection: Request POST https://127.0.0.1:5665/v1/console/execute-script?session=3270231b-f3fe-401d-a77b-2a5e9d3b0fd6&command&sandboxed=0 (from [::ffff:127.0.0.1]:58972), user: root, agent: Icinga/DebugConsole/v2.14.0-92-gf075d1e0d, status: OK) took 1ms.`

## URL filter

`[2024-01-16 17:40:35 +0100] information/HttpServerConnection: Request GET /v1/objects/services?filter=1 (from [::ffff:127.0.0.1]:58978), user: root, agent: curl/8.1.2, status: OK) took 31ms.`

## Body filter

`[2024-01-16 17:39:13 +0100] information/HttpServerConnection: Request GET /v1/objects/services (from [::ffff:127.0.0.1]:58973), user: root, agent: curl/8.1.2, status: OK) took 0ms. Service filter: y == service.name && x == host.name`

## Long body filter

`[2024-01-17 11:11:45 +0100] information/HttpServerConnection: Request GET /v1/objects/services (from [::ffff:127.0.0.1]:59835), user: root, agent: curl/8.1.2, status: OK) took 1ms. Service filter: y == service.name && x == host.name // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`

## Too long body filter

`[2024-01-17 11:11:25 +0100] information/HttpServerConnection: Request GET /v1/objects/services (from [::ffff:127.0.0.1]:59834), user: root, agent: curl/8.1.2, status: OK) took 1ms. Service filter: y == service.name && x == host.name // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...`

👍