### PR TITLE
Don't broadcast Checkable#next_check updates made just not to check twice

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -568,11 +568,11 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 
 	SetLastCheckStarted(Utility::GetTime());
 
-	/* This calls SetNextCheck() which updates the CheckerComponent's idle/pending
+	/* This calls SetNextCheck() for a later update of the CheckerComponent's idle/pending
 	 * queues and ensures that checks are not fired multiple times. ProcessCheckResult()
 	 * is called too late. See #6421.
 	 */
-	UpdateNextCheck();
+	UpdateNextCheck(nullptr, true);
 
 	bool reachable = IsReachable();
 
@@ -645,7 +645,7 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 			 * a check result from the remote instance. The check will be re-scheduled
 			 * using the proper check interval once we've received a check result.
 			 */
-			SetNextCheck(Utility::GetTime() + checkTimeout + 30);
+			SetNextCheck(Utility::GetTime() + checkTimeout + 30, true);
 
 		/*
 		 * Let the user know that there was a problem with the check if

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -51,7 +51,7 @@ long Checkable::GetSchedulingOffset()
 	return m_SchedulingOffset;
 }
 
-void Checkable::UpdateNextCheck(const MessageOrigin::Ptr& origin)
+void Checkable::UpdateNextCheck(const MessageOrigin::Ptr& origin, bool suppressEvents)
 {
 	double interval;
 
@@ -79,7 +79,7 @@ void Checkable::UpdateNextCheck(const MessageOrigin::Ptr& origin)
 		<< " (" << lastCheck << ") to next check time at "
 		<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", nextCheck) << " (" << nextCheck << ").";
 
-	SetNextCheck(nextCheck, false, origin);
+	SetNextCheck(nextCheck, suppressEvents, origin);
 }
 
 bool Checkable::HasBeenChecked() const

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -105,7 +105,7 @@ public:
 	long GetSchedulingOffset();
 	void SetSchedulingOffset(long offset);
 
-	void UpdateNextCheck(const MessageOrigin::Ptr& origin = nullptr);
+	void UpdateNextCheck(const MessageOrigin::Ptr& origin = nullptr, bool suppressEvents = false);
 
 	static String StateTypeToString(StateType type);
 


### PR DESCRIPTION
The checker sorts Checkables by next_check while picking the next due one,    so we (already) have to advance next_check while starting a check.    But the second master doesn't need this info, as it's not responsible.

refs #10082

## TODO

* [x] #10011