### PR TITLE
Make protected SharedObject#~SharedObject() non-virtual

### DIFF
--- a/lib/base/shared-object.hpp
+++ b/lib/base/shared-object.hpp
@@ -49,7 +49,6 @@ protected:
 		return *this;
 	}
 
-	inline virtual
 	~SharedObject() = default;
 
 private:


### PR DESCRIPTION
`virtual`, which isn't for free, is only needed for a base method to redirect direct calls by pointer to an override if any. But this method is protected, so it's not called directly.