### PR TITLE
Don't fail to remove obsolete downtimes

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -557,7 +557,7 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 			childCount += downtime->GetChildren().size();
 
 			try {
-				Downtime::RemoveDowntime(downtime->GetName(), true, true, false, author);
+				Downtime::RemoveDowntime(downtime->GetName(), true, DowntimeRemovedByUser, author);
 			} catch (const invalid_downtime_removal_error& error) {
 				Log(LogWarning, "ApiActions") << error.what();
 
@@ -578,7 +578,7 @@ Dictionary::Ptr ApiActions::RemoveDowntime(const ConfigObject::Ptr& object,
 
 	try {
 		String downtimeName = downtime->GetName();
-		Downtime::RemoveDowntime(downtimeName, true, true, false, author);
+		Downtime::RemoveDowntime(downtimeName, true, DowntimeRemovedByUser, author);
 
 		return ApiActions::CreateResult(200, "Successfully removed downtime '" + downtimeName +
 			"' and " + std::to_string(childCount) + " child downtimes.");

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -376,7 +376,7 @@ void Downtime::RemoveDowntime(const String& id, bool includeChildren, DowntimeRe
 
 	if (includeChildren) {
 		for (const Downtime::Ptr& child : downtime->GetChildren()) {
-			Downtime::RemoveDowntime(child->GetName(), true, removalReason);
+			Downtime::RemoveDowntime(child->GetName(), true, removalReason, removedBy);
 		}
 	}
 

--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -369,7 +369,7 @@ void Downtime::RemoveDowntime(const String& id, bool includeChildren, DowntimeRe
 
 	String config_owner = downtime->GetConfigOwner();
 
-	if (!config_owner.IsEmpty() && removalReason != DowntimeExpired) {
+	if (!config_owner.IsEmpty() && removalReason == DowntimeRemovedByUser) {
 		BOOST_THROW_EXCEPTION(invalid_downtime_removal_error("Cannot remove downtime '" + downtime->GetName() +
 			"'. It is owned by scheduled downtime object '" + config_owner + "'"));
 	}

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -18,6 +18,13 @@ enum DowntimeChildOptions
 	DowntimeNonTriggeredChildren
 };
 
+enum DowntimeRemovalReason
+{
+	DowntimeExpired,
+	DowntimeRemovedByUser,
+	DowntimeRemovedByConfigOwner,
+};
+
 /**
  * A downtime.
  *
@@ -52,7 +59,7 @@ public:
 		const String& scheduledBy = String(), const String& parent = String(), const String& id = String(),
 		const MessageOrigin::Ptr& origin = nullptr);
 
-	static void RemoveDowntime(const String& id, bool includeChildren, bool cancelled, bool expired = false,
+	static void RemoveDowntime(const String& id, bool includeChildren, DowntimeRemovalReason removalReason,
 		const String& removedBy = "", const MessageOrigin::Ptr& origin = nullptr);
 
 	void RegisterChild(const Downtime::Ptr& downtime);

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -993,7 +993,7 @@ void ExternalCommandProcessor::DelSvcDowntime(double, const std::vector<String>&
 	}
 
 	try {
-		Downtime::RemoveDowntime(rid, false, true);
+		Downtime::RemoveDowntime(rid, false, DowntimeRemovedByUser);
 
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Removed downtime ID " << arguments[0];
@@ -1112,7 +1112,7 @@ void ExternalCommandProcessor::DelHostDowntime(double, const std::vector<String>
 	}
 
 	try {
-		Downtime::RemoveDowntime(rid, false, true);
+		Downtime::RemoveDowntime(rid, false, DowntimeRemovedByUser);
 
 		Log(LogNotice, "ExternalCommandProcessor")
 			<< "Removed downtime ID " << arguments[0];
@@ -1147,7 +1147,7 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 	for (const Downtime::Ptr& downtime : host->GetDowntimes()) {
 		try {
 			String downtimeName = downtime->GetName();
-			Downtime::RemoveDowntime(downtimeName, false, true);
+			Downtime::RemoveDowntime(downtimeName, false, DowntimeRemovedByUser);
 
 			Log(LogNotice, "ExternalCommandProcessor")
 				<< "Removed downtime '" << downtimeName << "'.";
@@ -1169,7 +1169,7 @@ void ExternalCommandProcessor::DelDowntimeByHostName(double, const std::vector<S
 
 			try {
 				String downtimeName = downtime->GetName();
-				Downtime::RemoveDowntime(downtimeName, false, true);
+				Downtime::RemoveDowntime(downtimeName, false, DowntimeRemovedByUser);
 
 				Log(LogNotice, "ExternalCommandProcessor")
 					<< "Removed downtime '" << downtimeName << "'.";

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -323,7 +323,7 @@ void ScheduledDowntime::RemoveObsoleteDowntimes()
 			auto configOwnerHash (downtime->GetConfigOwnerHash());
 
 			if (!configOwnerHash.IsEmpty() && configOwnerHash != downtimeOptionsHash)
-				Downtime::RemoveDowntime(downtime->GetName(), false, true);
+				Downtime::RemoveDowntime(downtime->GetName(), false, DowntimeRemovedByConfigOwner);
 		}
 	}
 }


### PR DESCRIPTION
### Before

See #10042 

### After

- Deleting downtimes automatically due to owner config hash change.
```bash
[2024-05-15 16:52:17 +0200] information/ConfigObjectUtility: Deleted object 'downtime-test!39752e43-ffb6-40ee-8d17-c129a1b2f7c6' of type 'Downtime'.
[2024-05-15 16:52:17 +0200] information/Downtime: Removed downtime 'downtime-test!39752e43-ffb6-40ee-8d17-c129a1b2f7c6' from checkable 'downtime-test' (Reason: cancelled by 'downtime-test!backup-downtime').
```

- Deleting a downtime that belongs to a `ScheduledDowntime` object via the API
```bash
 curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5665/v1/actions/remove-downtime' \
 -d '{ "downtime": "downtime-test!baa2338e-34b0-44a1-94fa-c24f9b1f2b0a", "pretty": true }'

–––
HTTP/1.1 400 Bad Request
Server: Icinga/v2.14.0-175-g81aec894c
Content-Type: application/json
Content-Length: 246

{
    "results": [
        {
            "code": 400,
            "status": "Cannot remove downtime 'downtime-test!baa2338e-34b0-44a1-94fa-c24f9b1f2b0a'. It is owned by scheduled downtime object 'downtime-test!backup-downtime'"
        }
    ]
}
```

fixes #10042