### PR TITLE
Fix build on Mac with -DICINGA2_UNITY_BUILD=OFF -DICINGA2_WITH_LIVESTATUS=ON

### DIFF
--- a/lib/icinga/notification.hpp
+++ b/lib/icinga/notification.hpp
@@ -55,6 +55,7 @@ class ApplyRule;
 struct ScriptFrame;
 class Host;
 class Service;
+class UserGroup;
 
 /**
  * An Icinga notification specification.
@@ -73,7 +74,7 @@ public:
 	intrusive_ptr<NotificationCommand> GetCommand() const;
 	TimePeriod::Ptr GetPeriod() const;
 	std::set<User::Ptr> GetUsers() const;
-	std::set<UserGroup::Ptr> GetUserGroups() const;
+	std::set<intrusive_ptr<UserGroup>> GetUserGroups() const;
 
 	void UpdateNotificationNumber();
 	void ResetNotificationNumber();

--- a/lib/icinga/usergroup.hpp
+++ b/lib/icinga/usergroup.hpp
@@ -4,6 +4,7 @@
 #define USERGROUP_H
 
 #include "icinga/i2-icinga.hpp"
+#include "icinga/notification.hpp"
 #include "icinga/usergroup-ti.hpp"
 #include "icinga/user.hpp"
 


### PR DESCRIPTION
error: no matching function for call to 'intrusive_ptr_release'
...
candidate function not viable: cannot convert argument of incomplete type 'icinga::Notification *' to 'Object *' for 1st argument
void intrusive_ptr_release(Object *object);

## Edit

There are only 'skip'ped commits left to test.
The first bad commit could be any of:
7a0796061a0b38b93dc1717fd25a57cec992509c
10bde2075aa8017699f3738e9f01af2ac30e7ad1
4d3b1709fdb4cfefeb7e93718032b4905cd947b4
73e0d6e61baa5dfa88bba61bfe4235042aa06b38
e1c6c9eb19919ad085405592185a3854e9dcf435
2ad0a4b8c3852ad937fec9fc85780230257c821e
We cannot bisect more!