### PR TITLE
Overhaul Utility::FormatDateTime()

### DIFF
--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -1058,15 +1058,12 @@ String Utility::FormatDateTime(const char *format, double ts)
 	tm tmthen;
 
 #ifdef _MSC_VER
-	tm *temp = localtime(&tempts);
-
-	if (!temp) {
+	errno_t err = localtime_s(&tmthen, &tempts);
+	if (err) {
 		BOOST_THROW_EXCEPTION(posix_error()
-			<< boost::errinfo_api_function("localtime")
-			<< boost::errinfo_errno(errno));
+			<< boost::errinfo_api_function("localtime_s")
+			<< boost::errinfo_errno(err));
 	}
-
-	tmthen = *temp;
 #else /* _MSC_VER */
 	if (!localtime_r(&tempts, &tmthen)) {
 		BOOST_THROW_EXCEPTION(posix_error()

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -19,6 +19,7 @@
 #include <boost/thread/tss.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/regex.hpp>
@@ -1052,7 +1053,8 @@ String Utility::FormatDuration(double duration)
 String Utility::FormatDateTime(const char *format, double ts)
 {
 	char timestamp[128];
-	auto tempts = (time_t)ts; /* We don't handle sub-second timestamps here just yet. */
+	// Sub-second precision is removed, strftime() has no format specifiers for that anyway.
+	auto tempts = boost::numeric_cast<time_t>(ts);
 	tm tmthen;
 
 #ifdef _MSC_VER

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -77,7 +77,8 @@ public:
 	static String Join(const Array::Ptr& tokens, char separator, bool escapeSeparator = true);
 
 	static String FormatDuration(double duration);
-	static String FormatDateTime(const char *format, double ts);
+	static String FormatDateTime(const char* format, double ts);
+	static String FormatDateTime(const char* format, const tm* t);
 	static String FormatErrorNumber(int code);
 
 #ifndef _WIN32

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,6 +128,7 @@ add_boost_test(base
     base_utility/validateutf8
     base_utility/EscapeCreateProcessArg
     base_utility/TruncateUsingHash
+    base_utility/FormatDateTime
     base_value/scalar
     base_value/convert
     base_value/format

--- a/test/base-utility.cpp
+++ b/test/base-utility.cpp
@@ -191,6 +191,19 @@ BOOST_AUTO_TEST_CASE(FormatDateTime) {
 	// not really possible due to limitations in strftime() error handling, see comment in the implementation.
 	BOOST_CHECK_EQUAL("", Utility::FormatDateTime(repeat("%Y", 1000).c_str(), ts));
 
+	// Invalid format strings.
+	for (const char* format : {"%", "x % y", "x %! y"}) {
+		std::string result = Utility::FormatDateTime(format, ts);
+
+		// Implementations of strftime() seem to either keep invalid format specifiers and return them in the output, or
+		// treat them as an error which our implementation currently maps to the empty string due to strftime() not
+		// properly reporting errors. If this limitation of our implementation is lifted, other behavior like throwing
+		// an exception would also be valid.
+		BOOST_CHECK_MESSAGE(result.empty() || result == format,
+			"FormatDateTime(" << std::quoted(format) << ", " << ts << ") = " << std::quoted(result) <<
+			" should be one of [\"\", " << std::quoted(format) << "]");
+	}
+
 	// Out of range timestamps.
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::min(), -double_limit::infinity())), negative_overflow);
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::max(), +double_limit::infinity())), positive_overflow);

--- a/test/base-utility.cpp
+++ b/test/base-utility.cpp
@@ -186,6 +186,11 @@ BOOST_AUTO_TEST_CASE(FormatDateTime) {
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::min(), 0)), posix_error);
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::max(), 0)), posix_error);
 
+	// Excessive format strings can result in something too large for the buffer, errors out to the empty string.
+	// Note: both returning the proper result or throwing an exception would be fine too, unfortunately, that's
+	// not really possible due to limitations in strftime() error handling, see comment in the implementation.
+	BOOST_CHECK_EQUAL("", Utility::FormatDateTime(repeat("%Y", 1000).c_str(), ts));
+
 	// Out of range timestamps.
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::min(), -double_limit::infinity())), negative_overflow);
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::max(), +double_limit::infinity())), positive_overflow);

--- a/test/base-utility.cpp
+++ b/test/base-utility.cpp
@@ -137,6 +137,9 @@ BOOST_AUTO_TEST_CASE(TruncateUsingHash)
 
 BOOST_AUTO_TEST_CASE(FormatDateTime) {
 	using time_t_limit = std::numeric_limits<time_t>;
+	using double_limit = std::numeric_limits<double>;
+	using boost::numeric::negative_overflow;
+	using boost::numeric::positive_overflow;
 
 	// Helper to repeat a given string a number of times.
 	auto repeat = [](const std::string& s, size_t n) {
@@ -182,6 +185,10 @@ BOOST_AUTO_TEST_CASE(FormatDateTime) {
 	// timestamps, so localtime_r() returns EOVERFLOW which makes the implementation throw an exception.
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::min(), 0)), posix_error);
 	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::max(), 0)), posix_error);
+
+	// Out of range timestamps.
+	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::min(), -double_limit::infinity())), negative_overflow);
+	BOOST_CHECK_THROW(Utility::FormatDateTime("%Y", std::nextafter(time_t_limit::max(), +double_limit::infinity())), positive_overflow);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -527,16 +527,7 @@ struct Segment
 
 std::string pretty_time(const tm& t)
 {
-#if defined(__GNUC__) && __GNUC__ < 5
-	// GCC did not implement std::put_time() until version 5
-	char buf[128];
-	size_t n = strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z", &t);
-	return std::string(buf, n);
-#else /* defined(__GNUC__) && __GNUC__ < 5 */
-	std::ostringstream stream;
-	stream << std::put_time(&t, "%Y-%m-%d %H:%M:%S %Z");
-	return stream.str();
-#endif /* defined(__GNUC__) && __GNUC__ < 5 */
+	return Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %Z", &t);
 }
 
 std::string pretty_time(time_t t)


### PR DESCRIPTION
What started as a small "there's something strange happening" (that was the Windows invalid format string thing from the following list), it turned out that there was a lot of room for improvement within this function, so this PR does the following:

* Better input validation, the old code used a cast that was technically undefined behavior.
* Remove the use of a thread-unsafe function on Windows.
* Use the return value of `strftime()` to specify the length of the returned string, which prevents undefined behavior as the function makes no guarantees about the buffer contents when an error occurred.
* Add a workaround for invalid format strings on Windows (the C library there calls an invalid input handler on an invalid format string which may terminate the process).
* Add tests for the function in general and for the fixed edge-cases.
* Add an overload to allow calling the function with `tm*` as well (trivial implementation-wise, it just meant splitting the function in the middle) and replace a similar ad-hoc implementation within the tests.

The individual commit messages contain more details on the individual points.

Note that I initially wanted to use `std::put_time()` which does not have a fixed size output buffer and should allow using the error handling of the ostream. However, there seem to be an unfortunate implementation of this on some Windows versions where passing an invalid format string results in `std::bad_alloc` and the process allocating more and more memory before throwing the exception. I've kept the use of `strftime()` for now as the process trying to use all memory is arguable worse than the limitations of `strftime()`. Also, I can't remember that there were any complaints about that 127 byte limit and it should also be reasonable for normal use.

ref/IP/54443