### PR TITLE
Add closing quotationmarks in Validator for influxdb writer config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -255,6 +255,7 @@ Sascha Westermann <sascha.westermann@hl-services.de>
 Sebastian Brückner <mail@invlid.com>
 Sebastian Chrostek <sebastian@chrostek.net>
 Sebastian Eikenberg <eikese@mail.uni-paderborn.de>
+Sebastian Grund <s.grund@openinfrastructure.de>
 Sebastian Marsching <sebastian-git-2016@marsching.com>
 Silas <67681686+Tqnsls@users.noreply.github.com>
 Simon Murray <spjmurray@yahoo.co.uk>

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -571,7 +571,7 @@ void InfluxdbCommonWriter::ValidateHostTemplate(const Lazy<Dictionary::Ptr>& lva
 		ObjectLock olock(tags);
 		for (const Dictionary::Pair& pair : tags) {
 			if (!MacroProcessor::ValidateMacroString(pair.second))
-				BOOST_THROW_EXCEPTION(ValidationError(this, { "host_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second));
+				BOOST_THROW_EXCEPTION(ValidationError(this, { "host_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second + "'."));
 		}
 	}
 }
@@ -589,7 +589,7 @@ void InfluxdbCommonWriter::ValidateServiceTemplate(const Lazy<Dictionary::Ptr>& 
 		ObjectLock olock(tags);
 		for (const Dictionary::Pair& pair : tags) {
 			if (!MacroProcessor::ValidateMacroString(pair.second))
-				BOOST_THROW_EXCEPTION(ValidationError(this, { "service_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second));
+				BOOST_THROW_EXCEPTION(ValidationError(this, { "service_template", "tags", pair.first }, "Closing $ not found in macro format string '" + pair.second + "'."));
 		}
 	}
 }


### PR DESCRIPTION
When having a macro error in the influxdb writer config the error message is missing a closing single-quotation mark.

Before:
```
Error: Validation failed for object 'influxdb2' of type 'Influxdb2Writer'; Attribute 'host_template' -> 'tags' -> 'foo': Closing $ not found in macro format string 'bar$
Location: in /usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf: 14:3-20:3
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(12):   //flush_threshold = 1024
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(13):   //flush_interval = 10s
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(14):   host_template = {
                                                                      ^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(15):     measurement = "$host.check_command$"
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(16):     tags = {
                                                                    ^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(17):       hostname = "$host.name$"
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(18):       foo = "bar$"
                                                                    ^^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(19):     }
                                                                    ^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(20):   }
```

After:
```
Error: Validation failed for object 'influxdb2' of type 'Influxdb2Writer'; Attribute 'host_template' -> 'tags' -> 'foo': Closing $ not found in macro format string 'bar$'.
Location: in /usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf: 14:3-20:3
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(12):   //flush_threshold = 1024
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(13):   //flush_interval = 10s
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(14):   host_template = {
                                                                      ^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(15):     measurement = "$host.check_command$"
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(16):     tags = {
                                                                    ^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(17):       hostname = "$host.name$"
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(18):       foo = "bar$"
                                                                    ^^^^^^^^^^^^^^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(19):     }
                                                                    ^^^^^
/usr/local/icinga2/etc/icinga2/features-enabled/influxdb2.conf(20):   }
```

This is a small fix discussed here:
https://github.com/Icinga/icinga2/pull/10074#discussion_r1773046097
