### PR TITLE
GHA: drop Debian 10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,6 @@ jobs:
           - amazonlinux:2
           - amazonlinux:2023
           - centos:7 # and RHEL 7
-          - debian:10
           - debian:11 # and Raspbian 11
           - debian:12 # and Raspbian 12
           - fedora:37


### PR DESCRIPTION
which will be EOL in 2.5 months.

This is a follow-up of https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/75