### PR TITLE
Process `config::update/delete` cluster events gracefully

### DIFF
--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -462,3 +462,37 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 	Log(LogInformation, "ApiListener")
 		<< "Finished syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
 }
+
+/**
+ * Locks the specified object name of the given type. If it is already locked, the call blocks until the lock is released.
+ *
+ * @param Type::Ptr ptype The type of the object you want to lock
+ * @param String objName The object name you want to lock
+ */
+void ObjectNameMutex::Lock(const Type::Ptr& ptype, const String& objName)
+{
+	std::unique_lock<std::mutex> lock(m_Mutex);
+	m_CV.wait(lock, [this, &ptype, &objName]{
+		auto& locked = m_LockedObjectNames[ptype.get()];
+		return locked.find(objName) == locked.end();
+	});
+
+	// Add object name to the locked list again to block all other threads that try
+	// to process a message affecting the same object.
+	m_LockedObjectNames[ptype.get()].emplace(objName);
+}
+
+/**
+ * Unlocks the specified object name of the given type.
+ *
+ * @param Type::Ptr ptype The type of the object you want to unlock
+ * @param String objName The name of the object you want to unlock
+ */
+void ObjectNameMutex::Unlock(const Type::Ptr& ptype, const String& objName)
+{
+	{
+		std::unique_lock<std::mutex> lock(m_Mutex);
+		m_LockedObjectNames[ptype.get()].erase(objName);
+	}
+	m_CV.notify_all();
+}

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -72,6 +72,26 @@ enum class ApiCapabilities : uint_fast64_t
 };
 
 /**
+ * Allows you to easily lock/unlock a specific object of a given type by its name.
+ *
+ * That way, locking an object "this" of type Host does not affect an object "this" of
+ * type "Service" nor an object "other" of type "Host".
+ *
+ * @ingroup remote
+ */
+class ObjectNameMutex
+{
+public:
+	void Lock(const Type::Ptr& ptype, const String& objName);
+	void Unlock(const Type::Ptr& ptype, const String& objName);
+
+private:
+	std::mutex m_Mutex;
+	std::condition_variable m_CV;
+	std::map<Type*, std::set<String>> m_LockedObjectNames;
+};
+
+/**
 * @ingroup remote
 */
 class ApiListener final : public ObjectImpl<ApiListener>

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -277,6 +277,9 @@ private:
 	mutable std::mutex m_ActivePackageStagesLock;
 	std::map<String, String> m_ActivePackageStages;
 
+	/* ensures that at most one create/update/delete is being processed per object at each time */
+	mutable ObjectNameMutex m_ObjectConfigChangeLock;
+
 	void UpdateActivePackageStagesCache();
 };
 

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -5,6 +5,7 @@
 #include "remote/apilistener.hpp"
 #include "config/configcompiler.hpp"
 #include "config/configitem.hpp"
+#include "base/atomic-file.hpp"
 #include "base/configwriter.hpp"
 #include "base/exception.hpp"
 #include "base/dependencygraph.hpp"
@@ -198,13 +199,21 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		return false;
 	}
 
+	// AtomicFile doesn't create not yet existing directories, so we have to do it by ourselves.
 	Utility::MkDirP(Utility::DirName(path), 0700);
 
-	std::ofstream fp(path.CStr(), std::ofstream::out | std::ostream::trunc);
+	// Using AtomicFile guarantees that two different threads simultaneously creating and loading the same
+	// configuration file do not interfere with each other, as the configuration is stored in a unique temp file.
+	// When one thread fails to pass object validation, it only deletes its temporary file and does not affect
+	// the other thread in any way.
+	AtomicFile fp(path, 0644);
 	fp << config;
-	fp.close();
+	// Flush the output buffer to catch any errors ASAP and handle them accordingly!
+	// Note: AtomicFile places these configs in a temp file and will be automatically
+	//       discarded when it is not committed before going out of scope.
+	fp.flush();
 
