### PR TITLE
JsonRpcConnection: don't write new messages on shutdown

### DIFF
--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -110,6 +110,10 @@ void JsonRpcConnection::WriteOutgoingMessages(boost::asio::yield_context yc)
 		if (!queue.empty()) {
 			try {
 				for (auto& message : queue) {
+					if (m_ShuttingDown) {
+						break;
+					}
+
 					size_t bytesSent = JsonRpc::SendRawMessage(m_Stream, message, yc);
 
 					if (m_Endpoint) {


### PR DESCRIPTION
In fact, this is already done for the outer loop (for each bulk), just not yet for the inner one (for each message of a bulk). So once the remote signals EOF, don't try to process the remaining queue until write error (which can't be associated with a particular message anyway, due to buffering), but just let the peer go. Flush already half-written messages, though, if possible.

* **This is absolutely symmetrical to #10213**

closes #10216
closes #10219
closes #10220