### PR TITLE
ApiListener: Log connection attempts from an already connected client prominently

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -843,9 +843,11 @@ void ApiListener::NewClientHandlerInternal(
 		Log(LogNotice, "ApiListener", "New JSON-RPC client");
 
 		if (endpoint && endpoint->GetConnected()) {
-			Log(LogNotice, "ApiListener")
+			Log(LogInformation, "ApiListener")
 				<< "Ignoring JSON-RPC connection " << conninfo
-				<< ". We're already connected to Endpoint '" << endpoint->GetName() << "'.";
+				<< ". We're already connected to Endpoint '" << endpoint->GetName()
+				<< "' (last message sent: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S", endpoint->GetLastMessageSent())
+				<< ", last message received: " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S", endpoint->GetLastMessageReceived()) << ").";
 			return;
 		}
 


### PR DESCRIPTION
Something is definitely going wrong if a client tries to reconnect to this endpoint while it still has an active connection to that client. So we shouldn't hide this, but at least log it at info level. Apart from that, I've added some additional information about the currently active client, such as when the last message was sent and received.

## Tests

Start two Icinga 2 endpoints and try to connect to one of them using either ones certificate.
```bash
echo -n '86:{"jsonrpc":"2.0","method":"icinga::Hello","params":{"capabilities":3,"version":21400}}\r\n\r\n' | openssl s_client -connect localhost:5665 -cert satellite.crt -key satellite.key
```

Logs on the master endpoint:
```bash
[2024-10-30 11:47:10 +0100] information/ApiListener: New client connection for identity 'satellite' from [::1]:58029
[2024-10-30 11:47:10 +0100] information/ApiListener: Ignoring JSON-RPC connection from [::1]:58029. We're already connected to Endpoint 'satellite' (last message sent: 2024-10-30 11:47:09, last message received: 2024-10-30 11:46:33).
```