-	std::unique_ptr<Expression> expr = ConfigCompiler::CompileFile(path, String(), "_api");
+	std::unique_ptr<Expression> expr = ConfigCompiler::CompileText(path, config, String(), "_api");
 
 	try {
 		ActivationScope ascope;
@@ -225,9 +234,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		if (!ConfigItem::CommitItems(ascope.GetContext(), upq, newItems, true)) {
 			if (errors) {
 				Log(LogNotice, "ConfigObjectUtility")
-					<< "Failed to commit config item '" << fullName << "'. Aborting and removing config path '" << path << "'.";
-
-				Utility::Remove(path);
+					<< "Failed to commit config item '" << fullName << "'.";
 
 				for (const boost::exception_ptr& ex : upq.GetExceptions()) {
 					errors->Add(DiagnosticInformation(ex, false));
@@ -248,9 +255,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		if (!ConfigItem::ActivateItems(newItems, true, false, false, cookie)) {
 			if (errors) {
 				Log(LogNotice, "ConfigObjectUtility")
-					<< "Failed to activate config object '" << fullName << "'. Aborting and removing config path '" << path << "'.";
-
-				Utility::Remove(path);
+					<< "Failed to activate config object '" << fullName << "'.";
 
 				for (const boost::exception_ptr& ex : upq.GetExceptions()) {
 					errors->Add(DiagnosticInformation(ex, false));
@@ -275,6 +280,9 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		ConfigObject::Ptr obj = ctype->GetObject(fullName);
 
 		if (obj) {
+			// Object has surpassed the compiling/validation processes, we can safely commit the file!
+			fp.Commit();
+
 			Log(LogInformation, "ConfigObjectUtility")
 				<< "Created and activated object '" << fullName << "' of type '" << type->GetName() << "'.";
 		} else {
@@ -283,8 +291,6 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		}
 
 	} catch (const std::exception& ex) {
-		Utility::Remove(path);
-
 		if (errors)
 			errors->Add(DiagnosticInformation(ex, false));
 


### PR DESCRIPTION
Since the internal `config::Update` cluster events are using [`ConfigObjectUtility::CreateObject()`](https://github.com/Icinga/icinga2/blob/master/lib/remote/apilistener-configsync.cpp#L123) as well to create received runtime objects, we shouldn't persist the config file first to the disk and then load and validate it with [`ConfigCompiler::CompileFile()`](https://github.com/Icinga/icinga2/blob/master/lib/config/configcompiler.cpp#L259-L264). Otherwise, we are forced to remove the newly created file whenever we can't validate, commit or activate it. This approach would also have the downside that two cluster events for the same object arriving at the same moment from two different endpoints would result in two different threads simultaneously creating and loading the same configuration file - whereby only one of them surpasses the validation process, while the other one is facing an object `re-definition` error and tries to remove that configuration file it mistakenly thinks it has created. As a consequence, an object successfully created by the former is implicitly deleted by the latter thread, causing the objects to mysteriously disappear.

This PR fixes this by preserving the config in a temporary file for the entire validation process and is only moved to the actual config when the object was successfully created, otherwise that temp file will be discarded. Doing so, guarantees that two different threads simultaneously creating and loading the same configuration file do not interfere with each other. When one thread fails to pass object validation, it only deletes its temporary file and does not affect the other thread in any way. This PR additionally prevents two cluster events relating to the same object from being processed simultaneously.

## Tests

<details>
<summary>Master 1</summary>

```bash
object Endpoint "master1" {
}

object Endpoint "master2" {
	host = "IP-Address"
	log_duration = 30m
}

object Zone "master" {
	endpoints = [ "master1", "master2" ]
}

object Endpoint "satellite1" {
	log_duration = 30m
}

object Endpoint "satellite2" {
	log_duration = 30m
}

object Zone "satellite" {
	endpoints = [ "satellite1", "satellite2" ]
	parent = "master"
}

object Zone "global-templates" {
	global = true
}
```

</details>

<details>
<summary>Master 2</summary>

```bash
object Endpoint "master1" {
//	host = "IP-Address"
//	port = "5665"
	log_duration = 30m
}

object Endpoint "master2" { }

object Zone "master" {
	endpoints = [ "master1", "master2" ]
}

object Endpoint "satellite1" {
	log_duration = 30m
}

object Endpoint "satellite2" {
	log_duration = 30m
}

object Zone "satellite" {
	endpoints = [ "satellite1", "satellite2" ]
	parent = "master"
}

object Zone "global-templates" {
	global = true
}
```

</details>

<details>
<summary>Satellite</summary>

```bash
object Endpoint "master1" {
	host = "IP"
	port = "5665"
}

object Endpoint "master2" {
	host = "IP"
	port = "5665"
}

object Zone "master" {
	endpoints = [ "master1", "master2" ]
}

object Endpoint "satellite1" {
}

object Endpoint "satellite2" {
	log_duration = 30m
}

object Zone "satellite" {
	endpoints = [ "satellite1", "satellite2" ]
	parent = "master"
}

object Zone "global-templates" {
	global = true
}
```

</details>

### Results

#### Before

<details>
<summary>Master 1</summary>

```bash
root@debian-11:~# ls /var/lib/icinga2/api/packages/_api/9ff3d418-8691-4ca1-aba6-0fe2efec029a/conf.d/hosts/ | wc -l
1000
```

</details>

<details>
<summary>Master 2</summary>

```bash
root@config-sync centos]# ls /var/lib/icinga2/api/packages/_api/97d86dee-d245-468f-b7dc-bd6044376e2a/conf.d/hosts | wc -l
1000
```

</details>

<details>
<summary>Satellite</summary>

```bash
[root@config-sync-2 ~]# ls /var/lib/icinga2/api/packages/_api/fd7da15d-7167-4e25-8da0-21fc97381c1b/conf.d/hosts | wc -l
755
```

To make things even more mysterious, when you query one of the missing hosts via the API, you get the desired result, but it refers to a non-existent path. Nevertheless, the host disappears forever and cannot even be found via the API when the icinga2 daemon is restarted.

```bash
~/Workspace/icinga2 (master ✗) curl -k -s -S -i -u root:icinga 'https://10.27.0.198:5665/v1/objects/hosts/example-197?pretty=1'

{
    "results": [
        {
            "attrs": {
                "__name": "example-197",
            ...
           "source_location": {
                    "first_column": 0,
                    "first_line": 1,
                    "last_column": 24,
                    "last_line": 1,
                    "path": "/var/lib/icinga2/api/packages/_api/fd7da15d-7167-4e25-8da0-21fc97381c1b/conf.d/hosts/example-197.conf"
                },
....
```

```bash
[root@config-sync-2 ~]# cat /var/lib/icinga2/api/packages/_api/fd7da15d-7167-4e25-8da0-21fc97381c1b/conf.d/hosts/example-197.conf
cat: /var/lib/icinga2/api/packages/_api/fd7da15d-7167-4e25-8da0-21fc97381c1b/conf.d/hosts/example-197.conf: Datei oder Verzeichnis nicht gefunden
```

</details>


#### After

**Satellite:**
```bash
root@config-sync-2 ~]# ls /var/lib/icinga2/api/packages/_api/760f4e88-1688-46fd-a017-48905eb7fbb4/conf.d/hosts | wc -l
1000
```

fixes #9721 