### PR TITLE
Don't use thread-local var in coroutine & drop superfluous `CpuBoundWork` usage

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -348,8 +348,6 @@ bool EnsureValidBody(
 		Array::Ptr permissions = authenticatedUser->GetPermissions();
 
 		if (permissions) {
-			CpuBoundWork evalPermissions (yc);
-
 			ObjectLock olock(permissions);
 
 			for (const Value& permissionInfo : permissions) {


### PR DESCRIPTION
- c915949 - Acquiring a CPU slot just for traversing API user permissions without having to evaluate them is likewise just a wasted semaphore, thus this commit drops its usage.
- 74009f0 - It appears that the [`Checkable::ExecuteCommandProcessFinishedHandler`](https://github.com/Icinga/icinga2/blob/master/lib/icinga/checkable.hpp#L73) has been utilised in an erroneous manner. Specifically, the variable is defined as `thread_local`, yet the callback is executed by a different thread than the one that sets the actual callback, consequently resulting in the actual execute **command** handler being never called. To address this issue https://github.com/Icinga/icinga2/issues/10144, several functions have been altered to ensure thread safety, and the check results handlers are now executed correctly even from within a coroutine. Apart from that, in all instances where the `CpuBoundWork` class was utilised, they just wasted costly semaphores, as they were either used to decode JSON responses or process check results, thereby impacting the functionality of the primary components, such as RPC and HTTP connections, that are more crucial than generating a dumb windows check result and processing countless, seemingly inconsequential boost signals. Consequently, this commit eliminates also all instances of `CpuBoundWork` class within  `IfwApiCheckTask`, and delegates the process check result handling (as suggested in https://github.com/Icinga/icinga2/pull/10140#issuecomment-2321341579) to the global non-I/O thread pool instead.

fixes #10144