### PR TITLE
Don't unnecessarily shuffle items before config validation

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -439,12 +439,6 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	if (!total)
 		return true;
 
-	// Shuffle all items to evenly distribute them over the threads of the workqueue. This increases perfomance
-	// noticably in environments with lots of objects and available threads.
-	for (auto& kv : itemsByType) {
-		std::shuffle(std::begin(kv.second), std::end(kv.second), std::default_random_engine{});
-	}
-
 #ifdef I2_DEBUG
 	Log(LogDebug, "configitem")
 		<< "Committing " << total << " new items.";


### PR DESCRIPTION
Before ae693cb7e1df1b885142854cf8a0f8a7600a3fb7 (#9577) we've repeatedly looped over all items in parallel like this:

```
while not types.done:
  for t in types:
    if not t.done and t.dependencies.done:
      with parallel(all_items, CONCURRENCY) as some_items:
        for i in some_items:
          if i.type is t:
            i.commit()
```

I.e. all items got distributed over CONCURRENCY threads, but not always equally. E.g. it was the hosts' turn, but only two threads got hosts and did all the work. The others didn't do actual work (due to the lack of hosts in their queue) which reduced the performance. c721c302cd9c96bee25a20b3862dad347345648a (#6581) fixed it by shuffling all_items first. ae693cb7e1df1b885142854cf8a0f8a7600a3fb7 (#9577) made the latter unnecessary by replacing the above algorithm with this:

```
while not types.done:
  for t in types:
    if not t.done and t.dependencies.done:
      with parallel(all_items[t], CONCURRENCY) as some_items:
        for i in some_items:
          if i.type is t:
            i.commit()
```

I.e. parallel() gets only items of type t, so all threads get e.g. hosts.