### PR TITLE
Include references header in emails

### DIFF
--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -178,5 +178,5 @@ if [ -n "$MAILFROM" ] ; then
 
 else
   /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
+  | $MAILBIN -s "$SUBJECT" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -175,5 +175,5 @@ if [ -n "$MAILFROM" ] ; then
 
 else
   /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" $USEREMAIL
+  | $MAILBIN -s "$SUBJECT" -a "References: <$HOSTNAME@$ICINGA2HOST>" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -177,6 +177,11 @@ if [ -n "$MAILFROM" ] ; then
   fi
 
 else
-  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" $USEREMAIL
+  if [ -f /etc/debian_version ]; then
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
+  else
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -s "$SUBJECT" $USEREMAIL
+  fi
 fi

--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -157,6 +157,7 @@ if [ "$VERBOSE" = "true" ] ; then
   logger "$PROG sends $SUBJECT => $USEREMAIL"
 fi
 
+# A mail header to relate mails for the same host/service, to enable the use of threaded view in a client.
 REFHEADER="References: <$HOSTNAME@$ICINGA2HOST>"
 
 ## Send the mail using the $MAILBIN command.

--- a/etc/icinga2/scripts/mail-host-notification.sh
+++ b/etc/icinga2/scripts/mail-host-notification.sh
@@ -157,6 +157,8 @@ if [ "$VERBOSE" = "true" ] ; then
   logger "$PROG sends $SUBJECT => $USEREMAIL"
 fi
 
+REFHEADER="References: <$HOSTNAME@$ICINGA2HOST>"
+
 ## Send the mail using the $MAILBIN command.
 ## If an explicit sender was specified, try to set it.
 if [ -n "$MAILFROM" ] ; then
@@ -166,7 +168,7 @@ if [ -n "$MAILFROM" ] ; then
   ## Debian/Ubuntu use mailutils which requires `-a` to append the header
   if [ -f /etc/debian_version ]; then
     /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-    | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
+    | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
   ## Other distributions (RHEL/SUSE/etc.) prefer mailx which sets a sender address with `-r`
   else
     /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
@@ -175,5 +177,5 @@ if [ -n "$MAILFROM" ] ; then
 
 else
   /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" -a "References: <$HOSTNAME@$ICINGA2HOST>" $USEREMAIL
+  | $MAILBIN -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -170,6 +170,7 @@ if [ "$VERBOSE" = "true" ] ; then
   logger "$PROG sends $SUBJECT => $USEREMAIL"
 fi
 
+# A mail header to relate mails for the same host/service, to enable the use of threaded view in a client.
 REFHEADER="References: <$HOSTNAME+$SERVICENAME@$(hostname --fqdn)>"
 
 ## Send the mail using the $MAILBIN command.

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -170,6 +170,8 @@ if [ "$VERBOSE" = "true" ] ; then
   logger "$PROG sends $SUBJECT => $USEREMAIL"
 fi
 
+REFHEADER="References: <$HOSTNAME+$SERVICENAME@$(hostname --fqdn)>"
+
 ## Send the mail using the $MAILBIN command.
 ## If an explicit sender was specified, try to set it.
 if [ -n "$MAILFROM" ] ; then
@@ -179,7 +181,7 @@ if [ -n "$MAILFROM" ] ; then
   ## Debian/Ubuntu use mailutils which requires `-a` to append the header
   if [ -f /etc/debian_version ]; then
     /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-    | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" $USEREMAIL
+    | $MAILBIN -a "From: $MAILFROM" -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
   ## Other distributions (RHEL/SUSE/etc.) prefer mailx which sets a sender address with `-r`
   else
     /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
@@ -188,5 +190,5 @@ if [ -n "$MAILFROM" ] ; then
 
 else
   /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" -a "References: <$HOSTNAME+$SERVICENAME@$(hostname --fqdn)>" $USEREMAIL
+  | $MAILBIN -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -188,5 +188,5 @@ if [ -n "$MAILFROM" ] ; then
 
 else
   /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" $USEREMAIL
+  | $MAILBIN -s "$SUBJECT" -a "References: <$HOSTNAME+$SERVICENAME@$(hostname --fqdn)>" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -191,5 +191,5 @@ if [ -n "$MAILFROM" ] ; then
 
 else
   /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
+  | $MAILBIN -s "$SUBJECT" $USEREMAIL
 fi

--- a/etc/icinga2/scripts/mail-service-notification.sh
+++ b/etc/icinga2/scripts/mail-service-notification.sh
@@ -190,6 +190,11 @@ if [ -n "$MAILFROM" ] ; then
   fi
 
 else
-  /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
-  | $MAILBIN -s "$SUBJECT" $USEREMAIL
+  if [ -f /etc/debian_version ]; then
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -s "$SUBJECT" -a "$REFHEADER" $USEREMAIL
+  else
+    /usr/bin/printf "%b" "$NOTIFICATION_MESSAGE" | tr -d '\015' \
+    | $MAILBIN -s "$SUBJECT" $USEREMAIL
+  fi
 fi


### PR DESCRIPTION
I'd like to add a References header to notification emails to allow mail client to show it threaded.

This allows a mail client to group mails from the same service such that a recovery is directly below a warning or critical.
That makes it easier to see if a problem is already resolved.

There is one more line in each file that call the mail command (for non-debian). But not all systems seem to support the `-a` option. e.g. Alma linux which came with S-NAIL as mua does not support it, there `--custom-header=..` seems to be the option. 