### PR TITLE
JsonRpcConnection: Drop unused `m_NextHeartbeat` variable

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -38,7 +38,7 @@ JsonRpcConnection::JsonRpcConnection(const String& identity, bool authenticated,
 JsonRpcConnection::JsonRpcConnection(const String& identity, bool authenticated,
 	const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role, boost::asio::io_context& io)
 	: m_Identity(identity), m_Authenticated(authenticated), m_Stream(stream), m_Role(role),
-	m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_NextHeartbeat(0), m_IoStrand(io),
+	m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_IoStrand(io),
 	m_OutgoingMessagesQueued(io), m_WriterDone(io), m_ShuttingDown(false),
 	m_CheckLivenessTimer(io), m_HeartbeatTimer(io)
 {

--- a/lib/remote/jsonrpcconnection.hpp
+++ b/lib/remote/jsonrpcconnection.hpp
@@ -73,7 +73,6 @@ private:
 	ConnectionRole m_Role;
 	double m_Timestamp;
 	double m_Seen;
-	double m_NextHeartbeat;
 	boost::asio::io_context::strand m_IoStrand;
 	std::vector<String> m_OutgoingMessagesQueue;
 	AsioConditionVariable m_OutgoingMessagesQueued;


### PR DESCRIPTION
Is a leftover from https://github.com/Icinga/icinga2/pull/8097