### PR TITLE
IoEngine: Always log coroutine exception diagnostics

### DIFF
--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -109,8 +109,7 @@ public:
 					// https://github.com/boostorg/coroutine/issues/39
 					throw;
 				} catch (const std::exception& ex) {
-					Log(LogCritical, "IoEngine", "Exception in coroutine!");
-					Log(LogDebug, "IoEngine") << "Exception in coroutine: " << DiagnosticInformation(ex);
+					Log(LogCritical, "IoEngine") << "Exception in coroutine: " << DiagnosticInformation(ex);
 				} catch (...) {
 					Log(LogCritical, "IoEngine", "Exception in coroutine!");
 				}


### PR DESCRIPTION
While analyzing a possible memory leak, we encountered several coroutine exception messages, which unfortunately do not provide any information about what exactly went wrong, as exception diagnostics were previously only logged at the notice level.

ref/IP/48306