### PR TITLE
Consistently use Atomic, and not std::atomic

### DIFF
--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -87,6 +87,12 @@ template<typename T>
 class Locked
 {
 public:
+	Locked() = default;
+
+	Locked(T desired) : m_Value(std::move(desired))
+	{
+	}
+
 	inline T load() const
 	{
 		std::unique_lock<std::mutex> lock(m_Mutex);

--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -113,12 +113,12 @@ private:
 };
 
 /**
- * Type alias for std::atomic<T> if possible, otherwise Locked<T> is used as a fallback.
+ * Type alias for Atomic<T> if possible, otherwise Locked<T> is used as a fallback.
  *
  * @ingroup base
  */
 template <typename T>
-using AtomicOrLocked = std::conditional_t<std::is_trivially_copyable_v<T>, std::atomic<T>, Locked<T>>;
+using AtomicOrLocked = std::conditional_t<std::is_trivially_copyable_v<T>, Atomic<T>, Locked<T>>;
 
 }
 

--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -26,6 +26,8 @@ namespace icinga
 template<class T>
 class Atomic : public std::atomic<T> {
 public:
+	using std::atomic<T>::operator=;
+
 	/**
 	 * The only safe constructor of std::atomic#atomic
 	 *

--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -142,9 +142,10 @@ boost::asio::io_context& IoEngine::GetIoContext()
 	return m_IoContext;
 }
 
-IoEngine::IoEngine() : m_IoContext(), m_KeepAlive(boost::asio::make_work_guard(m_IoContext)), m_Threads(decltype(m_Threads)::size_type(Configuration::Concurrency * 2u))
+IoEngine::IoEngine() : m_IoContext(), m_KeepAlive(boost::asio::make_work_guard(m_IoContext)),
+	m_Threads(decltype(m_Threads)::size_type(Configuration::Concurrency * 2u)),
+	m_CpuBoundSemaphore(Configuration::Concurrency * 3u / 2u)
 {
-	m_CpuBoundSemaphore.store(Configuration::Concurrency * 3u / 2u);
 
 	for (auto& thread : m_Threads) {
 		thread = std::thread(&IoEngine::RunEventLoop, this);

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -10,7 +10,7 @@
 #include "base/lazy-init.hpp"
 #include "base/logger.hpp"
 #include "base/shared.hpp"
-#include <atomic>
+#include <cstdint>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -173,7 +173,7 @@ private:
 	boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_KeepAlive;
 	std::vector<std::thread> m_Threads;
 
-	std::atomic_uint_fast32_t m_CpuBoundSemaphore;
+	Atomic<int_fast32_t> m_CpuBoundSemaphore;
 	std::mutex m_CpuBoundWaitingMutex;
 	std::vector<std::pair<boost::asio::io_context::strand, Shared<AsioConditionVariable>::Ptr>> m_CpuBoundWaiting;
 };

--- a/lib/base/lazy-init.hpp
+++ b/lib/base/lazy-init.hpp
@@ -4,7 +4,7 @@
 #ifndef LAZY_INIT
 #define LAZY_INIT
 
-#include <atomic>
+#include "base/atomic.hpp"
 #include <functional>
 #include <mutex>
 #include <utility>
@@ -25,7 +25,6 @@ public:
 	inline
 	LazyInit(std::function<T()> initializer = []() { return T(); }) : m_Initializer(std::move(initializer))
 	{
-		m_Underlying.store(nullptr, std::memory_order_release);
 	}
 
 	LazyInit(const LazyInit&) = delete;
@@ -65,7 +64,7 @@ public:
 private:
 	std::function<T()> m_Initializer;
 	std::mutex m_Mutex;
-	std::atomic<T*> m_Underlying;
+	Atomic<T*> m_Underlying {nullptr};
 };
 
 }

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -35,7 +35,7 @@ REGISTER_TYPE(Logger);
 std::set<Logger::Ptr> Logger::m_Loggers;
 std::mutex Logger::m_Mutex;
 bool Logger::m_ConsoleLogEnabled = true;
-std::atomic<bool> Logger::m_EarlyLoggingEnabled (true);
+Atomic<bool> Logger::m_EarlyLoggingEnabled (true);
 bool Logger::m_TimestampEnabled = true;
 LogSeverity Logger::m_ConsoleLogSeverity = LogInformation;
 std::mutex Logger::m_UpdateMinLogSeverityMutex;

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -101,7 +101,7 @@ private:
 	static std::mutex m_Mutex;
 	static std::set<Logger::Ptr> m_Loggers;
 	static bool m_ConsoleLogEnabled;
-	static std::atomic<bool> m_EarlyLoggingEnabled;
+	static Atomic<bool> m_EarlyLoggingEnabled;
 	static bool m_TimestampEnabled;
 	static LogSeverity m_ConsoleLogSeverity;
 	static std::mutex m_UpdateMinLogSeverityMutex;

--- a/lib/base/namespace.hpp
+++ b/lib/base/namespace.hpp
@@ -5,12 +5,12 @@
 #define NAMESPACE_H
 
 #include "base/i2-base.hpp"
+#include "base/atomic.hpp"
 #include "base/object.hpp"
 #include "base/objectlock.hpp"
 #include "base/shared-object.hpp"
 #include "base/value.hpp"
 #include "base/debuginfo.hpp"
-#include <atomic>
 #include <map>
 #include <vector>
 #include <memory>
@@ -96,7 +96,7 @@ private:
 	std::map<String, NamespaceValue> m_Data;
 	mutable std::shared_timed_mutex m_DataMutex;
 	bool m_ConstValues;
-	std::atomic<bool> m_Frozen;
+	Atomic<bool> m_Frozen;
 };
 
 Namespace::Iterator begin(const Namespace::Ptr& x);

--- a/lib/base/object.cpp
+++ b/lib/base/object.cpp
@@ -28,11 +28,6 @@ static Timer::Ptr l_ObjectCountTimer;
  */
 Object::Object()
 {
-	m_References.store(0);
-
-#ifdef I2_DEBUG
-	m_LockOwner.store(decltype(m_LockOwner.load())());
-#endif /* I2_DEBUG */
 }
 
 /**

--- a/lib/base/object.hpp
+++ b/lib/base/object.hpp
@@ -5,10 +5,10 @@
 #define OBJECT_H
 
 #include "base/i2-base.hpp"
+#include "base/atomic.hpp"
 #include "base/debug.hpp"
 #include "base/intrusive-ptr.hpp"
 #include <boost/smart_ptr/intrusive_ptr.hpp>
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
@@ -194,11 +194,11 @@ private:
 	Object(const Object& other) = delete;
 	Object& operator=(const Object& rhs) = delete;
 
-	mutable std::atomic<uint_fast64_t> m_References;
+	mutable Atomic<uint_fast64_t> m_References {0};
 	mutable std::recursive_mutex m_Mutex;
 
 #ifdef I2_DEBUG
-	mutable std::atomic<std::thread::id> m_LockOwner;
+	mutable Atomic<std::thread::id> m_LockOwner {std::thread::id()};
 	mutable size_t m_LockCount = 0;
 #endif /* I2_DEBUG */
 

--- a/lib/base/tlsstream.hpp
+++ b/lib/base/tlsstream.hpp
@@ -5,13 +5,13 @@
 #define TLSSTREAM_H
 
 #include "base/i2-base.hpp"
+#include "base/atomic.hpp"
 #include "base/shared.hpp"
 #include "base/socket.hpp"
 #include "base/stream.hpp"
 #include "base/tlsutility.hpp"
 #include "base/fifo.hpp"
 #include "base/utility.hpp"
-#include <atomic>
 #include <memory>
 #include <utility>
 #include <variant>
@@ -32,7 +32,6 @@ public:
 	template<class... Args>
 	SeenStream(Args&&... args) : ARS(std::forward<Args>(args)...)
 	{
-		m_Seen.store(nullptr);
 	}
 
 	template<class... Args>
@@ -55,7 +54,7 @@ public:
 	}
 
 private:
