### PR TITLE
Atomic<T>#Atomic(T): fix C++ compliance

### DIFF
--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -12,7 +12,12 @@ namespace icinga
 {
 
 /**
- * Extends std::atomic with an atomic constructor.
+ * Like std::atomic, but enforces usage of its only safe constructor.
+ *
+ * "The default-initialized std::atomic<T> does not contain a T object,
+ * and its only valid uses are destruction and
+ * initialization by std::atomic_init, see LWG issue 2334."
+ *  -- https://en.cppreference.com/w/cpp/atomic/atomic/atomic
  *
  * @ingroup base
  */
@@ -20,24 +25,12 @@ template<class T>
 class Atomic : public std::atomic<T> {
 public:
 	/**
-	 * Like std::atomic#atomic, but operates atomically
+	 * The only safe constructor of std::atomic#atomic
 	 *
 	 * @param desired Initial value
 	 */
 	inline Atomic(T desired) : std::atomic<T>(desired)
 	{
-		this->store(desired);
-	}
-
-	/**
-	 * Like std::atomic#atomic, but operates atomically
-	 *
-	 * @param desired Initial value
-	 * @param order Initial store operation's memory order
-	 */
-	inline Atomic(T desired, std::memory_order order) : std::atomic<T>(desired)
-	{
-		this->store(desired, order);
 	}
 };
 

--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -24,7 +24,7 @@ public:
 	 *
 	 * @param desired Initial value
 	 */
-	inline Atomic(T desired)
+	inline Atomic(T desired) : std::atomic<T>(desired)
 	{
 		this->store(desired);
 	}
@@ -35,7 +35,7 @@ public:
 	 * @param desired Initial value
 	 * @param order Initial store operation's memory order
 	 */
-	inline Atomic(T desired, std::memory_order order)
+	inline Atomic(T desired, std::memory_order order) : std::atomic<T>(desired)
 	{
 		this->store(desired, order);
 	}


### PR DESCRIPTION
by not calling `std::atomic<T>::atomic(void)`.

After the latter the instance "does not contain a T object, and its only valid uses are destruction and initialization by std::atomic_init" which we don't call. So the only safe option is `std::atomic<T>::atomic(T)`.

https://en.cppreference.com/w/cpp/atomic/atomic/atomic

* Found by @julianbrost in https://github.com/Icinga/icinga2/pull/10214#issuecomment-2456968945