### PR TITLE
Timeout#Cancel(): allow waiting for the own coroutine to finish

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -153,3 +153,14 @@ void Timeout::Cancel()
 	boost::system::error_code ec;
 	m_Timer.cancel(ec);
 }
+
+/**
+ * Cancels the timeout and waits for the own coroutine to finish.
+ *
+ * @param yc Yield Context for ASIO
+ */
+void Timeout::Cancel(boost::asio::yield_context yc)
+{
+	Cancel();
+	m_Done.Wait(yc);
+}


### PR DESCRIPTION
Especially useful not to have to drag shared pointers around in the callback.