### PR TITLE
DependencyGraph: switch "parent" and "child" terminology

### DIFF
--- a/lib/base/dependencygraph.cpp
+++ b/lib/base/dependencygraph.cpp
@@ -7,18 +7,18 @@ using namespace icinga;
 std::mutex DependencyGraph::m_Mutex;
 std::map<Object *, std::map<Object *, int> > DependencyGraph::m_Dependencies;
 
-void DependencyGraph::AddDependency(Object *parent, Object *child)
+void DependencyGraph::AddDependency(Object* child, Object* parent)
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);
-	m_Dependencies[child][parent]++;
+	m_Dependencies[parent][child]++;
 }
 
-void DependencyGraph::RemoveDependency(Object *parent, Object *child)
+void DependencyGraph::RemoveDependency(Object* child, Object* parent)
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);
 
-	auto& refs = m_Dependencies[child];
-	auto it = refs.find(parent);
+	auto& refs = m_Dependencies[parent];
+	auto it = refs.find(child);
 
 	if (it == refs.end())
 		return;
@@ -29,15 +29,15 @@ void DependencyGraph::RemoveDependency(Object *parent, Object *child)
 		refs.erase(it);
 
 	if (refs.empty())
-		m_Dependencies.erase(child);
+		m_Dependencies.erase(parent);
 }
 
-std::vector<Object::Ptr> DependencyGraph::GetParents(const Object::Ptr& child)
+std::vector<Object::Ptr> DependencyGraph::GetChildren(const Object::Ptr& parent)
 {
 	std::vector<Object::Ptr> objects;
 
 	std::unique_lock<std::mutex> lock(m_Mutex);
-	auto it = m_Dependencies.find(child.get());
+	auto it = m_Dependencies.find(parent.get());
 
 	if (it != m_Dependencies.end()) {
 		typedef std::pair<Object *, int> kv_pair;

--- a/lib/base/dependencygraph.hpp
+++ b/lib/base/dependencygraph.hpp
@@ -18,9 +18,9 @@ namespace icinga {
 class DependencyGraph
 {
 public:
-	static void AddDependency(Object *parent, Object *child);
-	static void RemoveDependency(Object *parent, Object *child);
-	static std::vector<Object::Ptr> GetParents(const Object::Ptr& child);
+	static void AddDependency(Object* child, Object* parent);
+	static void RemoveDependency(Object* child, Object* parent);
+	static std::vector<Object::Ptr> GetChildren(const Object::Ptr& parent);
 
 private:
 	DependencyGraph();

--- a/lib/base/scriptutils.cpp
+++ b/lib/base/scriptutils.cpp
@@ -520,7 +520,7 @@ String ScriptUtils::MsiGetComponentPathShim(const String& component)
 
 Array::Ptr ScriptUtils::TrackParents(const Object::Ptr& child)
 {
-	return Array::FromVector(DependencyGraph::GetParents(child));
+	return Array::FromVector(DependencyGraph::GetChildren(child));
 }
 
 double ScriptUtils::Ptr(const Object::Ptr& object)

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -303,7 +303,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 bool ConfigObjectUtility::DeleteObjectHelper(const ConfigObject::Ptr& object, bool cascade,
 	const Array::Ptr& errors, const Array::Ptr& diagnosticInformation, const Value& cookie)
 {
-	std::vector<Object::Ptr> parents = DependencyGraph::GetParents(object);
+	auto parents (DependencyGraph::GetChildren(object));
 
 	Type::Ptr type = object->GetReflectionType();
 

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -208,7 +208,7 @@ bool ObjectQueryHandler::HandleRequest(
 					Array::Ptr used_by = new Array();
 					metaAttrs.emplace_back("used_by", used_by);
 
-					for (const Object::Ptr& pobj : DependencyGraph::GetParents((obj)))
+					for (auto& pobj : DependencyGraph::GetChildren(obj))
 					{
 						ConfigObject::Ptr configObj = dynamic_pointer_cast<ConfigObject>(pobj);
 


### PR DESCRIPTION
The .ti files call `DependencyGraph::AddDependency(this, service.get())`. Obviously, `service.get()` is the parent and `this` (Downtime, Notification, ...) is the child. The DependencyGraph terminology should reflect this not to confuse its future users.

* Digged out by @yhabteab in #10000