-	std::atomic<double*> m_Seen;
+	Atomic<double*> m_Seen {nullptr};
 };
 
 struct UnbufferedAsioTlsStreamParams

--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -12,7 +12,7 @@
 
 using namespace icinga;
 
-std::atomic<int> WorkQueue::m_NextID(1);
+Atomic<int> WorkQueue::m_NextID (1);
 boost::thread_specific_ptr<WorkQueue *> l_ThreadWorkQueue;
 
 WorkQueue::WorkQueue(size_t maxItems, int threadCount, LogSeverity statsLogLevel)

--- a/lib/base/workqueue.hpp
+++ b/lib/base/workqueue.hpp
@@ -5,6 +5,7 @@
 #define WORKQUEUE_H
 
 #include "base/i2-base.hpp"
+#include "base/atomic.hpp"
 #include "base/timer.hpp"
 #include "base/ringbuffer.hpp"
 #include "base/logger.hpp"
@@ -14,7 +15,6 @@
 #include <mutex>
 #include <queue>
 #include <deque>
-#include <atomic>
 
 namespace icinga
 {
@@ -122,7 +122,7 @@ protected:
 private:
 	int m_ID;
 	String m_Name;
-	static std::atomic<int> m_NextID;
+	static Atomic<int> m_NextID;
 	int m_ThreadCount;
 	bool m_Spawned{false};
 

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -6,11 +6,11 @@
 
 #include "config/i2-config.hpp"
 #include "config/expression.hpp"
+#include "base/atomic.hpp"
 #include "base/debuginfo.hpp"
 #include "base/shared-object.hpp"
 #include "base/type.hpp"
 #include <unordered_map>
-#include <atomic>
 
 namespace icinga
 {
@@ -105,7 +105,7 @@ private:
 	bool m_IgnoreOnError;
 	DebugInfo m_DebugInfo;
 	Dictionary::Ptr m_Scope;
-	std::atomic<bool> m_HasMatches;
+	Atomic<bool> m_HasMatches;
 
 	static TypeMap m_Types;
 	static RuleMap m_Rules;

--- a/lib/config/configitem.cpp
+++ b/lib/config/configitem.cpp
@@ -7,6 +7,7 @@
 #include "config/objectrule.hpp"
 #include "config/configcompiler.hpp"
 #include "base/application.hpp"
+#include "base/atomic.hpp"
 #include "base/configtype.hpp"
 #include "base/objectlock.hpp"
 #include "base/convert.hpp"
@@ -22,7 +23,6 @@
 #include "base/function.hpp"
 #include "base/utility.hpp"
 #include <boost/algorithm/string/join.hpp>
-#include <atomic>
 #include <sstream>
 #include <fstream>
 #include <algorithm>
@@ -450,7 +450,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 #endif /* I2_DEBUG */
 
 	for (auto& type : Type::GetConfigTypesSortedByLoadDependencies()) {
-		std::atomic<int> committed_items(0);
+		Atomic committed_items (0);
 
 		{
 			auto items (itemsByType.find(type.get()));
@@ -496,7 +496,7 @@ bool ConfigItem::CommitNewItems(const ActivationContext::Ptr& context, WorkQueue
 #endif /* I2_DEBUG */
 
 	for (auto& type : Type::GetConfigTypesSortedByLoadDependencies()) {
-		std::atomic<int> notified_items(0);
+		Atomic notified_items (0);
 
 		{
 			auto items (itemsByType.find(type.get()));

--- a/lib/icinga/scheduleddowntime.cpp
+++ b/lib/icinga/scheduleddowntime.cpp
@@ -391,4 +391,4 @@ bool ScheduledDowntime::AllConfigIsLoaded()
 	return m_AllConfigLoaded.load();
 }
 
-std::atomic<bool> ScheduledDowntime::m_AllConfigLoaded (false);
+Atomic<bool> ScheduledDowntime::m_AllConfigLoaded (false);

--- a/lib/icinga/scheduleddowntime.hpp
+++ b/lib/icinga/scheduleddowntime.hpp
@@ -5,9 +5,9 @@
 #define SCHEDULEDDOWNTIME_H
 
 #include "icinga/i2-icinga.hpp"
+#include "base/atomic.hpp"
 #include "icinga/scheduleddowntime-ti.hpp"
 #include "icinga/checkable.hpp"
-#include <atomic>
 
 namespace icinga
 {
@@ -50,7 +50,7 @@ private:
 	void CreateNextDowntime();
 	void RemoveObsoleteDowntimes();
 
-	static std::atomic<bool> m_AllConfigLoaded;
+	static Atomic<bool> m_AllConfigLoaded;
 
 	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
 	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter = false);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -19,8 +19,8 @@
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
-#include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -456,7 +456,7 @@ private:
 	 */
 	RedisConnection::Ptr m_RconWorker;
 	std::unordered_map<ConfigType*, RedisConnection::Ptr> m_Rcons;
-	std::atomic_size_t m_PendingRcons;
+	Atomic<size_t> m_PendingRcons {0};
 
 	struct {
 		DumpedGlobals CustomVar, ActionUrl, NotesUrl, IconImage, DependencyGroup;

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -5,13 +5,14 @@
 #define INFLUXDBCOMMONWRITER_H
 
 #include "perfdata/influxdbcommonwriter-ti.hpp"
+#include "base/atomic.hpp"
 #include "icinga/checkable.hpp"
 #include "base/configobject.hpp"
 #include "base/perfdatavalue.hpp"
 #include "base/workqueue.hpp"
 #include "remote/url.hpp"
 #include "perfdata/perfdatawriterconnection.hpp"
-#include <atomic>
+#include <cstddef>
 
 namespace icinga
 {
@@ -49,7 +50,7 @@ private:
 	std::atomic_bool m_FlushTimerInQueue{false};
 	WorkQueue m_WorkQueue{10000000, 1};
 	std::vector<String> m_DataBuffer;
-	std::atomic_size_t m_DataBufferSize{0};
+	Atomic<size_t> m_DataBufferSize {0};
 	Shared<boost::asio::ssl::context>::Ptr m_SslContext;
 	PerfdataWriterConnection::Ptr m_Connection;
 

--- a/lib/remote/apilistener-authority.cpp
+++ b/lib/remote/apilistener-authority.cpp
@@ -9,7 +9,7 @@
 
 using namespace icinga;
 
-std::atomic<bool> ApiListener::m_UpdatedObjectAuthority (false);
+Atomic<bool> ApiListener::m_UpdatedObjectAuthority (false);
 
 void ApiListener::UpdateObjectAuthority()
 {

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -19,7 +19,6 @@
 #include "base/tlsstream.hpp"
 #include "base/threadpool.hpp"
 #include "base/wait-group.hpp"
-#include <atomic>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
@@ -194,7 +193,7 @@ private:
 	StoppableWaitGroup::Ptr m_WaitGroup = new StoppableWaitGroup();
 
 	static ApiListener::Ptr m_Instance;
-	static std::atomic<bool> m_UpdatedObjectAuthority;
+	static Atomic<bool> m_UpdatedObjectAuthority;
 
 	boost::signals2::signal<void()> m_OnListenerShutdown;
 	StoppableWaitGroup::Ptr m_ListenerWaitGroup = new StoppableWaitGroup();

--- a/lib/remote/configstageshandler.hpp
+++ b/lib/remote/configstageshandler.hpp
@@ -4,6 +4,7 @@
 #ifndef CONFIGSTAGESHANDLER_H
 #define CONFIGSTAGESHANDLER_H
 
+#include "base/atomic.hpp"
 #include "remote/httphandler.hpp"
 
 namespace icinga

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -1069,7 +1069,9 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 			if (field.Attributes & FANoStorage)
 				continue;
 
-			m_Header << "\tAtomicOrLocked<" << field.Type.GetRealType() << "> m_" << field.GetFriendlyName() << ";" << std::endl;
+			m_Header << "\ttypedef " << field.Type.GetRealType() << " " << field.GetFriendlyName() << "_t;" << std::endl
+				<< "\tAtomicOrLocked<" << field.GetFriendlyName() << "_t> m_" << field.GetFriendlyName()
+				<< " {" << field.GetFriendlyName() << "_t()};" << std::endl;
 		}
 		
 		/* signal */


### PR DESCRIPTION
Atomic enforces usage of its only safe constructor,    in contrast to std::atomic.

> The default-initialized std::atomic<T> does not contain    a T object, and its only valid uses are destruction and    initialization by std::atomic_init, see LWG issue 2334.

   -- https://en.cppreference.com/w/cpp/atomic/atomic/atomic