### PR TITLE
Add user object to the filter namespace

### DIFF
--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -216,6 +216,8 @@ std::vector<Value> FilterUtility::GetFilterTargets(const QueryDescription& qd, c
 	Namespace::Ptr permissionFrameNS = new Namespace();
 	ScriptFrame permissionFrame(false, permissionFrameNS);
 
+	permissionFrameNS->Set("user", user);
+
 	for (const String& type : qd.Types) {
 		String attr = type;
 		boost::algorithm::to_lower(attr);


### PR DESCRIPTION
The current evaluation context of the `filter` function defined for an `ApiUser` doesn't provide any way to access the user object itself.

With the patch applied the problem of having an `ApiUser` per `Host` (see https://community.icinga.com/t/per-host-api-user-for-passive-check-submission/9053/3 , for instance) can be solved by first defining a template like this:

    template ApiUser "usersync" {
      permissions = [{
        permission = "actions/process-check-result"
        filter = () => {
          return host.name == user.client_cn
        }
      }]
    }

And then by creating an `ApiUser` that imports it, possibly using the REST API. I. e.:

    curl ... -X PUT 'https://localhost:5665/v1/objects/apiusers/userforhost1' -d '{"attrs": {"client_cn": "host1"}, "templates": ["usersync"]}'