### PR TITLE
GHA: Drop CentOS 7

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -33,16 +33,6 @@ case "$DISTRO" in
       {boost,libedit,mariadb1\*,ncurses,openssl,postgresql,systemd}-devel
     ;;
 
-  centos:*)
-    yum install -y centos-release-scl epel-release
-    yum install -y bison ccache cmake3 devtoolset-11-gcc-c++ flex ninja-build \
-      {boost169,libedit,mariadb,ncurses,openssl,postgresql,systemd}-devel
-
-    ln -vs /usr/bin/cmake3 /usr/local/bin/cmake
-    ln -vs /usr/bin/ccache /usr/lib64/ccache/g++
-    CMAKE_OPTS='-DBOOST_INCLUDEDIR=/usr/include/boost169 -DBOOST_LIBRARYDIR=/usr/lib64/boost169'
-    ;;
-
   debian:*|ubuntu:*)
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-{recommends,suggests} -y bison \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,6 @@ jobs:
         distro:
           - amazonlinux:2
           - amazonlinux:2023
-          - centos:7 # and RHEL 7
           - debian:11 # and Raspbian 11
           - debian:12 # and Raspbian 12
           - fedora:37


### PR DESCRIPTION
As seen in the recent GHA run for #10102, CentOS is now dysfunctional.

> Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
> 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"

> $ host mirrorlist.centos.org
> Host mirrorlist.centos.org not found: 3(NXDOMAIN)

Since CentOS Linux 7 has reached its end of life at June 30 together with RHEL7's end of maintenance, there will be no further updates.

https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/