### PR TITLE
ApiListener: Log error context only once

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1554,7 +1554,7 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 					count++;
 				} catch (const std::exception& ex) {
 					Log(LogWarning, "ApiListener")
-						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex, false);
+						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << ex.what();
 
 					Log(LogDebug, "ApiListener")
 						<< "Error while replaying log for endpoint '" << endpoint->GetName() << "': " << DiagnosticInformation(ex);


### PR DESCRIPTION
When logging at the warning level, the logger will automatically look up for registered context and append them to the log entry accordingly.

https://github.com/Icinga/icinga2/blob/92399a9d9cfc29bf5341075aa8821bff40afd0d7/lib/base/logger.cpp#L279-L287

### Before

```bash
[2024-10-30 17:01:01 +0100] information/ApiListener: Sending replay log for endpoint 'satellite' in zone 'master'.
[2024-10-30 17:01:01 +0100] warning/JsonRpcConnection: API client disconnected for identity 'satellite'
[2024-10-30 17:01:01 +0100] warning/ApiListener: Error while replaying log for endpoint 'satellite': Error: Cannot send message to already disconnected API client 'satellite'!

Context:

        (0) Replaying log for Endpoint 'satellite'
Context:
        (0) Replaying log for Endpoint 'satellite'

[2024-10-30 17:01:01 +0100] warning/ApiListener: Removing API client for endpoint 'satellite'. 0 API clients left.
```

### After

```bash
[2024-10-30 16:58:23 +0100] information/ApiListener: Sending replay log for endpoint 'satellite' in zone 'master'.
[2024-10-30 16:58:23 +0100] warning/JsonRpcConnection: API client disconnected for identity 'satellite'
[2024-10-30 16:58:23 +0100] warning/ApiListener: Removing API client for endpoint 'satellite'. 0 API clients left.
[2024-10-30 16:58:23 +0100] warning/ApiListener: Error while replaying log for endpoint 'satellite': Cannot send message to already disconnected API client 'satellite'!
Context:
        (0) Replaying log for Endpoint 'satellite'

[2024-10-30 16:58:23 +0100] information/ApiListener: Finished sending replay log for endpoint 'satellite' in zone 'master'.
```