### PR TITLE
GHA: Drop ubuntu 23.{04,10} (EOL)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,8 +37,6 @@ jobs:
           - rockylinux:9 # RHEL 9
           - ubuntu:20.04
           - ubuntu:22.04
-          - ubuntu:23.04
-          - ubuntu:23.10
           - ubuntu:24.04
           - ubuntu:24.10
 


### PR DESCRIPTION
https://ubuntu.com/about/release-cycle