### PR TITLE
Fix broken downtime comment sync

### DIFF
--- a/lib/base/dependencygraph.hpp
+++ b/lib/base/dependencygraph.hpp
@@ -5,7 +5,9 @@
 
 #include "base/i2-base.hpp"
 #include "base/configobject.hpp"
-#include <map>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
 #include <mutex>
 
 namespace icinga {
@@ -20,13 +22,82 @@ class DependencyGraph
 public:
 	static void AddDependency(ConfigObject* child, ConfigObject* parent);
 	static void RemoveDependency(ConfigObject* child, ConfigObject* parent);
+	static std::vector<ConfigObject::Ptr> GetParents(const ConfigObject::Ptr& child);
 	static std::vector<ConfigObject::Ptr> GetChildren(const ConfigObject::Ptr& parent);
 
 private:
 	DependencyGraph();
 
+	/**
+	 * Represents an undirected dependency edge between two objects.
+	 *
+	 * It allows to traverse the graph in both directions, i.e. from parent to child and vice versa.
+	 */
+	struct Edge
+	{
+		ConfigObject* parent; // The parent object of the child one.
+		ConfigObject* child; // The dependent object of the parent.
+		// Counter for the number of parent <-> child edges to allow duplicates.
+		int count;
+
+		Edge(ConfigObject* parent, ConfigObject* child, int count = 1): parent(parent), child(child), count(count)
+		{
+		}
+
+		struct Hash
+		{
+			/**
+			 * Generates a unique hash of the given Edge object.
+			 *
+			 * Note, the hash value is generated only by combining the hash values of the parent and child pointers.
+			 *
+			 * @param edge The Edge object to be hashed.
+			 *
+			 * @return size_t The resulting hash value of the given object.
+			 */
+			size_t operator()(const Edge& edge) const
+			{
+				size_t seed = 0;
+				boost::hash_combine(seed, edge.parent);
+				boost::hash_combine(seed, edge.child);
+
+				return seed;
+			}
+		};
+
+		struct Equal
+		{
+			/**
+			 * Compares whether the two Edge objects contain the same parent and child pointers.
+			 *
+			 * Note, the member property count is not taken into account for equality checks.
+			 *
+			 * @param a The first Edge object to compare.
+			 * @param b The second Edge object to compare.
+			 *
+			 * @return bool Returns true if the two objects are equal, false otherwise.
+			 */
+			bool operator()(const Edge& a, const Edge& b) const
+			{
+				return a.parent == b.parent && a.child == b.child;
+			}
+		};
+	};
+
+	using DependencyMap = boost::multi_index_container<
+		Edge, // The value type we want to sore in the container.
+		boost::multi_index::indexed_by<
+			// The first indexer is used for lookups by the Edge from child to parent, thus it
+			// needs its own hash function and comparison predicate.
+			boost::multi_index::hashed_unique<boost::multi_index::identity<Edge>, Edge::Hash, Edge::Equal>,
+			// These two indexers are used for lookups by the parent and child pointers.
+			boost::multi_index::hashed_non_unique<boost::multi_index::member<Edge, ConfigObject*, &Edge::parent>>,
+			boost::multi_index::hashed_non_unique<boost::multi_index::member<Edge, ConfigObject*, &Edge::child>>
+		>
+	>;
+
 	static std::mutex m_Mutex;
-	static std::map<ConfigObject*, std::map<ConfigObject*, int>> m_Dependencies;
+	static DependencyMap m_Dependencies;
 };
 
 }

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -5,11 +5,13 @@
 #include "remote/configobjectutility.hpp"
 #include "remote/jsonrpc.hpp"
 #include "base/configtype.hpp"
-#include "base/json.hpp"
 #include "base/convert.hpp"
+#include "base/dependencygraph.hpp"
+#include "base/json.hpp"
 #include "config/vmops.hpp"
 #include "remote/configobjectslock.hpp"
 #include <fstream>
+#include <unordered_set>
 
 using namespace icinga;
 
@@ -393,6 +395,40 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 	}
 }
 
