### PR TITLE
Fix lost recovery notifications after recovery outside of notification time period

### DIFF
--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -203,7 +203,7 @@ void Checkable::FireSuppressedNotifications()
 			 * If any of these conditions is not met, processing the suppressed notification is further delayed.
 			 */
 			if (!state_suppressed && GetStateType() == StateTypeHard && !IsLikelyToBeCheckedSoon() && !wasLastParentRecoveryRecent.Get()) {
-				if (NotificationReasonApplies(type)) {
+				if (cr->GetState() != GetStateBeforeSuppression()) {
 					Checkable::OnNotificationsRequested(this, type, cr, "", "", nullptr);
 				}
 				subtract |= NotificationRecovery|NotificationProblem;
@@ -266,12 +266,12 @@ bool Checkable::NotificationReasonApplies(NotificationType type)
 		case NotificationProblem:
 			{
 				auto cr (GetLastCheckResult());
-				return cr && !IsStateOK(cr->GetState()) && cr->GetState() != GetStateBeforeSuppression();
+				return cr && !IsStateOK(cr->GetState());
 			}
 		case NotificationRecovery:
 			{
 				auto cr (GetLastCheckResult());
-				return cr && IsStateOK(cr->GetState()) && cr->GetState() != GetStateBeforeSuppression();
+				return cr && IsStateOK(cr->GetState());
 			}
 		case NotificationFlappingStart:
 			return IsFlapping();


### PR DESCRIPTION
This fixes an issue where recovery notifications get lost if they happen outside of a notification time period.

Not all calls to `Checkable::NotificationReasonApplies()` need `GetStateBeforeSuppression()` to be checked. In fact, for one caller, `FireSuppressedNotifications()` in
`lib/notification/notificationcomponent.cpp`, the state before suppression may not even be initialized properly, so that the default value of OK is used which can lead to incorrect return values. Note the difference between suppressions happening on the level of the `Checkable` object level and the `Notification` object level. Only the first sets the state before suppression in the `Checkable` object, but so far, also the latter used that value incorrectly.

This commit moves the check of `GetStateBeforeSuppression()` from `Checkable::NotificationReasonApplies()` to the one place where it's actually relevant: `Checkable::FireSuppressedNotifications()`. This made the existing call to `NotificationReasonApplies()` unneccessary as it would always return true: the `type` argument is computed based on the current check result, so there's no need to check it against the current check result.

* Backport of #10187