### PR TITLE
HttpServerConnection: Don't spawn useless coroutines

### DIFF
--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -28,7 +28,6 @@ public:
 	HttpServerConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream);
 
 	void Start();
-	void Disconnect();
 	void StartStreaming();
 
 	bool Disconnected();
@@ -44,6 +43,8 @@ private:
 	boost::asio::deadline_timer m_CheckLivenessTimer;
 
 	HttpServerConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io);
+
+	void Disconnect(boost::asio::yield_context yc);
 
 	void ProcessMessages(boost::asio::yield_context yc);
 	void CheckLiveness(boost::asio::yield_context yc);


### PR DESCRIPTION
Currently, for each `Disconnect()` call, we spawn a coroutine, but every one of them is just usesless, except the first one. However, since all `Disconnect()` usages share the same asio strand and cannot interfere with each other, spawning another coroutine within `Disconnect()` isn't even necessary. When a coroutine calls `Disconnect()` now, it will immediately initiate an async shutdown of the socket, potentially causing the coroutine to yield and allowing the others to resume. Therefore, the `m_ShuttingDown` flag is still required by the coroutines to be checked regularly.