### PR TITLE
Fix missing values in PerfData normalization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,6 +163,7 @@ Luca Lesinigo <luca@lm-net.it>
 Lucas Bremgartner <breml@users.noreply.github.com>
 Lucas Fairchild-Madar <lucas.madar@gmail.com>
 Luiz Amaral <luiz.amaral@innogames.com>
+Maciej Dems <maciej.dems@p.lodz.pl>
 Magnus Bäck <magnus@noun.se>
 Maik Stuebner <maik@stuebner.info>
 Malte Rabenseifner <mail@malte-rabenseifner.de>

--- a/lib/base/perfdatavalue.cpp
+++ b/lib/base/perfdatavalue.cpp
@@ -363,20 +363,27 @@ String PerfdataValue::Format() const
 
 	result << unit;
 
+	std::string interm(";");
 	if (!GetWarn().IsEmpty()) {
-		result << ";" << Convert::ToString(GetWarn());
+		result << interm << Convert::ToString(GetWarn());
+		interm.clear();
+	}
 
-		if (!GetCrit().IsEmpty()) {
-			result << ";" << Convert::ToString(GetCrit());
+	interm += ";";
+	if (!GetCrit().IsEmpty()) {
+		result << interm << Convert::ToString(GetCrit());
+		interm.clear();
+	}
 
-			if (!GetMin().IsEmpty()) {
-				result << ";" << Convert::ToString(GetMin());
+	interm += ";";
+	if (!GetMin().IsEmpty()) {
+		result << interm << Convert::ToString(GetMin());
+		interm.clear();
+	}
 
-				if (!GetMax().IsEmpty()) {
-					result << ";" << Convert::ToString(GetMax());
-				}
-			}
-		}
+	interm += ";";
+	if (!GetMax().IsEmpty()) {
+		result << interm << Convert::ToString(GetMax());
 	}
 
 	return result.str();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -196,11 +196,12 @@ add_boost_test(base
     icinga_perfdata/normalize
     icinga_perfdata/uom
     icinga_perfdata/warncritminmax
-    icinga_perfdata/ignore_invalid_warn_crit_min_max
+    icinga_perfdata/ignore_warn_crit_ranges
     icinga_perfdata/invalid
     icinga_perfdata/multi
     icinga_perfdata/scientificnotation
     icinga_perfdata/parse_edgecases
+    icinga_perfdata/empty_warn_crit_min_max
     methods_pluginnotificationtask/truncate_long_output
     remote_configpackageutility/ValidateName
     remote_url/id_and_path

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -11,60 +11,60 @@ BOOST_AUTO_TEST_SUITE(icinga_perfdata)
 BOOST_AUTO_TEST_CASE(empty)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("");
-	BOOST_CHECK(pd->GetLength() == 0);
+	BOOST_CHECK_EQUAL(pd->GetLength(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(simple)
 {
 	PerfdataValue::Ptr pdv = PerfdataValue::Parse("test=123456");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 123456);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 123456);
 
 	String str = pdv->Format();
-	BOOST_CHECK(str == "test=123456");
+	BOOST_CHECK_EQUAL(str, "test=123456");
 }
 
 BOOST_AUTO_TEST_CASE(quotes)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("'hello world'=123456");
-	BOOST_CHECK(pd->GetLength() == 1);
-	
+	BOOST_CHECK_EQUAL(pd->GetLength(), 1);
+
 	PerfdataValue::Ptr pdv = PerfdataValue::Parse("'hello world'=123456");
-	BOOST_CHECK(pdv->GetLabel() == "hello world");
-	BOOST_CHECK(pdv->GetValue() == 123456);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "hello world");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 123456);
 }
 
 BOOST_AUTO_TEST_CASE(multiple)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=123456 testB=123456");
-	BOOST_CHECK(pd->GetLength() == 2);
+	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd);
-	BOOST_CHECK(str == "testA=123456 testB=123456");
+	BOOST_CHECK_EQUAL(str, "testA=123456 testB=123456");
 }
 
 BOOST_AUTO_TEST_CASE(multiline)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata(" 'testA'=123456  'testB'=123456");
-	BOOST_CHECK(pd->GetLength() == 2);
+	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd);
-	BOOST_CHECK(str == "testA=123456 testB=123456");
+	BOOST_CHECK_EQUAL(str, "testA=123456 testB=123456");
 
 	pd = PluginUtility::SplitPerfdata(" 'testA'=123456  \n'testB'=123456");
