### PR TITLE
Fix and cleanup broken and obsolete links

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -553,19 +553,19 @@ the Icinga DB daemon that synchronizes monitoring data between the Redis server 
 The Icinga DB daemon package is also included in the Icinga repository, and since it is already set up,
 you have completed the instructions here and can proceed to
 <!-- {% if amazon_linux %} -->
-[install the Icinga DB daemon on Amazon Linux](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/01-Amazon-Linux/#installing-icinga-db-package),
+[install the Icinga DB daemon on Amazon Linux](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/Amazon-Linux/#installing-the-package),
 <!-- {% endif %} -->
 <!-- {% if debian %} -->
-[install the Icinga DB daemon on Debian](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/03-Debian/#installing-icinga-db-package),
+[install the Icinga DB daemon on Debian](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/Debian/#installing-the-package),
 <!-- {% endif %} -->
 <!-- {% if rhel %} -->
-[install the Icinga DB daemon on RHEL](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/04-RHEL/#installing-icinga-db-package),
+[install the Icinga DB daemon on RHEL](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/RHEL/#installing-the-package),
 <!-- {% endif %} -->
 <!-- {% if sles %} -->
-[install the Icinga DB daemon on SLES](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/05-SLES/#installing-icinga-db-package),
+[install the Icinga DB daemon on SLES](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/SLES/#installing-the-package),
 <!-- {% endif %} -->
 <!-- {% if ubuntu %} -->
-[install the Icinga DB daemon on Ubuntu](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/06-Ubuntu/#installing-icinga-db-package),
+[install the Icinga DB daemon on Ubuntu](https://icinga.com/docs/icinga-db/latest/doc/02-Installation/Ubuntu/#installing-the-package),
 <!-- {% endif %} -->
 which will also guide you through the setup of the database and Icinga DB Web.
 <!-- {% endif %} -->

--- a/doc/04-configuration.md
+++ b/doc/04-configuration.md
@@ -593,7 +593,7 @@ Read more on that topic [here](03-monitoring-basics.md#notification-commands).
 
 #### groups.conf <a id="groups-conf"></a>
 
-The example host defined in [hosts.conf](hosts-conf) already has the
+The example host defined in [hosts.conf](#hosts-conf) already has the
 custom variable `os` set to `Linux` and is therefore automatically
 a member of the host group `linux-servers`.
 

--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -484,7 +484,7 @@ host or service is considered flapping until it drops below the low flapping thr
 The attribute `flapping_ignore_states` allows to ignore state changes to specified states during the flapping calculation.
 
 `FlappingStart` and `FlappingEnd` notifications will be sent out accordingly, if configured. See the chapter on
-[notifications](alert-notifications) for details
+[notifications](03-monitoring-basics.md#notifications) for details
 
 > Note: There is no distinctions between hard and soft states with flapping. All state changes count and notifications
 > will be sent out regardless of the objects state.

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -1009,7 +1009,7 @@ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 There are several actions available for Icinga 2 provided by the `/v1/actions`
 URL endpoint. You can run actions by sending a `POST` request.
 
-The following actions are also used by [Icinga Web 2](https://icinga.com/products/icinga-web-2/):
+The following actions are also used by [Icinga Web 2](https://icinga.com/docs/icinga-web/latest/):
 
 * sending check results to Icinga from scripts, remote agents, etc.
 * scheduling downtimes from external scripts or cronjobs
@@ -2699,7 +2699,7 @@ The following languages are covered:
 * [Golang](12-icinga2-api.md#icinga2-api-clients-programmatic-examples-golang)
 * [Powershell](12-icinga2-api.md#icinga2-api-clients-programmatic-examples-powershell)
 
-The [request method](icinga2-api-requests) is `POST` using [X-HTTP-Method-Override: GET](12-icinga2-api.md#icinga2-api-requests-method-override)
+The [request method](#icinga2-api-requests) is `POST` using [X-HTTP-Method-Override: GET](12-icinga2-api.md#icinga2-api-requests-method-override)
 which allows you to send a JSON request body. The examples request specific service
 attributes joined with host attributes. `attrs` and `joins` are therefore specified
 as array.

--- a/doc/13-addons.md
+++ b/doc/13-addons.md
@@ -71,9 +71,6 @@ via email.
 
 ![Icinga Reporting](images/addons/icinga_reporting.png)
 
-Follow along in this [hands-on blog post](https://icinga.com/2019/06/17/icinga-reporting-hands-on/).
-
-
 ## Graphs and Metrics <a id="addons-graphs-metrics"></a>
 
 ### Graphite <a id="addons-graphing-graphite"></a>
@@ -185,7 +182,7 @@ in a tree or list overview and can be added to any dashboard.
 
 ![Icinga Web 2 Business Process](images/addons/icingaweb2_businessprocess.png)
 
-Read more [here](https://icinga.com/products/icinga-business-process-modelling/).
+Read more [here](https://icinga.com/docs/icinga-business-process-modeling/latest/).
 
 ### Certificate Monitoring <a id="addons-visualization-certificate-monitoring"></a>
 
@@ -194,8 +191,7 @@ actions and view all details at a glance.
 
 ![Icinga Certificate Monitoring](images/addons/icinga_certificate_monitoring.png)
 
-Read more [here](https://icinga.com/products/icinga-certificate-monitoring/)
-and [here](https://icinga.com/2019/06/03/monitoring-automation-with-icinga-certificate-monitoring/).
+Read more [here](https://icinga.com/products/icinga-certificate-monitoring/).
 
 ### Dashing Dashboard <a id="addons-visualization-dashing-dashboard"></a>
 
@@ -204,7 +200,7 @@ on top of Dashing and uses the [REST API](12-icinga2-api.md#icinga2-api) to visu
 on with your monitoring. It combines several popular widgets and provides development
 instructions for your own implementation.
 
-The dashboard also allows to embed the [Icinga Web 2](https://icinga.com/products/icinga-web-2/)
+The dashboard also allows to embed the [Icinga Web 2](https://icinga.com/docs/icinga-web/latest/)
 host and service problem lists as Iframe.
 
 ![Dashing dashboard](images/addons/dashing_icinga2.png)
@@ -233,10 +229,6 @@ There's a variety of resources available, for example different notification scr
 * IRC
 * Ticket systems
 * etc.
-
-Blog posts and howtos:
-
-* [Environmental Monitoring and Alerting](https://icinga.com/2019/09/02/environmental-monitoring-and-alerting-via-text-message/)
 
 Additionally external services can be [integrated with Icinga 2](https://icinga.com/products/integrations/):
 

--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -19,8 +19,8 @@ findings and details please.
 	* `icinga2 --version`
 	* `icinga2 feature list`
 	* `icinga2 daemon -C`
-	* [Icinga Web 2](https://icinga.com/products/icinga-web-2/) version (screenshot from System - About)
-	* [Icinga Web 2 modules](https://icinga.com/products/icinga-web-2-modules/) e.g. the Icinga Director (optional)
+	* [Icinga Web 2](https://icinga.com/docs/icinga-web/latest/) version (screenshot from System - About)
+	* Icinga Web 2 modules e.g. the Icinga Director (optional)
 * Configuration insights:
 	* Provide complete configuration snippets explaining your problem in detail
 	* Your [icinga2.conf](04-configuration.md#icinga2-conf) file
@@ -872,7 +872,7 @@ trying because you probably have a problem that requires manual intervention.
 
 ### Late Check Results <a id="late-check-results"></a>
 
-[Icinga Web 2](https://icinga.com/products/icinga-web-2/) provides
+[Icinga Web 2](https://icinga.com/docs/icinga-web/latest/) provides
 a dashboard overview for `overdue checks`.
 
 The REST API provides the [status](12-icinga2-api.md#icinga2-api-status) URL endpoint with some generic metrics
@@ -887,8 +887,7 @@ You can also calculate late check results via the REST API:
 * Fetch the `last_check` timestamp from each object
 * Compare the timestamp with the current time and add `check_interval` multiple times (change it to see which results are really late, like five times check_interval)
 
-You can use the [icinga2 console](11-cli-commands.md#cli-command-console) to connect to the instance, fetch all data
-and calculate the differences. More infos can be found in [this blogpost](https://icinga.com/2016/08/11/analyse-icinga-2-problems-using-the-console-api/).
+You can use the [icinga2 console](11-cli-commands.md#cli-command-console) to connect to the instance, fetch all data and calculate the differences.
 
 ```
 # ICINGA2_API_USERNAME=root ICINGA2_API_PASSWORD=icinga icinga2 console --connect 'https://localhost:5665/'

--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -2334,7 +2334,7 @@ for implementation details.
 
 CMake determines the Icinga 2 version number using `git describe` if the
 source directory is contained in a Git repository. Otherwise the version number
-is extracted from the [ICINGA2_VERSION](ICINGA2_VERSION) file. This behavior can be
+is extracted from the `ICINGA2_VERSION` file. This behavior can be
 overridden by creating a file called `icinga-version.h.force` in the source
 directory. Alternatively the `-DICINGA2_GIT_VERSION_INFO=OFF` option for CMake
 can be used to disable the usage of `git describe`.
@@ -2520,7 +2520,7 @@ chmod +x /etc/init.d/icinga2
 
 Icinga 2 reads a single configuration file which is used to specify all
 configuration settings (global settings, hosts, services, etc.). The
-configuration format is explained in detail in the [doc/](doc/) directory.
+configuration format is explained in detail in the `doc/` directory.
 
 By default `make install` installs example configuration files in
 `/usr/local/etc/icinga2` unless you have specified a different prefix or


### PR DESCRIPTION
Fixes broken links in the documentation, or removes them where the content no longer exists.

Main motivation for the backport: fix the broken links in https://icinga.com/docs/icinga-2/latest/doc/02-installation/01-Debian/#install-icinga-db-daemon (and on the other installation pages).

backport of #10282