### PR TITLE
ApiListener: Reset `m_LogMessageCount` when rotating

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1375,7 +1375,6 @@ void ApiListener::OpenLogFile()
 	}
 
 	m_LogFile = new StdioStream(fp.release(), true);
-	m_LogMessageCount = 0;
 	SetLogMessageTimestamp(Utility::GetTime());
 }
 
@@ -1405,6 +1404,9 @@ void ApiListener::RotateLogFile()
 	if (!Utility::PathExists(newpath)) {
 		try {
 			Utility::RenameFile(oldpath, newpath);
+
+			// We're rotating the current log file, so reset the log message counter as well.
+			m_LogMessageCount = 0;
 		} catch (const std::exception& ex) {
 			Log(LogCritical, "ApiListener")
 				<< "Cannot rotate replay log file from '" << oldpath << "' to '"


### PR DESCRIPTION
Closing and re-opening that very same log file shouldn't reset the counter, otherwise some log files may exceed the max limit per file as their offset indicator is reset each time they are re-opened.

ref/IP/48306