### PR TITLE
JsonRpcConnection: don't write any data on shutdown

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -110,6 +110,10 @@ void JsonRpcConnection::WriteOutgoingMessages(boost::asio::yield_context yc)
 		if (!queue.empty()) {
 			try {
 				for (auto& message : queue) {
+					if (m_ShuttingDown) {
+						return;
+					}
+
 					size_t bytesSent = JsonRpc::SendRawMessage(m_Stream, message, yc);
 
 					if (m_Endpoint) {

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -121,6 +121,10 @@ void JsonRpcConnection::WriteOutgoingMessages(boost::asio::yield_context yc)
 					}
 				}
 
+				if (m_ShuttingDown) {
+					return;
+				}
+
 				m_Stream->async_flush(yc);
 			} catch (const std::exception& ex) {
 				Log(m_ShuttingDown ? LogDebug : LogWarning, "JsonRpcConnection")


### PR DESCRIPTION
In fact, this is already done for the outer loop (for each bulk), just not yet for the inner one (for each message of a bulk). So once the remote signals EOF, don't try to get things done until write error (which can't be associated with a particular message anyway, due to buffering), but just let the peer go.