### PR TITLE
Added the `--dane` option to the command definition ssl_cert

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5942,6 +5942,7 @@ ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot
 ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking.
 ssl_cert_ignore_sct           | **Optional.** Do not check for signed certificate timestamps.
 ssl_cert_ignore_tls_renegotiation  | **Optional.** Do not check for renegotiation.
+ssl_cert_dane                 | **Optional.** Verify that valid DANE records exist {211,301,302,311 or empty string}.
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5942,7 +5942,7 @@ ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot
 ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking.
 ssl_cert_ignore_sct           | **Optional.** Do not check for signed certificate timestamps.
 ssl_cert_ignore_tls_renegotiation  | **Optional.** Do not check for renegotiation.
-ssl_cert_dane                 | **Optional.** Verify that valid DANE records exist {211,301,302,311 or empty string}.
+ssl_cert_dane                 | **Optional.** Verify that valid DANE records exist ({211,301,302,311} or empty string).
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -5942,7 +5942,7 @@ ssl_cert_ignore_ocsp_errors   | **Optional.** Continue if the OCSP status cannot
 ssl_cert_ignore_ocsp_timeout  | **Optional.** Ignore OCSP result when timeout occurs while checking.
 ssl_cert_ignore_sct           | **Optional.** Do not check for signed certificate timestamps.
 ssl_cert_ignore_tls_renegotiation  | **Optional.** Do not check for renegotiation.
-ssl_cert_dane                 | **Optional.** Verify that valid DANE records exist ({211,301,302,311} or empty string).
+ssl_cert_dane                 | **Optional.** Verify that valid DANE records exist ({211,301,302,311,312} or empty string).
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -582,6 +582,11 @@ object CheckCommand "ssl_cert" {
 			value = "$ssl_cert_maximum_validity$"
 			description = "The maximum validity of the certificate in days (default: 397)"
 		}
+		"--dane" = {
+			value = "$ssl_cert_dane$"
+			description = "verify that valid DANE records exist (since OpenSSL 1.1.0)"
+			repeat_key = false
+		}
 
 	}
 


### PR DESCRIPTION
fixes #10195

Added the `ssl_cert_date` option to the `ssl_cert` command definition. Values can be an empty string or a specification of the TLSA record type to check (201, 301, 302, or 311).