### PR TITLE
ssl_cert: Allow forcing IPv4 or IPv6 check

### DIFF
--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -582,7 +582,14 @@ object CheckCommand "ssl_cert" {
 			set_if = "$ssl_cert_ignore_tls_renegotiation$"
 			description = "Do not check for renegotiation"
 		}
-
+		"-4" = {
+			set_if = "$ssl_ipv4$"
+			description = "Force IPv4 connection"
+		}
+		"-6" = {
+			set_if = "$ssl_ipv6$"
+			description = "Force IPv6 connection"
+		}
 	}
 
 	vars.ssl_cert_address = "$check_address$"


### PR DESCRIPTION
Enable passing the -4 and -6 options to check_ssl_cert to force an IPv4 or IPv6 connection.