### PR TITLE
check_systemd: Fix executable name and include latest arguments

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -2135,7 +2135,7 @@ In order to find out about the command argument, call the plugin's help
 or consult the README.
 
 ```
-./check_systemd.py --help
+./check_systemd --help
 
 ...
 
@@ -2194,7 +2194,7 @@ With the [example above](03-monitoring-basics.md#command-arguments-value),
 inspect the parameter's help text.
 
 ```
-./check_systemd.py --help
+./check_systemd --help
 
 ...
 

--- a/doc/05-service-monitoring.md
+++ b/doc/05-service-monitoring.md
@@ -281,10 +281,10 @@ that [it works](05-service-monitoring.md#service-monitoring-plugins-it-works). T
 `--help` parameter to see the actual parameters (docs might be outdated).
 
 ```
-./check_systemd.py --help
+./check_systemd --help
 
-usage: check_systemd.py [-h] [-c SECONDS] [-e UNIT | -u UNIT] [-v] [-V]
-                        [-w SECONDS]
+usage: check_systemd [-h] [-c SECONDS] [-e UNIT | -u UNIT] [-v] [-V]
+                     [-w SECONDS]
 
 ...
 
@@ -319,7 +319,7 @@ Start with the basic plugin call without any parameters.
 
 ```
 object CheckCommand "systemd" { // Plugin name without 'check_' prefix
-  command = [ PluginContribDir + "/check_systemd.py" ] // Use the 'PluginContribDir' constant, see the contributed ITL commands
+  command = [ PluginContribDir + "/check_systemd" ] // Use the 'PluginContribDir' constant, see the contributed ITL commands
 }
 ```
 

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -3652,7 +3652,7 @@ iostat\_cwrite | **Required.** Critical threshold for KB/s writes (default: 200)
 
 #### systemd <a id="plugin-contrib-command-systemd"></a>
 
-The [check_systemd.py](https://github.com/Josef-Friedrich/check_systemd) plugin
+The [check_systemd](https://github.com/Josef-Friedrich/check_systemd) plugin
 will report a degraded system to your monitoring solution. It requires only the [nagiosplugin](https://nagiosplugin.readthedocs.io/en/stable) library.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -3653,21 +3653,32 @@ iostat\_cwrite | **Required.** Critical threshold for KB/s writes (default: 200)
 #### systemd <a id="plugin-contrib-command-systemd"></a>
 
 The [check_systemd](https://github.com/Josef-Friedrich/check_systemd) plugin
-will report a degraded system to your monitoring solution. It requires only the [nagiosplugin](https://nagiosplugin.readthedocs.io/en/stable) library.
+will report a degraded system to your monitoring solution.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
-Name                            | Description
---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------
-systemd\_unit                   | **Optional.** Name of the systemd unit that is being tested.
-systemd\_exclude\_unit          | **Optional.** Exclude a systemd unit from the checks. This option can be applied multiple times. Also supports regular expressions.
-systemd\_no\_startup\_time      | **Optional.** Don’t check the startup time. Using this option the options `systemd_warning` and `systemd_critical` have no effect. (Default: `false`)
-systemd\_warning                | **Optional.** Startup time in seconds to result in a warning status. (Default: `60s`)
-systemd\_critical               | **Optional.** Startup time in seconds to result in a critical status. (Default: `120s`)
-systemd\_dead\_timers           | **Optional.** Detect dead / inactive timers. (Default: `false`)
-systemd\_dead\_timers\_warning  | **Optional.** Time ago in seconds for dead / inactive timers to trigger a warning state (by default 6 days).
-systemd\_dead\_timers\_critical | **Optional.** Time ago in seconds for dead / inactive timers to trigger a critical state (by default 7 days).
-systemd\_verbose\_level         | **Optional.** Increase verbosity level (Accepted values: `1`, `2` or `3`). (Defaults to none)
+Name                             | Description
+---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------
+systemd\_verbose\_level          | **Optional.** Increase verbosity level (Accepted values: `1`, `2` or `3`). (Defaults to none)
+systemd\_ignore\_inactive\_state | **Optional.** Ignore an inactive state on a specific unit. Only affective if used with `systemd_unit`.
+systemd\_include                 | **Optional.** Include systemd units to the checks, regular expressions are supported. This option can be applied multiple times.
+systemd\_unit                    | **Optional.** Name of the systemd unit that is being tested.
+systemd\_include\_type           | **Optional.** Unit types to be tested (for example: `service`, `timer`). This option can be applied multiple times.
+systemd\_exclude\_unit           | **Optional.** Exclude a systemd unit from the checks, regular expressions are supported. This option can be applied multiple times.
+systemd\_exclude\_unit\_name     | **Optional.** Exclude a systemd unit from the checks. This option can be applied multiple times.
+systemd\_exclude\_type           | **Optional.** Exclude a systemd unit type (for example: `service`, `timer`)
+systemd\_state                   | **Optional.** Specify the active state that the systemd unit must have (for example: `active`, `inactive`)
+systemd\_dead\_timers            | **Optional.** Detect dead / inactive timers, see `systemd_dead_timers_{warning,critical}`. (Default `false`)
+systemd\_dead\_timers\_warning   | **Optional.** Time ago in seconds for dead / inactive timers to trigger a warning state. (Default 6 days)
+systemd\_dead\_timers\_critical  | **Optional.** Time ago in seconds for dead / inactive timers to trigger a critical state. (Default 7 days)
+systemd\_no\_startup\_time       | **Optional.** Don't check the startup time. Using this option, the options `systemd_{warning,critical}` have no effect. (Default `false`)
+systemd\_warning                 | **Optional.** Startup time in seconds to result in a warning status. (Default 60 seconds)
+systemd\_critical                | **Optional.** Startup time in seconds to result in a critical status. (Default 120 seconds)
+systemd\_dbus                    | **Optional.** Use systemd's D-Bus API instead of parsing command output. Only partially implemented!
+systemd\_cli                     | **Optional.** Use text output from parsing command output. (Default)
+systemd\_user                    | **Optional.** Also show user (systemctl --user) units.
+
+
 
 #### yum <a id="plugin-contrib-command-yum"></a>
 

--- a/itl/plugins-contrib.d/systemd.conf
+++ b/itl/plugins-contrib.d/systemd.conf
@@ -1,7 +1,7 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 object CheckCommand "systemd" {
-	command = [ PluginContribDir + "/check_systemd.py" ]
+	command = [ PluginContribDir + "/check_systemd" ]
 
 	arguments = {
 		"--unit" = {

--- a/itl/plugins-contrib.d/systemd.conf
+++ b/itl/plugins-contrib.d/systemd.conf
@@ -4,39 +4,7 @@ object CheckCommand "systemd" {
 	command = [ PluginContribDir + "/check_systemd" ]
 
 	arguments = {
-		"--unit" = {
-			value = "$systemd_unit$"
-			description = "Name of the systemd unit that is being tested."
-		}
-		"--exclude" = {
-			value = "$systemd_exclude_unit$"
-			description = "Exclude a systemd unit from the checks. This option can be applied multiple times. Also supports regular expressions."
-			repeat_key = true
-		}
-		"--no-startup-time" = {
-			set_if = "$systemd_no_startup_time$"
-			description = "Don’t check the startup time. Using this option the options `systemd_warning` and `systemd_critical` have no effect. (Default: `false`)"
-		}
-		"--warning" = {
-			value = "$systemd_warning$"
-			description = "Startup time in seconds to result in a warning status. (Default: `60s`)"
-		}
-		"--critical" = {
-			value = "$systemd_critical$"
-			description = "Startup time in seconds to result in a critical status. (Default: `120s`)"
-		}
-		"--dead-timers" = {
-			set_if = "$systemd_dead_timers$"
-			description = "Detect dead / inactive timers. (Default: `false`)"
-		}
-		"--dead-timers-warning" = {
-			value = "$systemd_dead_timers_warning$"
-			description = "Time ago in seconds for dead / inactive timers to trigger a warning state (by default 6 days)."
-		}
-		"--dead-timers-critical" = {
-			value = "$systemd_dead_timers_critical$"
-			description = "Time ago in seconds for dead / inactive timers to trigger a critical state (by default 7 days)."
-		}
+		/* General options */
 		"-v" = {
 			set_if = {{ macro("$systemd_verbose_level$") == 1 }}
 			description = "Increase verbosity level (Accepted values: `1`, `2` or `3`). Defaults to none."
@@ -46,6 +14,86 @@ object CheckCommand "systemd" {
 		}
 		"-vvv" = {
 			set_if = {{ macro("$systemd_verbose_level$") == 3 }}
+		}
+
+		/* Options related to unit selection */
+		"--ignore-inactive-state" = {
+			set_if = "$systemd_ignore_inactive_state$"
+			description = "Ignore an inactive state on a specific unit. Only affective if used with `systemd_unit`."
+		}
+		"--include" = {
+			value = "$systemd_include$"
+			description = "Include systemd units to the checks, regular expressions are supported. This option can be applied multiple times."
+			repeat_key = true
+		}
+		"--unit" = {
+			value = "$systemd_unit$"
+			description = "Name of the systemd unit that is being tested."
+		}
+		"--include-type" = {
+			value = "$systemd_include_type$"
+			description = "Unit types to be tested (for example: `service`, `timer`). This option can be applied multiple times."
+			repeat_key = true
+		}
+		"--exclude" = {
+			value = "$systemd_exclude_unit$"
+			description = "Exclude a systemd unit from the checks, regular expressions are supported. This option can be applied multiple times."
+			repeat_key = true
+		}
+		"--exclude-unit" = {
+			value = "$systemd_exclude_unit_name$"
+			description = "Exclude a systemd unit from the checks. This option can be applied multiple times."
+			repeat_key = true
+		}
+		"--exclude-type" = {
+			value = "$systemd_exclude_type$"
+			description = "Exclude a systemd unit type (for example: `service`, `timer`)"
+		}
+		"--state" = {
+			value = "$systemd_state$"
+			description = "Specify the active state that the systemd unit must have (for example: `active`, `inactive`)"
+		}
+
+		/* Timers related options */
+		"--dead-timers" = {
+			set_if = "$systemd_dead_timers$"
+			description = "Detect dead / inactive timers, see `systemd_dead_timers_{warning,critical}`. (Default `false`)"
+		}
+		"--dead-timers-warning" = {
+			value = "$systemd_dead_timers_warning$"
+			description = "Time ago in seconds for dead / inactive timers to trigger a warning state. (Default 6 days)"
+		}
+		"--dead-timers-critical" = {
+			value = "$systemd_dead_timers_critical$"
+			description = "Time ago in seconds for dead / inactive timers to trigger a critical state. (Default 7 days)"
+		}
+
+		/* Startup time related options */
+		"--no-startup-time" = {
+			set_if = "$systemd_no_startup_time$"
+			description = "Don't check the startup time. Using this option, the options `systemd_{warning,critical}` have no effect. (Default `false`)"
+		}
+		"--warning" = {
+			value = "$systemd_warning$"
+			description = "Startup time in seconds to result in a warning status. (Default 60 seconds)"
+		}
+		"--critical" = {
+			value = "$systemd_critical$"
+			description = "Startup time in seconds to result in a critical status. (Default 120 seconds)"
+		}
+
+		/* Monitoring data acquisition */
+		"--dbus" = {
+			set_if = "$systemd_dbus$"
+			description = "Use systemd's D-Bus API instead of parsing command output. Only partially implemented!"
+		}
+		"--cli" = {
+			set_if = "$systemd_cli$"
+			description = "Use text output from parsing command output. (Default)"
+		}
+		"--user" = {
+			set_if = "$systemd_user$"
+			description = "Also show user (systemctl --user) units."
 		}
 	}
 }


### PR DESCRIPTION
The executable name for check_systemd's dropped the `.py` suffix for version 2.0.3[^0], released in April 2019[^1]. However, the old name is still being referenced, both in documentation as well as in the ITL's CheckCommand's command, making it unusable.

Closes #9547.

[^0]: https://github.com/Josef-Friedrich/check_systemd/compare/v2.0.2...v2.0.3#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7
[^1]: https://github.com/Josef-Friedrich/check_systemd/releases/tag/v2.0.3