### PR TITLE
pki::RequestCertificate: don't persist untrusted CSRs over 1GiB total

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -277,14 +277,14 @@ delayed_request:
 			decltype(fs::file_size({})) total = 0;
 			boost::system::error_code ec;
 
-			for (fs::directory_iterator dirIt (fs::path(requestDir.GetData())), dirEnd; !ec && dirIt != dirEnd; dirIt.increment(ec)) {
+			fs::directory_iterator dirIt(fs::path(requestDir), ec);
+			fs::directory_iterator dirEnd;
+			for (; !ec && dirIt != dirEnd; dirIt.increment(ec)) {
 				boost::system::error_code ec;
 				auto stats (dirIt->symlink_status(ec));
 
 				if (!ec && fs::is_regular_file(stats)) {
-					auto size (fs::file_size(dirIt->path(), ec));
-
-					if (!ec) {
+					if (auto size(fs::file_size(dirIt->path(), ec)); !ec) {
 						total += size;
 					}
 				}


### PR DESCRIPTION
Otherwise anonymous peers could fill the disk with CSRs.
Would take a long time and the admin would notice as with Icinga they have a monitoring tool by definition.
But better safe than sorry.

## Before

```
[2024-03-08 10:24:14 +0100] information/JsonRpcConnection: Received certificate request for CN '2024-03-08 10:24:10.881432 +0100 CET m=+3.505743859' which couldn't be verified: self signed certificate (code 18)
[2024-03-08 10:24:14 +0100] information/JsonRpcConnection: Certificate request for CN '2024-03-08 10:24:09.374815 +0100 CET m=+1.999114695' is pending. Waiting for approval.
```

... until disk says _nope_.

## After

```
[2024-03-08 10:28:44 +0100] critical/JsonRpcConnection: Temporarily rejecting certificate request for CN '2024-03-08 10:28:42.061735 +0100 CET m=+1.365551804'. Storage quota exceeded!
```