### PR TITLE
add multiplier option to check_snmp which is available since monitori…

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1322,6 +1322,7 @@ snmp_invert_search  | **Optional.** Invert search result and return CRITICAL sta
 snmp_units          | **Optional.** Units label(s) for output value (e.g., 'sec.').
 snmp_version        | **Optional.** Version to use. E.g. 1, 2, 2c or 3.
 snmp_miblist        | **Optional.** MIB's to use, comma separated. Defaults to "ALL".
+snmp_multiplier     |**Optional.** Multiplies current value, 0 < n < 1 works as divider, defaults to 1
 snmp_rate_multiplier | **Optional.** Converts rate per second. For example, set to 60 to convert to per minute.
 snmp_rate           | **Optional.** Boolean. Enable rate calculation.
 snmp_getnext        | **Optional.** Boolean. Use SNMP GETNEXT. Defaults to false.
@@ -1357,6 +1358,7 @@ snmpv3_eregi         | **Optional.** Return OK state (for that OID) if case-inse
 snmpv3_invert_search | **Optional.** Invert search result and return CRITICAL if found
 snmpv3_label         | **Optional.** Prefix label for output value.
 snmpv3_units         | **Optional.** Units label(s) for output value (e.g., 'sec.').
+snmp3_multiplier     |**Optional.** Multiplies current value, 0 < n < 1 works as divider, defaults to 1
 snmpv3_rate_multiplier | **Optional.** Converts rate per second. For example, set to 60 to convert to per minute.
 snmpv3_rate          | **Optional.** Boolean. Enable rate calculation.
 snmpv3_timeout       | **Optional.** The command timeout in seconds. Defaults to 10 seconds.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1770,6 +1770,10 @@ object CheckCommand "snmp" {
 			value = "$snmp_miblist$"
 			description = "List of MIBS to be loaded (default = none if using numeric OIDs or 'ALL' for symbolic OIDs.)"
 		}
+		"-M" = {
+			value = "$snmp_multiplier$"
+			description = "Multiplies current value, 0 < n < 1 works as divider, defaults to 1"
+		}
 		"--rate-multiplier" = {
 			value = "$snmp_rate_multiplier$"
 			description = "Converts rate per second. For example, set to 60 to convert to per minute"
@@ -1897,6 +1901,10 @@ object CheckCommand "snmpv3" {
 		"-m" = {
 			value = "$snmpv3_miblist$"
 			description = "List of SNMP MIBs for translating OIDs between numeric and textual representation"
+		}
+		"-M" = {
+			value = "$snmpv3_multiplier$"
+			description = "Multiplies current value, 0 < n < 1 works as divider, defaults to 1"
 		}
 		"-u" = {
 			value = "$snmpv3_units$"


### PR DESCRIPTION
monitoring-plugins added a multiplier option in 2.3.3: https://github.com/monitoring-plugins/monitoring-plugins/releases/tag/v2.3.3

This PR adds the option to the ITL definition for `check_snmp`


It Fixes #9907