-	BOOST_CHECK(pd->GetLength() == 2);
+	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	str = PluginUtility::FormatPerfdata(pd);
-	BOOST_CHECK(str == "testA=123456 testB=123456");
+	BOOST_CHECK_EQUAL(str, "testA=123456 testB=123456");
 }
 
 BOOST_AUTO_TEST_CASE(normalize)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=2m;3;4;1;5 testB=2foobar");
-	BOOST_CHECK(pd->GetLength() == 2);
+	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd, true);
-	BOOST_CHECK(str == "testA=120s;180;240;60;300 testB=2");
+	BOOST_CHECK_EQUAL(str, "testA=120s;180;240;60;300 testB=2");
 }
 
 BOOST_AUTO_TEST_CASE(uom)
@@ -72,219 +72,219 @@ BOOST_AUTO_TEST_CASE(uom)
 	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=123456B");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 123456);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 123456);
 	BOOST_CHECK(!pv->GetCounter());
-	BOOST_CHECK(pv->GetUnit() == "bytes");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "bytes");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	String str = pv->Format();
-	BOOST_CHECK(str == "test=123456B");
+	BOOST_CHECK_EQUAL(str, "test=123456B");
 
 	pv = PerfdataValue::Parse("test=1000ms;200;500");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "seconds");
-	BOOST_CHECK(pv->GetWarn() == 0.2);
-	BOOST_CHECK(pv->GetCrit() == 0.5);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "seconds");
+	BOOST_CHECK_EQUAL(pv->GetWarn(), 0.2);
+	BOOST_CHECK_EQUAL(pv->GetCrit(), 0.5);
 
 	pv = PerfdataValue::Parse("test=1000ms");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "seconds");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "seconds");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1s");
+	BOOST_CHECK_EQUAL(str, "test=1s");
 
 	pv = PerfdataValue::Parse("test=1kAm");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 60 * 1000);
-	BOOST_CHECK(pv->GetUnit() == "ampere-seconds");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 60 * 1000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "ampere-seconds");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=60000As");
+	BOOST_CHECK_EQUAL(str, "test=60000As");
 
 	pv = PerfdataValue::Parse("test=1MA");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1000 * 1000);
-	BOOST_CHECK(pv->GetUnit() == "amperes");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1000 * 1000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "amperes");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1000000A");
+	BOOST_CHECK_EQUAL(str, "test=1000000A");
 
 	pv = PerfdataValue::Parse("test=1gib");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1024 * 1024 * 1024);
-	BOOST_CHECK(pv->GetUnit() == "bits");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1024 * 1024 * 1024);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "bits");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1073741824b");
+	BOOST_CHECK_EQUAL(str, "test=1073741824b");
 
 	pv = PerfdataValue::Parse("test=1dBm");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "decibel-milliwatts");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "decibel-milliwatts");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1dBm");
+	BOOST_CHECK_EQUAL(str, "test=1dBm");
 
 	pv = PerfdataValue::Parse("test=1C");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "degrees-celsius");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "degrees-celsius");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1C");
+	BOOST_CHECK_EQUAL(str, "test=1C");
 
 	pv = PerfdataValue::Parse("test=1F");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "degrees-fahrenheit");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "degrees-fahrenheit");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1F");
+	BOOST_CHECK_EQUAL(str, "test=1F");
 
 	pv = PerfdataValue::Parse("test=1K");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "degrees-kelvin");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "degrees-kelvin");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1K");
+	BOOST_CHECK_EQUAL(str, "test=1K");
 
 	pv = PerfdataValue::Parse("test=1t");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1000 * 1000);
-	BOOST_CHECK(pv->GetUnit() == "grams");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1000 * 1000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "grams");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1000000g");
+	BOOST_CHECK_EQUAL(str, "test=1000000g");
 
 	pv = PerfdataValue::Parse("test=1hl");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 100);
-	BOOST_CHECK(pv->GetUnit() == "liters");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 100);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "liters");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=100l");
+	BOOST_CHECK_EQUAL(str, "test=100l");
 
 	pv = PerfdataValue::Parse("test=1lm");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "lumens");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "lumens");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1lm");
+	BOOST_CHECK_EQUAL(str, "test=1lm");
 
 	pv = PerfdataValue::Parse("test=1TO");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1000.0 * 1000 * 1000 * 1000);
-	BOOST_CHECK(pv->GetUnit() == "ohms");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1000.0 * 1000 * 1000 * 1000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "ohms");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1000000000000O");
+	BOOST_CHECK_EQUAL(str, "test=1000000000000O");
 
 	pv = PerfdataValue::Parse("test=1PV");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1000.0 * 1000 * 1000 * 1000 * 1000);
