### PR TITLE
OpenTsdbWriter#CheckResultHandler(): clarify log messages

### DIFF
--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -207,8 +207,8 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 				
 				if (!missing_macro.IsEmpty()) {
 					Log(LogDebug, "OpenTsdbWriter")
-						<< "Unable to resolve macro:'" << missing_macro 
-						<< "' for this host or service.";
+						<< "Unable to resolve macro '" << missing_macro 
+						<< "' for checkable '" << checkable->GetName() << "'.";
 					
 					continue;
 				}
@@ -227,8 +227,8 @@ void OpenTsdbWriter::CheckResultHandler(const Checkable::Ptr& checkable, const C
 			
 			if (!missing_macro.IsEmpty()) {
 				Log(LogDebug, "OpenTsdbWriter")
-					<< "Unable to resolve macro:'" << missing_macro 
-					<< "' for this host or service.";
+					<< "Unable to resolve macro '" << missing_macro 
+					<< "' for checkable '" << checkable->GetName() << "'.";
 				
 			}
 			else {


### PR DESCRIPTION
Clarify which "host or service" an "Unable to resolve macro" debug log message refers to.

As you suggested in https://github.com/Icinga/icinga2/pull/7928#pullrequestreview-1893793813