### PR TITLE
Ido*sqlConnection#FieldToEscapedString(): don't write out of range time

### DIFF
--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -891,9 +891,9 @@ bool IdoMysqlConnection::FieldToEscapedString(const String& key, const Value& va
 
 		*result = static_cast<long>(dbrefcol);
 	} else if (DbValue::IsTimestamp(value)) {
-		long ts = rawvalue;
+		double ts = rawvalue;
 		std::ostringstream msgbuf;
-		msgbuf << "FROM_UNIXTIME(" << ts << ")";
+		msgbuf << "FROM_UNIXTIME(" << std::fixed << std::setprecision(0) << ts << ")";
 		*result = Value(msgbuf.str());
 	} else if (DbValue::IsObjectInsertID(value)) {
 		auto id = static_cast<long>(rawvalue);

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -700,9 +700,9 @@ bool IdoPgsqlConnection::FieldToEscapedString(const String& key, const Value& va
 
 		*result = static_cast<long>(dbrefcol);
 	} else if (DbValue::IsTimestamp(value)) {
-		long ts = rawvalue;
+		double ts = rawvalue;
 		std::ostringstream msgbuf;
-		msgbuf << "TO_TIMESTAMP(" << ts << ") AT TIME ZONE 'UTC'";
+		msgbuf << "TO_TIMESTAMP(" << std::fixed << std::setprecision(0) << ts << ") AT TIME ZONE 'UTC'";
 		*result = Value(msgbuf.str());
 	} else if (DbValue::IsObjectInsertID(value)) {
 		auto id = static_cast<long>(rawvalue);


### PR DESCRIPTION
MySQL's FROM_UNIXTIME() NULLs ts <1970, errors for >2038.    Postgres' TO_TIMESTAMP() errors for all ts not between 4713BC - 294276AD.

ref/IP/53323