### PR TITLE
Fix broken `TimePeriod/ScheduledDowntime`s

### DIFF
--- a/lib/icinga/legacytimeperiod.cpp
+++ b/lib/icinga/legacytimeperiod.cpp
@@ -31,7 +31,7 @@ bool LegacyTimePeriod::IsInTimeRange(const tm *begin, const tm *end, int stride,
 	tsend = mktime_const(end);
 	tsref = mktime_const(reference);
 
-	if (tsref < tsbegin || tsref > tsend)
+	if (tsref < tsbegin || tsref >= tsend)
 		return false;
 
 	int daynumber = (tsref - tsbegin) / (24 * 60 * 60);

--- a/lib/icinga/timeperiod.cpp
+++ b/lib/icinga/timeperiod.cpp
@@ -291,7 +291,7 @@ bool TimePeriod::IsInside(double ts) const
 	if (segments) {
 		ObjectLock dlock(segments);
 		for (const Dictionary::Ptr& segment : segments) {
-			if (ts > segment->Get("begin") && ts < segment->Get("end"))
+			if (ts >= segment->Get("begin") && ts < segment->Get("end"))
 				return true;
 		}
 	}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,6 +186,8 @@ add_boost_test(base
     icinga_macros/simple
     icinga_legacytimeperiod/simple
     icinga_legacytimeperiod/is_in_range
+    icinga_legacytimeperiod/out_of_range_segments
+    icinga_legacytimeperiod/include_exclude_timeperiods
     icinga_legacytimeperiod/advanced
     icinga_legacytimeperiod/dst
     icinga_legacytimeperiod/dst_isinside

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,6 +185,7 @@ add_boost_test(base
     icinga_notification/recovery_filter_duplicate
     icinga_macros/simple
     icinga_legacytimeperiod/simple
+    icinga_legacytimeperiod/is_in_range
     icinga_legacytimeperiod/advanced
     icinga_legacytimeperiod/dst
     icinga_legacytimeperiod/dst_isinside

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -257,6 +257,154 @@ BOOST_AUTO_TEST_CASE(is_in_range)
 	BOOST_CHECK_EQUAL(true, LegacyTimePeriod::IsInTimeRange(&tm_beg, &tm_end, 2, &reference));
 }
 
+BOOST_AUTO_TEST_CASE(out_of_range_segments)
+{
+	TimePeriod::Ptr tp = new TimePeriod();
+	tp->SetUpdate(new Function("LegacyTimePeriod", LegacyTimePeriod::ScriptFunc, {"tp", "begin", "end"}), true);
+
+	// A single day range shouldn't span to the following day too (see https://github.com/Icinga/icinga2/issues/9388).
+	tp->SetRanges(new Dictionary({{"2024-06-12", "00:00-24:00"}}), true);
+	tp->UpdateRegion(1718150400, 1718236800, true);  // 2024-06-12 00:00:00 - 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(true, tp->IsInside(1718200800)); // 2024-06-12 14:00:00 UTC
+	{
+		Array::Ptr segments = tp->GetSegments();
+		BOOST_REQUIRE_EQUAL(1, segments->GetLength());
+
+		Dictionary::Ptr segment = segments->Get(0);
+		BOOST_CHECK_EQUAL(1718150400, segment->Get("begin")); // 2024-06-12 00:00:00 UTC
+		BOOST_CHECK_EQUAL(1718236800, segment->Get("end")); // 2024-06-12 24:00:00 UTC
+	}
+	tp->UpdateRegion(1718236800, 1718323200, true);  // 2024-06-13 00:00:00 - 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(false, tp->IsInside(1718287200)); // 2024-06-13 14:00:00 UTC
+	{
+		Array::Ptr segments = tp->GetSegments();
+		BOOST_CHECK_EQUAL(0, segments->GetLength()); // There should be no segments at all!
+	}
+
+	// One partially day range shouldn't contain more than a single segment (see https://github.com/Icinga/icinga2/issues/9781).
+	tp->SetRanges(new Dictionary({{"2024-06-12", "10:00-12:00"}}), true);
+	tp->UpdateRegion(1718150400, 1718236800, true);  // 2024-06-12 00:00:00 - 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(true, tp->IsInside(1718190000)); // 2024-06-12 11:00:00 UTC
+	{
+		Array::Ptr segments = tp->GetSegments();
+		BOOST_REQUIRE_EQUAL(1, segments->GetLength());
+
+		Dictionary::Ptr segment = segments->Get(0);
+		BOOST_CHECK_EQUAL(1718186400, segment->Get("begin")); // 2024-06-12 10:00:00 UTC (range start date)
+		BOOST_CHECK_EQUAL(1718193600, segment->Get("end")); // 2024-06-12 12:00:00 UTC (range end date)
+	}
+	tp->UpdateRegion(1718236800, 1718323200, true);  // 2024-06-13 00:00:00 - 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(false, tp->IsInside(1718287200)); // 2024-06-13 14:00:00 UTC
+	BOOST_CHECK_EQUAL(0, tp->GetSegments()->GetLength()); // There should be no segments at all!
+}
+
+BOOST_AUTO_TEST_CASE(include_exclude_timeperiods)
+{
+	Function::Ptr update = new Function("LegacyTimePeriod", LegacyTimePeriod::ScriptFunc, {"tp", "begin", "end"});
+	TimePeriod::Ptr excludedTp = new TimePeriod();
+	excludedTp->SetName("excluded", true);
+	excludedTp->SetUpdate(update, true);
+	excludedTp->SetRanges(new Dictionary({{"2024-06-11", "00:00-24:00"}}), true);
+
+	excludedTp->UpdateRegion(1718064000, 1718323200, true);  // 2024-06-11 00:00:00 - 2024-06-13 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(1, excludedTp->GetSegments()->GetLength());
+	BOOST_CHECK_EQUAL(true, excludedTp->IsInside(1718114400)); // 2024-06-11 14:00:00 UTC
+	BOOST_CHECK_EQUAL(false, excludedTp->IsInside(1718200800)); // 2024-06-12 14:00:00 UTC
+	BOOST_CHECK_EQUAL(false, excludedTp->IsInside(1718287200)); // 2024-06-13 14:00:00 UTC
+
+	// Register the excluded timeperiod to make it globally visible.
+	excludedTp->Register();
+
+	Dictionary::Ptr ranges = new Dictionary({
+		{"2024-06-11", "09:00-17:00"},
+		{"2024-06-12", "09:00-17:00"},
+		{"2024-06-13", "09:00-17:00"}
+	});
+
+	TimePeriod::Ptr tp = new TimePeriod();
+	tp->SetExcludes(new Array({"excluded"}), true);
+	tp->SetUpdate(update, true);
+	tp->SetRanges(ranges, true);
+	tp->UpdateRegion(1718064000, 1718323200, true);  // 2024-06-11 00:00:00 - 2024-06-13 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(false, tp->IsInside(1718114400)); // 2024-06-11 14:00:00 UTC
+	BOOST_CHECK_EQUAL(false, tp->IsInside(1718150400)); // 2024-06-12 00:00:00 UTC
+	BOOST_CHECK_EQUAL(true, tp->IsInside(1718200800)); // 2024-06-12 14:00:00 UTC
+	BOOST_CHECK_EQUAL(false, tp->IsInside(1718323200)); // 2024-06-13 00:00:00 UTC
+	BOOST_CHECK_EQUAL(true, tp->IsInside(1718287200)); // 2024-06-13 14:00:00 UTC
+	{
+		Array::Ptr segments = tp->GetSegments();
+		// The updated region is 2024-06-11 - 13, so there should only be 2 segements, when the excludes works correctly.
+		BOOST_REQUIRE_EQUAL(2, segments->GetLength());
+
+		Dictionary::Ptr segment = segments->Get(0);
+		BOOST_CHECK_EQUAL(1718182800, segment->Get("begin")); // 2024-06-12 09:00:00 UTC
+		BOOST_CHECK_EQUAL(1718211600, segment->Get("end")); // 2024-06-12 17:00:00 UTC
+
+		BOOST_CHECK_EQUAL(true, tp->IsInside(segment->Get("begin")));
+		BOOST_CHECK_EQUAL(false, tp->IsInside(segment->Get("end")));
+
+		BOOST_CHECK_EQUAL(false, excludedTp->IsInside(segment->Get("begin")));
+		BOOST_CHECK_EQUAL(false, excludedTp->IsInside(segment->Get("end")));
+
+		segment = segments->Get(1);
+		BOOST_CHECK_EQUAL(1718269200, segment->Get("begin")); // 2024-06-13 09:00:00 UTC
+		BOOST_CHECK_EQUAL(1718298000, segment->Get("end")); // 2024-06-13 17:00:00 UTC
+
+		BOOST_CHECK_EQUAL(true, tp->IsInside(segment->Get("begin")));
+		BOOST_CHECK_EQUAL(false, tp->IsInside(segment->Get("end")));
+
+		BOOST_CHECK_EQUAL(false, excludedTp->IsInside(segment->Get("begin")));
+		BOOST_CHECK_EQUAL(false, excludedTp->IsInside(segment->Get("end")));
+	}
+
+	// Include timeperiod test cases ...
+	TimePeriod::Ptr includedTp = new TimePeriod();
+	includedTp->SetName("included", true);
+	includedTp->SetUpdate(update, true);
+	includedTp->SetRanges(new Dictionary({{"2024-06-11", "08:00-17:00"}}), true);
+
+	includedTp->UpdateRegion(1718064000, 1718323200, true);  // 2024-06-11 00:00:00 - 2024-06-13 24:00:00 UTC
+
+	BOOST_CHECK_EQUAL(1, includedTp->GetSegments()->GetLength());
+	BOOST_CHECK_EQUAL(true, includedTp->IsInside(1718114400)); // 2024-06-11 14:00:00 UTC
+	BOOST_CHECK_EQUAL(false, includedTp->IsInside(1718200800)); // 2024-06-12 14:00:00 UTC
+	BOOST_CHECK_EQUAL(false, includedTp->IsInside(1718287200)); // 2024-06-13 14:00:00 UTC
+
+	// Register the timeperiod to make it globally visible.
+	includedTp->Register();
+
+	tp->SetIncludes(new Array({"included"}), true);
+	tp->UpdateRegion(1718064000, 1718323200, true);  // 2024-06-11 00:00:00 - 2024-06-13 24:00:00 UTC
+	{
+		Array::Ptr segments = tp->GetSegments();
+		// The updated region is 2024-06-11 - 13, so there should be 3 segements, when the *prefer* includes works correctly.
+		BOOST_REQUIRE_EQUAL(3, segments->GetLength());
+
+		Dictionary::Ptr segment = segments->Get(0);
+		BOOST_CHECK_EQUAL(1718182800, segment->Get("begin")); // 2024-06-12 09:00:00 UTC
+		BOOST_CHECK_EQUAL(1718211600, segment->Get("end")); // 2024-06-12 17:00:00 UTC
+
+		segment = segments->Get(1);
+		BOOST_CHECK_EQUAL(1718269200, segment->Get("begin")); // 2024-06-13 09:00:00 UTC
+		BOOST_CHECK_EQUAL(1718298000, segment->Get("end")); // 2024-06-13 17:00:00 UTC
+
+		segment = segments->Get(2);
+		BOOST_CHECK_EQUAL(1718092800, segment->Get("begin")); // 2024-06-11 08:00:00 UTC
+		BOOST_CHECK_EQUAL(1718125200, segment->Get("end")); // 2024-06-11 17:00:00 UTC
+
+		BOOST_CHECK_EQUAL(true, tp->IsInside(segment->Get("begin")));
+		BOOST_CHECK_EQUAL(true, includedTp->IsInside(segment->Get("begin")));
+		BOOST_CHECK_EQUAL(false, tp->IsInside(segment->Get("end")));
+		BOOST_CHECK_EQUAL(false, includedTp->IsInside(segment->Get("end")));
+	}
+}
+
 struct DateTime
 {
 	struct {


### PR DESCRIPTION
This PR fixes a broken behaviour of the  [`LegacyTimePeriod::IsInTimeRange()`](https://github.com/Icinga/icinga2/blob/master/lib/icinga/legacytimeperiod.cpp#L27) method that affects the overall time period and scheduled downtime handling and frustrates so many users just due to this nasty little logic error.

[`LegacyTimePeriod::ScriptFunc()`](https://github.com/Icinga/icinga2/blob/master/lib/icinga/legacytimeperiod.cpp#L582) calls `IsInDayDefinition()` with the current time range e.g. (`2024-01-29`) and a reference time, which is the local time of the Icinga 2 daemon being started, i.e the time being Icinga 2 started at.
https://github.com/Icinga/icinga2/blob/01a6c4c1ce15184f465a7f0fc309bcf6779cdeb3/lib/icinga/legacytimeperiod.cpp#L622

[`LegacyTimePeriod::IsInDayDefinition()`](https://github.com/Icinga/icinga2/blob/master/lib/icinga/legacytimeperiod.cpp#L390) then parses the specified time range "daydef" with the `ParseTimeRange()` method and passes the arguments `begin` and `end`.

https://github.com/Icinga/icinga2/blob/01a6c4c1ce15184f465a7f0fc309bcf6779cdeb3/lib/icinga/legacytimeperiod.cpp#L392-L395

[`LegacyTimePeriod::ParseTimeRange()`](https://github.com/Icinga/icinga2/blob/master/lib/icinga/legacytimeperiod.cpp#L338) then calls `ParseTimeSpec()`, which normalises the `begin` and `end` arguments if they are set, which is true in this case.

https://github.com/Icinga/icinga2/blob/01a6c4c1ce15184f465a7f0fc309bcf6779cdeb3/lib/icinga/legacytimeperiod.cpp#L183-L192

https://github.com/Icinga/icinga2/blob/01a6c4c1ce15184f465a7f0fc309bcf6779cdeb3/lib/icinga/legacytimeperiod.cpp#L194-L202

At this point, the end time is normalised the same way as the start date, but its **tm_hour** is set to **24**, and passing it through `mtkime(3)` produces the exactly the same timestamp as the given reference time, which is erroneously considered to be within range.

PS: You might want to check @julianbrost clarification https://github.com/Icinga/icinga2/pull/9983#issuecomment-2277929333 with a bit more context of the problem. 

## Tests

<details>
<summary>Test cases for #9781</summary>

```bash
object TimePeriod "broken_calendar" {
  ranges = {
    "2024-01-29 - 2024-01-29" = "07:00-08:00"
  }
}
```

**Before:**
```bash
                "is_inside": false,
                "name": "broken_calendar",
                "prefer_includes": true,
                "ranges": {
                    "2024-01-29 - 2024-01-29": "07:00-08:00"
                },
                "segments": [
                    {
                        "begin": 1706508000,
                        "end": 1706511600
                    },
                    {
                        "begin": 1706594400,
                        "end": 1706598000
                    }
                ],
---

~/Workspace/icinga2 (master ✗) date -r 1706508000
Mon Jan 29 07:00:00 CET 2024
~/Workspace/icinga2 (master ✗) date -r 1706511600
Mon Jan 29 08:00:00 CET 2024
~/Workspace/icinga2 (master ✗) date -r 1706594400
Tue Jan 30 07:00:00 CET 2024
~/Workspace/icinga2 (master ✗) date -r 1706598000
Tue Jan 30 08:00:00 CET 2024
```

Even if the time period is not active, it has exceeded the time span and still includes the next day after the end of the range!

**After:**
```bash
                "is_inside": false,
                "name": "broken_calendar",
                "ranges": {
                    "2024-01-29 - 2024-01-29": "07:00-08:00"
                },
                "segments": [
                    {
                        "begin": 1706508000,
                        "end": 1706511600
                    }
                ],
---

~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706508000
Mon Jan 29 07:00:00 CET 2024
~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706511600
Mon Jan 29 08:00:00 CET 2024
```

</details>

<details>
<summary>Test cases for #9388</summary>

```bash
object TimePeriod "broken_calendar" {
  ranges = {
    "2024-01-28" = "00:00-24:00"
  }
}
```

**Before:**
```bash
                "is_inside": true,
                "name": "broken_calendar",
                "ranges": {
                    "2024-01-28": "00:00-24:00"
                },
                "segments": [
                    {
                        "begin": 1706482800,
                        "end": 1706569200
                    }
                ],
---

~/Workspace/icinga2 (master ✗) date -r 1706482800
Mon Jan 29 00:00:00 CET 2024
~/Workspace/icinga2 (master ✗) date -r 1706569200
Tue Jan 30 00:00:00 CET 2024
```

*There should be no segments at all, as the time period only covers 28 January*.

**After:**
```bash
                "is_inside": false,
                "name": "broken_calendar",
                "ranges": {
                    "2024-01-28": "00:00-24:00"
                },
                "segments": [],
---
```

</details>

<details>
<summary>Test cases for #8741 and #7398</summary>

```bash
object TimePeriod "holidays" {
    ranges = {
        "january 28" = "00:00-24:00"
    }
}

object TimePeriod "broken_calendar" {
  excludes = [ "holidays" ]
  ranges = {
    "monday"   = "09:00-17:00"
    "tuesday"   = "09:00-17:00"
  }
}
```

**Before:**
```bash
                "excludes": [
                    "holidays"
                ],
                "is_inside": false,
                "name": "broken_calendar",
                "ranges": {
                    "monday": "09:00-17:00",
                    "tuesday": "09:00-17:00"
                },
                "segments": [
                    {
                        "begin": 1706601600,
                        "end": 1706630400
                    }
                ],
---

~/Workspace/icinga2 (master ✗) date -r 1706601600
Tue Jan 30 09:00:00 CET 2024
~/Workspace/icinga2 (master ✗) date -r 1706630400
Tue Jan 30 17:00:00 CET 2024
```

Today (**monday**) is just getting skipped!

**After:**
```bash
                "excludes": [
                    "holidays"
                ],
                "is_inside": true,
                "name": "broken_calendar",
                "prefer_includes": true,
                "ranges": {
                    "monday": "09:00-17:00",
                    "tuesday": "09:00-17:00"
                },
                "segments": [
                    {
                        "begin": 1706515200,
                        "end": 1706544000
                    },
                    {
                        "begin": 1706601600,
                        "end": 1706630400
                    }
                ],
---

~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706515200 // First segment start date
Mon Jan 29 09:00:00 CET 2024
~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706544000 // First segment end date
Mon Jan 29 17:00:00 CET 2024
~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706601600 // Second segment start date
Tue Jan 30 09:00:00 CET 2024
~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706630400. // Second segment end date
Tue Jan 30 17:00:00 CET 2024
```

</details>

<details>
<summary>Test cases for #7239</summary>

```bash
object TimePeriod "holidays" {
    ranges = {
        "january 28" = "00:00-24:00"
    }
}

object TimePeriod "offDuty" {
	ranges = {
		"monday"  = "00:00-09:00"
	}

	includes = [ "holidays" ]
}
```

**Before:**
```bash
---
                "includes": [
                    "holidays"
                ],
                "is_inside": true,
                "ranges": {
                    "monday": "00:00-09:00"
                },
                "segments": [
                    {
                        "begin": 1706482800,
                        "end": 1706569200
                    }
                ],
---

~/Workspace/icinga2 (master ✗) date -r 1706482800
Mon Jan 29 00:00:00 CET 2024
~/Workspace/icinga2 (master ✗) date -r 1706569200
Tue Jan 30 00:00:00 CET 2024
```

Firstly, the period shouldn't be active and secondly, the end date spans across the entire day.

**After:**
```bash
                "includes": [
                    "holidays"
                ],
                "is_inside": false,
                "name": "offDuty",
                "ranges": {
                    "monday": "00:00-09:00"
                },
                "segments": [
                    {
                        "begin": 1706482800,
                        "end": 1706515200
                    }
                ],
---

~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706482800
Mon Jan 29 00:00:00 CET 2024
~/Workspace/icinga2 (broken-timeperiod ✗) date -r 1706515200
Mon Jan 29 09:00:00 CET 2024
```

</details>

fixes #9781
fixes #9388
fixes #8741
fixes #7398
fixes #7239
fixes also https://community.icinga.com/t/i-get-notifications-for-users-outside-their-timeperiod/13126