### PR TITLE
Add a dedicated method for disconnecting TLS connections

### DIFF
--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -7,6 +7,8 @@
 #include "base/logger.hpp"
 #include "base/configuration.hpp"
 #include "base/convert.hpp"
+#include "base/defer.hpp"
+#include "base/io-engine.hpp"
 #include <boost/asio/ssl/context.hpp>
 #include <boost/asio/ssl/verify_context.hpp>
 #include <boost/asio/ssl/verify_mode.hpp>
@@ -102,4 +104,66 @@ void UnbufferedAsioTlsStream::BeforeHandshake(handshake_type type)
 		SSL_set_tlsext_host_name(native_handle(), serverName.CStr());
 	}
 #endif /* SSL_CTRL_SET_TLSEXT_HOSTNAME */
+}
+
+/**
+ * Forcefully close the connection, typically (details are up to the operating system) using a TCP RST.
+ */
+void AsioTlsStream::ForceDisconnect()
+{
+	if (!lowest_layer().is_open()) {
+		// Already disconnected, nothing to do.
+		return;
+	}
+
+	boost::system::error_code ec;
+
+	// Close the socket. In case the connection wasn't shut down cleanly by GracefulDisconnect(), the operating system
+	// will typically terminate the connection with a TCP RST. Otherwise, this just releases the file descriptor.
+	lowest_layer().close(ec);
+}
+
+/**
+ * Try to cleanly shut down the connection. This involves sending a TLS close_notify shutdown alert and terminating the
+ * underlying TCP connection. Sending these additional messages can block, hence the method takes a yield context and
+ * internally implements a timeout of 10 seconds for the operation after which the connection is forcefully terminated
+ * using ForceDisconnect().
+ *
+ * @param strand Asio strand used for other operations on this connection.
+ * @param yc Yield context for Asio coroutines
+ */
+void AsioTlsStream::GracefulDisconnect(boost::asio::io_context::strand& strand, boost::asio::yield_context& yc)
+{
+	if (!lowest_layer().is_open()) {
+		// Already disconnected, nothing to do.
+		return;
+	}
+
+	{
+		Timeout::Ptr shutdownTimeout(new Timeout(strand.context(), strand, boost::posix_time::seconds(10),
+			[this](boost::asio::yield_context yc) {
+				// Forcefully terminate the connection if async_shutdown() blocked more than 10 seconds.
+				ForceDisconnect();
+			}
+		));
+		Defer cancelTimeout ([&shutdownTimeout]() {
+			shutdownTimeout->Cancel();
+		});
+
+		// Close the TLS connection, effectively uses SSL_shutdown() to send a close_notify shutdown alert to the peer.
+		boost::system::error_code ec;
+		next_layer().async_shutdown(yc[ec]);
+	}
+
+	if (!lowest_layer().is_open()) {
+		// Connection got closed in the meantime, most likely by the timeout, so nothing more to do.
+		return;
+	}
+
+	// Shut down the TCP connection.
+	boost::system::error_code ec;
+	lowest_layer().shutdown(lowest_layer_type::shutdown_both, ec);
+
+	// Clean up the connection (closes the file descriptor).
+	ForceDisconnect();
 }

--- a/lib/base/tlsstream.hpp
+++ b/lib/base/tlsstream.hpp
@@ -111,6 +111,9 @@ public:
 	{
 	}
 
+	void ForceDisconnect();
+	void GracefulDisconnect(boost::asio::io_context::strand& strand, boost::asio::yield_context& yc);
+
 private:
 	inline
 	AsioTlsStream(UnbufferedAsioTlsStreamParams init)

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -102,6 +102,8 @@ static void DoIfwNetIo(
 	}
 
 	{
+		// Using async_shutdown() instead of AsioTlsStream::GracefulDisconnect() as this whole function
+		// is already guarded by a timeout based on the check timeout.
 		boost::system::error_code ec;
 		sslConn.async_shutdown(yc[ec]);
 	}

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -719,6 +719,9 @@ void ApiListener::NewClientHandlerInternal(
 			// Ignore the error, but do not throw an exception being swallowed at all cost.
 			// https://github.com/Icinga/icinga2/issues/7351
 			boost::system::error_code ec;
+
+			// Using async_shutdown() instead of AsioTlsStream::GracefulDisconnect() as this whole function
+			// is already guarded by a timeout based on the connect timeout.
 			sslConn.async_shutdown(yc[ec]);
 		}
 	});


### PR DESCRIPTION
Properly closing a TLS connection involves sending some shutdown messages so that both ends know that the connection wasn't truncated maliciously. Exchanging those messages can stall for a long time if the underlying TCP connection is broken. The HTTP connection handling was missing any kind of timeout for the TLS shutdown so that dead connections could hang around for a long time.

This PR introduces two new methods on `AsioTlsStream`, namely `ForceDisconnect()` which just wraps the call for closing the TCP connection and `GracefulShutdown()` which performs the TLS shutdown with a timeout similar to it was done in `JsonRpcConnection::Disconnect()` before.

fixes #9986