### PR TITLE
RedisConnection#Connect(): get rid of spin lock

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -124,23 +124,23 @@ void IoEngine::RunEventLoop()
 	}
 }
 
-AsioConditionVariable::AsioConditionVariable(boost::asio::io_context& io, bool init)
+AsioEvent::AsioEvent(boost::asio::io_context& io, bool init)
 	: m_Timer(io)
 {
 	m_Timer.expires_at(init ? boost::posix_time::neg_infin : boost::posix_time::pos_infin);
 }
 
-void AsioConditionVariable::Set()
+void AsioEvent::Set()
 {
 	m_Timer.expires_at(boost::posix_time::neg_infin);
 }
 
-void AsioConditionVariable::Clear()
+void AsioEvent::Clear()
 {
 	m_Timer.expires_at(boost::posix_time::pos_infin);
 }
 
-void AsioConditionVariable::Wait(boost::asio::yield_context yc)
+void AsioEvent::Wait(boost::asio::yield_context yc)
 {
 	boost::system::error_code ec;
 	m_Timer.async_wait(yc[ec]);

--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -146,6 +146,33 @@ void AsioEvent::Wait(boost::asio::yield_context yc)
 	m_Timer.async_wait(yc[ec]);
 }
 
+AsioDualEvent::AsioDualEvent(boost::asio::io_context& io, bool init)
+	: m_IsTrue(io, init), m_IsFalse(io, !init)
+{
+}
+
+void AsioDualEvent::Set()
+{
+	m_IsTrue.Set();
+	m_IsFalse.Clear();
+}
+
+void AsioDualEvent::Clear()
+{
+	m_IsTrue.Clear();
+	m_IsFalse.Set();
+}
+
+void AsioDualEvent::WaitForSet(boost::asio::yield_context yc)
+{
+	m_IsTrue.Wait(std::move(yc));
+}
+
+void AsioDualEvent::WaitForClear(boost::asio::yield_context yc)
+{
+	m_IsFalse.Wait(std::move(yc));
+}
+
 /**
  * Cancels any pending timeout callback.
  *

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -176,6 +176,26 @@ private:
 };
 
 /**
+ * Like AsioEvent, which only allows waiting for an event to be set, but additionally supports waiting for clearing
+ *
+ * @ingroup base
+ */
+class AsioDualEvent
+{
+public:
+	AsioDualEvent(boost::asio::io_context& io, bool init = false);
+
+	void Set();
+	void Clear();
+
+	void WaitForSet(boost::asio::yield_context yc);
+	void WaitForClear(boost::asio::yield_context yc);
+
+private:
+	AsioEvent m_IsTrue, m_IsFalse;
+};
+
+/**
  * I/O timeout emulator
  *
  * This class provides a workaround for Boost.ASIO's lack of built-in timeout support.

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -158,14 +158,14 @@ class TerminateIoThread : public std::exception
 };
 
 /**
- * Condition variable which doesn't block I/O threads
+ * Awaitable flag which doesn't block I/O threads, inspired by threading.Event from Python
  *
  * @ingroup base
  */
-class AsioConditionVariable
+class AsioEvent
 {
 public:
-	AsioConditionVariable(boost::asio::io_context& io, bool init = false);
+	AsioEvent(boost::asio::io_context& io, bool init = false);
 
 	void Set();
 	void Clear();

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -262,7 +262,7 @@ namespace icinga
 		std::set<QueryPriority> m_SuppressedQueryKinds;
 
 		// Indicate that there's something to send/receive
-		AsioConditionVariable m_QueuedWrites, m_QueuedReads;
+		AsioEvent m_QueuedWrites, m_QueuedReads;
 
 		std::function<void(boost::asio::yield_context& yc)> m_ConnectedCallback;
 

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -262,7 +262,8 @@ namespace icinga
 		std::set<QueryPriority> m_SuppressedQueryKinds;
 
 		// Indicate that there's something to send/receive
-		AsioEvent m_QueuedWrites, m_QueuedReads;
+		AsioEvent m_QueuedWrites;
+		AsioDualEvent m_QueuedReads;
 
 		std::function<void(boost::asio::yield_context& yc)> m_ConnectedCallback;
 

--- a/lib/remote/jsonrpcconnection.hpp
+++ b/lib/remote/jsonrpcconnection.hpp
@@ -75,8 +75,8 @@ private:
 	double m_Seen;
 	boost::asio::io_context::strand m_IoStrand;
 	std::vector<String> m_OutgoingMessagesQueue;
-	AsioConditionVariable m_OutgoingMessagesQueued;
-	AsioConditionVariable m_WriterDone;
+	AsioEvent m_OutgoingMessagesQueued;
+	AsioEvent m_WriterDone;
 	Atomic<bool> m_ShuttingDown;
 	boost::asio::deadline_timer m_CheckLivenessTimer, m_HeartbeatTimer;
 


### PR DESCRIPTION
Instead of IoEngine::YieldCurrentCoroutine(yc) until m_Queues.FutureResponseActions.empty(), async-wait a CV which is updated along with m_Queues.FutureResponseActions.

👍 Re-connect still works on Redis restart, even if latter interrupted an outgoing message!

```
[2024-12-06 10:24:02 +0100] critical/IcingaDB: Error during sending query 'XADD' 'icinga:stats' 'MAXLEN' '1' '*' 'ApiListener' '{"perfdata":[{"counter":false,"crit":null,"label":"api_num_co...' ... which has been fired and forgotten: Broken pipe
[2024-12-06 10:24:02 +0100] information/IcingaDB: Connected to Redis server
```

ref/NC/820479
claimed they start Icinga 2 with Icinga DB enabled – and it OOMs. I hope this spin lock is not responsible, but better safe than sorry.

Also, I'm sure we all agree that spin locks should be avoided, at least where easily possible.

* https://github.com/Icinga/icinga2/pull/10117#issuecomment-2376219250
* https://github.com/Icinga/icinga2/pull/9990