### PR TITLE
JsonRpcConnection#Send*(): discard messages ASAP once shutting down

### DIFF
--- a/lib/base/defer.hpp
+++ b/lib/base/defer.hpp
@@ -22,6 +22,8 @@ public:
 	{
 	}
 
+	Defer() = default;
+
 	Defer(const Defer&) = delete;
 	Defer(Defer&&) = delete;
 	Defer& operator=(const Defer&) = delete;
@@ -37,6 +39,11 @@ public:
 				// https://stackoverflow.com/questions/130117/throwing-exceptions-out-of-a-destructor
 			}
 		}
+	}
+
+	inline void SetFunc(std::function<void()> func)
+	{
+		m_Func = std::move(func);
 	}
 
 	inline

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1021,6 +1021,10 @@ void ApiListener::ApiTimerHandler()
 				maxTs = client->GetTimestamp();
 		}
 
+		Log(LogNotice, "ApiListener")
+			<< "Setting log position for identity '" << endpoint->GetName() << "': "
+			<< Utility::FormatDateTime("%Y/%m/%d %H:%M:%S", ts);
+
 		for (const JsonRpcConnection::Ptr& client : endpoint->GetClients()) {
 			if (client->GetTimestamp() == maxTs) {
 				try {
@@ -1033,10 +1037,6 @@ void ApiListener::ApiTimerHandler()
 				client->Disconnect();
 			}
 		}
-
-		Log(LogNotice, "ApiListener")
-			<< "Setting log position for identity '" << endpoint->GetName() << "': "
-			<< Utility::FormatDateTime("%Y/%m/%d %H:%M:%S", ts);
 	}
 }
 

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1437,10 +1437,12 @@ void ApiListener::LogGlobHandler(std::vector<int>& files, const String& file)
 void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 {
 	Endpoint::Ptr endpoint = client->GetEndpoint();
+	Defer resetEndpointSyncing ([&endpoint]() {
+		ObjectLock olock(endpoint);
+		endpoint->SetSyncing(false);
+	});
 
 	if (endpoint->GetLogDuration() == 0) {
-		ObjectLock olock2(endpoint);
-		endpoint->SetSyncing(false);
 		return;
 	}
 
@@ -1457,14 +1459,10 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 	Zone::Ptr target_zone = target_endpoint->GetZone();
 
 	if (!target_zone) {
-		ObjectLock olock2(endpoint);
-		endpoint->SetSyncing(false);
 		return;
 	}
 
-	bool stopReplay = false;
-
-	do {
+	for (;;) {
 		std::unique_lock<std::mutex> lock(m_LogLock);
 
 		CloseLogFile();
@@ -1546,9 +1544,7 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 
 					Log(LogDebug, "ApiListener")
 						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex);
-
-					stopReplay = true;
-					break;
+					return;
 				}
 
 				peer_ts = pmessage->Get("timestamp");
@@ -1569,10 +1565,6 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 			}
 
 			logStream->Close();
-
-			if (stopReplay) {
-				break;
-			}
 		}
 
 		if (count > 0) {
@@ -1587,12 +1579,9 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		if (last_sync) {
 			OpenLogFile();
 
-			break;
+			return;
 		}
-	} while (!stopReplay);
-
-	ObjectLock olock2 (endpoint);
-	endpoint->SetSyncing(false);
+	}
 }
 
 void ApiListener::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata)

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1023,7 +1023,12 @@ void ApiListener::ApiTimerHandler()
 
 		for (const JsonRpcConnection::Ptr& client : endpoint->GetClients()) {
 			if (client->GetTimestamp() == maxTs) {
-				client->SendMessage(lmessage);
+				try {
+					client->SendMessage(lmessage);
+				} catch (const std::runtime_error& ex) {
+					Log(LogNotice, "ApiListener")
+						<< "Error while setting log position for identity '" << endpoint->GetName() << "': " << DiagnosticInformation(ex, false);
+				}
 			} else {
 				client->Disconnect();
 			}
@@ -1195,7 +1200,12 @@ void ApiListener::SyncSendMessage(const Endpoint::Ptr& endpoint, const Dictionar
 			if (client->GetTimestamp() != maxTs)
 				continue;
 
-			client->SendMessage(message);
+			try {
+				client->SendMessage(message);
+			} catch (const std::runtime_error& ex) {
+				Log(LogNotice, "ApiListener")
+					<< "Error while sending message to endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex, false);
+			}
 		}
 	}
 }

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1462,7 +1462,9 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		return;
 	}
 
-	for (;;) {
+	bool stopReplay = false;
+
+	do {
 		std::unique_lock<std::mutex> lock(m_LogLock);
 
 		CloseLogFile();
@@ -1545,6 +1547,7 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 					Log(LogDebug, "ApiListener")
 						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex);
 
+					stopReplay = true;
 					break;
 				}
 
@@ -1566,6 +1569,10 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 			}
 
 			logStream->Close();
+
+			if (stopReplay) {
+				break;
+			}
 		}
 
 		if (count > 0) {
@@ -1578,16 +1585,14 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		}
 
 		if (last_sync) {
-			{
-				ObjectLock olock2(endpoint);
-				endpoint->SetSyncing(false);
-			}
-
 			OpenLogFile();
 
 			break;
 		}
