### PR TITLE
Fix path of redis-check-script in check-command for accessing redis-check script.

### DIFF
--- a/itl/plugins-contrib.d/databases.conf
+++ b/itl/plugins-contrib.d/databases.conf
@@ -762,7 +762,7 @@ object CheckCommand "elasticsearch" {
 object CheckCommand "redis" {
 	import "ipv4-or-ipv6"
 
-	command = [ PluginContribDir + "/check_redis.pl" ]
+	command = [ PluginContribDir + "/check_redis" ]
 
 	arguments = {
 		"--hostname" = {


### PR DESCRIPTION
There is an issue with calling the redis-check-script caused by the a wrong path. 
The redis check script is only named "check_redis" and not "check_redis.pl"