### PR TITLE
JsonRpcConnection#Disconnect(): don't cleanly shutdown TLS (nor TCP)

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -223,8 +223,6 @@ void JsonRpcConnection::Disconnect()
 
 			m_OutgoingMessagesQueued.Set();
 
-			m_WriterDone.Wait(yc);
-
 			/*
 			 * Do not swallow exceptions in a coroutine.
 			 * https://github.com/Icinga/icinga2/issues/7351
@@ -239,6 +237,8 @@ void JsonRpcConnection::Disconnect()
 			m_HeartbeatTimer.cancel();
 
 			m_Stream->lowest_layer().cancel(ec);
+
+			m_WriterDone.Wait(yc);
 
 			Timeout::Ptr shutdownTimeout (new Timeout(
 				m_IoStrand.context(),

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -240,20 +240,6 @@ void JsonRpcConnection::Disconnect()
 
 			m_WriterDone.Wait(yc);
 
-			Timeout::Ptr shutdownTimeout (new Timeout(
-				m_IoStrand.context(),
-				m_IoStrand,
-				boost::posix_time::seconds(10),
-				[this, keepAlive](asio::yield_context yc) {
-					boost::system::error_code ec;
-					m_Stream->lowest_layer().cancel(ec);
-				}
-			));
-
-			m_Stream->next_layer().async_shutdown(yc[ec]);
-
-			shutdownTimeout->Cancel();
-
 			m_Stream->lowest_layer().shutdown(m_Stream->lowest_layer().shutdown_both, ec);
 		});
 	}

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -239,8 +239,6 @@ void JsonRpcConnection::Disconnect()
 			m_Stream->lowest_layer().cancel(ec);
 
 			m_WriterDone.Wait(yc);
-
-			m_Stream->lowest_layer().shutdown(m_Stream->lowest_layer().shutdown_both, ec);
 		});
 	}
 }


### PR DESCRIPTION
The TCP connection may be broken, e.g. by some firewall (or attacker) in the middle, so that the TLS shutdown takes longer than necessary, if it even completes successfully.

On the other hand, the peer isn't a browser, but also an Icinga 2 node, designed to handle TLS/TCP stream truncation (what effectively happens now) gracefully. A clean TLS shutdown also doesn't improve security as, again, a MITM could prevent it.

closes #10210