### PR TITLE
Call ConfigObject#Register() after #OnAllConfigLoaded() for runtime creation

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -162,7 +162,7 @@ public:
  *
  * @returns The ConfigObject that was created/updated.
  */
-ConfigObject::Ptr ConfigItem::Commit(bool discard)
+ConfigObject::Ptr ConfigItem::Commit(bool discard, bool registerObject)
 {
 	Type::Ptr type = GetType();
 
@@ -311,7 +311,9 @@ ConfigObject::Ptr ConfigItem::Commit(bool discard)
 
 	dhint.reset();
 
-	dobj->Register();
+	if (registerObject) {
+		dobj->Register();
+	}
 
 	m_Object = dobj;
 

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -393,7 +393,7 @@ ConfigItem::Ptr ConfigItem::GetByTypeAndName(const Type::Ptr& type, const String
 	return it2->second;
 }
 
-bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems)
+bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool registerEarly)
 {
 	typedef std::pair<ConfigItem::Ptr, bool> ItemPair;
 	std::unordered_map<Type*, std::vector<ItemPair>> itemsByType;
@@ -462,10 +462,10 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 					newItems.emplace_back(pair.first);
 				}
 
-				upq.ParallelFor(items->second, [&committed_items](const ItemPair& ip) {
+				upq.ParallelFor(items->second, [&committed_items, registerEarly](const ItemPair& ip) {
 					const ConfigItem::Ptr& item = ip.first;
 
-					if (!item->Commit(ip.second)) {
+					if (!item->Commit(ip.second, registerEarly)) {
 						if (item->IsIgnoreOnError()) {
 							item->Unregister();
 						}
@@ -521,7 +521,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 					}
 				}
 
-				upq.ParallelFor(items->second, [&notified_items](const ItemPair& ip) {
+				upq.ParallelFor(items->second, [&notified_items, registerEarly](const ItemPair& ip) {
 					const ConfigItem::Ptr& item = ip.first;
 
 					if (!item->m_Object)
@@ -530,6 +530,10 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 					try {
 						item->m_Object->OnAllConfigLoaded();
 						notified_items++;
+
+						if (!registerEarly) {
+							item->m_Object->Register();
+						}
 					} catch (const std::exception& ex) {
 						if (!item->m_IgnoreOnError)
 							throw;
@@ -590,7 +594,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 			return false;
 
 		// Make sure to activate any additionally generated items
-		if (!CommitNewItems(context, upq, newItems))
+		if (!CommitNewItems(context, upq, newItems, registerEarly))
 			return false;
 	}
 
@@ -602,7 +606,7 @@ bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& u
 	if (!silent)
 		Log(LogInformation, "ConfigItem", "Committing config item(s).");
 
-	if (!CommitNewItems(context, upq, newItems)) {
+	if (!CommitNewItems(context, upq, newItems, true)) {
 		upq.ReportExceptions("config");
 
 		for (const ConfigItem::Ptr& item : newItems) {

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -601,12 +601,12 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 	return true;
 }
 
-bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent)
+bool ConfigItem::CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent, bool registerEarly)
 {
 	if (!silent)
 		Log(LogInformation, "ConfigItem", "Committing config item(s).");
 
-	if (!CommitNewItems(context, upq, newItems, true)) {
+	if (!CommitNewItems(context, upq, newItems, registerEarly)) {
 		upq.ReportExceptions("config");
 
 		for (const ConfigItem::Ptr& item : newItems) {

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -97,7 +97,7 @@ private:
 	static ConfigItem::Ptr GetObjectUnlocked(const String& type,
 		const String& name);
 
-	ConfigObject::Ptr Commit(bool discard);
+	ConfigObject::Ptr Commit(bool discard, bool registerObject = true);
 
 	static bool CommitNewItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems);
 };

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -53,7 +53,7 @@ public:
 	static ConfigItem::Ptr GetByTypeAndName(const Type::Ptr& type,
 		const String& name);
 
-	static bool CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent = false);
+	static bool CommitItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool silent = false, bool registerEarly = true);
 	static bool ActivateItems(const std::vector<ConfigItem::Ptr>& newItems, bool runtimeCreated = false,
 		bool mainConfigActivation = false, bool withModAttrs = false, const Value& cookie = Empty);
 

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -97,9 +97,9 @@ private:
 	static ConfigItem::Ptr GetObjectUnlocked(const String& type,
 		const String& name);
 
-	ConfigObject::Ptr Commit(bool discard, bool registerObject = true);
+	ConfigObject::Ptr Commit(bool discard, bool registerObject);
 
-	static bool CommitNewItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems);
+	static bool CommitNewItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems, bool registerEarly);
 };
 
 /**

--- a/lib/config/configitem.hpp
+++ b/lib/config/configitem.hpp
@@ -97,7 +97,7 @@ private:
 	static ConfigItem::Ptr GetObjectUnlocked(const String& type,
 		const String& name);
 
-	ConfigObject::Ptr Commit(bool discard = true);
+	ConfigObject::Ptr Commit(bool discard);
 
 	static bool CommitNewItems(const ActivationContext::Ptr& context, WorkQueue& upq, std::vector<ConfigItem::Ptr>& newItems);
 };

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -230,7 +230,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 		 * Disable logging for object creation, but do so ourselves later on.
 		 * Duplicate the error handling for better logging and debugging here.
 		 */
-		if (!ConfigItem::CommitItems(ascope.GetContext(), upq, newItems, true)) {
+		if (!ConfigItem::CommitItems(ascope.GetContext(), upq, newItems, true, false)) {
 			if (errors) {
 				Log(LogNotice, "ConfigObjectUtility")
 					<< "Failed to commit config item '" << fullName << "'. Aborting and removing config path '" << path << "'.";


### PR DESCRIPTION
so that they're invisible until successful complete initialization.    Otherwise some members may be still NULL and crash the daemon.

ref/IP/53428

## What Icinga does with config

1. Parse AST
2. Eval AST, which produces ConfigItems
3. Commit and register, for each item/object
4. Call ConfigObject#OnAllConfigLoaded to init remaining members, e.g. Downtime#m_Checkable

Registering an object makes it immediately available for all object getters by type, as well as DSL get_host(), etc.. This is fine for the config load, "otherwise [such a stupid config](https://github.com/Icinga/icingaweb2-module-director/blob/428a49f4330c8863094e29582e106c3d8f9ef9f5/library/Director/Objects/IcingaService.php#L503-L510) won't function properly." [©](https://github.com/Icinga/icinga2/pull/10057#discussion_r1601228673) @yhabteab

But not for runtime objects! ConfigObject#Start() has already been called for all and everything does something. E.g. IcingaDB#UpdateAllConfigObjects() operates on all objects as soon as registered – ready or not:

```
(gdb) frame 8
#8  0x0000000000f9ecac in icinga::IcingaDB::PrepareObject (object=...,
    attributes=..., checksums=...)
    at /usr/include/boost/smart_ptr/intrusive_ptr.hpp:179
179     /usr/include/boost/smart_ptr/intrusive_ptr.hpp: No such file or directory.
(gdb) p downtime.px->m_Checkable
$6 = {px = 0x0}
(gdb)
```

closes #10151