### PR TITLE
GHA: Windows: use Server 2022, not 2019

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         bits: [32, 64]
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       BITS: '${{ matrix.bits }}'


### PR DESCRIPTION
Recently, we've upgraded our build infrastructure. The GHA shall ensure the latter can build Icinga 2.