### PR TITLE
Timeout: use less resources, clean them up better and make cancellation deterministic

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -148,8 +148,6 @@ void AsioConditionVariable::Wait(boost::asio::yield_context yc)
 
 void Timeout::Cancel()
 {
-	m_Cancelled.store(true);
-
 	boost::system::error_code ec;
 	m_Timer.cancel(ec);
 }

--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -148,6 +148,8 @@ void AsioConditionVariable::Wait(boost::asio::yield_context yc)
 
 void Timeout::Cancel()
 {
+	m_Cancelled->store(true);
+
 	boost::system::error_code ec;
 	m_Timer.cancel(ec);
 }

--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -146,6 +146,11 @@ void AsioConditionVariable::Wait(boost::asio::yield_context yc)
 	m_Timer.async_wait(yc[ec]);
 }
 
+/**
+ * Cancels any pending timeout callback.
+ *
+ * Must be called in the strand in which the callback was scheduled!
+ */
 void Timeout::Cancel()
 {
 	m_Cancelled->store(true);

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -199,7 +199,7 @@ public:
 			}
 
 			auto f (onTimeout);
-			f(std::move(yc));
+			f();
 		});
 	}
 

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -165,6 +165,22 @@ private:
 /**
  * I/O timeout emulator
  *
+ * This class provides a workaround for Boost.ASIO's lack of built-in timeout support.
+ * While Boost.ASIO handles asynchronous operations, it does not natively support timeouts for these operations.
+ * This class uses a boost::asio::deadline_timer to emulate a timeout by scheduling a callback to be triggered
+ * after a specified duration, effectively adding timeout behavior where none exists.
+ * The callback is executed within the provided strand, ensuring thread-safety.
+ *
+ * The constructor returns immediately after scheduling the timeout callback.
+ * The callback itself is invoked asynchronously when the timeout occurs.
+ * This allows the caller to continue execution while the timeout is running in the background.
+ *
+ * The class provides a Cancel() method to unschedule any pending callback. If the callback has already been run,
+ * calling Cancel() has no effect. This method can be used to abort the timeout early if the monitored operation
+ * completes before the callback has been run. The Timeout destructor also automatically cancels any pending callback.
+ * A callback is considered pending even if the timeout has already expired,
+ * but the callback has not been executed yet due to a busy strand.
+ *
  * @ingroup base
  */
 class Timeout
@@ -172,6 +188,14 @@ class Timeout
 public:
 	using Timer = boost::asio::deadline_timer;
 
+	/**
+	 * Schedules onTimeout to be triggered after timeoutFromNow on strand.
+	 *
+	 * @param strand The strand in which the callback will be executed.
+	 *				 The caller must also run in this strand, as well as Cancel() and the destructor!
+	 * @param timeoutFromNow The duration after which the timeout callback will be triggered.
+	 * @param onTimeout The callback to invoke when the timeout occurs.
+	 */
 	template<class OnTimeout>
 	Timeout(boost::asio::io_context::strand& strand, const Timer::duration_type& timeoutFromNow, OnTimeout onTimeout)
 		: m_Timer(strand.context(), timeoutFromNow), m_Cancelled(Shared<Atomic<bool>>::Make(false))
@@ -192,6 +216,11 @@ public:
 	Timeout& operator=(const Timeout&) = delete;
 	Timeout& operator=(Timeout&&) = delete;
 
+	/**
+	 * Cancels any pending timeout callback.
+	 *
+	 * Must be called in the strand in which the callback was scheduled!
+	 */
 	~Timeout()
 	{
 		Cancel();
@@ -201,6 +230,14 @@ public:
 
 private:
 	Timer m_Timer;
+
+	/**
+	 * Indicates whether the Timeout has been cancelled.
+	 *
+	 * This must be Shared<> between the lambda in the constructor and Cancel() for the case
+	 * the destructor calls Cancel() while the lambda is already queued in the strand.
+	 * The whole Timeout instance can't be kept alive by the lambda because this would delay the destructor.
+	 */
 	Shared<Atomic<bool>>::Ptr m_Cancelled;
 };
 

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -9,7 +9,6 @@
 #include "base/lazy-init.hpp"
 #include "base/logger.hpp"
 #include "base/shared.hpp"