-	}
+	} while (!stopReplay);
+
+	ObjectLock olock2 (endpoint);
+	endpoint->SetSyncing(false);
 }
 
 void ApiListener::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perfdata)

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1466,12 +1466,14 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		std::unique_lock<std::mutex> lock(m_LogLock);
 
 		CloseLogFile();
+		Defer reopenLog;
 
 		if (count == -1 || count > 50000) {
 			OpenLogFile();
 			lock.unlock();
 		} else {
 			last_sync = true;
+			reopenLog.SetFunc([this]() { OpenLogFile(); });
 		}
 
 		count = 0;
@@ -1577,8 +1579,6 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		}
 
 		if (last_sync) {
-			OpenLogFile();
-
 			return;
 		}
 	}

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -163,6 +163,10 @@ ConnectionRole JsonRpcConnection::GetRole() const
 
 void JsonRpcConnection::SendMessage(const Dictionary::Ptr& message)
 {
+	if (m_ShuttingDown) {
+		return;
+	}
+
 	Ptr keepAlive (this);
 
 	m_IoStrand.post([this, keepAlive, message]() { SendMessageInternal(message); });
@@ -170,9 +174,17 @@ void JsonRpcConnection::SendMessage(const Dictionary::Ptr& message)
 
 void JsonRpcConnection::SendRawMessage(const String& message)
 {
+	if (m_ShuttingDown) {
+		return;
+	}
+
 	Ptr keepAlive (this);
 
 	m_IoStrand.post([this, keepAlive, message]() {
+		if (m_ShuttingDown) {
+			return;
+		}
+
 		m_OutgoingMessagesQueue.emplace_back(message);
 		m_OutgoingMessagesQueued.Set();
 	});
@@ -180,6 +192,10 @@ void JsonRpcConnection::SendRawMessage(const String& message)
 
 void JsonRpcConnection::SendMessageInternal(const Dictionary::Ptr& message)
 {
+	if (m_ShuttingDown) {
+		return;
+	}
+
 	m_OutgoingMessagesQueue.emplace_back(JsonEncode(message));
 	m_OutgoingMessagesQueued.Set();
 }

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -188,12 +188,10 @@ void JsonRpcConnection::Disconnect()
 {
 	namespace asio = boost::asio;
 
-	JsonRpcConnection::Ptr keepAlive (this);
+	if (!m_ShuttingDown.exchange(true)) {
+		JsonRpcConnection::Ptr keepAlive (this);
 
-	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) {
-		if (!m_ShuttingDown) {
-			m_ShuttingDown = true;
-
+		IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) {
 			Log(LogWarning, "JsonRpcConnection")
 				<< "API client disconnected for identity '" << m_Identity << "'";
 
@@ -241,8 +239,8 @@ void JsonRpcConnection::Disconnect()
 			shutdownTimeout->Cancel();
 
 			m_Stream->lowest_layer().shutdown(m_Stream->lowest_layer().shutdown_both, ec);
-		}
-	});
+		});
+	}
 }
 
 void JsonRpcConnection::MessageHandler(const String& jsonString)

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -164,7 +164,7 @@ ConnectionRole JsonRpcConnection::GetRole() const
 void JsonRpcConnection::SendMessage(const Dictionary::Ptr& message)
 {
 	if (m_ShuttingDown) {
-		return;
+		BOOST_THROW_EXCEPTION(std::runtime_error("Cannot send message to already disconnected API client '" + GetIdentity() + "'!"));
 	}
 
 	Ptr keepAlive (this);
@@ -175,7 +175,7 @@ void JsonRpcConnection::SendMessage(const Dictionary::Ptr& message)
 void JsonRpcConnection::SendRawMessage(const String& message)
 {
 	if (m_ShuttingDown) {
-		return;
+		BOOST_THROW_EXCEPTION(std::runtime_error("Cannot send message to already disconnected API client '" + GetIdentity() + "'!"));
 	}
 
 	Ptr keepAlive (this);

--- a/lib/remote/jsonrpcconnection.hpp
+++ b/lib/remote/jsonrpcconnection.hpp
@@ -5,6 +5,7 @@
 
 #include "remote/i2-remote.hpp"
 #include "remote/endpoint.hpp"
+#include "base/atomic.hpp"
 #include "base/io-engine.hpp"
 #include "base/tlsstream.hpp"
 #include "base/timer.hpp"
@@ -77,7 +78,7 @@ private:
 	std::vector<String> m_OutgoingMessagesQueue;
 	AsioConditionVariable m_OutgoingMessagesQueued;
 	AsioConditionVariable m_WriterDone;
-	bool m_ShuttingDown;
+	Atomic<bool> m_ShuttingDown;
 	boost::asio::deadline_timer m_CheckLivenessTimer, m_HeartbeatTimer;
 
 	JsonRpcConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role, boost::asio::io_context& io);


### PR DESCRIPTION
Especially ApiListener#ReplayLog() enqueued lots of messages into
    JsonRpcConnection#{m_IoStrand,m_OutgoingMessagesQueue} (RAM) even if
    the connection was shut(ting) down. Now #Disconnect() takes effect ASAP.

fixes #9985