### PR TITLE
Consult Checkable#state_before_suppression only if there's a suppression

### DIFF
--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -262,16 +262,20 @@ void Checkable::FireSuppressedNotificationsTimer(const Timer * const&)
  */
 bool Checkable::NotificationReasonApplies(NotificationType type)
 {
+	const auto stateNotifications (NotificationRecovery | NotificationProblem);
+
 	switch (type) {
 		case NotificationProblem:
 			{
 				auto cr (GetLastCheckResult());
-				return cr && !IsStateOK(cr->GetState()) && cr->GetState() != GetStateBeforeSuppression();
+				return cr && !IsStateOK(cr->GetState())
+					&& !(cr->GetState() == GetStateBeforeSuppression() && GetSuppressedNotifications() & stateNotifications);
 			}
 		case NotificationRecovery:
 			{
 				auto cr (GetLastCheckResult());
-				return cr && IsStateOK(cr->GetState()) && cr->GetState() != GetStateBeforeSuppression();
+				return cr && IsStateOK(cr->GetState())
+					&& !(cr->GetState() == GetStateBeforeSuppression() && GetSuppressedNotifications() & stateNotifications);
 			}
 		case NotificationFlappingStart:
 			return IsFlapping();


### PR DESCRIPTION
It's only set along with adding NotificationProblem or NotificationRecovery to Checkable#suppressed_notifications and never reset. Also its default, ServiceOK, is an actual state. Not being aware of these facts confuses Checkable#NotificationReasonApplies() which is a condition for cleaning Notification#suppressed_notifications in FireSuppressedNotifications(). I.e. suppressed notifications can get lost.

fixes #10025