### PR TITLE
Unregister invalid config objects properly

### DIFF
--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -472,13 +472,16 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 				continue;
 
 			std::atomic<int> committed_items(0);
-			std::mutex newItemsMutex;
 
 			{
 				auto items (itemsByType.find(type.get()));
 
 				if (items != itemsByType.end()) {
-					upq.ParallelFor(items->second, [&committed_items, &newItems, &newItemsMutex](const ItemPair& ip) {
+					for (const ItemPair& pair: items->second) {
+						newItems.emplace_back(pair.first);
+					}
+
+					upq.ParallelFor(items->second, [&committed_items](const ItemPair& ip) {
 						const ConfigItem::Ptr& item = ip.first;
 
 						if (!item->Commit(ip.second)) {
@@ -490,9 +493,6 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 						}
 
 						committed_items++;
-
-						std::unique_lock<std::mutex> lock(newItemsMutex);
-						newItems.emplace_back(item);
 					});
 
 					upq.Join();


### PR DESCRIPTION
When trying to create an object via the API, the `ConfigItemBuilder` will first generate a `ConfigItem` for this config object and register it in the `ConfigItem::m_Items` map. This config item generation includes some basic object validations, such as making sure that there is no already registered config item for that object name and type in `ConfigItem::m_Items`, which contains all the committed items of the Icinga 2 process.
https://github.com/Icinga/icinga2/blob/07d253009a976f71f26e61a47d2d31488f3aba66/lib/config/vmops.hpp#L142-L150 https://github.com/Icinga/icinga2/blob/07d253009a976f71f26e61a47d2d31488f3aba66/lib/config/vmops.hpp#L172

`ConfigItem::CommitItems()` takes actually care of unregistering the newly created objects if `CommitNewItems()` returns false. However, since the elements from `ConfigItem::m_Items` are only copied to the `newItems` vector after they have been successfully committed, it is impossible to unregister them here and leaves a half-committed objects.
https://github.com/Icinga/icinga2/blob/07d253009a976f71f26e61a47d2d31488f3aba66/lib/config/configitem.cpp#L631-L635

Fortunately, this has only been broken since `v2.14.0` with 400117e and this PR reverts it to its original form.

fixes #10110 