### PR TITLE
release.md: don't update doc/21-development.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -35,7 +35,6 @@ https://packages.icinga.com/windows/dependencies/, e.g.:
 
 ### Update Build Server, CI/CD and Documentation
 
-* [doc/21-development.md](doc/21-development.md)
 * [doc/win-dev.ps1](doc/win-dev.ps1) (also affects CI/CD)
 * [tools/win32/configure.ps1](tools/win32/configure.ps1)
 * [tools/win32/configure-dev.ps1](tools/win32/configure-dev.ps1)


### PR DESCRIPTION
The exact Boost version noted there for Windows doesn't matter.

* (Said @julianbrost in https://github.com/Icinga/icinga2/pull/10114#discussion_r1723429901)