### PR TITLE
Vim Syntax: Fix Syntax Error shown on Vim 9.1

### DIFF
--- a/tools/syntax/vim/syntax/icinga2.vim
+++ b/tools/syntax/vim/syntax/icinga2.vim
@@ -296,14 +296,7 @@ syn keyword		valueNull		contained	null
 " ########################################
 " ### Where to apply
 
-syn region		icingaDefBody start='{' end='}'
-	\ contains=icinga2Comment, icinga2LineComment, StringS, StringD, macro, Braces, Parens, Lambda, icinga2ObjType, icinga2ObjDef,
-	\ icinga2ApplyDef, icinga2ObjAttr, icinga2Keyword, icinga2AssignCond,
-	\ icinga2Cond, icinga2Loop, icinga2Exception, icinga2Debugger, icinga2Operators, icinga2GFunction, icinga2AFunction,
-	\ icinga2MathFunction, icinga2GlobalConstant, icinga2PathConstant, icinga2UserConstant, icinga2Gconst, icinga2Namespace,
-	\ icinga2JsonFunction, icinga2NumberFunction, icinga2BoolFunction,
-	\ icinga2StrFunction, icinga2ObjectFunction, icinga2TypeFunction, icinga2ArrFunction, icinga2DictFunction,
-	\ icinga2DTFunction, valueNumber, valueBoolean, valueNull
+syn region		icingaDefBody start='{' end='}' contains=icinga2Comment,icinga2LineComment,StringS,StringD,macro,Braces,Parens,Lambda,icinga2ObjType,icinga2ObjDef,icinga2ApplyDef,icinga2ObjAttr,icinga2Keyword,icinga2AssignCond,icinga2Cond,icinga2Loop,icinga2Exception,icinga2Debugger,icinga2Operators,icinga2GFunction,icinga2AFunction,icinga2MathFunction,icinga2GlobalConstant,icinga2PathConstant,icinga2UserConstant,icinga2Gconst,icinga2Namespace,icinga2JsonFunction,icinga2NumberFunction,icinga2BoolFunction,icinga2StrFunction,icinga2ObjectFunction,icinga2TypeFunction,icinga2ArrFunction,icinga2DictFunction,icinga2DTFunction,valueNumber,valueBoolean,valueNull
 
 
 " ########################################


### PR DESCRIPTION
There occurs a Vim syntax error on a fresh openSUSE Leap 15.5 system when trying to edit the Icinga 2 configuration. The specific packages were vim-9.1.0330-150500.20.12.1.x86_64, vim-icinga2-2.14.2-1.x86_64 and the following error was shown:

```
$ vim -R /etc/icinga2/conf.d/notifications.conf
Error detected while processing /usr/share/vim/vim91/suse.vimrc[10]../usr/share/vim/vim91/syntax/syntax.vim[44]..BufRead Autocommands for "/*etc/icinga2/*.conf"..FileType Autocommands for "*"..Syntax Autocommands for "*"..function <SNR>3_SynSet[25]..script /usr/share/vim/site/syntax/icinga2.vim: line  300:
E10: \ should be followed by /, ? or &
line  301:
E10: \ should be followed by /, ? or &
line  302:
E10: \ should be followed by /, ? or &
line  303:
E10: \ should be followed by /, ? or &
line  304:
E10: \ should be followed by /, ? or &
line  305:
E10: \ should be followed by /, ? or &
line  306:
E10: \ should be followed by /, ? or &
Press ENTER or type command to continue
```

ref/IP/53301