-#include "base/shared-object.hpp"
 #include <atomic>
 #include <exception>
 #include <memory>
@@ -168,10 +167,9 @@ private:
  *
  * @ingroup base
  */
-class Timeout : public SharedObject
+class Timeout
 {
 public:
-	DECLARE_PTR_TYPEDEFS(Timeout);
 	using Timer = boost::asio::deadline_timer;
 
 	template<class OnTimeout>
@@ -189,7 +187,7 @@ public:
 		));
 	}
 
-	~Timeout() override
+	~Timeout()
 	{
 		Cancel();
 	}

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -187,6 +187,11 @@ public:
 		));
 	}
 
+	Timeout(const Timeout&) = delete;
+	Timeout(Timeout&&) = delete;
+	Timeout& operator=(const Timeout&) = delete;
+	Timeout& operator=(Timeout&&) = delete;
+
 	~Timeout()
 	{
 		Cancel();

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -140,12 +140,12 @@ void AsioTlsStream::GracefulDisconnect(boost::asio::io_context::strand& strand, 
 	}
 
 	{
-		Timeout::Ptr shutdownTimeout(new Timeout(strand, boost::posix_time::seconds(10),
+		Timeout shutdownTimeout (strand, boost::posix_time::seconds(10),
 			[this] {
 				// Forcefully terminate the connection if async_shutdown() blocked more than 10 seconds.
 				ForceDisconnect();
 			}
-		));
+		);
 
 		// Close the TLS connection, effectively uses SSL_shutdown() to send a close_notify shutdown alert to the peer.
 		boost::system::error_code ec;

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -140,7 +140,7 @@ void AsioTlsStream::GracefulDisconnect(boost::asio::io_context::strand& strand, 
 	}
 
 	{
-		Timeout::Ptr shutdownTimeout(new Timeout(strand.context(), strand, boost::posix_time::seconds(10),
+		Timeout::Ptr shutdownTimeout(new Timeout(strand, boost::posix_time::seconds(10),
 			[this] {
 				// Forcefully terminate the connection if async_shutdown() blocked more than 10 seconds.
 				ForceDisconnect();

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -146,9 +146,6 @@ void AsioTlsStream::GracefulDisconnect(boost::asio::io_context::strand& strand, 
 				ForceDisconnect();
 			}
 		));
-		Defer cancelTimeout ([&shutdownTimeout]() {
-			shutdownTimeout->Cancel();
-		});
 
 		// Close the TLS connection, effectively uses SSL_shutdown() to send a close_notify shutdown alert to the peer.
 		boost::system::error_code ec;

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -141,7 +141,7 @@ void AsioTlsStream::GracefulDisconnect(boost::asio::io_context::strand& strand, 
 
 	{
 		Timeout::Ptr shutdownTimeout(new Timeout(strand.context(), strand, boost::posix_time::seconds(10),
-			[this](boost::asio::yield_context yc) {
+			[this] {
 				// Forcefully terminate the connection if async_shutdown() blocked more than 10 seconds.
 				ForceDisconnect();
 			}

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -318,7 +318,6 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					auto conn (Shared<AsioTlsStream>::Make(m_Strand.context(), *m_TLSContext, m_Host));
 					auto& tlsConn (conn->next_layer());
 					auto connectTimeout (MakeTimeout(conn));
-					Defer cancelTimeout ([&connectTimeout]() { connectTimeout->Cancel(); });
 
 					icinga::Connect(conn->lowest_layer(), m_Host, Convert::ToString(m_Port), yc);
 					tlsConn.async_handshake(tlsConn.client, yc);
@@ -348,7 +347,6 @@ void RedisConnection::Connect(asio::yield_context& yc)
 
 					auto conn (Shared<TcpConn>::Make(m_Strand.context()));
 					auto connectTimeout (MakeTimeout(conn));
-					Defer cancelTimeout ([&connectTimeout]() { connectTimeout->Cancel(); });
 
 					icinga::Connect(conn->next_layer(), m_Host, Convert::ToString(m_Port), yc);
 					Handshake(conn, yc);
@@ -361,7 +359,6 @@ void RedisConnection::Connect(asio::yield_context& yc)
 
 				auto conn (Shared<UnixConn>::Make(m_Strand.context()));
 				auto connectTimeout (MakeTimeout(conn));
-				Defer cancelTimeout ([&connectTimeout]() { connectTimeout->Cancel(); });
 
 				conn->next_layer().async_connect(Unix::endpoint(m_Path.CStr()), yc);
 				Handshake(conn, yc);

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -222,7 +222,7 @@ namespace icinga
 		void Handshake(StreamPtr& stream, boost::asio::yield_context& yc);
 
 		template<class StreamPtr>
-		Timeout::Ptr MakeTimeout(StreamPtr& stream);
+		Timeout MakeTimeout(StreamPtr& stream);
 
 		String m_Path;
 		String m_Host;
@@ -512,9 +512,9 @@ void RedisConnection::Handshake(StreamPtr& strm, boost::asio::yield_context& yc)
  * @param stream Redis server connection
  */
 template<class StreamPtr>
-Timeout::Ptr RedisConnection::MakeTimeout(StreamPtr& stream)
+Timeout RedisConnection::MakeTimeout(StreamPtr& stream)
 {
-	return new Timeout(
+	return Timeout(
 		m_Strand,
 		boost::posix_time::microseconds(intmax_t(m_ConnectTimeout * 1000000)),
 		[stream] {

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -520,7 +520,7 @@ Timeout::Ptr RedisConnection::MakeTimeout(StreamPtr& stream)
 		m_Strand.context(),
 		m_Strand,
 		boost::posix_time::microseconds(intmax_t(m_ConnectTimeout * 1000000)),
-		[keepAlive, stream](boost::asio::yield_context yc) {
+		[keepAlive, stream] {
 			boost::system::error_code ec;
 			stream->lowest_layer().cancel(ec);
 		}

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -514,13 +514,11 @@ void RedisConnection::Handshake(StreamPtr& strm, boost::asio::yield_context& yc)
 template<class StreamPtr>
 Timeout::Ptr RedisConnection::MakeTimeout(StreamPtr& stream)
 {
-	Ptr keepAlive (this);
-
 	return new Timeout(
 		m_Strand.context(),
 		m_Strand,
 		boost::posix_time::microseconds(intmax_t(m_ConnectTimeout * 1000000)),
-		[keepAlive, stream] {
+		[stream] {
 			boost::system::error_code ec;
 			stream->lowest_layer().cancel(ec);
 		}

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -515,7 +515,6 @@ template<class StreamPtr>
 Timeout::Ptr RedisConnection::MakeTimeout(StreamPtr& stream)
 {
 	return new Timeout(
-		m_Strand.context(),
 		m_Strand,
 		boost::posix_time::microseconds(intmax_t(m_ConnectTimeout * 1000000)),
 		[stream] {

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -467,8 +467,6 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 				}
 			);
 
-			Defer cancelTimeout ([&timeout]() { timeout->Cancel(); });
-
 			DoIfwNetIo(yc, cr, psCommand, psHost, expectedSan, psPort, *conn, *req);
 
 			cr->SetExecutionEnd(Utility::GetTime());

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -457,7 +457,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		*strand,
 		[strand, checkable, cr, psCommand, psHost, expectedSan, psPort, conn, req, checkTimeout, reportResult = std::move(reportResult)](asio::yield_context yc) {
 			Timeout::Ptr timeout = new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(checkTimeout * 1e6)),
-				[&conn, &checkable](boost::asio::yield_context yc) {
+				[&conn, &checkable] {
 					Log(LogNotice, "IfwApiCheckTask")
 						<< "Timeout while checking " << checkable->GetReflectionType()->GetName()
 						<< " '" << checkable->GetName() << "', cancelling attempt";

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -456,7 +456,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	IoEngine::SpawnCoroutine(
 		*strand,
 		[strand, checkable, cr, psCommand, psHost, expectedSan, psPort, conn, req, checkTimeout, reportResult = std::move(reportResult)](asio::yield_context yc) {
-			Timeout::Ptr timeout = new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(checkTimeout * 1e6)),
+			Timeout::Ptr timeout = new Timeout(*strand, boost::posix_time::microseconds(int64_t(checkTimeout * 1e6)),
 				[&conn, &checkable] {
 					Log(LogNotice, "IfwApiCheckTask")
 						<< "Timeout while checking " << checkable->GetReflectionType()->GetName()

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -456,7 +456,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	IoEngine::SpawnCoroutine(
 		*strand,
 		[strand, checkable, cr, psCommand, psHost, expectedSan, psPort, conn, req, checkTimeout, reportResult = std::move(reportResult)](asio::yield_context yc) {
-			Timeout::Ptr timeout = new Timeout(*strand, boost::posix_time::microseconds(int64_t(checkTimeout * 1e6)),
+			Timeout timeout (*strand, boost::posix_time::microseconds(int64_t(checkTimeout * 1e6)),
 				[&conn, &checkable] {
 					Log(LogNotice, "IfwApiCheckTask")
 						<< "Timeout while checking " << checkable->GetReflectionType()->GetName()

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -543,7 +543,6 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 						sslConn->lowest_layer().cancel(ec);
 					}
 				));
-				Defer cancelTimeout([timeout]() { timeout->Cancel(); });
 
 				NewClientHandler(yc, strand, sslConn, String(), RoleServer);
 			});
@@ -595,7 +594,6 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 					sslConn->lowest_layer().cancel(ec);
 				}
 			));
-			Defer cancelTimeout([&timeout]() { timeout->Cancel(); });
 
 			Connect(sslConn->lowest_layer(), host, port, yc);
 
@@ -693,8 +691,6 @@ void ApiListener::NewClientHandlerInternal(
 		));
 
 		sslConn.async_handshake(role == RoleClient ? sslConn.client : sslConn.server, yc[ec]);
-
-		handshakeTimeout->Cancel();
 	}
 
 	if (ec) {

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -535,7 +535,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
 				Timeout::Ptr timeout(new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
-					[sslConn, remoteEndpoint](asio::yield_context yc) {
+					[sslConn, remoteEndpoint] {
 						Log(LogWarning, "ApiListener")
 							<< "Timeout while processing incoming connection from " << remoteEndpoint;
 
@@ -586,7 +586,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 			lock.unlock();
 
 			Timeout::Ptr timeout(new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
-				[sslConn, endpoint, host, port](asio::yield_context yc) {
+				[sslConn, endpoint, host, port] {
 					Log(LogCritical, "ApiListener")
 						<< "Timeout while reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host
 						<< "' and port '" << port << "', cancelling attempt";
@@ -687,7 +687,7 @@ void ApiListener::NewClientHandlerInternal(
 			strand->context(),
 			*strand,
 			boost::posix_time::microseconds(intmax_t(Configuration::TlsHandshakeTimeout * 1000000)),
-			[strand, client](asio::yield_context yc) {
+			[strand, client] {
 				boost::system::error_code ec;
 				client->lowest_layer().cancel(ec);
 			}

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -534,7 +534,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 			auto strand (Shared<asio::io_context::strand>::Make(io));
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
-				Timeout::Ptr timeout(new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
+				Timeout::Ptr timeout (new Timeout(*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
 					[sslConn, remoteEndpoint] {
 						Log(LogWarning, "ApiListener")
 							<< "Timeout while processing incoming connection from " << remoteEndpoint;
@@ -585,7 +585,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 
 			lock.unlock();
 
-			Timeout::Ptr timeout(new Timeout(strand->context(), *strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
+			Timeout::Ptr timeout (new Timeout(*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
 				[sslConn, endpoint, host, port] {
 					Log(LogCritical, "ApiListener")
 						<< "Timeout while reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host
@@ -684,7 +684,6 @@ void ApiListener::NewClientHandlerInternal(
 
 	{
 		Timeout::Ptr handshakeTimeout (new Timeout(
-			strand->context(),
 			*strand,
 			boost::posix_time::microseconds(intmax_t(Configuration::TlsHandshakeTimeout * 1000000)),
 			[client] {

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -534,7 +534,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 			auto strand (Shared<asio::io_context::strand>::Make(io));
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
-				Timeout::Ptr timeout (new Timeout(*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
+				Timeout timeout (*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
 					[sslConn, remoteEndpoint] {
 						Log(LogWarning, "ApiListener")
 							<< "Timeout while processing incoming connection from " << remoteEndpoint;
@@ -542,7 +542,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 						boost::system::error_code ec;
 						sslConn->lowest_layer().cancel(ec);
 					}
-				));
+				);
 
 				NewClientHandler(yc, strand, sslConn, String(), RoleServer);
 			});
@@ -584,7 +584,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 
 			lock.unlock();
 
-			Timeout::Ptr timeout (new Timeout(*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
+			Timeout timeout (*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
 				[sslConn, endpoint, host, port] {
 					Log(LogCritical, "ApiListener")
 						<< "Timeout while reconnecting to endpoint '" << endpoint->GetName() << "' via host '" << host
@@ -593,7 +593,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 					boost::system::error_code ec;
 					sslConn->lowest_layer().cancel(ec);
 				}
-			));
+			);
 
 			Connect(sslConn->lowest_layer(), host, port, yc);
 
@@ -681,14 +681,14 @@ void ApiListener::NewClientHandlerInternal(
 	boost::system::error_code ec;
 
 	{
-		Timeout::Ptr handshakeTimeout (new Timeout(
+		Timeout handshakeTimeout (
 			*strand,
 			boost::posix_time::microseconds(intmax_t(Configuration::TlsHandshakeTimeout * 1000000)),
 			[client] {
 				boost::system::error_code ec;
 				client->lowest_layer().cancel(ec);
 			}
-		));
+		);
 
 		sslConn.async_handshake(role == RoleClient ? sslConn.client : sslConn.server, yc[ec]);
 	}

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -687,7 +687,7 @@ void ApiListener::NewClientHandlerInternal(
 			strand->context(),
 			*strand,
 			boost::posix_time::microseconds(intmax_t(Configuration::TlsHandshakeTimeout * 1000000)),
-			[strand, client] {
+			[client] {
 				boost::system::error_code ec;
 				client->lowest_layer().cancel(ec);
 			}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,6 +62,7 @@ set(base_test_SOURCES
   base-convert.cpp
   base-dictionary.cpp
   base-fifo.cpp
+  base-io-engine.cpp
   base-json.cpp
   base-match.cpp
   base-netstring.cpp
@@ -128,6 +129,11 @@ add_boost_test(base
     base_dictionary/keys_ordered
     base_fifo/construct
     base_fifo/io
+    base_io_engine/timeout_run
+    base_io_engine/timeout_cancelled
+    base_io_engine/timeout_scope
+    base_io_engine/timeout_due_cancelled
+    base_io_engine/timeout_due_scope
     base_json/encode
     base_json/decode
     base_json/invalid1

--- a/test/base-io-engine.cpp
+++ b/test/base-io-engine.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(timeout_run)
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
 		boost::asio::deadline_timer timer (io);
 
-		Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
 		BOOST_CHECK_EQUAL(called, 0);
 
 		timer.expires_from_now(boost::posix_time::millisec(200));
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(timeout_cancelled)
 
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
 		boost::asio::deadline_timer timer (io);
-		Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 		timer.expires_from_now(boost::posix_time::millisec(200));
 		timer.async_wait(yc);
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(timeout_scope)
 		boost::asio::deadline_timer timer (io);
 
 		{
-			Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+			Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 			timer.expires_from_now(boost::posix_time::millisec(200));
 			timer.async_wait(yc);
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
 
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
 		boost::asio::deadline_timer timer (io);
-		Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 		// Give the timeout enough time to become due while blocking its strand to prevent it from actually running...
 		Utility::Sleep(0.4);
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(timeout_due_scope)
 		boost::asio::deadline_timer timer (io);
 
 		{
-			Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+			Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 			// Give the timeout enough time to become due while blocking its strand to prevent it from actually running...
 			Utility::Sleep(0.4);

--- a/test/base-io-engine.cpp
+++ b/test/base-io-engine.cpp
@@ -1,0 +1,143 @@
+/* Icinga 2 | (c) 2024 Icinga GmbH | GPLv2+ */
+
+#include "base/io-engine.hpp"
+#include "base/utility.hpp"
+#include <boost/asio.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+BOOST_AUTO_TEST_SUITE(base_io_engine)
+
+BOOST_AUTO_TEST_CASE(timeout_run)
+{
+	boost::asio::io_context io;
+	boost::asio::io_context::strand strand (io);
+	int called = 0;
+
+	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
+		boost::asio::deadline_timer timer (io);
+
+		Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		BOOST_CHECK_EQUAL(called, 0);
+
+		timer.expires_from_now(boost::posix_time::millisec(200));
+		timer.async_wait(yc);
+		BOOST_CHECK_EQUAL(called, 0);
+
+		timer.expires_from_now(boost::posix_time::millisec(200));
+		timer.async_wait(yc);
+	});
+
+	io.run();
+	BOOST_CHECK_EQUAL(called, 1);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_cancelled)
+{
+	boost::asio::io_context io;
+	boost::asio::io_context::strand strand (io);
+	int called = 0;
+
+	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
+		boost::asio::deadline_timer timer (io);
+		Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+
+		timer.expires_from_now(boost::posix_time::millisec(200));
+		timer.async_wait(yc);
+
+		timeout->Cancel();
+		BOOST_CHECK_EQUAL(called, 0);
+
+		timer.expires_from_now(boost::posix_time::millisec(200));
+		timer.async_wait(yc);
+	});
+
+	io.run();
+	BOOST_CHECK_EQUAL(called, 0);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_scope)
+{
+	boost::asio::io_context io;
+	boost::asio::io_context::strand strand (io);
+	int called = 0;
+
+	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
+		boost::asio::deadline_timer timer (io);
+
+		{
+			Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+
+			timer.expires_from_now(boost::posix_time::millisec(200));
+			timer.async_wait(yc);
+		}
+
+		BOOST_CHECK_EQUAL(called, 0);
+
+		timer.expires_from_now(boost::posix_time::millisec(200));
+		timer.async_wait(yc);
+	});
+
+	io.run();
+	BOOST_CHECK_EQUAL(called, 0);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
+{
+	boost::asio::io_context io;
+	boost::asio::io_context::strand strand (io);
+	int called = 0;
+
+	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
+		boost::asio::deadline_timer timer (io);
+		Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+
+		// Give the timeout enough time to become due while blocking its strand to prevent it from actually running...
+		Utility::Sleep(0.4);
+
+		BOOST_CHECK_EQUAL(called, 0);
+
+		// ... so that this shall still work:
+		timeout->Cancel();
+
+		BOOST_CHECK_EQUAL(called, 0);
+
+		timer.expires_from_now(boost::posix_time::millisec(100));
+		timer.async_wait(yc);
+	});
+
+	io.run();
+	BOOST_CHECK_EQUAL(called, 0);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_due_scope)
+{
+	boost::asio::io_context io;
+	boost::asio::io_context::strand strand (io);
+	int called = 0;
+
+	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
+		boost::asio::deadline_timer timer (io);
+
+		{
+			Timeout::Ptr timeout = new Timeout(io, strand, boost::posix_time::millisec(300), [&called] { ++called; });
+
+			// Give the timeout enough time to become due while blocking its strand to prevent it from actually running...
+			Utility::Sleep(0.4);
+
+			BOOST_CHECK_EQUAL(called, 0);
+		} // ... so that Timeout#~Timeout() shall still work here.
+
+		BOOST_CHECK_EQUAL(called, 0);
+
+		timer.expires_from_now(boost::posix_time::millisec(100));
+		timer.async_wait(yc);
+	});
+
+	io.run();
+	BOOST_CHECK_EQUAL(called, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/base-io-engine.cpp
+++ b/test/base-io-engine.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(timeout_run)
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
 		boost::asio::deadline_timer timer (io);
 
-		Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		Timeout timeout (strand, boost::posix_time::millisec(300), [&called] { ++called; });
 		BOOST_CHECK_EQUAL(called, 0);
 
 		timer.expires_from_now(boost::posix_time::millisec(200));
@@ -46,12 +46,12 @@ BOOST_AUTO_TEST_CASE(timeout_cancelled)
 
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
 		boost::asio::deadline_timer timer (io);
-		Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		Timeout timeout (strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 		timer.expires_from_now(boost::posix_time::millisec(200));
 		timer.async_wait(yc);
 
-		timeout->Cancel();
+		timeout.Cancel();
 		BOOST_CHECK_EQUAL(called, 0);
 
 		timer.expires_from_now(boost::posix_time::millisec(200));
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(timeout_scope)
 		boost::asio::deadline_timer timer (io);
 
 		{
-			Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
+			Timeout timeout (strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 			timer.expires_from_now(boost::posix_time::millisec(200));
 			timer.async_wait(yc);
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
 
 	boost::asio::spawn(strand, [&](boost::asio::yield_context yc) {
 		boost::asio::deadline_timer timer (io);
-		Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
+		Timeout timeout (strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 		// Give the timeout enough time to become due while blocking its strand to prevent it from actually running...
 		Utility::Sleep(0.4);
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
 		BOOST_CHECK_EQUAL(called, 0);
 
 		// ... so that this shall still work:
-		timeout->Cancel();
+		timeout.Cancel();
 
 		BOOST_CHECK_EQUAL(called, 0);
 
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(timeout_due_scope)
 		boost::asio::deadline_timer timer (io);
 
 		{
-			Timeout::Ptr timeout = new Timeout(strand, boost::posix_time::millisec(300), [&called] { ++called; });
+			Timeout timeout (strand, boost::posix_time::millisec(300), [&called] { ++called; });
 
 			// Give the timeout enough time to become due while blocking its strand to prevent it from actually running...
 			Utility::Sleep(0.4);

--- a/test/base-io-engine.cpp
+++ b/test/base-io-engine.cpp
@@ -5,6 +5,7 @@
 #include <boost/asio.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <BoostTestTargetConfig.h>
+#include <thread>
 
 using namespace icinga;
 
@@ -30,7 +31,10 @@ BOOST_AUTO_TEST_CASE(timeout_run)
 		timer.async_wait(yc);
 	});
 
+	std::thread eventLoop ([&io] { io.run(); });
 	io.run();
+	eventLoop.join();
+
 	BOOST_CHECK_EQUAL(called, 1);
 }
 
@@ -54,7 +58,10 @@ BOOST_AUTO_TEST_CASE(timeout_cancelled)
 		timer.async_wait(yc);
 	});
 
+	std::thread eventLoop ([&io] { io.run(); });
 	io.run();
+	eventLoop.join();
+
 	BOOST_CHECK_EQUAL(called, 0);
 }
 
@@ -80,7 +87,10 @@ BOOST_AUTO_TEST_CASE(timeout_scope)
 		timer.async_wait(yc);
 	});
 
+	std::thread eventLoop ([&io] { io.run(); });
 	io.run();
+	eventLoop.join();
+
 	BOOST_CHECK_EQUAL(called, 0);
 }
 
@@ -108,7 +118,10 @@ BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
 		timer.async_wait(yc);
 	});
 
+	std::thread eventLoop ([&io] { io.run(); });
 	io.run();
+	eventLoop.join();
+
 	BOOST_CHECK_EQUAL(called, 0);
 }
 
@@ -136,7 +149,10 @@ BOOST_AUTO_TEST_CASE(timeout_due_scope)
 		timer.async_wait(yc);
 	});
 
+	std::thread eventLoop ([&io] { io.run(); });
 	io.run();
+	eventLoop.join();
+
 	BOOST_CHECK_EQUAL(called, 0);
 }
 


### PR DESCRIPTION
👍 Now we got unit tests!!! ❤️ 144abb1fa
👍 Now the destructor leads to cancellation. 21fc94661
👍 Now the callback is "atomic", i.e. it doesn't yield. 32e64b63d 175099c41 This way cancellation can't happen in a callback yield, making sure once cancelled, the callback won't (continue to) run. Also, we don't need any coroutine which has to carry around shared pointers which prevent own destruction...

closes #10250
closes #10252