+/**
+ * Syncs the specified object and its direct and indirect parents to the provided client
+ * in topological order of their dependency graph recursively.
+ *
+ * Objects that the client does not have access to are skipped without going through their dependency graph.
+ *
+ * Please do not use this method to forward remote generated cluster updates; it should only be used to
+ * send local updates to that specific non-nullptr client.
+ *
+ * @param object The config object you want to sync.
+ * @param azone The zone of the client you want to send the update to.
+ * @param client The JsonRpc client you send the update to.
+ * @param syncedObjects Used to cache the already synced objects.
+ */
+void ApiListener::UpdateConfigObjectWithParents(const ConfigObject::Ptr& object, const Zone::Ptr& azone,
+	const JsonRpcConnection::Ptr& client, std::unordered_set<ConfigObject*>& syncedObjects)
+{
+	if (syncedObjects.find(object.get()) != syncedObjects.end()) {
+		return;
+	}
+
+	/* don't sync objects for non-matching parent-child zones */
+	if (!azone->CanAccessObject(object)) {
+		return;
+	}
+	syncedObjects.emplace(object.get());
+
+	for (const auto& parent : DependencyGraph::GetParents(object)) {
+		UpdateConfigObjectWithParents(parent, azone, client, syncedObjects);
+	}
+
+	/* send the config object to the connected client */
+	UpdateConfigObject(object, nullptr, client);
+}
 
 void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,
 	const JsonRpcConnection::Ptr& client)
@@ -454,19 +490,17 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 	Log(LogInformation, "ApiListener")
 		<< "Syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
 
+	std::unordered_set<ConfigObject*> syncedObjects;
 	for (const Type::Ptr& type : Type::GetAllTypes()) {
-		auto *dtype = dynamic_cast<ConfigType *>(type.get());
-
-		if (!dtype)
-			continue;
-
-		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
-			/* don't sync objects for non-matching parent-child zones */
-			if (!azone->CanAccessObject(object))
-				continue;
-
-			/* send the config object to the connected client */
-			UpdateConfigObject(object, nullptr, aclient);
+		if (auto *ctype = dynamic_cast<ConfigType *>(type.get())) {
+			for (const auto& object : ctype->GetObjects()) {
+				// All objects must be synced sorted by their dependency graph.
+				// Otherwise, downtimes/comments etc. might get synced before their respective Checkables, which will
+				// result in comments and downtimes being ignored by the other endpoint since it does not yet know
+				// about their checkables. Given that the runtime config updates event does not trigger a reload on the
+				// remote endpoint, these objects won't be synced again until the next reload.
+				UpdateConfigObjectWithParents(object, azone, aclient, syncedObjects);
+			}
 		}
 	}
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -247,6 +247,8 @@ private:
 	/* configsync */
 	void UpdateConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,
 		const JsonRpcConnection::Ptr& client = nullptr);
+	void UpdateConfigObjectWithParents(const ConfigObject::Ptr& object, const Zone::Ptr& azone,
+		const JsonRpcConnection::Ptr& client, std::unordered_set<ConfigObject*>& syncedObjects);
 	void DeleteConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,
 		const JsonRpcConnection::Ptr& client = nullptr);
 	void SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient);


### PR DESCRIPTION
All objects must be synced sorted by their load dependency. Otherwise, downtimes and/or comments might get synced before their respective Checkables, which will result in comments and downtimes being ignored by the other endpoint since it does not yet know about their checkables. Given that the runtime config updates event does not trigger a reload on the remote endpoint, these objects won't be synced again until the next reload.

```bash
~/master2/icinga2 (bundled-cluster-fixes ✗) ls prefix/var/lib/icinga2/api/packages/_api/*/conf.d/downtimes | wc -l
    3501
```

```bash
~/master2/icinga2 (bundled-cluster-fixes ✗) curl -sSku root:icinga 'https://localhost:5666/v1/objects/downtimes?pretty=1' | grep ' "attrs": {' | wc -l
    1501
~/master1/icinga2 (bundled-cluster-fixes ✗) curl -sSku root:icinga 'https://localhost:5665/v1/objects/downtimes?pretty=1' | grep ' "attrs": {' | wc -l
    3501
```

After master2 reload:
```bash
~/master2/icinga2 (bundled-cluster-fixes ✗) curl -sSku root:icinga 'https://localhost:5666/v1/objects/downtimes?pretty=1' | grep ' "attrs": {' | wc -l
    3501
```

closes #7786
closes #9873

## TODO

* [x] #10148
* [x] rebase