### PR TITLE
Don't generate a mutex for each Locked<T>, share one per object

### DIFF
--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -5,8 +5,6 @@
 
 #include <atomic>
 #include <mutex>
-#include <type_traits>
-#include <utility>
 
 namespace icinga
 {
@@ -34,8 +32,10 @@ public:
 	}
 };
 
+class LockedMutex;
+
 /**
- * Wraps any T into a std::atomic<T>-like interface that locks using a mutex.
+ * Wraps any T into an interface similar to std::atomic<T>, that locks using a mutex.
  *
  * In contrast to std::atomic<T>, Locked<T> is also valid for types that are not trivially copyable.
  * In case T is trivially copyable, std::atomic<T> is almost certainly the better choice.
@@ -46,38 +46,44 @@ template<typename T>
 class Locked
 {
 public:
-	inline T load() const
-	{
-		std::unique_lock<std::mutex> lock(m_Mutex);
-
-		return m_Value;
-	}
-
-	inline void store(T desired)
-	{
-		std::unique_lock<std::mutex> lock(m_Mutex);
-
-		m_Value = std::move(desired);
-	}
+	T load(LockedMutex& mtx) const;
+	void store(T desired, LockedMutex& mtx);
 
 private:
-	mutable std::mutex m_Mutex;
 	T m_Value;
 };
 
 /**
- * Type alias for std::atomic<T> if possible, otherwise Locked<T> is used as a fallback.
+ * Wraps std::mutex, so that only Locked<T> can (un)lock it.
+ *
+ * The latter tiny lock scope is enforced this way to prevent deadlocks while passing around mutexes.
  *
  * @ingroup base
  */
-template <typename T>
-using AtomicOrLocked =
-#if defined(__GNUC__) && __GNUC__ < 5
-	// GCC does not implement std::is_trivially_copyable until version 5.
-	typename std::conditional<std::is_fundamental<T>::value || std::is_pointer<T>::value, std::atomic<T>, Locked<T>>::type;
-#else /* defined(__GNUC__) && __GNUC__ < 5 */
-	typename std::conditional<std::is_trivially_copyable<T>::value, std::atomic<T>, Locked<T>>::type;
-#endif /* defined(__GNUC__) && __GNUC__ < 5 */
+class LockedMutex
+{
+	template<class T>
+	friend class Locked;
+
+private:
+	std::mutex m_Mutex;
+};
+
+template<class T>
+T Locked<T>::load(LockedMutex& mtx) const
+{
+	std::unique_lock lock (mtx.m_Mutex);
+
+	return m_Value;
+}
+
+template<class T>
+void Locked<T>::store(T desired, LockedMutex& mtx)
+{
+	std::unique_lock lock (mtx.m_Mutex);
+
+	m_Value = std::move(desired);
+}
 
 }
 

--- a/lib/base/configobject.ti
+++ b/lib/base/configobject.ti
@@ -59,7 +59,7 @@ abstract class ConfigObject : ConfigObjectBase < ConfigType
 	[config, no_user_modify] String __name (Name);
 	[config, no_user_modify, required] String "name" (ShortName) {
 		get {{{
-			String shortName = m_ShortName.load();
+			String shortName = m_ShortName.load(m_FieldsMutex);
 			if (shortName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icinga/host.ti
+++ b/lib/icinga/host.ti
@@ -21,7 +21,7 @@ class Host : Checkable
 
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icinga/hostgroup.ti
+++ b/lib/icinga/hostgroup.ti
@@ -11,7 +11,7 @@ class HostGroup : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -33,7 +33,7 @@ class Service : Checkable < ServiceNameComposer
 
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetShortName();
 			else

--- a/lib/icinga/servicegroup.ti
+++ b/lib/icinga/servicegroup.ti
@@ -11,7 +11,7 @@ class ServiceGroup : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icinga/timeperiod.ti
+++ b/lib/icinga/timeperiod.ti
@@ -12,7 +12,7 @@ class TimePeriod : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icinga/user.ti
+++ b/lib/icinga/user.ti
@@ -13,7 +13,7 @@ class User : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icinga/usergroup.ti
+++ b/lib/icinga/usergroup.ti
@@ -11,7 +11,7 @@ class UserGroup : CustomVarObject
 {
 	[config] String display_name {
 		get {{{
-			String displayName = m_DisplayName.load();
+			String displayName = m_DisplayName.load(m_FieldsMutex);
 			if (displayName.IsEmpty())
 				return GetName();
 			else

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -32,7 +32,7 @@ REGISTER_TYPE(IcingaDB);
 IcingaDB::IcingaDB()
 	: m_Rcon(nullptr)
 {
-	m_RconLocked.store(nullptr);
+	m_RconLocked.store(nullptr, m_FieldsMutex);
 
 	m_WorkQueue.SetName("IcingaDB");
 
@@ -84,7 +84,7 @@ void IcingaDB::Start(bool runtimeCreated)
 	m_Rcon = new RedisConnection(GetHost(), GetPort(), GetPath(), GetUsername(), GetPassword(), GetDbIndex(),
 		GetEnableTls(), GetInsecureNoverify(), GetCertPath(), GetKeyPath(), GetCaPath(), GetCrlPath(),
 		GetTlsProtocolmin(), GetCipherList(), GetConnectTimeout(), GetDebugInfo());
-	m_RconLocked.store(m_Rcon);
+	m_RconLocked.store(m_Rcon, m_FieldsMutex);
 
 	for (const Type::Ptr& type : GetTypes()) {
 		auto ctype (dynamic_cast<ConfigType*>(type.get()));

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -48,7 +48,7 @@ public:
 
 	inline RedisConnection::Ptr GetConnection()
 	{
-		return m_RconLocked.load();
+		return m_RconLocked.load(m_FieldsMutex);
 	}
 
 	template<class T>


### PR DESCRIPTION
This reduces RAM usage per object by sizeof(mutex)*(FIELDS-1).

[The `atomic_load(const std::shared_ptr<T>*)` idea](https://github.com/Icinga/icinga2/issues/10113) would, without doubt, also consume less RAM. However, it would scale worse, the more objects you have, with a fixed number of mutexes. Neither one SpinMutex per property, nor one std::mutex per object suffer from this limitation.