### PR TITLE
Mention plugin exit codes outside [0..3] in the plugin output and warning log

### DIFF
--- a/lib/base/process.hpp
+++ b/lib/base/process.hpp
@@ -5,6 +5,7 @@
 
 #include "base/i2-base.hpp"
 #include "base/dictionary.hpp"
+#include <cstdint>
 #include <iosfwd>
 #include <deque>
 #include <vector>
@@ -25,7 +26,7 @@ struct ProcessResult
 	pid_t PID;
 	double ExecutionStart;
 	double ExecutionEnd;
-	long ExitStatus;
+	int_fast64_t ExitStatus;
 	String Output;
 };
 

--- a/lib/icinga/checkresult.ti
+++ b/lib/icinga/checkresult.ti
@@ -1,5 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
+#include <cstdint>
+
 library icinga;
 
 namespace icinga
@@ -50,7 +52,7 @@ class CheckResult
 	[state] Timestamp execution_end;
 
 	[state] Value command;
-	[state] int exit_status;
+	[state] int_fast64_t exit_status;
 
 	[state, enum] ServiceState "state";
 	[state, enum] ServiceState previous_hard_state;


### PR DESCRIPTION
to simplify debugging. Now customers seeing a misbehaving plugin don't have to turn on debug logs.

ref/IP/52294

## Test

```
                "last_check_result": {
...
                    "exit_status": 128,
                    "output": "execvpe(/Users/aklimov/NET/WS/prefix/usr/lib/nagios/plugins/check_disk) failed: No such file or directory\n<Terminated with exit code 128.>",
...
                },
```

👍