### PR TITLE
CMakeLists.txt: set(CPACK_WIX_INSTALL_SCOPE NONE)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,7 @@ set(CPACK_WIX_UI_DIALOG "${CMAKE_CURRENT_SOURCE_DIR}/icinga-installer/dlgbmp.bmp
 set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_BINARY_DIR}/icinga-installer/icinga2.wixpatch.Debug")
 set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_BINARY_DIR}/icinga-installer/icinga2.wixpatch")
 set(CPACK_WIX_EXTENSIONS "WixUtilExtension" "WixNetFxExtension")
+set(CPACK_WIX_INSTALL_SCOPE NONE)
 
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION "sbin")
 set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)


### PR DESCRIPTION
to stick to CMake pre-v3.29 behavior. CMake v3.29 introduces CPACK_WIX_INSTALL_SCOPE. Its default conflicts with the ALLUSERS property in our icinga-installer/icinga2.wixpatch.cmake. ([Discussion and alternatives](https://github.com/Icinga/icinga2/pull/10037#pullrequestreview-2001484246))

# ⚠️This blocks literally every other PR ⚠️