### PR TITLE
ApiListener#AddConnection(): check connect timeout after DNS resolution

### DIFF
--- a/lib/base/tcpsocket.cpp
+++ b/lib/base/tcpsocket.cpp
@@ -214,17 +214,19 @@ void TcpSocket::Connect(const String& node, const String& service)
 	}
 }
 
-void icinga::Connect(AsioTcpSocket& socket, const String& node, const String& service, boost::asio::yield_context* yc)
-{
-	using boost::asio::ip::tcp;
+using boost::asio::ip::tcp;
 
+AsioDnsResponse icinga::Resolve(const String& node, const String& service, boost::asio::yield_context* yc)
+{
 	tcp::resolver resolver (IoEngine::Get().GetIoContext());
 
-	auto result = yc
-		? resolver.async_resolve(node.GetData(), service.GetData(), *yc)
+	return yc ? resolver.async_resolve(node.GetData(), service.GetData(), *yc)
 		: resolver.resolve(node.GetData(), service.GetData());
+}
 
-	auto current (result.begin());
+void icinga::Connect(AsioTcpSocket& socket, const AsioDnsResponse& to, boost::asio::yield_context* yc)
+{
+	auto current (to.begin());
 
 	for (;;) {
 		try {
@@ -241,7 +243,7 @@ void icinga::Connect(AsioTcpSocket& socket, const String& node, const String& se
 		} catch (const std::exception& ex) {
 			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
 
-			if (se && se->code() == boost::asio::error::operation_aborted || ++current == result.end()) {
+			if (se && se->code() == boost::asio::error::operation_aborted || ++current == to.end()) {
 				throw;
 			}
 

--- a/lib/base/tcpsocket.cpp
+++ b/lib/base/tcpsocket.cpp
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: 2012 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include "base/io-engine.hpp"
 #include "base/tcpsocket.hpp"
 #include "base/logger.hpp"
 #include "base/utility.hpp"
 #include "base/exception.hpp"
+#include <boost/asio/error.hpp>
+#include <boost/system/system_error.hpp>
 #include <boost/exception/errinfo_api_function.hpp>
 #include <boost/exception/errinfo_errno.hpp>
 #include <iostream>
@@ -208,5 +211,43 @@ void TcpSocket::Connect(const String& node, const String& service)
 			<< boost::errinfo_api_function(func)
 			<< errinfo_win32_error(error));
 #endif /* _WIN32 */
+	}
+}
+
+void icinga::Connect(AsioTcpSocket& socket, const String& node, const String& service, boost::asio::yield_context* yc)
+{
+	using boost::asio::ip::tcp;
+
+	tcp::resolver resolver (IoEngine::Get().GetIoContext());
+
+	auto result = yc
+		? resolver.async_resolve(node.GetData(), service.GetData(), *yc)
+		: resolver.resolve(node.GetData(), service.GetData());
+
+	auto current (result.begin());
+
+	for (;;) {
+		try {
+			socket.open(current->endpoint().protocol());
+			socket.set_option(tcp::socket::keep_alive(true));
+
+			if (yc) {
+				socket.async_connect(current->endpoint(), *yc);
+			} else {
+				socket.connect(current->endpoint());
+			}
+
+			break;
+		} catch (const std::exception& ex) {
+			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
+
+			if (se && se->code() == boost::asio::error::operation_aborted || ++current == result.end()) {
+				throw;
+			}
+
+			if (socket.is_open()) {
+				socket.close();
+			}
+		}
 	}
 }

--- a/lib/base/tcpsocket.hpp
+++ b/lib/base/tcpsocket.hpp
@@ -37,19 +37,28 @@ public:
  * @ingroup base
  */
 template<class Socket>
-void Connect(Socket& socket, const String& node, const String& service)
+void Connect(Socket& socket, const String& node, const String& service, boost::asio::yield_context* yc)
 {
 	using boost::asio::ip::tcp;
 
 	tcp::resolver resolver (IoEngine::Get().GetIoContext());
-	auto result (resolver.resolve(node.GetData(), service.GetData()));
+
+	auto result = yc
+		? resolver.async_resolve(node.GetData(), service.GetData(), *yc)
+		: resolver.resolve(node.GetData(), service.GetData());
+
 	auto current (result.begin());
 
 	for (;;) {
 		try {
 			socket.open(current->endpoint().protocol());
 			socket.set_option(tcp::socket::keep_alive(true));
-			socket.connect(current->endpoint());
+
+			if (yc) {
+				socket.async_connect(current->endpoint(), *yc);
+			} else {
+				socket.connect(current->endpoint());
+			}
 
 			break;
 		} catch (const std::exception& ex) {
@@ -67,33 +76,15 @@ void Connect(Socket& socket, const String& node, const String& service)
 }
 
 template<class Socket>
-void Connect(Socket& socket, const String& node, const String& service, boost::asio::yield_context yc)
+inline void Connect(Socket& socket, const String& node, const String& service)
 {
-	using boost::asio::ip::tcp;
+	Connect(socket, node, service, nullptr);
+}
 
-	tcp::resolver resolver (IoEngine::Get().GetIoContext());
-	auto result (resolver.async_resolve(node.GetData(), service.GetData(), yc));
-	auto current (result.begin());
-
-	for (;;) {
-		try {
-			socket.open(current->endpoint().protocol());
-			socket.set_option(tcp::socket::keep_alive(true));
-			socket.async_connect(current->endpoint(), yc);
-
-			break;
-		} catch (const std::exception& ex) {
-			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
-
-			if ((se && se->code() == boost::asio::error::operation_aborted) || ++current == result.end()) {
-				throw;
-			}
-
-			if (socket.is_open()) {
-				socket.close();
-			}
-		}
-	}
+template<class Socket>
+inline void Connect(Socket& socket, const String& node, const String& service, boost::asio::yield_context yc)
+{
+	Connect(socket, node, service, &yc);
 }
 
 }

--- a/lib/base/tcpsocket.hpp
+++ b/lib/base/tcpsocket.hpp
@@ -29,22 +29,45 @@ public:
 };
 
 typedef boost::asio::ip::tcp::socket::lowest_layer_type AsioTcpSocket;
+typedef boost::asio::ip::tcp::resolver::results_type AsioDnsResponse;
+
+AsioDnsResponse Resolve(const String& node, const String& service, boost::asio::yield_context* yc);
+
+inline AsioDnsResponse Resolve(const String& node, const String& service)
+{
+	return Resolve(node, service, nullptr);
+}
+
+inline AsioDnsResponse Resolve(const String& node, const String& service, boost::asio::yield_context yc)
+{
+	return Resolve(node, service, &yc);
+}
 
 /**
  * TCP Connect based on Boost ASIO.
  *
  * @ingroup base
  */
-void Connect(AsioTcpSocket& socket, const String& node, const String& service, boost::asio::yield_context* yc);
+void Connect(AsioTcpSocket& socket, const AsioDnsResponse& to, boost::asio::yield_context* yc);
 
 inline void Connect(AsioTcpSocket& socket, const String& node, const String& service)
 {
-	Connect(socket, node, service, nullptr);
+	Connect(socket, Resolve(node, service, nullptr), nullptr);
 }
 
 inline void Connect(AsioTcpSocket& socket, const String& node, const String& service, boost::asio::yield_context yc)
 {
-	Connect(socket, node, service, &yc);
+	Connect(socket, Resolve(node, service, &yc), &yc);
+}
+
+inline void Connect(AsioTcpSocket& socket, const AsioDnsResponse& to)
+{
+	Connect(socket, to, nullptr);
+}
+
+inline void Connect(AsioTcpSocket& socket, const AsioDnsResponse& to, boost::asio::yield_context yc)
+{
+	Connect(socket, to, &yc);
 }
 
 }

--- a/lib/base/tcpsocket.hpp
+++ b/lib/base/tcpsocket.hpp
@@ -5,12 +5,9 @@
 #define TCPSOCKET_H
 
 #include "base/i2-base.hpp"
-#include "base/io-engine.hpp"
 #include "base/socket.hpp"
-#include <boost/asio/error.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
-#include <boost/system/system_error.hpp>
 
 namespace icinga
 {
@@ -31,58 +28,21 @@ public:
 	void Connect(const String& node, const String& service);
 };
 
+typedef boost::asio::ip::tcp::socket::lowest_layer_type AsioTcpSocket;
+
 /**
  * TCP Connect based on Boost ASIO.
  *
  * @ingroup base
  */
-template<class Socket>
-void Connect(Socket& socket, const String& node, const String& service, boost::asio::yield_context* yc)
-{
-	using boost::asio::ip::tcp;
+void Connect(AsioTcpSocket& socket, const String& node, const String& service, boost::asio::yield_context* yc);
 
-	tcp::resolver resolver (IoEngine::Get().GetIoContext());
-
-	auto result = yc
-		? resolver.async_resolve(node.GetData(), service.GetData(), *yc)
-		: resolver.resolve(node.GetData(), service.GetData());
-
-	auto current (result.begin());
-
-	for (;;) {
-		try {
-			socket.open(current->endpoint().protocol());
-			socket.set_option(tcp::socket::keep_alive(true));
-
-			if (yc) {
-				socket.async_connect(current->endpoint(), *yc);
-			} else {
-				socket.connect(current->endpoint());
-			}
-
-			break;
-		} catch (const std::exception& ex) {
-			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
-
-			if ((se && se->code() == boost::asio::error::operation_aborted) || ++current == result.end()) {
-				throw;
-			}
-
-			if (socket.is_open()) {
-				socket.close();
-			}
-		}
-	}
-}
-
-template<class Socket>
-inline void Connect(Socket& socket, const String& node, const String& service)
+inline void Connect(AsioTcpSocket& socket, const String& node, const String& service)
 {
 	Connect(socket, node, service, nullptr);
 }
 
-template<class Socket>
-inline void Connect(Socket& socket, const String& node, const String& service, boost::asio::yield_context yc)
+inline void Connect(AsioTcpSocket& socket, const String& node, const String& service, boost::asio::yield_context yc)
 {
 	Connect(socket, node, service, &yc);
 }

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -644,21 +644,30 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 		try {
 			boost::shared_lock<decltype(m_SSLContextMutex)> lock (m_SSLContextMutex);
 			auto sslConn (Shared<AsioTlsStream>::Make(io, *m_SSLContext, endpoint->GetName()));
+			bool timedOut = false;
 
 			lock.unlock();
 
 			Timeout timeout (*strand, std::chrono::duration<double>{GetConnectTimeout()},
-				[sslConn, endpoint, host, port] {
+				[sslConn, endpoint, host, port, &timedOut] {
 					Log(LogCritical, "ApiListener")
 						<< "Timeout while reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host
 						<< "' and port '" << port << "', cancelling attempt";
 
 					boost::system::error_code ec;
 					sslConn->lowest_layer().cancel(ec);
+					timedOut = true;
 				}
 			);
 
-			Connect(sslConn->lowest_layer(), host, port, yc);
+			auto ips (Resolve(host, port, yc));
+
+			if (timedOut) {
+				endpoint->SetConnecting(false);
+				return;
+			}
+
+			Connect(sslConn->lowest_layer(), ips, yc);
 
 			NewClientHandler(yc, strand, sslConn, endpoint->GetName(), RoleClient);
 


### PR DESCRIPTION
ASIO DNS resolution can't be cancelled. If it takes longer than
ApiListener#connect_timeout, the latter becomes a no-op as it cancels
socket I/O which doesn't even start before DNS resolution.

## Before

```
[2024-01-25 11:50:57 +0000] information/ApiListener: Reconnecting to endpoint 'aklimov-i2all-master-2' via host 'al2klimov.hopto.org' and port '5665'
[2024-01-25 11:51:12 +0000] critical/ApiListener: Timeout while reconnecting to endpoint 'aklimov-i2all-master-2' via host 'al2klimov.hopto.org' and port '5665', cancelling attempt
[2024-01-25 11:51:17 +0000] critical/ApiListener: Cannot connect to host 'al2klimov.hopto.org' on port '5665': Host not found (authoritative)
```

👎 Timeout "fires" after 15s w/o any effect, DNS times out by itself after another 5s.

## After

```
[2024-01-26 11:56:16 +0000] information/ApiListener: Reconnecting to endpoint 'aklimov-i2all-master-2' via host 'al2klimov.hopto.org' and port '5665'
[2024-01-26 11:56:16 +0000] information/IcingaDB: Pending queries: 0 (Input: 1/s; Output: 1/s)
[2024-01-26 11:56:26 +0000] information/IdoMysqlConnection: 'ido-mysql' resumed.
[2024-01-26 11:56:26 +0000] information/DbConnection: Resuming IDO connection: ido-mysql
[2024-01-26 11:56:26 +0000] information/InfluxdbWriter: 'influxdb' resumed.
[2024-01-26 11:56:26 +0000] information/IdoMysqlConnection: Last update by endpoint 'aklimov-i2all-master-2' was 8.0741s ago (< failover timeout of 30s). Retrying.
[2024-01-26 11:56:36 +0000] critical/ApiListener: Cannot connect to host 'al2klimov.hopto.org' on port '5665': Host not found (authoritative)
[2024-01-26 11:56:36 +0000] information/WorkQueue: #7 (ApiListener, RelayQueue) items: 5, rate: 196.333/s (11780/min 11780/5min 11780/15min);
[2024-01-26 11:56:37 +0000] information/ApiListener: Reconnecting to endpoint 'aklimov-i2all-master-2' via host 'al2klimov.hopto.org' and port '5665'
[2024-01-26 11:56:37 +0000] information/IdoMysqlConnection: Last update by endpoint 'aklimov-i2all-master-2' was 9.16835s ago (< failover timeout of 30s). Retrying.
[2024-01-26 11:56:47 +0000] information/IdoMysqlConnection: Last update by endpoint 'aklimov-i2all-master-2' was 9.16004s ago (< failover timeout of 30s). Retrying.
[2024-01-26 11:56:57 +0000] information/IdoMysqlConnection: Last update by endpoint 'aklimov-i2all-master-2' was 9.15969s ago (< failover timeout of 30s). Retrying.
[2024-01-26 11:56:57 +0000] critical/ApiListener: Cannot connect to host 'al2klimov.hopto.org' on port '5665': Host not found (authoritative)
```

👍 The timeout doesn't even start if DNS fails.

```
[2024-01-26 13:08:52 +0100] information/ApiListener: Reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665'
[2024-01-26 13:08:52 +0100] information/CheckerComponent: 'checker' started.
[2024-01-26 13:08:52 +0100] information/ConfigItem: Activated all objects.
[2024-01-26 13:09:02 +0100] information/WorkQueue: #7 (ApiListener, SyncQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2024-01-26 13:09:02 +0100] information/WorkQueue: #6 (ApiListener, RelayQueue) items: 0, rate:  0/s (0/min 0/5min 0/15min);
[2024-01-26 13:09:07 +0100] critical/ApiListener: Timeout while reconnecting to endpoint 'al2klimov.de' via host 'al2klimov.de' and port '5665', cancelling attempt
[2024-01-26 13:09:07 +0100] critical/ApiListener: Cannot connect to host 'al2klimov.de' on port '5665': Operation canceled
```

👍 The timeout starts if DNS succeeds and fires immediately once due.