### PR TITLE
21-development.md: fix indentation

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -1736,10 +1736,10 @@ and don't care for the details,
 
 1. ensure there are 35 GB free space on C:
 2. run the following in an administrative Powershell:
-  1. `Enable-WindowsOptionalFeature -FeatureName "NetFx3" -Online`
-     (reboot when asked!)
-  2. `powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-Expression (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/Icinga/icinga2/master/doc/win-dev.ps1')"`
-    (will take some time)
+    1. `Enable-WindowsOptionalFeature -FeatureName "NetFx3" -Online`
+       (reboot when asked!)
+    2. `powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-Expression (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/Icinga/icinga2/master/doc/win-dev.ps1')"`
+       (will take some time)
 
 This installs everything needed for cloning and building Icinga 2
 on the command line (Powershell) as follows:


### PR DESCRIPTION
The last two points need to be children of the second one, but currently GitHub weights them equally.

## Test

Before: https://github.com/Icinga/icinga2/blob/v2.14.0/doc/21-development.md#tldr

After: https://github.com/Icinga/icinga2/blob/b088d981ff633804c2fd17446316ad187250c6f4/doc/21-development.md#tldr