### PR TITLE
Update `object#config_hash` after all relations queries

### DIFF
--- a/lib/db_ido/hostdbobject.cpp
+++ b/lib/db_ido/hostdbobject.cpp
@@ -330,8 +330,6 @@ void HostDbObject::OnConfigUpdateHeavy()
 	}
 
 	DbObject::OnMultipleQueries(queries);
-
-	DoCommonConfigUpdate();
 }
 
 void HostDbObject::OnConfigUpdateLight()

--- a/lib/db_ido/servicedbobject.cpp
+++ b/lib/db_ido/servicedbobject.cpp
@@ -282,8 +282,6 @@ void ServiceDbObject::OnConfigUpdateHeavy()
 	}
 
 	DbObject::OnMultipleQueries(queries);
-
-	DoCommonConfigUpdate();
 }
 
 void ServiceDbObject::OnConfigUpdateLight()


### PR DESCRIPTION
The IDO is writing the checksums of all `Host` or/and `Service` attributes, including group memberships, to the database when the object is first created or, one of its attributes e.g. `enable_flapping_detection` changes. However, when either the Icinga 2 or the MySQL service is stopped/reloaded unexpectedly right after the IDO has written the checksums to the database but before the remaining queries of the group memberships are executed, the group members will never be written to the database until someone modifies one of the object attributes.

This PR defers the `config_hash` column update until all object relationships have been updated/inserted.

**Master:**
- Upsert all object config fields including `config_hash` column, and ...
- Update/Insert all relations such as `hostgroup_members`, `servicegroup_members` etc.

**This PR:**
- Upsert all object config fields including `config_hash`, but `config_hash` is set to `NULL`
- Update/Insert all relations such as `hostgroup_members`, `servicegroup_members` etc.
- Update object `config_hash` column to the current in memory value.

closes #8813
ref/IP/53530