### PR TITLE
Reject infinite performance data values

### DIFF
--- a/lib/base/perfdatavalue.cpp
+++ b/lib/base/perfdatavalue.cpp
@@ -259,6 +259,10 @@ PerfdataValue::Ptr PerfdataValue::Parse(const String& perfdata)
 
 	double value = Convert::ToDouble(tokens[0].SubStr(0, pos));
 
+	if (!std::isfinite(value)) {
+		BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid performance data value: " + perfdata + " is outside of any reasonable range"));
+	}
+
 	bool counter = false;
 	String unit;
 	Value warn, crit, min, max;

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -336,6 +336,10 @@ BOOST_AUTO_TEST_CASE(invalid)
 	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;1;123,456;1;1"), boost::exception);
 	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;1;1;123,456;1"), boost::exception);
 	BOOST_CHECK_THROW(PerfdataValue::Parse("test=1;1;1;1;123,456"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=inf"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=Inf"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=-inf"), boost::exception);
+	BOOST_CHECK_THROW(PerfdataValue::Parse("test=-Inf"), boost::exception);
 }
 
 BOOST_AUTO_TEST_CASE(multi)


### PR DESCRIPTION
Some fault monitoring plugins may return "inf" or "-inf" as values due to a failure to initialize or other errors.

This patch introduces a check on whether the parse value is infinite (or negative infinite) and rejects the data point if that is the case.

The reasoning here is: There is no possible way a value of "inf" is ever a true measuring or even useful. Furthermore, when passed to the performance data writers, it may be rejected by the backend and lead to further complications.

fixes #10073