### PR TITLE
ApiListener#ListenerCoroutineProc(): get remote endpoint ASAP for logging

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -513,6 +513,8 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 
 			server->async_accept(socket.lowest_layer(), yc);
 
+			auto remoteEndpoint (socket.lowest_layer().remote_endpoint());
+
 			if (!crlPath.IsEmpty()) {
 				time_t currentCreationTime = Utility::GetFileCreationTime(crlPath);
 
@@ -531,12 +533,11 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 
 			auto strand (Shared<asio::io_context::strand>::Make(io));
 
-			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn](asio::yield_context yc) {
+			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
 				Timeout::Ptr timeout(new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
-					[sslConn](asio::yield_context yc) {
+					[sslConn, remoteEndpoint](asio::yield_context yc) {
 						Log(LogWarning, "ApiListener")
-							<< "Timeout while processing incoming connection from "
-							<< sslConn->lowest_layer().remote_endpoint();
+							<< "Timeout while processing incoming connection from " << remoteEndpoint;
 
 						boost::system::error_code ec;
 						sslConn->lowest_layer().cancel(ec);


### PR DESCRIPTION
On incoming connection timeout we log the remote endpoint which isn't available if it was already disconnected - an exception is thrown.  Get it as long as we're still connected not to lose it, nor to get an exception.

ref/IP/48306

This is my alternative implementation for:

closes #9996