### PR TITLE
openSUSE install docs: remove false info

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -150,12 +150,6 @@ SUSEConnect -p PackageHub/$VERSION_ID/x86_64
 zypper ar https://packages.icinga.com/openSUSE/ICINGA-release.repo
 zypper ref
 ```
-
-You need to additionally add the `server:monitoring` repository to fulfill dependencies:
-
-```bash
-zypper ar https://download.opensuse.org/repositories/server:/monitoring/15.3/server:monitoring.repo
-```
 <!-- {% endif %} -->
 
 <!-- {% if amazon_linux %} -->


### PR DESCRIPTION
No packages to be installed according to these instructions require the given repo. I've tested v15.3.

ref/IP/56121

* FWIW, #9230 introduced that w/o any justification. (PR discussion misses "SUSE".)