### PR TITLE
IcingaDB#SerializeState(): limit execution_time and latency to 2^32-1

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2642,8 +2642,8 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 
 		if (!cr->GetCommand().IsEmpty())
 			attrs->Set("check_commandline", FormatCommandLine(cr->GetCommand()));
-		attrs->Set("execution_time", TimestampToMilliseconds(fmax(0.0, cr->CalculateExecutionTime())));
-		attrs->Set("latency", TimestampToMilliseconds(cr->CalculateLatency()));
+		attrs->Set("execution_time", std::min((long long)UINT32_MAX, TimestampToMilliseconds(fmax(0.0, cr->CalculateExecutionTime()))));
+		attrs->Set("latency", std::min((long long)UINT32_MAX, TimestampToMilliseconds(cr->CalculateLatency())));
 		attrs->Set("check_source", cr->GetCheckSource());
 		attrs->Set("scheduling_source", cr->GetSchedulingSource());
 	}


### PR DESCRIPTION
not to write higher values into Redis than the Icinga DB schema can hold. This fixes yet another potential Go daemon crash.

ref/IP/53518

CC @RincewindsHat