-	BOOST_CHECK(pv->GetUnit() == "volts");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1000.0 * 1000 * 1000 * 1000 * 1000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "volts");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1000000000000000V");
+	BOOST_CHECK_EQUAL(str, "test=1000000000000000V");
 
 	pv = PerfdataValue::Parse("test=1EWh");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1000.0 * 1000 * 1000 * 1000 * 1000 * 1000);
-	BOOST_CHECK(pv->GetUnit() == "watt-hours");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1000.0 * 1000 * 1000 * 1000 * 1000 * 1000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "watt-hours");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1000000000000000000Wh");
+	BOOST_CHECK_EQUAL(str, "test=1000000000000000000Wh");
 
 	pv = PerfdataValue::Parse("test=1000mW");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 1);
-	BOOST_CHECK(pv->GetUnit() == "watts");
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetMin() == Empty);
-	BOOST_CHECK(pv->GetMax() == Empty);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "watts");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
 
 	str = pv->Format();
-	BOOST_CHECK(str == "test=1W");
+	BOOST_CHECK_EQUAL(str, "test=1W");
 }
 
 BOOST_AUTO_TEST_CASE(warncritminmax)
@@ -292,28 +292,28 @@ BOOST_AUTO_TEST_CASE(warncritminmax)
 	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=123456B;1000;2000;3000;4000");
 	BOOST_CHECK(pv);
 
-	BOOST_CHECK(pv->GetValue() == 123456);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 123456);
 	BOOST_CHECK(!pv->GetCounter());
-	BOOST_CHECK(pv->GetUnit() == "bytes");
-	BOOST_CHECK(pv->GetWarn() == 1000);
-	BOOST_CHECK(pv->GetCrit() == 2000);
-	BOOST_CHECK(pv->GetMin() == 3000);
-	BOOST_CHECK(pv->GetMax() == 4000);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "bytes");
+	BOOST_CHECK_EQUAL(pv->GetWarn(), 1000);
+	BOOST_CHECK_EQUAL(pv->GetCrit(), 2000);
+	BOOST_CHECK_EQUAL(pv->GetMin(), 3000);
+	BOOST_CHECK_EQUAL(pv->GetMax(), 4000);
 
-	BOOST_CHECK(pv->Format() == "test=123456B;1000;2000;3000;4000");
+	BOOST_CHECK_EQUAL(pv->Format(), "test=123456B;1000;2000;3000;4000");
 }
 
 BOOST_AUTO_TEST_CASE(ignore_invalid_warn_crit_min_max)
 {
 	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=123456;1000:2000;0:3000;3000;4000");
 	BOOST_CHECK(pv);
-	BOOST_CHECK(pv->GetValue() == 123456);
-	BOOST_CHECK(pv->GetWarn() == Empty);
-	BOOST_CHECK(pv->GetCrit() == Empty);
-	BOOST_CHECK(pv->GetMin() == 3000);
-	BOOST_CHECK(pv->GetMax() == 4000);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 123456);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), 3000);
+	BOOST_CHECK_EQUAL(pv->GetMax(), 4000);
 
-	BOOST_CHECK(pv->Format() == "test=123456");
+	BOOST_CHECK_EQUAL(pv->Format(), "test=123456");
 }
 
 BOOST_AUTO_TEST_CASE(invalid)
@@ -332,57 +332,57 @@ BOOST_AUTO_TEST_CASE(invalid)
 BOOST_AUTO_TEST_CASE(multi)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("test::a=3 b=4");
-	BOOST_CHECK(pd->Get(0) == "test::a=3");
-	BOOST_CHECK(pd->Get(1) == "test::b=4");
+	BOOST_CHECK_EQUAL(pd->Get(0), "test::a=3");
+	BOOST_CHECK_EQUAL(pd->Get(1), "test::b=4");
 }
 
 BOOST_AUTO_TEST_CASE(scientificnotation)
 {
 	PerfdataValue::Ptr pdv = PerfdataValue::Parse("test=1.1e+1");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 11);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 11);
 
 	String str = pdv->Format();
-	BOOST_CHECK(str == "test=11");
+	BOOST_CHECK_EQUAL(str, "test=11");
 
 	pdv = PerfdataValue::Parse("test=1.1e1");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 11);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 11);
 
 	str = pdv->Format();
-	BOOST_CHECK(str == "test=11");
+	BOOST_CHECK_EQUAL(str, "test=11");
 
 	pdv = PerfdataValue::Parse("test=1.1e-1");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 0.11);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 0.11);
 
 	str = pdv->Format();
