### PR TITLE
Remove redundant "Validation failed" prefix from ValidationError exceptions

### DIFF
--- a/lib/icinga/command.cpp
+++ b/lib/icinga/command.cpp
@@ -35,7 +35,7 @@ void Command::Validate(int types, const ValidationUtils& utils)
 					Value argvalue = argdict->Get("value");
 
 					if (argvalue.IsString() && !MacroProcessor::ValidateMacroString(argvalue))
-						BOOST_THROW_EXCEPTION(ValidationError(this, { "arguments", kv.first, "value" }, "Validation failed: Closing $ not found in macro format string '" + argvalue + "'."));
+						BOOST_THROW_EXCEPTION(ValidationError(this, { "arguments", kv.first, "value" }, "Closing $ not found in macro format string '" + argvalue + "'."));
 				}
 
 				if (argdict->Contains("set_if")) {

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -739,7 +739,7 @@ void Notification::Validate(int types, const ValidationUtils& utils)
 	Array::Ptr groups = GetUserGroupsRaw();
 
 	if ((!users || users->GetLength() == 0) && (!groups || groups->GetLength() == 0))
-		BOOST_THROW_EXCEPTION(ValidationError(this, std::vector<String>(), "Validation failed: No users/user_groups specified."));
+		BOOST_THROW_EXCEPTION(ValidationError(this, std::vector<String>(), "No users/user_groups specified."));
 }
 
 void Notification::ValidateStates(const Lazy<Array::Ptr>& lvalue, const ValidationUtils& utils)

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -48,14 +48,13 @@ void IcingaDB::Validate(int types, const ValidationUtils& utils)
 		return;
 
 	if (GetEnableTls() && GetCertPath().IsEmpty() != GetKeyPath().IsEmpty()) {
-		BOOST_THROW_EXCEPTION(ValidationError(this, std::vector<String>(), "Validation failed: Either both a client certificate (cert_path) and its private key (key_path) or none of them must be given."));
+		BOOST_THROW_EXCEPTION(ValidationError(this, std::vector<String>(), "Either both a client certificate (cert_path) and its private key (key_path) or none of them must be given."));
 	}
 
 	try {
 		InitEnvironmentId();
 	} catch (const std::exception& e) {
-		BOOST_THROW_EXCEPTION(ValidationError(this, std::vector<String>(),
-			String("Validation failed: ") + e.what()));
+		BOOST_THROW_EXCEPTION(ValidationError(this, std::vector<String>(), e.what()));
 	}
 }
 


### PR DESCRIPTION
ValidationError#ValidationError() already prefixes #m_What, which #what() returns, with "Validation failed for object". Example:

`[2024-10-24 09:27:15 +0200] critical/config: Error: Validation failed for object 'icingadb' of type 'IcingaDB': Redis password must be set, if username is provided.`

* Digged out during https://github.com/Icinga/icinga2/pull/10102#discussion_r1812148275