### PR TITLE
CMake: require Boost unit_test_framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ else()
   set(LOGROTATE_CREATE "\n\tcreate 644 ${ICINGA2_USER} ${ICINGA2_GROUP}")
 endif()
 
-find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS coroutine context date_time filesystem iostreams thread system program_options regex REQUIRED)
+find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS coroutine context date_time filesystem iostreams thread system program_options regex unit_test_framework REQUIRED)
 
 # Boost.Coroutine2 (the successor of Boost.Coroutine)
 # (1) doesn't even exist in old Boost versions and


### PR DESCRIPTION
Even with `-DICINGA2_WITH_TESTS=ON -DBUILD_TESTING=ON` CLion (and likely not only it) doesn't recognize any test/ files as part of the project, nor allows them to run without the unit_test_framework.

@yhabteab Again thank you for your help with fixing missing unit_test_framework on my WS.