### PR TITLE
Log: fix some parts of messages not being discarded early

### DIFF
--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -121,7 +121,10 @@ public:
 	template<typename T>
 	Log& operator<<(const T& val)
 	{
-		m_Buffer << val;
+		if (!m_IsNoOp) {
+			m_Buffer << val;
+		}
+
 		return *this;
 	}
 


### PR DESCRIPTION
`m_IsNoOp` was introduced to avoid building up log messages that will later be discarded, like debug messages if no debug logging is configured. However, it looks like the template `operator<<` implemented in the header file was forgotten when adding this feature, all other places writing into `m_Buffer` already have an if guard like added by this commit.