### PR TITLE
Drop redundant `CpuBoundWork` usages in `lib/remote`

### DIFF
--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -116,15 +116,11 @@ bool EventsHandler::HandleRequest(
 		auto event (subscriber.GetInbox()->Shift(yc));
 
 		if (event) {
-			CpuBoundWork buildingResponse (yc);
-
 			String body = JsonEncode(event);
 
 			boost::algorithm::replace_all(body, "\n", "");
 
 			asio::const_buffer payload (body.CStr(), body.GetLength());
-
-			buildingResponse.Done();
 
 			asio::async_write(stream, payload, yc);
 			asio::async_write(stream, newLine, yc);

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -240,8 +240,6 @@ bool HandleAccessControl(
 		auto headerAllowOrigin (listener->GetAccessControlAllowOrigin());
 
 		if (headerAllowOrigin) {
-			CpuBoundWork allowOriginHeader (yc);
-
 			auto allowedOrigins (headerAllowOrigin->ToSet<String>());
 
 			if (!allowedOrigins.empty()) {
@@ -250,8 +248,6 @@ bool HandleAccessControl(
 				if (allowedOrigins.find(std::string(origin)) != allowedOrigins.end()) {
 					response.set(http::field::access_control_allow_origin, origin);
 				}
-
-				allowOriginHeader.Done();
 
 				response.set(http::field::access_control_allow_credentials, "true");
 
@@ -537,8 +533,6 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 			auto authenticatedUser (m_ApiUser);
 
 			if (!authenticatedUser) {
-				CpuBoundWork fetchingAuthenticatedUser (yc);
-
 				authenticatedUser = ApiUser::GetByAuthHeader(std::string(request[http::field::authorization]));
 			}
 

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -102,8 +102,6 @@ void HttpServerConnection::Disconnect()
 			auto listener (ApiListener::GetInstance());
 
 			if (listener) {
-				CpuBoundWork removeHttpClient (yc);
-
 				listener->RemoveHttpClient(this);
 			}
 		}

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -81,6 +81,8 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 			CpuBoundWork handleMessage (yc);
 
 			MessageHandler(message);
+
+			l_TaskStats.InsertValue(Utility::GetTime(), 1);
 		} catch (const std::exception& ex) {
 			Log(m_ShuttingDown ? LogDebug : LogWarning, "JsonRpcConnection")
 				<< "Error while processing JSON-RPC message for identity '" << m_Identity
@@ -88,10 +90,6 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 
 			break;
 		}
-
-		CpuBoundWork taskStats (yc);
-
-		l_TaskStats.InsertValue(Utility::GetTime(), 1);
 	}
 
 	Disconnect();


### PR DESCRIPTION
These scopes do not need their own CPU slot to continue, but they just slow down the overall request handling and waste expensive CPU slots that would have been used by other connections awaiting to obtain a free slot. https://github.com/Icinga/icinga2/issues/9988#issuecomment-1933604617