### PR TITLE
Drop redundant `CpuBoundWork` usage in `JsonRpcConnection::Disconnect()`

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -199,14 +199,14 @@ void JsonRpcConnection::Disconnect()
 			Log(LogWarning, "JsonRpcConnection")
 				<< "API client disconnected for identity '" << m_Identity << "'";
 
-			{
-				CpuBoundWork removeClient (yc);
-
-				if (m_Endpoint) {
-					m_Endpoint->RemoveClient(this);
-				} else {
-					ApiListener::GetInstance()->RemoveAnonymousClient(this);
-				}
+			// We need to unregister the endpoint client as soon as possible not to confuse Icinga 2,
+			// given that Endpoint::GetConnected() is just performing a check that the endpoint's client
+			// cache is not empty, which could result in an already disconnected endpoint never trying to
+			// reconnect again. See #7444.
+			if (m_Endpoint) {
+				m_Endpoint->RemoveClient(this);
+			} else {
+				ApiListener::GetInstance()->RemoveAnonymousClient(this);
 			}
 
 			m_OutgoingMessagesQueued.Set();


### PR DESCRIPTION
Although there is locking involved here, it shoudln't take too long for the thread to actually acquire it, since there aren't that many threads dealing with endpoint clients concurrently. It's just wasting pointless time trying to obtain a CPU slot.

refs #9988