### PR TITLE
Update ITL for check_ssh

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1480,13 +1480,15 @@ connects to an SSH server at a specified host and port.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
-Name            | Description
-----------------|--------------
-ssh_address     | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-ssh_port        | **Optional.** The port that should be checked. Defaults to 22.
-ssh_timeout     | **Optional.** Seconds before connection times out. Defaults to 10.
-ssh_ipv4        | **Optional.** Use IPv4 connection. Defaults to false.
-ssh_ipv6        | **Optional.** Use IPv6 connection. Defaults to false.
+Name                | Description
+--------------------|--------------
+ssh_address         | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+ssh_port            | **Optional.** The port that should be checked. Defaults to 22.
+ssh_timeout         | **Optional.** Seconds before connection times out. Defaults to 10.
+ssh_ipv4            | **Optional.** Use IPv4 connection. Defaults to false.
+ssh_ipv6            | **Optional.** Use IPv6 connection. Defaults to false.
+ssh_remote_version  | **Optional.** Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1).
+ssh_remote_protocol | **Optional.** Alert if protocol doesn't match expected protocol version (ex: 2.0).
 
 
 ### ssl <a id="plugin-check-command-ssl"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1550,6 +1550,14 @@ object CheckCommand "ssh" {
 			set_if = "$ssh_ipv6$"
 			description = "Use IPv6 connection"
 		}
+		"-r" = {
+			value = "$ssh_remote_version$"
+			description = "Alert if string doesn't match expected server version (ex: OpenSSH_3.9p1)"
+		}
+		"-P" = {
+			value = "$ssh_remote_protocol$"
+			description = "Alert if protocol doesn't match expected protocol version (ex: 2.0)"
+		}
 	}
 
 	vars.ssh_address = "$check_address$"


### PR DESCRIPTION
Successor of #9923 as described over there, <https://github.com/Icinga/icinga2/pull/9923#issuecomment-2577216250>.
These changes are originally from @MarcusCaepio.

---

Adds parameters for check_ssh (-r and -P) based on nagios-plugins 2.3.3 / monitoring-plugins 2.3
Fixes #9922 