### PR TITLE
Enhance documentation regarding internal icinga config sync check

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ Christian Gut <cycloon@is-root.org>
 Christian Harke <ch.harke@gmail.com>
 Christian Jonak <christian@jonak.org>
 Christian Lehmann <christian_lehmann@gmx.de>
+Christian Lauf <github.com@christian-lauf.info>
 Christian Loos <cloos@netsandbox.de>
 Christian Schmidt <github@chsc.dk>
 Christopher Peterson <3893680+cspeterson@users.noreply.github.com>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -75,8 +75,10 @@ plugin scripts.
 
 ### icinga <a id="itl-icinga"></a>
 
-Check command for the built-in `icinga` check. This check returns performance
-data for the current Icinga instance, reports as warning if the last reload failed and optionally allows for minimum version checks.
+Check command for the built-in `icinga` check. This check returns performance data for the current Icinga instance,
+reports as warning if the last reload/config-sync failed and optionally allows for minimum version checks.
+
+For the config sync check to work this must be executed on Satellites/Agents.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -76,9 +76,9 @@ plugin scripts.
 ### icinga <a id="itl-icinga"></a>
 
 Check command for the built-in `icinga` check. This check returns performance data for the current Icinga instance,
-reports as warning if the last reload/config-sync failed and optionally allows for minimum version checks.
+reports as warning if the last reload or config sync failed and optionally allows for minimum version checks.
 
-For the config sync check to work this must be executed on Satellites/Agents.
+For the config sync check to work, it must be run on the satellite or agent.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -1640,7 +1640,7 @@ Typical errors are:
 * The api feature doesn't [accept config](06-distributed-monitoring.md#distributed-monitoring-top-down-config-sync). This is logged into `/var/lib/icinga2/icinga2.log`.
 * The received configuration zone is not configured in [zones.conf](04-configuration.md#zones-conf) and Icinga denies it. This is logged into `/var/lib/icinga2/icinga2.log`.
 * The satellite/agent has local configuration in `/etc/icinga2/zones.d` and thinks it is authoritive for this zone. It then denies the received update. Purge the content from `/etc/icinga2/zones.d`, `/var/lib/icinga2/api/zones/*` and restart Icinga to fix this.
-* Configuration parts stored outside of `/etc/icinga2/zones.d` on the master, for example a constant in /etc/icinga2/constants.conf, which are then missing on the satellite/agent.
+* Configuration parts stored outside of `/etc/icinga2/zones.d` on the master, for example a constant in `/etc/icinga2/constants.conf`, are then missing on the satellite/agent.
 
 Note that if set up, the [built-in icinga CheckCommand](10-icinga-template-library.md#icinga) will notify you in case the config sync wasn't successful.
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -1642,7 +1642,7 @@ Typical errors are:
 * The satellite/agent has local configuration in `/etc/icinga2/zones.d` and thinks it is authoritive for this zone. It then denies the received update. Purge the content from `/etc/icinga2/zones.d`, `/var/lib/icinga2/api/zones/*` and restart Icinga to fix this.
 * Configuration parts stored outside of `/etc/icinga2/zones.d` on the master, for example a constant in /etc/icinga2/constants.conf, which are then missing on the satellite/agent.
 
-Note that if set up, the [internal icinga CheckCommand](10-icinga-template-library.md#icinga-) will notify you in case the config sync wasn't successful.
+Note that if set up, the [built-in icinga CheckCommand](10-icinga-template-library.md#icinga) will notify you in case the config sync wasn't successful.
 
 #### New configuration does not trigger a reload <a id="troubleshooting-cluster-config-sync-no-reload"></a>
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -1642,7 +1642,7 @@ Typical errors are:
 * The satellite/agent has local configuration in `/etc/icinga2/zones.d` and thinks it is authoritive for this zone. It then denies the received update. Purge the content from `/etc/icinga2/zones.d`, `/var/lib/icinga2/api/zones/*` and restart Icinga to fix this.
 * Configuration parts stored outside of `/etc/icinga2/zones.d` on the master, for example a constant in /etc/icinga2/constants.conf, which are then missing on the satellite/agent.
 
-Note that if set up, the [internal icinga CheckCommand](10-icinga-template-library.md#icinga) will notify you in case the config sync wasn't successful.
+Note that if set up, the [internal icinga CheckCommand](10-icinga-template-library.md#icinga-) will notify you in case the config sync wasn't successful.
 
 #### New configuration does not trigger a reload <a id="troubleshooting-cluster-config-sync-no-reload"></a>
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -1642,7 +1642,7 @@ Typical errors are:
 * The satellite/agent has local configuration in `/etc/icinga2/zones.d` and thinks it is authoritive for this zone. It then denies the received update. Purge the content from `/etc/icinga2/zones.d`, `/var/lib/icinga2/api/zones/*` and restart Icinga to fix this.
 * Configuration parts stored outside of `/etc/icinga2/zones.d` on the master, for example a constant in /etc/icinga2/constants.conf, which are then missing on the satellite/agent.
 
-Note that if set up, the [internal icinga CheckCommand](10-icinga-template-library.md#icinga-) will notify you in case the config sync wasn't successful.
+Note that if set up, the [internal icinga CheckCommand](10-icinga-template-library.md#icinga) will notify you in case the config sync wasn't successful.
 
 #### New configuration does not trigger a reload <a id="troubleshooting-cluster-config-sync-no-reload"></a>
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -1640,6 +1640,9 @@ Typical errors are:
 * The api feature doesn't [accept config](06-distributed-monitoring.md#distributed-monitoring-top-down-config-sync). This is logged into `/var/lib/icinga2/icinga2.log`.
 * The received configuration zone is not configured in [zones.conf](04-configuration.md#zones-conf) and Icinga denies it. This is logged into `/var/lib/icinga2/icinga2.log`.
 * The satellite/agent has local configuration in `/etc/icinga2/zones.d` and thinks it is authoritive for this zone. It then denies the received update. Purge the content from `/etc/icinga2/zones.d`, `/var/lib/icinga2/api/zones/*` and restart Icinga to fix this.
+* Configuration parts stored outside of `/etc/icinga2/zones.d` on the master, for example a constant in /etc/icinga2/constants.conf, which are then missing on the satellite/agent.
+
+Note that if set up, the [internal icinga CheckCommand](10-icinga-template-library.md#icinga-) will notify you in case the config sync wasn't successful.
 
 #### New configuration does not trigger a reload <a id="troubleshooting-cluster-config-sync-no-reload"></a>
 


### PR DESCRIPTION
Hi,

I had the problem that I converted my non-distributed monitoring to a distributed one. That worked fine for years, but due to a new NotificationCommand I noticed that I had defined a necessary Token inside /etc/icinga2/constants.conf file, which of course is not synced to the satellites/agents.
I only noticed this a few weeks after these changes, as another new service check wasn't being rolled out to the agents.
(Small homelab environment, not many changes are happening.)

After figuring this all out I learned only through the Community forum that the internal icinga CheckCommand checks for successful config syncs IF it is executed on the satellites/agents. Which was not the case in my scenario as I didn't properly migrate that service for a redundant setup.

However.. The documentation on this is very sparse. The config file sync check is only named indirectly and you only understand what that means when you already know what the CheckCommand does. - Not really helpful.
Also the troubleshooting section made no mention of that.

With this commit I try to fix these 2 minor issues. Hoping other people will spot their errors faster than me. ;-)