### PR TITLE
Bugfix/configobject shutdown order 10179

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -295,6 +295,7 @@ vigiroux <vincent.giroux@nokia.com>
 Vytenis Darulis <vytenis@uber.com>
 Wenger Florian <wenger@unifox.at>
 Will Frey <will.frey@digitalreasoning.com>
+William Calliari <william.calliari@wuerth-phoenix.net>
 Winfried Angele <winfried.angele@gmail.com>
 Wolfgang Nieder <wnd@gmx.net>
 XnS <git@xns.be>

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -585,10 +585,12 @@ void ConfigObject::StopObjects()
 {
 	std::vector<Type::Ptr> types = Type::GetAllTypes();
 
+	// The higher the activation priority, the later the config object will be
+	// loaded, with the CheckerComponent at 300 being last. To make sure they
+	// are shutting down in the right order, we need to shut down the objects
+	// with the highest priority first.
 	std::sort(types.begin(), types.end(), [](const Type::Ptr& a, const Type::Ptr& b) {
-		if (a->GetActivationPriority() > b->GetActivationPriority())
-			return true;
-		return false;
+		return a->GetActivationPriority() < b->GetActivationPriority();
 	});
 
 	for (const Type::Ptr& type : types) {
@@ -600,7 +602,13 @@ void ConfigObject::StopObjects()
 		for (const ConfigObject::Ptr& object : dtype->GetObjects()) {
 #ifdef I2_DEBUG
 			Log(LogDebug, "ConfigObject")
-				<< "Deactivate() called for config object '" << object->GetName() << "' with type '" << type->GetName() << "'.";
+				<< "Deactivate() called for config object '"
+				<< object->GetName()
+				<< "' with type '"
+				<< type->GetName()
+				<< "' and priority "
+				<< object->GetActivationPriority()
+				<< ".";
 #endif /* I2_DEBUG */
 			object->Deactivate();
 		}

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -607,7 +607,7 @@ void ConfigObject::StopObjects()
 				<< "' with type '"
 				<< type->GetName()
 				<< "' and priority "
-				<< object->GetActivationPriority()
+				<< type->GetActivationPriority()
 				<< ".";
 #endif /* I2_DEBUG */
 			object->Deactivate();

--- a/lib/db_ido/dbconnection.ti
+++ b/lib/db_ido/dbconnection.ti
@@ -10,6 +10,8 @@ namespace icinga
 
 abstract class DbConnection : ConfigObject
 {
+	activation_priority 250;
+
 	[config] String table_prefix {
 		default {{{ return "icinga_"; }}}
 	};

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -20,6 +20,8 @@ public:
 
 class Notification : CustomVarObject < NotificationNameComposer
 {
+	activation_priority 200;
+
 	load_after Host;
 	load_after Service;
 

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -12,7 +12,7 @@ namespace icinga
 
 class ApiListener : ConfigObject
 {
-	activation_priority 50;
+	activation_priority 300;
 
 	[config, deprecated] String cert_path;
 	[config, deprecated] String key_path;

--- a/lib/remote/endpoint.ti
+++ b/lib/remote/endpoint.ti
@@ -10,6 +10,8 @@ namespace icinga
 
 class Endpoint : ConfigObject
 {
+	activation_priority 300;
+
 	load_after Zone;
 
 	[config] String host;


### PR DESCRIPTION
This PR fixes #10179.

## Shutdown the object in the correct order.

During a restart the objects are shut down in the reversed order they should be. With this the CheckerComponent is still updating objects after the IDO, Icingadb, Notifications, etc. have already been shutdown, leading to icinga2 getting out of sync with external components.

## Increase activation_priority for key config objects to ensure correct startup and shutdown order

Make sure all configobjects are started and shut down in the right order, so that each object has its possible dependencies loaded before starting execution.

