### PR TITLE
JsonRpcConnection#Disconnect(): wait for #WriteOutgoingMessages() after cancelling I/O

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -223,8 +223,6 @@ void JsonRpcConnection::Disconnect()
 
 			m_OutgoingMessagesQueued.Set();
 
-			m_WriterDone.Wait(yc);
-
 			/*
 			 * Do not swallow exceptions in a coroutine.
 			 * https://github.com/Icinga/icinga2/issues/7351
@@ -239,6 +237,8 @@ void JsonRpcConnection::Disconnect()
 			m_HeartbeatTimer.cancel();
 
 			m_Stream->lowest_layer().cancel(ec);
+
+			m_WriterDone.Wait(yc);
 
 			Timeout::Ptr shutdownTimeout (new Timeout(
 				m_IoStrand.context(),


### PR DESCRIPTION
While #Disconnect() is running in foreground on #m_IoStrand, #WriteOutgoingMessages() could wait for #m_OutgoingMessagesQueued or, theoretically, pending I/O. Also cancelling such I/O makes sense, to wake up #WriteOutgoingMessages() first if necessary.