-	BOOST_CHECK(str == "test=0.110000");
+	BOOST_CHECK_EQUAL(str, "test=0.110000");
 
 	pdv = PerfdataValue::Parse("test=1.1E1");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 11);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 11);
 
 	str = pdv->Format();
-	BOOST_CHECK(str == "test=11");
+	BOOST_CHECK_EQUAL(str, "test=11");
 
 	pdv = PerfdataValue::Parse("test=1.1E-1");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 0.11);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 0.11);
 
 	str = pdv->Format();
-	BOOST_CHECK(str == "test=0.110000");
+	BOOST_CHECK_EQUAL(str, "test=0.110000");
 
 	pdv = PerfdataValue::Parse("test=1.1E-1;1.2e+1;1.3E-1;1.4e-2;1.5E2");
-	BOOST_CHECK(pdv->GetLabel() == "test");
-	BOOST_CHECK(pdv->GetValue() == 0.11);
-	BOOST_CHECK(pdv->GetWarn() == 12);
-	BOOST_CHECK(pdv->GetCrit() == 0.13);
-	BOOST_CHECK(pdv->GetMin() == 0.014);
-	BOOST_CHECK(pdv->GetMax() == 150);
+	BOOST_CHECK_EQUAL(pdv->GetLabel(), "test");
+	BOOST_CHECK_EQUAL(pdv->GetValue(), 0.11);
+	BOOST_CHECK_EQUAL(pdv->GetWarn(), 12);
+	BOOST_CHECK_EQUAL(pdv->GetCrit(), 0.13);
+	BOOST_CHECK_EQUAL(pdv->GetMin(), 0.014);
+	BOOST_CHECK_EQUAL(pdv->GetMax(), 150);
 
 	str = pdv->Format();
-	BOOST_CHECK(str == "test=0.110000;12;0.130000;0.014000;150");
+	BOOST_CHECK_EQUAL(str, "test=0.110000;12;0.130000;0.014000;150");
 }
 
 BOOST_AUTO_TEST_CASE(parse_edgecases)
@@ -390,18 +390,18 @@ BOOST_AUTO_TEST_CASE(parse_edgecases)
 	// Trailing decimal point
 	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=23.");
 	BOOST_CHECK(pv);
-	BOOST_CHECK(pv->GetValue() == 23.0);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 23.0);
 
 	// Leading decimal point
 	pv = PerfdataValue::Parse("test=.42");
 	BOOST_CHECK(pv);
-	BOOST_CHECK(pv->GetValue() == 0.42);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 0.42);
 
 	// E both as exponent and unit prefix
 	pv = PerfdataValue::Parse("test=+1.5E-15EB");
 	BOOST_CHECK(pv);
-	BOOST_CHECK(pv->GetValue() == 1.5e3);
-	BOOST_CHECK(pv->GetUnit() == "bytes");
+	BOOST_CHECK_EQUAL(pv->GetValue(), 1.5e3);
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "bytes");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(warncritminmax)
 	BOOST_CHECK_EQUAL(pv->Format(), "test=123456B;1000;2000;3000;4000");
 }
 
-BOOST_AUTO_TEST_CASE(ignore_invalid_warn_crit_min_max)
+BOOST_AUTO_TEST_CASE(ignore_warn_crit_ranges)
 {
 	PerfdataValue::Ptr pv = PerfdataValue::Parse("test=123456;1000:2000;0:3000;3000;4000");
 	BOOST_CHECK(pv);
@@ -313,7 +313,16 @@ BOOST_AUTO_TEST_CASE(ignore_invalid_warn_crit_min_max)
 	BOOST_CHECK_EQUAL(pv->GetMin(), 3000);
 	BOOST_CHECK_EQUAL(pv->GetMax(), 4000);
 
-	BOOST_CHECK_EQUAL(pv->Format(), "test=123456");
+	BOOST_CHECK_EQUAL(pv->Format(), "test=123456;;;3000;4000");
+}
+
+BOOST_AUTO_TEST_CASE(empty_warn_crit_min_max)
+{
+	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=5;;7;1;9 testB=5;7;;1;9 testC=5;;;1;9 testD=2m;;;1 testE=5;;7;;");
+	BOOST_CHECK_EQUAL(pd->GetLength(), 5);
+
+	String str = PluginUtility::FormatPerfdata(pd, true);
+	BOOST_CHECK_EQUAL(str, "testA=5;;7;1;9 testB=5;7;;1;9 testC=5;;;1;9 testD=120s;;;60 testE=5;;7");
 }
 
 BOOST_AUTO_TEST_CASE(invalid)


### PR DESCRIPTION
This is a fix to annoying bug #9634. It does not show problems with tests like #9807.

fixes #9634