### PR TITLE
Sync dependencies to Redis

### DIFF
--- a/lib/icinga/CMakeLists.txt
+++ b/lib/icinga/CMakeLists.txt
@@ -39,7 +39,7 @@ set(icinga_SOURCES
   comment.cpp comment.hpp comment-ti.hpp
   compatutility.cpp compatutility.hpp
   customvarobject.cpp customvarobject.hpp customvarobject-ti.hpp
-  dependency.cpp dependency.hpp dependency-ti.hpp dependency-apply.cpp
+  dependency.cpp dependency-group.cpp dependency.hpp dependency-ti.hpp dependency-apply.cpp
   downtime.cpp downtime.hpp downtime-ti.hpp
   envresolver.cpp envresolver.hpp
   eventcommand.cpp eventcommand.hpp eventcommand-ti.hpp

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -154,6 +154,10 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	bool reachable = IsReachable();
 	bool notification_reachable = IsReachable(DependencyNotification);
 
+	// Cache whether the previous state of this Checkable affects its children before overwriting the last check result.
+	// This will be used to determine whether the on reachability changed event should be triggered.
+	bool affectsPreviousStateChildren(reachable && AffectsChildren());
+
 	ObjectLock olock(this);
 
 	CheckResult::Ptr old_cr = GetLastCheckResult();
@@ -533,7 +537,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	}
 
 	/* update reachability for child objects */
-	if ((stateChange || hardChange) && !children.empty())
+	if ((stateChange || hardChange) && !children.empty() && (affectsPreviousStateChildren || AffectsChildren()))
 		OnReachabilityChanged(this, cr, children, origin);
 
 	return Result::Ok;

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -223,7 +223,6 @@ void Checkable::GetAllChildrenInternal(std::set<Checkable::Ptr>& seenChildren, i
 
 	for (const Checkable::Ptr& checkable : GetChildren()) {
 		if (auto [_, inserted] = seenChildren.insert(checkable); inserted) {
-			seenChildren.emplace(checkable);
 			checkable->GetAllChildrenInternal(seenChildren, level + 1);
 		}
 	}

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -206,7 +206,7 @@ bool Checkable::IsReachable(DependencyType dt, int rstack) const
 	}
 
 	for (auto& dependencyGroup : GetDependencyGroups()) {
-		if (auto state(dependencyGroup->GetState(dt, rstack + 1)); !state.Reachable || !state.OK) {
+		if (auto state(dependencyGroup->GetState(this, dt, rstack + 1)); !state.Reachable || !state.OK) {
 			Log(LogDebug, "Checkable")
 				<< "Dependency group '" << dependencyGroup->GetRedundancyGroupName() << "' have failed for checkable '"
 				<< GetName() << "': Marking as unreachable.";

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -250,12 +250,8 @@ bool Checkable::AffectsChildren() const
 std::set<Checkable::Ptr> Checkable::GetParents() const
 {
 	std::set<Checkable::Ptr> parents;
-
-	for (const Dependency::Ptr& dep : GetDependencies()) {
-		Checkable::Ptr parent = dep->GetParent();
-
-		if (parent && parent.get() != this)
-			parents.insert(parent);
+	for (auto& dependencyGroup : GetDependencyGroups()) {
+		dependencyGroup->LoadParents(parents);
 	}
 
 	return parents;

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -44,6 +44,12 @@ std::vector<Dependency::Ptr> Checkable::GetDependencies() const
 	return dependencies;
 }
 
+bool Checkable::HasAnyDependencies() const
+{
+	std::unique_lock lock(m_DependencyMutex);
+	return !m_DependencyGroups.empty() || !m_ReverseDependencies.empty();
+}
+
 void Checkable::AddReverseDependency(const Dependency::Ptr& dep)
 {
 	std::unique_lock<std::mutex> lock(m_DependencyMutex);

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -206,7 +206,7 @@ bool Checkable::IsReachable(DependencyType dt, int rstack) const
 	}
 
 	for (auto& dependencyGroup : GetDependencyGroups()) {
-		if (auto state(dependencyGroup->GetState(this, dt, rstack + 1)); !state.Reachable || !state.OK) {
+		if (auto state(dependencyGroup->GetState(this, dt, rstack + 1)); state != DependencyGroup::State::Ok) {
 			Log(LogDebug, "Checkable")
 				<< "Dependency group '" << dependencyGroup->GetRedundancyGroupName() << "' have failed for checkable '"
 				<< GetName() << "': Marking as unreachable.";

--- a/lib/icinga/checkable-dependency.cpp
+++ b/lib/icinga/checkable-dependency.cpp
@@ -15,6 +15,18 @@ using namespace icinga;
  */
 static constexpr int l_MaxDependencyRecursionLevel(256);
 
+void Checkable::AddDependencyGroup(const DependencyGroup::Ptr& dependencyGroup)
+{
+	std::unique_lock lock(m_DependencyMutex);
+	m_DependencyGroups.insert(dependencyGroup);
+}
+
+void Checkable::RemoveDependencyGroup(const DependencyGroup::Ptr& dependencyGroup)
+{
+	std::unique_lock lock(m_DependencyMutex);
+	m_DependencyGroups.erase(dependencyGroup);
+}
+
 void Checkable::AddDependency(const Dependency::Ptr& dep)
 {
 	std::unique_lock<std::mutex> lock(m_DependencyMutex);

--- a/lib/icinga/checkable-notification.cpp
+++ b/lib/icinga/checkable-notification.cpp
@@ -167,8 +167,7 @@ void Checkable::FireSuppressedNotifications()
 				}
 			}
 
-			for (auto& dep : GetDependencies()) {
-				auto parent (dep->GetParent());
+			for (auto& parent : GetParents()) {
 				ObjectLock oLock (parent);
 
 				if (!parent->GetProblem() && parent->GetLastStateChange() >= threshold) {

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -80,6 +80,8 @@ void Checkable::OnAllConfigLoaded()
 
 void Checkable::Start(bool runtimeCreated)
 {
+	PushDependencyGroupsToRegistry();
+
 	double now = Utility::GetTime();
 
 	{

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -189,7 +189,7 @@ public:
 	void PushDependencyGroupsToRegistry();
 	std::vector<intrusive_ptr<DependencyGroup>> GetDependencyGroups() const;
 	void AddDependency(const intrusive_ptr<Dependency>& dependency);
-	void RemoveDependency(const intrusive_ptr<Dependency>& dependency);
+	void RemoveDependency(const intrusive_ptr<Dependency>& dependency, bool runtimeRemoved = false);
 	std::vector<intrusive_ptr<Dependency> > GetDependencies() const;
 	bool HasAnyDependencies() const;
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -82,6 +82,7 @@ public:
 	void AddGroup(const String& name);
 
 	bool IsReachable(DependencyType dt = DependencyState, intrusive_ptr<Dependency> *failedDependency = nullptr, int rstack = 0) const;
+	bool AffectsChildren() const;
 
 	AcknowledgementType GetAcknowledgement();
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -187,8 +187,7 @@ public:
 	/* Dependencies */
 	void AddDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
 	void RemoveDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
-	void AddDependency(const intrusive_ptr<Dependency>& dep);
-	void RemoveDependency(const intrusive_ptr<Dependency>& dep);
+	std::vector<intrusive_ptr<DependencyGroup>> GetDependencyGroups() const;
 	std::vector<intrusive_ptr<Dependency> > GetDependencies() const;
 
 	void AddReverseDependency(const intrusive_ptr<Dependency>& dep);
@@ -250,7 +249,6 @@ private:
 	/* Dependencies */
 	mutable std::mutex m_DependencyMutex;
 	std::set<intrusive_ptr<DependencyGroup>> m_DependencyGroups;
-	std::set<intrusive_ptr<Dependency> > m_Dependencies;
 	std::set<intrusive_ptr<Dependency> > m_ReverseDependencies;
 
 	void GetAllChildrenInternal(std::set<Checkable::Ptr>& seenChildren, int level = 0) const;

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -186,6 +186,7 @@ public:
 	bool IsFlapping() const;
 
 	/* Dependencies */
+	void PushDependencyGroupsToRegistry();
 	std::vector<intrusive_ptr<DependencyGroup>> GetDependencyGroups() const;
 	void AddDependency(const intrusive_ptr<Dependency>& dependency);
 	void RemoveDependency(const intrusive_ptr<Dependency>& dependency);
@@ -250,6 +251,7 @@ private:
 
 	/* Dependencies */
 	mutable std::mutex m_DependencyMutex;
+	bool m_DependencyGroupsPushedToRegistry{false};
 	std::map<std::variant<Checkable*, String>, intrusive_ptr<DependencyGroup>> m_DependencyGroups;
 	std::set<intrusive_ptr<Dependency> > m_ReverseDependencies;
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -81,7 +81,7 @@ public:
 
 	void AddGroup(const String& name);
 
-	bool IsReachable(DependencyType dt = DependencyState, intrusive_ptr<Dependency> *failedDependency = nullptr, int rstack = 0) const;
+	bool IsReachable(DependencyType dt = DependencyState, int rstack = 0) const;
 	bool AffectsChildren() const;
 
 	AcknowledgementType GetAcknowledgement();

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -77,6 +77,7 @@ public:
 	std::set<Checkable::Ptr> GetParents() const;
 	std::set<Checkable::Ptr> GetChildren() const;
 	std::set<Checkable::Ptr> GetAllChildren() const;
+	size_t GetAllChildrenCount() const;
 
 	void AddGroup(const String& name);
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -189,6 +189,7 @@ public:
 	void RemoveDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
 	std::vector<intrusive_ptr<DependencyGroup>> GetDependencyGroups() const;
 	std::vector<intrusive_ptr<Dependency> > GetDependencies() const;
+	bool HasAnyDependencies() const;
 
 	void AddReverseDependency(const intrusive_ptr<Dependency>& dep);
 	void RemoveReverseDependency(const intrusive_ptr<Dependency>& dep);

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <variant>
 
 namespace icinga
 {
@@ -185,9 +186,9 @@ public:
 	bool IsFlapping() const;
 
 	/* Dependencies */
-	void AddDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
-	void RemoveDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
 	std::vector<intrusive_ptr<DependencyGroup>> GetDependencyGroups() const;
+	void AddDependency(const intrusive_ptr<Dependency>& dependency);
+	void RemoveDependency(const intrusive_ptr<Dependency>& dependency);
 	std::vector<intrusive_ptr<Dependency> > GetDependencies() const;
 	bool HasAnyDependencies() const;
 
@@ -249,7 +250,7 @@ private:
 
 	/* Dependencies */
 	mutable std::mutex m_DependencyMutex;
-	std::set<intrusive_ptr<DependencyGroup>> m_DependencyGroups;
+	std::map<std::variant<Checkable*, String>, intrusive_ptr<DependencyGroup>> m_DependencyGroups;
 	std::set<intrusive_ptr<Dependency> > m_ReverseDependencies;
 
 	void GetAllChildrenInternal(std::set<Checkable::Ptr>& seenChildren, int level = 0) const;

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -57,6 +57,7 @@ enum FlappingStateFilter
 class CheckCommand;
 class EventCommand;
 class Dependency;
+class DependencyGroup;
 
 /**
  * An Icinga service.
@@ -184,6 +185,8 @@ public:
 	bool IsFlapping() const;
 
 	/* Dependencies */
+	void AddDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
+	void RemoveDependencyGroup(const intrusive_ptr<DependencyGroup>& dependencyGroup);
 	void AddDependency(const intrusive_ptr<Dependency>& dep);
 	void RemoveDependency(const intrusive_ptr<Dependency>& dep);
 	std::vector<intrusive_ptr<Dependency> > GetDependencies() const;
@@ -246,6 +249,7 @@ private:
 
 	/* Dependencies */
 	mutable std::mutex m_DependencyMutex;
+	std::set<intrusive_ptr<DependencyGroup>> m_DependencyGroups;
 	std::set<intrusive_ptr<Dependency> > m_Dependencies;
 	std::set<intrusive_ptr<Dependency> > m_ReverseDependencies;
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -249,7 +249,7 @@ private:
 	std::set<intrusive_ptr<Dependency> > m_Dependencies;
 	std::set<intrusive_ptr<Dependency> > m_ReverseDependencies;
 
-	void GetAllChildrenInternal(std::set<Checkable::Ptr>& children, int level = 0) const;
+	void GetAllChildrenInternal(std::set<Checkable::Ptr>& seenChildren, int level = 0) const;
 
 	/* Flapping */
 	static const std::map<String, int> m_FlappingStateFilterMap;

--- a/lib/icinga/dependency-group.cpp
+++ b/lib/icinga/dependency-group.cpp
@@ -134,6 +134,20 @@ std::vector<Dependency::Ptr> DependencyGroup::GetDependenciesForChild(const Chec
 }
 
 /**
+ * Load all parent Checkables of the current dependency group.
+ *
+ * @param parents The set to load the parent Checkables into.
+ */
+void DependencyGroup::LoadParents(std::set<Checkable::Ptr>& parents) const
+{
+	std::lock_guard lock(m_Mutex);
+	for (auto& [compositeKey, children] : m_Members) {
+		ASSERT(!children.empty()); // We should never have an empty map for any given key at any given time.
+		parents.insert(std::get<0>(compositeKey));
+	}
+}
+
+/**
  * Retrieve the number of dependency objects in the current dependency group.
  *
  * This function mainly exists for optimization purposes, i.e. instead of getting a copy of the members and

--- a/lib/icinga/dependency-group.cpp
+++ b/lib/icinga/dependency-group.cpp
@@ -1,0 +1,340 @@
+/* Icinga 2 | (c) 2024 Icinga GmbH | GPLv2+ */
+
+#include "icinga/dependency.hpp"
+#include "base/object-packer.hpp"
+
+using namespace icinga;
+
+std::mutex DependencyGroup::m_RegistryMutex;
+DependencyGroup::RegistryType DependencyGroup::m_Registry;
+
+/**
+ * Refresh the global registry of dependency groups.
+ *
+ * Registers the provided dependency object to an existing dependency group with the same redundancy
+ * group name (if any), or creates a new one and registers it to the child Checkable and the registry.
+ *
+ * Note: This is a helper function intended for internal use only, and you should acquire the global registry mutex
+ * before calling this function.
+ *
+ * @param dependency The dependency object to refresh the registry for.
+ * @param unregister A flag indicating whether the provided dependency object should be unregistered from the registry.
+ */
+void DependencyGroup::RefreshRegistry(const Dependency::Ptr& dependency, bool unregister)
+{
+	auto registerRedundancyGroup = [](const DependencyGroup::Ptr& dependencyGroup) {
+		if (auto [it, inserted](m_Registry.insert(dependencyGroup.get())); !inserted) {
+			DependencyGroup::Ptr existingGroup(*it);
+			dependencyGroup->CopyDependenciesTo(existingGroup);
+		}
+	};
+
+	// Retrieve all the dependency groups with the same redundancy group name of the provided dependency object.
+	// This allows us to shorten the lookup for the _one_ optimal group to (un)register the dependency from/to.
+	auto [begin, end] = m_Registry.get<1>().equal_range(dependency->GetRedundancyGroup());
+	for (auto it(begin); it != end; ++it) {
+		DependencyGroup::Ptr existingGroup(*it);
+		auto child(dependency->GetChild());
+		if (auto dependencies(existingGroup->GetDependenciesForChild(child.get())); !dependencies.empty()) {
+			m_Registry.erase(existingGroup->GetCompositeKey()); // Will be re-registered when needed down below.
+			if (unregister) {
+				existingGroup->RemoveDependency(dependency);
+				// Remove the connection between the child Checkable and the dependency group if it has no members
+				// left or the above removed member was the only member of the group that the child depended on.
+				if (existingGroup->IsEmpty() || dependencies.size() == 1) {
+					child->RemoveDependencyGroup(existingGroup);
+				}
+			}
+
+			size_t totalDependencies(existingGroup->GetDependenciesCount());
+			// If the existing dependency group has an identical member already, or the child Checkable of the
+			// dependency object is the only member of it (totalDependencies == dependencies.size()), we can simply
+			// add the dependency object to the existing group.
+			if (!unregister && (existingGroup->HasParentWithConfig(dependency) || totalDependencies == dependencies.size())) {
+				existingGroup->AddDependency(dependency);
+			} else if (!unregister || (dependencies.size() > 1 && totalDependencies >= dependencies.size())) {
+				// The child Checkable is going to have a new dependency group, so we must detach the existing one.
+				child->RemoveDependencyGroup(existingGroup);
+
+				Ptr replacementGroup(unregister ? nullptr : new DependencyGroup(existingGroup->GetRedundancyGroupName(), dependency));
+				for (auto& existingDependency : dependencies) {
+					if (existingDependency != dependency) {
+						existingGroup->RemoveDependency(existingDependency);
+						if (replacementGroup) {
+							replacementGroup->AddDependency(existingDependency);
+						} else {
+							replacementGroup = new DependencyGroup(existingGroup->GetRedundancyGroupName(), existingDependency);
+						}
+					}
+				}
+
+				child->AddDependencyGroup(replacementGroup);
+				registerRedundancyGroup(replacementGroup);
+			}
+
+			if (!existingGroup->IsEmpty()) {
+				registerRedundancyGroup(existingGroup);
+			}
+			return;
+		}
+	}
+
+	if (!unregister) {
+		// We couldn't find any existing dependency group to register the dependency to, so we must
+		// initiate a new one and attach it to the child Checkable and register to the global registry.
+		DependencyGroup::Ptr newGroup(new DependencyGroup(dependency->GetRedundancyGroup()));
+		newGroup->AddDependency(dependency);
+		dependency->GetChild()->AddDependencyGroup(newGroup);
+		registerRedundancyGroup(newGroup);
+	}
+}
+
+/**
+ * Register the provided dependency to the global dependency group registry.
+ *
+ * @param dependency The dependency to register.
+ */
+void DependencyGroup::Register(const Dependency::Ptr& dependency)
+{
+	std::lock_guard lock(m_RegistryMutex);
+	RefreshRegistry(dependency, false);
+}
+
+/**
+ * Unregister the provided dependency from the dependency group it was member of.
+ *
+ * @param dependency The dependency to unregister.
+ */
+void DependencyGroup::Unregister(const Dependency::Ptr& dependency)
+{
+	std::lock_guard lock(m_RegistryMutex);
+	RefreshRegistry(dependency, true);
+}
+
+/**
+ * Retrieve the size of the global dependency group registry.
+ *
+ * @return size_t - Returns the size of the global dependency groups registry.
+ */
+size_t DependencyGroup::GetRegistrySize()
+{
+	std::lock_guard lock(m_RegistryMutex);
+	return m_Registry.size();
+}
+
+DependencyGroup::DependencyGroup(String name): m_RedundancyGroupName(std::move(name))
+{
+}
+
+/**
+ * Create a composite key for the provided dependency.
+ *
+ * The composite key consists of all the properties of the provided dependency object that influence its availability.
+ *
+ * @param dependency The dependency object to create a composite key for.
+ *
+ * @return - Returns the composite key for the provided dependency.
+ */
+DependencyGroup::CompositeKeyType DependencyGroup::MakeCompositeKeyFor(const Dependency::Ptr& dependency)
+{
+	return std::make_tuple(
+		dependency->GetParent().get(),
+		dependency->GetPeriod().get(),
+		dependency->GetStateFilter(),
+		dependency->GetIgnoreSoftStates()
+	);
+}
+
+/**
+ * Check if the current dependency group is empty.
+ *
+ * @return bool - Returns true if the current dependency group has no members, otherwise false.
+ */
+bool DependencyGroup::IsEmpty() const
+{
+	std::lock_guard lock(m_Mutex);
+	return m_Members.empty();
+}
+
+/**
+ * Retrieve all dependency objects of the current dependency group the provided child Checkable depend on.
+ *
+ * @param child The child Checkable to get the dependencies for.
+ *
+ * @return - Returns all the dependencies of the provided child Checkable in the current dependency group.
+ */
+std::vector<Dependency::Ptr> DependencyGroup::GetDependenciesForChild(const Checkable* child) const
+{
+	std::lock_guard lock(m_Mutex);
+	std::vector<Dependency::Ptr> dependencies;
+	for (auto& [_, children] : m_Members) {
+		auto [begin, end] = children.equal_range(child);
+		std::transform(begin, end, std::back_inserter(dependencies), [](const auto& pair) {
+			return pair.second;
+		});
+	}
+	return dependencies;
+}
+
+/**
+ * Retrieve the number of dependency objects in the current dependency group.
+ *
+ * This function mainly exists for optimization purposes, i.e. instead of getting a copy of the members and
+ * counting them, we can directly query the number of dependencies in the group.
+ *
+ * @return size_t
+ */
+size_t DependencyGroup::GetDependenciesCount() const
+{
+	std::lock_guard lock(m_Mutex);
+	size_t count(0);
+	for (auto& [_, dependencies] : m_Members) {
+		count += dependencies.size();
+	}
+	return count;
+}
+
+/**
+ * Add a dependency object to the current dependency group.
+ *
+ * @param dependency The dependency to add to the dependency group.
+ */
+void DependencyGroup::AddDependency(const Dependency::Ptr& dependency)
+{
+	std::lock_guard lock(m_Mutex);
+	auto compositeKey(MakeCompositeKeyFor(dependency));
+	if (auto it(m_Members.find(compositeKey)); it != m_Members.end()) {
+		it->second.emplace(dependency->GetChild().get(), dependency.get());
+	} else {
+		m_Members.emplace(compositeKey, MemberValueType{{dependency->GetChild().get(), dependency.get()}});
+	}
+}
+
+/**
+ * Remove a dependency object from the current dependency group.
+ *
+ * @param dependency The dependency to remove from the dependency group.
+ */
+void DependencyGroup::RemoveDependency(const Dependency::Ptr& dependency)
+{
+	std::lock_guard lock(m_Mutex);
+	if (auto it(m_Members.find(MakeCompositeKeyFor(dependency))); it != m_Members.end()) {
+		auto [begin, end] = it->second.equal_range(dependency->GetChild().get());
+		for (auto childrenIt(begin); childrenIt != end; ++childrenIt) {
+			if (childrenIt->second == dependency) {
+				// This will also remove the child Checkable from the multimap container
+				// entirely if this was the last child of it.
+				it->second.erase(childrenIt);
+				// If the composite key has no more children left, we can remove it entirely as well.
+				if (it->second.empty()) {
+					m_Members.erase(it);
+				}
+				return;
+			}
+		}
+	}
+}
+
+/**
+ * Copy the dependency objects of the current dependency group to the provided dependency group (destination).
+ *
+ * @param dest The dependency group to move the dependencies to.
+ */
+void DependencyGroup::CopyDependenciesTo(const DependencyGroup::Ptr& dest)
+{
+	VERIFY(this != dest); // Prevent from doing something stupid, i.e. deadlocking ourselves.
+
+	std::lock_guard lock(m_Mutex);
+	DependencyGroup::Ptr thisPtr(this); // Just in case the Checkable below was our last reference.
+	for (auto& [_, children] : m_Members) {
+		Checkable::Ptr previousChild;
+		for (auto& [checkable, dependency] : children) {
+			dest->AddDependency(dependency);
+			if (!previousChild || previousChild != checkable) {
+				previousChild = dependency->GetChild();
+				previousChild->RemoveDependencyGroup(thisPtr);
+				previousChild->AddDependencyGroup(dest);
+			}
+		}
+	}
+}
+
+/**
+ * Set the Icinga DB identifier for the current dependency group.
+ *
+ * The only usage of this function is the Icinga DB feature used to cache the unique hash of this dependency groups.
+ *
+ * @param identifier The Icinga DB identifier to set.
+ */
+void DependencyGroup::SetIcingaDBIdentifier(const String& identifier)
+{
+	std::lock_guard lock(m_Mutex);
+	m_IcingaDBIdentifier = identifier;
+}
+
+/**
+ * Retrieve the Icinga DB identifier for the current dependency group.
+ *
+ * When the identifier is not already set by Icinga DB via the SetIcingaDBIdentifier method,
+ * this will just return an empty string.
+ *
+ * @return - Returns the Icinga DB identifier for the current dependency group.
+ */
+String DependencyGroup::GetIcingaDBIdentifier() const
+{
+	std::lock_guard lock(m_Mutex);
+	return m_IcingaDBIdentifier;
+}
+
+/**
+ * Retrieve the redundancy group name of the current dependency group.
+ *
+ * If the current dependency group doesn't represent a redundancy group, this will return an empty string.
+ *
+ * @return - Returns the name of the current dependency group.
+ */
+const String& DependencyGroup::GetRedundancyGroupName() const
+{
+	// We don't need to lock the mutex here, as the name is set once during
+	// the object construction and never changed afterwards.
+	return m_RedundancyGroupName;
+}
+
+/**
+ * Retrieve the unique composite key of the current dependency group.
+ *
+ * The composite key consists of some unique data of the group members, and should be used to generate
+ * a unique deterministic hash for the dependency group. Additionally, for explicitly configured redundancy
+ * groups, the non-unique dependency group name is also included on top of the composite keys.
+ *
+ * @return - Returns the composite key of the current dependency group.
+ */
+String DependencyGroup::GetCompositeKey()
+{
+	// This a copy of the CompositeKeyType definition but with the String type instead of Checkable* and TimePeriod*.
+	// This is because we need to produce a deterministic value from the composite key after each restart and that's
+	// not achievable using pointers.
+	using StringTuple = std::tuple<String, String, int, bool>;
+	std::vector<StringTuple> compositeKeys;
+	{
+		std::lock_guard lock(m_Mutex);
+		for (auto& [compositeKey, _] : m_Members) {
+			auto [parent, tp, stateFilter, ignoreSoftStates] = compositeKey;
+			compositeKeys.emplace_back(parent->GetName(), tp ? tp->GetName() : "", stateFilter, ignoreSoftStates);
+		}
+	}
+
+	// IMPORTANT: The order of the composite keys must be sorted to ensure the deterministic hash value.
+	std::sort(compositeKeys.begin(), compositeKeys.end());
+
+	Array::Ptr data(new Array{GetRedundancyGroupName()});
+	for (auto& compositeKey : compositeKeys) {
+		auto [parent, tp, stateFilter, ignoreSoftStates] = compositeKey;
+		data->Add(std::move(parent));
+		data->Add(std::move(tp));
+		data->Add(stateFilter);
+		data->Add(ignoreSoftStates);
+	}
+
+	return PackObject(data);
+}

--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -251,7 +251,7 @@ void Dependency::OnAllConfigLoaded()
 	// InitChildParentReferences() has to be called before.
 	VERIFY(m_Child && m_Parent);
 
-	DependencyGroup::Register(this);
+	m_Child->AddDependency(this);
 	m_Parent->AddReverseDependency(this);
 }
 
@@ -259,7 +259,7 @@ void Dependency::Stop(bool runtimeRemoved)
 {
 	ObjectImpl<Dependency>::Stop(runtimeRemoved);
 
-	DependencyGroup::Unregister(this);
+	GetChild()->RemoveDependency(this);
 	GetParent()->RemoveReverseDependency(this);
 }
 

--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -251,7 +251,7 @@ void Dependency::OnAllConfigLoaded()
 	// InitChildParentReferences() has to be called before.
 	VERIFY(m_Child && m_Parent);
 
-	m_Child->AddDependency(this);
+	DependencyGroup::Register(this);
 	m_Parent->AddReverseDependency(this);
 }
 
@@ -259,7 +259,7 @@ void Dependency::Stop(bool runtimeRemoved)
 {
 	ObjectImpl<Dependency>::Stop(runtimeRemoved);
 
-	GetChild()->RemoveDependency(this);
+	DependencyGroup::Unregister(this);
 	GetParent()->RemoveReverseDependency(this);
 }
 

--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -259,7 +259,7 @@ void Dependency::Stop(bool runtimeRemoved)
 {
 	ObjectImpl<Dependency>::Stop(runtimeRemoved);
 
-	GetChild()->RemoveDependency(this);
+	GetChild()->RemoveDependency(this, runtimeRemoved);
 	GetParent()->RemoveReverseDependency(this);
 }
 

--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -123,7 +123,7 @@ public:
 		}
 
 		// Explicitly configured dependency objects
-		for (const auto& dep : checkable->GetDependencies()) {
+		for (const auto& dep : checkable->GetDependencies(/* includePending = */ true)) {
 			m_Stack.emplace_back(dep);
 			AssertNoCycle(dep->GetParent());
 			m_Stack.pop_back();

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -180,6 +180,15 @@ protected:
 
 private:
 	mutable std::mutex m_Mutex;
+	/**
+	 * This identifier is used by Icinga DB to cache the unique hash of this dependency group.
+	 *
+	 * For redundancy groups, once Icinga DB sets this identifier, it will never change again for the lifetime
+	 * of the object. For non-redundant dependency groups, this identifier is (mis)used to cache the shared edge
+	 * state ID of the group. Specifically, non-redundant dependency groups are irrelevant for Icinga DB, so since
+	 * this field isn't going to be used for anything else, we use it to cache the computed shared edge state ID.
+	 * Likewise, if that gets set, it will never change again for the lifetime of the object as well.
+	 */
 	String m_IcingaDBIdentifier;
 	String m_RedundancyGroupName;
 	MembersMap m_Members;

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -182,7 +182,7 @@ private:
 	{
 		size_t operator()(const DependencyGroup::Ptr& dependencyGroup) const
 		{
-			size_t hash = 0;
+			size_t hash = std::hash<String>{}(dependencyGroup->GetRedundancyGroupName());
 			for (const auto& [key, group] : dependencyGroup->m_Members) {
 				boost::hash_combine(hash, key);
 			}
@@ -194,6 +194,10 @@ private:
 	{
 		bool operator()(const DependencyGroup::Ptr& lhs, const DependencyGroup::Ptr& rhs) const
 		{
+			if (lhs->GetRedundancyGroupName() != rhs->GetRedundancyGroupName()) {
+				return false;
+			}
+
 			return std::equal(
 				lhs->m_Members.begin(), lhs->m_Members.end(),
 				rhs->m_Members.begin(), rhs->m_Members.end(),

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -163,6 +163,14 @@ public:
 	const String& GetRedundancyGroupName() const;
 	String GetCompositeKey();
 
+	struct State
+	{
+		bool Reachable; // Whether the dependency group is reachable.
+		bool OK; // Whether the dependency group is reachable and OK.
+	};
+
+	State GetState(DependencyType dt = DependencyState, int rstack = 0) const;
+
 protected:
 	void AddDependency(const Dependency::Ptr& dependency);
 	void RemoveDependency(const Dependency::Ptr& dependency);

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -170,7 +170,7 @@ public:
 		bool OK; // Whether the dependency group is reachable and OK.
 	};
 
-	State GetState(DependencyType dt = DependencyState, int rstack = 0) const;
+	State GetState(const Checkable* child, DependencyType dt = DependencyState, int rstack = 0) const;
 
 	static boost::signals2::signal<void(const Checkable::Ptr&, const DependencyGroup::Ptr&)> OnChildRegistered;
 	static boost::signals2::signal<void(const DependencyGroup::Ptr&, const std::vector<Dependency::Ptr>&, bool)> OnChildRemoved;

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -8,9 +8,6 @@
 #include "icinga/i2-icinga.hpp"
 #include "icinga/dependency-ti.hpp"
 #include "icinga/timeperiod.hpp"
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/mem_fun.hpp>
 #include <map>
 #include <tuple>
 #include <unordered_map>
@@ -136,9 +133,10 @@ public:
 	using MembersMap = std::map<CompositeKeyType, MemberValueType>;
 
 	explicit DependencyGroup(String name);
+	DependencyGroup(String name, const std::set<Dependency::Ptr>& dependencies);
 
-	static void Register(const Dependency::Ptr& dependency);
-	static void Unregister(const Dependency::Ptr& dependency);
+	static DependencyGroup::Ptr Register(const DependencyGroup::Ptr& dependencyGroup);
+	static std::set<Dependency::Ptr> Unregister(const DependencyGroup::Ptr& dependencyGroup, const Checkable::Ptr& child);
 	static size_t GetRegistrySize();
 
 	static CompositeKeyType MakeCompositeKeyFor(const Dependency::Ptr& dependency);
@@ -176,7 +174,29 @@ protected:
 	void RemoveDependency(const Dependency::Ptr& dependency);
 	void CopyDependenciesTo(const DependencyGroup::Ptr& dest);
 
-	static void RefreshRegistry(const Dependency::Ptr& dependency, bool unregister);
+	struct Hash
+	{
+		size_t operator()(const DependencyGroup::Ptr& dependencyGroup) const
+		{
+			size_t hash = 0;
+			for (const auto& [key, group] : dependencyGroup->m_Members) {
+				boost::hash_combine(hash, key);
+			}
+			return hash;
+		}
+	};
+
+	struct Equal
+	{
+		bool operator()(const DependencyGroup::Ptr& lhs, const DependencyGroup::Ptr& rhs) const
+		{
+			return std::equal(
+				lhs->m_Members.begin(), lhs->m_Members.end(),
+				rhs->m_Members.begin(), rhs->m_Members.end(),
+				[](const auto& l, const auto& r) { return l.first == r.first; }
+			);
+		}
+	};
 
 private:
 	mutable std::mutex m_Mutex;
@@ -193,25 +213,7 @@ private:
 	String m_RedundancyGroupName;
 	MembersMap m_Members;
 
-	using RegistryType = boost::multi_index_container<
-		DependencyGroup*, // The type of the elements stored in the container.
-		boost::multi_index::indexed_by<
-			// This unique index allows to search/erase dependency groups by their composite key in an efficient manner.
-			boost::multi_index::hashed_unique<
-				boost::multi_index::mem_fun<DependencyGroup, String, &DependencyGroup::GetCompositeKey>,
-				std::hash<String>
-			>,
-			// This non-unique index allows to search for dependency groups by their name, and reduces the overall
-			// runtime complexity. Without this index, we would have to iterate over all elements to find the one
-			// with the desired members and since containers don't allow erasing elements while iterating, we would
-			// have to copy each of them to a temporary container, and then erase and reinsert them back to the original
-			// container. This produces way too much overhead, and slows down the startup time of Icinga 2 significantly.
-			boost::multi_index::hashed_non_unique<
-				boost::multi_index::const_mem_fun<DependencyGroup, const String&, &DependencyGroup::GetName>,
-				std::hash<String>
-			>
-		>
-	>;
+	using RegistryType = std::unordered_set<DependencyGroup::Ptr, Hash, Equal>;
 
 	// The global registry of dependency groups.
 	static std::mutex m_RegistryMutex;

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -152,6 +152,8 @@ public:
 	}
 
 	bool IsEmpty() const;
+	void AddDependency(const Dependency::Ptr& dependency);
+	void RemoveDependency(const Dependency::Ptr& dependency);
 	std::vector<Dependency::Ptr> GetDependenciesForChild(const Checkable* child) const;
 	size_t GetDependenciesCount() const;
 
@@ -169,9 +171,7 @@ public:
 
 	State GetState(DependencyType dt = DependencyState, int rstack = 0) const;
 
-protected:
-	void AddDependency(const Dependency::Ptr& dependency);
-	void RemoveDependency(const Dependency::Ptr& dependency);
+private:
 	void CopyDependenciesTo(const DependencyGroup::Ptr& dest);
 
 	struct Hash

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -136,7 +136,7 @@ public:
 	DependencyGroup(String name, const std::set<Dependency::Ptr>& dependencies);
 
 	static DependencyGroup::Ptr Register(const DependencyGroup::Ptr& dependencyGroup);
-	static std::set<Dependency::Ptr> Unregister(const DependencyGroup::Ptr& dependencyGroup, const Checkable::Ptr& child);
+	static std::pair<std::set<Dependency::Ptr>, bool> Unregister(const DependencyGroup::Ptr& dependencyGroup, const Checkable::Ptr& child);
 	static size_t GetRegistrySize();
 
 	static CompositeKeyType MakeCompositeKeyFor(const Dependency::Ptr& dependency);
@@ -170,6 +170,9 @@ public:
 	};
 
 	State GetState(DependencyType dt = DependencyState, int rstack = 0) const;
+
+	static boost::signals2::signal<void(const Checkable::Ptr&, const DependencyGroup::Ptr&)> OnChildRegistered;
+	static boost::signals2::signal<void(const DependencyGroup::Ptr&, const std::vector<Dependency::Ptr>&, bool)> OnChildRemoved;
 
 private:
 	void CopyDependenciesTo(const DependencyGroup::Ptr& dest);

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -132,7 +132,6 @@ public:
 	using MemberValueType = std::unordered_multimap<const Checkable*, Dependency*>;
 	using MembersMap = std::map<CompositeKeyType, MemberValueType>;
 
-	explicit DependencyGroup(String name);
 	DependencyGroup(String name, const std::set<Dependency::Ptr>& dependencies);
 
 	static DependencyGroup::Ptr Register(const DependencyGroup::Ptr& dependencyGroup);
@@ -151,7 +150,7 @@ public:
 		return !m_RedundancyGroupName.IsEmpty();
 	}
 
-	bool IsEmpty() const;
+	bool HasChildren() const;
 	void AddDependency(const Dependency::Ptr& dependency);
 	void RemoveDependency(const Dependency::Ptr& dependency);
 	std::vector<Dependency::Ptr> GetDependenciesForChild(const Checkable* child) const;

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -155,6 +155,7 @@ public:
 	void AddDependency(const Dependency::Ptr& dependency);
 	void RemoveDependency(const Dependency::Ptr& dependency);
 	std::vector<Dependency::Ptr> GetDependenciesForChild(const Checkable* child) const;
+	void LoadParents(std::set<Checkable::Ptr>& parents) const;
 	size_t GetDependenciesCount() const;
 
 	void SetIcingaDBIdentifier(const String& identifier);

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -163,12 +163,7 @@ public:
 	const String& GetRedundancyGroupName() const;
 	String GetCompositeKey();
 
-	struct State
-	{
-		bool Reachable; // Whether the dependency group is reachable.
-		bool OK; // Whether the dependency group is reachable and OK.
-	};
-
+	enum class State { Ok, Failed, Unreachable };
 	State GetState(const Checkable* child, DependencyType dt = DependencyState, int rstack = 0) const;
 
 	static boost::signals2::signal<void(const Checkable::Ptr&, const DependencyGroup::Ptr&)> OnChildRegistered;

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -77,7 +77,7 @@ class Dependency : CustomVarObject < DependencyNameComposer
 		}}}
 	};
 
-	[config] String redundancy_group;
+	[config, no_user_modify] String redundancy_group;
 
 	[config, navigation] name(TimePeriod) period (PeriodRaw) {
 		navigate {{{

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -81,16 +81,16 @@ class Dependency : CustomVarObject < DependencyNameComposer
 
 	[config, no_user_modify] String redundancy_group;
 
-	[config, navigation] name(TimePeriod) period (PeriodRaw) {
+	[config, no_user_modify, navigation] name(TimePeriod) period (PeriodRaw) {
 		navigate {{{
 			return TimePeriod::GetByName(GetPeriodRaw());
 		}}}
 	};
 
-	[config] array(Value) states;
+	[config, no_user_modify] array(Value) states;
 	[no_user_view, no_user_modify] int state_filter_real (StateFilter);
 
-	[config] bool ignore_soft_states {
+	[config, no_user_modify] bool ignore_soft_states {
 		default {{{ return true; }}}
 	};
 

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -20,6 +20,8 @@ public:
 
 class Dependency : CustomVarObject < DependencyNameComposer
 {
+	activation_priority -10;
+
 	load_after Host;
 	load_after Service;
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1210,7 +1210,7 @@ void IcingaDB::InsertCheckableDependencies(
 					// to the DependencyEdgeState HMSETs. The latter is shared by all child Checkables of the current
 					// redundancy group, and since they all depend on the redundancy group, the state of that group is
 					// basically the state of the dependency edges between the children and the redundancy group.
-					auto stateAttrs(SerializeRedundancyGroupState(dependencyGroup));
+					auto stateAttrs(SerializeRedundancyGroupState(checkable, dependencyGroup));
 					AddDataToHmSets(hMSets, RedisKey::RedundancyGroupState, redundancyGroupId, stateAttrs);
 					AddDataToHmSets(hMSets, RedisKey::DependencyEdgeState, redundancyGroupId, Dictionary::Ptr(new Dictionary{
 						{"id", redundancyGroupId},
@@ -1416,7 +1416,7 @@ void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const De
 		}
 
 		if (isRedundancyGroup) {
-			Dictionary::Ptr stateAttrs(SerializeRedundancyGroupState(dependencyGroup));
+			Dictionary::Ptr stateAttrs(SerializeRedundancyGroupState(checkable, dependencyGroup));
 
 			Dictionary::Ptr sharedGroupState(stateAttrs->ShallowClone());
 			sharedGroupState->Remove("redundancy_group_id");

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1482,6 +1482,11 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 		attributes->Set("notes", checkable->GetNotes());
 		attributes->Set("icon_image_alt", checkable->GetIconImageAlt());
 
+		if (size_t totalChildren (checkable->GetAllChildrenCount()); totalChildren > 0) {
+			// Only set the Redis key if the Checkable has actually some child dependencies.
+			attributes->Set("total_children", totalChildren);
+		}
+
 		attributes->Set("checkcommand_id", GetObjectIdentifier(checkable->GetCheckCommand()));
 
 		Endpoint::Ptr commandEndpoint = checkable->GetCommandEndpoint();

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2828,6 +2828,7 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	attrs->Set("check_attempt", checkable->GetCheckAttempt());
 
 	attrs->Set("is_active", checkable->IsActive());
+	attrs->Set("affects_children", checkable->AffectsChildren());
 
 	CheckResult::Ptr cr = checkable->GetLastCheckResult();
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -273,11 +273,6 @@ void IcingaDB::UpdateAllConfigObjects()
 
 		upqObjectType.ParallelFor(objectChunks, [&](decltype(objectChunks)::const_reference chunk) {
 			std::map<String, std::vector<String>> hMSets;
-			// Two values are appended per object: Object ID (Hash encoded) and Object State (IcingaDB::SerializeState() -> JSON encoded)
-			std::vector<String> states = {"HMSET", m_PrefixConfigObject + lcType + ":state"};
-			// Two values are appended per object: Object ID (Hash encoded) and State Checksum ({ "checksum": checksum } -> JSON encoded)
-			std::vector<String> statesChksms = {"HMSET", m_PrefixConfigCheckSum + lcType + ":state"};
-			std::vector<std::vector<String> > transaction = {{"MULTI"}};
 			std::vector<String> hostZAdds = {"ZADD", "icinga:nextupdate:host"}, serviceZAdds = {"ZADD", "icinga:nextupdate:service"};
 
 			auto skimObjects ([&]() {
@@ -317,9 +312,11 @@ void IcingaDB::UpdateAllConfigObjects()
 					String objectKey = GetObjectIdentifier(object);
 					Dictionary::Ptr state = SerializeState(dynamic_pointer_cast<Checkable>(object));
 
+					auto& states = hMSets[m_PrefixConfigObject + lcType + ":state"];
 					states.emplace_back(objectKey);
 					states.emplace_back(JsonEncode(state));
 
+					auto& statesChksms = hMSets[m_PrefixConfigCheckSum + lcType + ":state"];
 					statesChksms.emplace_back(objectKey);
 					statesChksms.emplace_back(JsonEncode(new Dictionary({{"checksum", HashValue(state)}})));
 				}
@@ -328,27 +325,9 @@ void IcingaDB::UpdateAllConfigObjects()
 				if (!(bulkCounter % 100)) {
 					skimObjects();
 
-					for (auto& kv : hMSets) {
-						if (!kv.second.empty()) {
-							kv.second.insert(kv.second.begin(), {"HMSET", kv.first});
-							transaction.emplace_back(std::move(kv.second));
-						}
-					}
-
-					if (states.size() > 2) {
-						transaction.emplace_back(std::move(states));
-						transaction.emplace_back(std::move(statesChksms));
-						states = {"HMSET", m_PrefixConfigObject + lcType + ":state"};
-						statesChksms = {"HMSET", m_PrefixConfigCheckSum + lcType + ":state"};
-					}
+					ExecuteRedisTransaction(rcon, hMSets, {});
 
 					hMSets = decltype(hMSets)();
-
-					if (transaction.size() > 1) {
-						transaction.push_back({"EXEC"});
-						rcon->FireAndForgetQueries(std::move(transaction), Prio::Config);
-						transaction = {{"MULTI"}};
-					}
 				}
 
 				auto checkable (dynamic_pointer_cast<Checkable>(object));
@@ -371,22 +350,7 @@ void IcingaDB::UpdateAllConfigObjects()
 
 			skimObjects();
 
-			for (auto& kv : hMSets) {
-				if (!kv.second.empty()) {
-					kv.second.insert(kv.second.begin(), {"HMSET", kv.first});
-					transaction.emplace_back(std::move(kv.second));
-				}
-			}
-
-			if (states.size() > 2) {
-				transaction.emplace_back(std::move(states));
-				transaction.emplace_back(std::move(statesChksms));
-			}
-
-			if (transaction.size() > 1) {
-				transaction.push_back({"EXEC"});
-				rcon->FireAndForgetQueries(std::move(transaction), Prio::Config);
-			}
+			ExecuteRedisTransaction(rcon, hMSets, {});
 
 			for (auto zAdds : {&hostZAdds, &serviceZAdds}) {
 				if (zAdds->size() > 2u) {
@@ -1472,34 +1436,7 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 		UpdateState(checkable, runtimeUpdate ? StateUpdate::Full : StateUpdate::Volatile);
 	}
 
-	std::vector<std::vector<String> > transaction = {{"MULTI"}};
-
-	for (auto& kv : hMSets) {
-		if (!kv.second.empty()) {
-			kv.second.insert(kv.second.begin(), {"HMSET", kv.first});
-			transaction.emplace_back(std::move(kv.second));
-		}
-	}
-
-	for (auto& objectAttributes : runtimeUpdates) {
-		std::vector<String> xAdd({"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*"});
-		ObjectLock olock(objectAttributes);
-
-		for (const Dictionary::Pair& kv : objectAttributes) {
-			String value = IcingaToStreamValue(kv.second);
-			if (!value.IsEmpty()) {
-				xAdd.emplace_back(kv.first);
-				xAdd.emplace_back(value);
-			}
-		}
-
-		transaction.emplace_back(std::move(xAdd));
-	}
-
-	if (transaction.size() > 1) {
-		transaction.push_back({"EXEC"});
-		m_Rcon->FireAndForgetQueries(std::move(transaction), Prio::Config, {1});
-	}
+	ExecuteRedisTransaction(m_Rcon, hMSets, runtimeUpdates);
 
 	if (checkable) {
 		SendNextUpdate(checkable);
@@ -3295,4 +3232,53 @@ void IcingaDB::AddDataToHmSets(std::map<String, RedisConnection::Query>& hMSets,
 
 	query->emplace_back(id);
 	query->emplace_back(JsonEncode(data));
+}
+
+/**
+ * Execute the provided HMSET values and runtime updates in a single Redis transaction on the provided Redis connection.
+ *
+ * The HMSETs should just contain the necessary key value pairs to be set in Redis, i.e, without the HMSET command
+ * itself. This function will then go through each of the map keys and prepend the HMSET command when transforming the
+ * map into valid Redis queries. Likewise, the runtime updates should just contain the key value pairs to be streamed
+ * to the icinga:runtime pipeline, and this function will generate a XADD query for each one of the vector elements.
+ *
+ * @param rcon The Redis connection to execute the transaction on.
+ * @param hMSets A map of Redis keys and their respective HMSET values.
+ * @param runtimeUpdates A list of dictionaries to be sent to the icinga:runtime stream.
+ */
+void IcingaDB::ExecuteRedisTransaction(const RedisConnection::Ptr& rcon, std::map<String, RedisConnection::Query>& hMSets,
+	const std::vector<Dictionary::Ptr>& runtimeUpdates)
+{
+	RedisConnection::Queries transaction{{"MULTI"}};
+	for (auto& [redisKey, query] : hMSets) {
+		if (!query.empty()) {
+			query.insert(query.begin(), {"HSET", redisKey});
+			transaction.emplace_back(std::move(query));
+		}
+	}
+
+	for (auto& attrs : runtimeUpdates) {
+		RedisConnection::Query xAdd{"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*"};
+
+		ObjectLock olock(attrs);
+		for (auto& [key, value] : attrs) {
+			if (auto streamVal(IcingaToStreamValue(value)); !streamVal.IsEmpty()) {
+				xAdd.emplace_back(key);
+				xAdd.emplace_back(std::move(streamVal));
+			}
+		}
+
+		transaction.emplace_back(std::move(xAdd));
+	}
+
+	if (transaction.size() > 1) {
+		transaction.emplace_back(RedisConnection::Query{"EXEC"});
+		if (!runtimeUpdates.empty()) {
+			rcon->FireAndForgetQueries(std::move(transaction), Prio::Config, {1});
+		} else {
+			// This is likely triggered by the initial Redis config dump, so a) we don't need to record the number of
+			// affected objects and b) we don't really know how many objects are going to be affected by this tx.
+			rcon->FireAndForgetQueries(std::move(transaction), Prio::Config);
+		}
+	}
 }

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -3383,10 +3383,12 @@ void IcingaDB::DeleteState(const String& id, RedisKey redisKey, bool hasChecksum
 	hdels.emplace_back(RedisConnection::Query{"HDEL", m_PrefixConfigObject + redisKeyWithoutPrefix, id});
 
 	m_Rcon->FireAndForgetQueries(std::move(hdels), Prio::RuntimeStateSync);
-	m_Rcon->FireAndForgetQueries({{
+	// TODO: This is currently purposefully commented out due to how Icinga DB (Go) handles runtime state
+	//       upsert and delete events. See https://github.com/Icinga/icingadb/pull/894 for more details.
+	/*m_Rcon->FireAndForgetQueries({{
 		"XADD", "icinga:runtime:state", "MAXLEN", "~", "1000000", "*",
 		"redis_key", m_PrefixConfigObject + redisKeyWithoutPrefix, "id", id, "runtime_type", "delete"
-	}}, Prio::RuntimeStateStream, {0, 1});
+	}}, Prio::RuntimeStateStream, {0, 1});*/
 }
 
 /**

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -96,8 +96,11 @@ void IcingaDB::ConfigStaticInitialize()
 		AcknowledgementClearedHandler(checkable, removedBy, changeTime);
 	});
 
-	Checkable::OnReachabilityChanged.connect([](const Checkable::Ptr&, const CheckResult::Ptr&, std::set<Checkable::Ptr> children, const MessageOrigin::Ptr&) {
-		IcingaDB::ReachabilityChangeHandler(children);
+	Checkable::OnReachabilityChanged.connect([](const Checkable::Ptr& parent, const CheckResult::Ptr&, std::set<Checkable::Ptr>, const MessageOrigin::Ptr&) {
+		// Icinga DB Web needs to know about the reachability of all children, not just the direct ones.
+		// These might get updated with their next check result anyway, but we can't rely on that, since
+		// they might not be actively checked or have a very high check interval.
+		IcingaDB::ReachabilityChangeHandler(parent->GetAllChildren());
 	});
 
 	/* triggered on create, update and delete objects */

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -217,7 +217,9 @@ void IcingaDB::UpdateAllConfigObjects()
 		// This allows us to wait on both types to be dumped before we send a config dump done signal for those keys.
 		m_PrefixConfigObject + "dependency:node",
 		m_PrefixConfigObject + "dependency:edge",
+		m_PrefixConfigObject + "dependency:edge:state",
 		m_PrefixConfigObject + "redundancygroup",
+		m_PrefixConfigObject + "redundancygroup:state",
 	};
 	DeleteKeys(m_Rcon, globalKeys, Prio::Config);
 	DeleteKeys(m_Rcon, {"icinga:nextupdate:host", "icinga:nextupdate:service"}, Prio::Config);
@@ -1341,6 +1343,90 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, StateUpdate mode)
 		}
 
 		m_Rcon->FireAndForgetQuery(std::move(streamadd), Prio::RuntimeStateStream, {0, 1});
+	}
+}
+
+/**
+ * Send dependencies state information of the given Checkable to Redis.
+ *
+ * If the dependencyGroup parameter is set, only the dependencies state of that group are sent. Otherwise, all
+ * dependency groups of the provided Checkable are processed.
+ *
+ * @param checkable The Checkable you want to send the dependencies state update for
+ * @param onlyDependencyGroup If set, send state updates only for this dependency group and its dependencies.
+ */
+void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const DependencyGroup::Ptr& onlyDependencyGroup) const
+{
+	if (!m_Rcon || !m_Rcon->IsConnected()) {
+		return;
+	}
+
+	std::vector<DependencyGroup::Ptr> dependencyGroups{onlyDependencyGroup};
+	if (!onlyDependencyGroup) {
+		dependencyGroups = checkable->GetDependencyGroups();
+		if (dependencyGroups.empty()) {
+			return;
+		}
+	}
+
+	RedisConnection::Queries streamStates;
+	auto addDependencyStateToStream([this, &streamStates](const String& redisKey, const Dictionary::Ptr& stateAttrs) {
+		RedisConnection::Query xAdd{
+			"XADD", "icinga:runtime:state", "MAXLEN", "~", "1000000", "*", "runtime_type", "upsert",
+			"redis_key", redisKey
+		};
+		ObjectLock olock(stateAttrs);
+		for (auto& [key, value] : stateAttrs) {
+			xAdd.emplace_back(key);
+			xAdd.emplace_back(IcingaToStreamValue(value));
+		}
+		streamStates.emplace_back(std::move(xAdd));
+	});
+
+	for (auto& dependencyGroup : dependencyGroups) {
+		bool isRedundancyGroup(dependencyGroup->IsRedundancyGroup());
+		if (isRedundancyGroup && dependencyGroup->GetIcingaDBIdentifier().IsEmpty()) {
+			// Way too soon! The Icinga DB hash will be set during the initial config dump, but this state
+			// update seems to occur way too early. So, we've to skip it for now and wait for the next one.
+			// The m_ConfigDumpInProgress flag is probably still set to true at this point!
+			continue;
+		}
+
+		auto dependencies(dependencyGroup->GetDependenciesForChild(checkable.get()));
+		std::sort(dependencies.begin(), dependencies.end(), [](const Dependency::Ptr& lhs, const Dependency::Ptr& rhs) {
+			return lhs->GetParent() < rhs->GetParent();
+		});
+		for (auto it(dependencies.begin()); it != dependencies.end(); /* no increment */) {
+			const auto& dependency(*it);
+
+			Dictionary::Ptr stateAttrs;
+			// Note: The following loop is intended to cover some possible special cases but may not occur in practice
+			// that often. That is, having two or more dependency objects that point to the same parent Checkable.
+			// So, traverse all those duplicates and merge their relevant state information into a single edge.
+			for (; it != dependencies.end() && (*it)->GetParent() == dependency->GetParent(); ++it) {
+				if (!stateAttrs || stateAttrs->Get("failed") == false) {
+					stateAttrs = SerializeDependencyEdgeState(dependencyGroup, *it);
+				}
+			}
+
+			addDependencyStateToStream(m_PrefixConfigObject + "dependency:edge:state", stateAttrs);
+		}
+
+		if (isRedundancyGroup) {
+			Dictionary::Ptr stateAttrs(SerializeRedundancyGroupState(dependencyGroup));
+
+			Dictionary::Ptr sharedGroupState(stateAttrs->ShallowClone());
+			sharedGroupState->Remove("redundancy_group_id");
+			sharedGroupState->Remove("is_reachable");
+			sharedGroupState->Remove("last_state_change");
+
+			addDependencyStateToStream(m_PrefixConfigObject + "redundancygroup:state", stateAttrs);
+			addDependencyStateToStream(m_PrefixConfigObject + "dependency:edge:state", sharedGroupState);
+		}
+	}
+
+	if (!streamStates.empty()) {
+		m_Rcon->FireAndForgetQueries(std::move(streamStates), Prio::RuntimeStateStream, {0, 1});
 	}
 }
 
@@ -2933,6 +3019,7 @@ void IcingaDB::ReachabilityChangeHandler(const std::set<Checkable::Ptr>& childre
 	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		for (auto& checkable : children) {
 			rw->UpdateState(checkable, StateUpdate::Full);
+			rw->UpdateDependenciesState(checkable);
 		}
 	}
 }

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1386,6 +1386,7 @@ void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const De
 		streamStates.emplace_back(std::move(xAdd));
 	});
 
+	std::map<String, RedisConnection::Query> hMSets;
 	for (auto& dependencyGroup : dependencyGroups) {
 		bool isRedundancyGroup(dependencyGroup->IsRedundancyGroup());
 		if (isRedundancyGroup && dependencyGroup->GetIcingaDBIdentifier().IsEmpty()) {
@@ -1413,6 +1414,7 @@ void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const De
 			}
 
 			addDependencyStateToStream(m_PrefixConfigObject + "dependency:edge:state", stateAttrs);
+			AddDataToHmSets(hMSets, RedisKey::DependencyEdgeState, stateAttrs->Get("id"), stateAttrs);
 		}
 
 		if (isRedundancyGroup) {
@@ -1425,10 +1427,19 @@ void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const De
 
 			addDependencyStateToStream(m_PrefixConfigObject + "redundancygroup:state", stateAttrs);
 			addDependencyStateToStream(m_PrefixConfigObject + "dependency:edge:state", sharedGroupState);
+			AddDataToHmSets(hMSets, RedisKey::RedundancyGroupState, dependencyGroup->GetIcingaDBIdentifier(), stateAttrs);
+			AddDataToHmSets(hMSets, RedisKey::DependencyEdgeState, dependencyGroup->GetIcingaDBIdentifier(), sharedGroupState);
 		}
 	}
 
 	if (!streamStates.empty()) {
+		RedisConnection::Queries queries;
+		for (auto& [redisKey, query] : hMSets) {
+			query.insert(query.begin(), {"HSET", redisKey});
+			queries.emplace_back(std::move(query));
+		}
+
+		m_Rcon->FireAndForgetQueries(std::move(queries), Prio::RuntimeStateSync);
 		m_Rcon->FireAndForgetQueries(std::move(streamStates), Prio::RuntimeStateStream, {0, 1});
 	}
 }

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -62,7 +62,6 @@ std::vector<Type::Ptr> IcingaDB::GetTypes()
 		// Then sync them for similar reasons.
 		Downtime::TypeInstance,
 		Comment::TypeInstance,
-		Dependency::TypeInstance,
 
 		HostGroup::TypeInstance,
 		ServiceGroup::TypeInstance,
@@ -208,10 +207,17 @@ void IcingaDB::UpdateAllConfigObjects()
 	m_Rcon->FireAndForgetQuery({"XADD", "icinga:dump", "MAXLEN", "1", "*", "key", "*", "state", "wip"}, Prio::Config);
 
 	const std::vector<String> globalKeys = {
-			m_PrefixConfigObject + "customvar",
-			m_PrefixConfigObject + "action:url",
-			m_PrefixConfigObject + "notes:url",
-			m_PrefixConfigObject + "icon:image",
+		m_PrefixConfigObject + "customvar",
+		m_PrefixConfigObject + "action:url",
+		m_PrefixConfigObject + "notes:url",
+		m_PrefixConfigObject + "icon:image",
+
+		// These keys aren't tied to a specific Checkable type but apply to both "Host" and "Service" types,
+		// and as such we've to make sure to clear them before we actually start dumping the actual objects.
+		// This allows us to wait on both types to be dumped before we send a config dump done signal for those keys.
+		m_PrefixConfigObject + "dependency:node",
+		m_PrefixConfigObject + "dependency:edge",
+		m_PrefixConfigObject + "redundancygroup",
 	};
 	DeleteKeys(m_Rcon, globalKeys, Prio::Config);
 	DeleteKeys(m_Rcon, {"icinga:nextupdate:host", "icinga:nextupdate:service"}, Prio::Config);
@@ -222,6 +228,7 @@ void IcingaDB::UpdateAllConfigObjects()
 		m_DumpedGlobals.ActionUrl.Reset();
 		m_DumpedGlobals.NotesUrl.Reset();
 		m_DumpedGlobals.IconImage.Reset();
+		m_DumpedGlobals.DependencyGroup.Reset();
 	});
 
 	upq.ParallelFor(types, false, [this](const Type::Ptr& type) {
@@ -793,138 +800,9 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 			}
 		}
 
+		InsertCheckableDependencies(checkable, hMSets, runtimeUpdate ? &runtimeUpdates : nullptr);
+
 		return;
-	}
-
-	if (type == Dependency::TypeInstance) {
-		auto& dependencyNodes (hMSets[m_PrefixConfigObject + "dependency:node"]);
-		auto& dependencyEdges (hMSets[m_PrefixConfigObject + "dependency:edge"]);
-		auto& redundancyGroups (hMSets[m_PrefixConfigObject + "redundancygroup"]);
-
-		Dependency::Ptr dependency = static_pointer_cast<Dependency>(object);
-
-		Host::Ptr parentHost, childHost;
-		Service::Ptr parentService, childService;
-		tie(parentHost, parentService) = GetHostService(dependency->GetParent());
-		tie(childHost, childService) = GetHostService(dependency->GetChild());
-		String redundancyGroup = dependency->GetRedundancyGroup();
-
-		String redundancyGroupId, dependencyNodeParentId, dependencyNodeChildId, dependencyNodeReduId;
-
-		Dictionary::Ptr parentNodeData, childNodeData;
-
-		if (parentService) {
-			dependencyNodeParentId = HashValue(new Array({
-						m_EnvironmentId,
-						GetObjectIdentifier(parentHost),
-						GetObjectIdentifier(parentService)}));
-			parentNodeData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"host_id", GetObjectIdentifier(parentHost)},
-					{"service_id", GetObjectIdentifier(parentService)}});
-
-			m_CheckablesToDependencies->Set(GetObjectIdentifier(parentService), dependency);
-		} else {
-			dependencyNodeParentId = HashValue(new Array({
-						m_EnvironmentId,
-						GetObjectIdentifier(parentHost)}));
-			parentNodeData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"host_id", GetObjectIdentifier(parentHost)}});
-
-			m_CheckablesToDependencies->Set(GetObjectIdentifier(parentHost), dependency);
-		}
-
-		if (childService) {
-			dependencyNodeChildId = HashValue(new Array({
-						m_EnvironmentId,
-						GetObjectIdentifier(childHost),
-						GetObjectIdentifier(childService)}));
-			childNodeData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"host_id", GetObjectIdentifier(childHost)},
-					{"service_id", GetObjectIdentifier(childService)}});
-
-			m_CheckablesToDependencies->Set(GetObjectIdentifier(childService), dependency);
-		} else {
-			dependencyNodeChildId = HashValue(new Array({
-						m_EnvironmentId,
-						GetObjectIdentifier(childHost)}));
-			childNodeData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"host_id", GetObjectIdentifier(childHost)}});
-
-			m_CheckablesToDependencies->Set(GetObjectIdentifier(childHost), dependency);
-		}
-
-		dependencyNodes.emplace_back(dependencyNodeParentId);
-		dependencyNodes.emplace_back(JsonEncode(parentNodeData));
-		dependencyNodes.emplace_back(dependencyNodeChildId);
-		dependencyNodes.emplace_back(JsonEncode(childNodeData));
-
-		if (runtimeUpdate) {
-			AddObjectDataToRuntimeUpdates(runtimeUpdates, dependencyNodeParentId, m_PrefixConfigObject + "dependency:node", parentNodeData);
-			AddObjectDataToRuntimeUpdates(runtimeUpdates, dependencyNodeChildId, m_PrefixConfigObject + "dependency:node", childNodeData);
-		}
-
-		if (!redundancyGroup.IsEmpty()) {
-			/* TODO: name should be suffixed with names of all children.
-			 * however, at this point I don't have this information,
-			 * only the direct neighbors.
-			 */
-			redundancyGroupId = HashValue(new Array({m_EnvironmentId, redundancyGroup, dependencyNodeChildId}));
-			dependencyNodeReduId = redundancyGroupId;
-
-			redundancyGroups.emplace_back(redundancyGroupId);
-			Dictionary::Ptr groupData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"name", redundancyGroupId},
-					{"display_name", redundancyGroup}});
-			redundancyGroups.emplace_back(JsonEncode(groupData));
-
-			dependencyNodes.emplace_back(dependencyNodeReduId);
-			Dictionary::Ptr reduNodeData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"redundancy_group_id", redundancyGroupId}});
-			dependencyNodes.emplace_back(JsonEncode(reduNodeData));
-
-			String edgeInId = HashValue(new Array({m_EnvironmentId, dependencyNodeChildId, dependencyNodeReduId}));
-			dependencyEdges.emplace_back(edgeInId);
-			Dictionary::Ptr edgeInData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"from_node_id", dependencyNodeChildId},
-					{"to_node_id", dependencyNodeReduId}});
-			dependencyEdges.emplace_back(JsonEncode(edgeInData));
-
-			String edgeOutId = HashValue(new Array({m_EnvironmentId, dependencyNodeReduId, dependencyNodeParentId}));
-			dependencyEdges.emplace_back(edgeOutId);
-			Dictionary::Ptr edgeOutData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"from_node_id", dependencyNodeReduId},
-					{"to_node_id", dependencyNodeParentId},
-					{"dependency_id", GetObjectIdentifier(dependency)}});
-			dependencyEdges.emplace_back(JsonEncode(edgeOutData));
-
-			if (runtimeUpdate) {
-				AddObjectDataToRuntimeUpdates(runtimeUpdates, redundancyGroupId, m_PrefixConfigObject + "redundancygroup", groupData);
-				AddObjectDataToRuntimeUpdates(runtimeUpdates, dependencyNodeReduId, m_PrefixConfigObject + "dependency:node", reduNodeData);
-				AddObjectDataToRuntimeUpdates(runtimeUpdates, edgeInId, m_PrefixConfigObject + "dependency:edge", edgeInData);
-				AddObjectDataToRuntimeUpdates(runtimeUpdates, edgeOutId, m_PrefixConfigObject + "dependency:edge", edgeOutData);
-			}
-		} else {
-			String edgeId = HashValue(new Array({m_EnvironmentId, dependencyNodeChildId, dependencyNodeParentId}));
-			dependencyEdges.emplace_back(edgeId);
-			Dictionary::Ptr edgeData = new Dictionary({
-					{"environment_id", m_EnvironmentId},
-					{"from_node_id", dependencyNodeChildId},
-					{"to_node_id", dependencyNodeParentId},
-					{"dependency_id", GetObjectIdentifier(dependency)}});
-			dependencyEdges.emplace_back(JsonEncode(edgeData));
-
-			if (runtimeUpdate) {
-				AddObjectDataToRuntimeUpdates(runtimeUpdates, edgeId, m_PrefixConfigObject + "dependency:edge", edgeData);
-			}
-		}
 	}
 
 	if (type == TimePeriod::TypeInstance) {
@@ -1257,44 +1135,156 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 	}
 }
 
-void IcingaDB::UpdateDependencyState(const Dependency::Ptr& dependency)
+/**
+ * Inserts the dependency data for a Checkable object into the given Redis HMSETs and runtime updates.
+ *
+ * This function is responsible for serializing the in memory representation Checkable dependencies into
+ * Redis HMSETs and runtime updates (if any) according to the Icinga DB schema. The serialized data consists
+ * of the following Redis HMSETs:
+ * - RedisKey::DependencyNode: Contains dependency node data representing each host, service, and redundancy group
+ *   in the dependency graph.
+ * - RedisKey::DependencyEdge: Dependency edge information representing all connections between the nodes.
+ * - RedisKey::RedundancyGroup: Redundancy group data representing all redundancy groups in the graph.
+ *
+ * For initial dumps, it shouldn't be necessary to set the `runtimeUpdates` parameter.
+ *
+ * @param checkable The checkable object to extract dependencies from.
+ * @param hMSets The map of Redis HMSETs to insert the dependency data into.
+ * @param runtimeUpdates If set, runtime updates are additionally added to this vector.
+ */
+void IcingaDB::InsertCheckableDependencies(
+	const Checkable::Ptr& checkable,
+	std::map<String, RedisConnection::Query>& hMSets,
+	std::vector<Dictionary::Ptr>* runtimeUpdates
+)
 {
-	if (!m_Rcon || !m_Rcon->IsConnected()) {
+	// Only generate a dependency node event if the Checkable is actually part of some dependency graph.
+	// That's, it either depends on other Checkables or others depend on it, and in both cases, we have
+	// to at least generate a dependency node entry for it.
+	if (!checkable->HasAnyDependencies()) {
 		return;
 	}
 
-	auto& redundancyGroupStates (hMSets[m_PrefixConfigObject + "redundancygroup:state"]);
+	// First and foremost, generate a dependency node entry for the provided Checkable object and insert it into
+	// the HMSETs map and if set, the `runtimeUpdates` vector.
+	auto [host, service] = GetHostService(checkable);
+	auto checkableId(GetObjectIdentifier(checkable));
+	{
+		Dictionary::Ptr data(new Dictionary{{"environment_id", m_EnvironmentId}, {"host_id", GetObjectIdentifier(host)}});
+		if (service) {
+			data->Set("service_id", checkableId);
+		}
 
-	String redundancyGroup = dependency->GetRedundancyGroup();
+		AddDataToHmSets(hMSets, RedisKey::DependencyNode, checkableId, data);
+		if (runtimeUpdates) {
+			AddObjectDataToRuntimeUpdates(*runtimeUpdates, checkableId, m_PrefixConfigObject + "dependency:node", data);
+		}
+	}
 
-	if (!redundancyGroup.IsEmpty()) {
-		Host::Ptr childHost;
-		Service::Ptr childService;
-		tie(childHost, childService) = GetHostService(dependency->GetChild());
+	for (auto& dependencyGroup : checkable->GetDependencyGroups()) {
+		String edgeFromNodeId(checkableId);
 
-		String dependencyNodeChildId = HashValue(
-					(childService)
-					? new Array({ m_EnvironmentId, GetObjectIdentifier(childHost), GetObjectIdentifier(childService) })
-					: new Array({ m_EnvironmentId, GetObjectIdentifier(childHost) }));
-		String redundancyGroupId = HashValue(new Array({
-					m_EnvironmentId,
-					redundancyGroup,
-					dependencyNodeChildId}));
+		if (dependencyGroup->IsRedundancyGroup()) {
+			auto redundancyGroupId(HashValue(new Array{m_EnvironmentId, dependencyGroup->GetCompositeKey()}));
+			dependencyGroup->SetIcingaDBIdentifier(redundancyGroupId);
 
-		redundancyGroupStates.emplace_back(redundancyGroupId);
-		Dictionary::Ptr groupStateData = new Dictionary({
+			edgeFromNodeId = redundancyGroupId;
+
+			// During the initial config sync, multiple children can depend on the same redundancy group, sync it only
+			// the first time it is encountered. Though, if this is a runtime update, we have to re-serialize and sync
+			// the redundancy group unconditionally, as we don't know whether it was already synced or the context that
+			// triggered this update.
+			if (runtimeUpdates || m_DumpedGlobals.DependencyGroup.IsNew(redundancyGroupId)) {
+				Dictionary::Ptr groupData(new Dictionary{
+					{"environment_id", m_EnvironmentId},
+					{"display_name", dependencyGroup->GetRedundancyGroupName()},
+				});
+				// Set/refresh the redundancy group data in the Redis HMSETs (redundancy_group database table).
+				AddDataToHmSets(hMSets, RedisKey::RedundancyGroup, redundancyGroupId, groupData);
+
+				Dictionary::Ptr nodeData(new Dictionary{
+					{"environment_id", m_EnvironmentId},
+					{"redundancy_group_id", redundancyGroupId},
+				});
+				// Obviously, the redundancy group is part of some dependency chain, thus we have to generate
+				// dependency node entry for it as well.
+				AddDataToHmSets(hMSets, RedisKey::DependencyNode, redundancyGroupId, nodeData);
+
+				if (runtimeUpdates) {
+					// Send the same data sent to the Redis HMSETs to the runtime updates stream as well.
+					AddObjectDataToRuntimeUpdates(*runtimeUpdates, redundancyGroupId, m_PrefixConfigObject + "redundancygroup", groupData);
+					AddObjectDataToRuntimeUpdates(*runtimeUpdates, redundancyGroupId, m_PrefixConfigObject + "dependency:node", nodeData);
+				}
+			}
+
+			Dictionary::Ptr data(new Dictionary{
 				{"environment_id", m_EnvironmentId},
-				{"redundancy_group_id", redundancyGroupId},
-				{"failed", !((childService) ? childService->IsReachable() : childHost->IsReachable())},
-				{"last_state_change", TimestampToMilliseconds(Utility::GetTime())}});
-		redundancyGroupStates.emplace_back(JsonEncode(groupStateData));
+				{"from_node_id", checkableId},
+				{"to_node_id", redundancyGroupId},
+				// All redundancy group members share the same state, thus use the group ID as a reference.
+				{"dependency_edge_state_id", redundancyGroupId},
+				{"display_name", dependencyGroup->GetRedundancyGroupName()},
+			});
 
-		// TODO
-		// AddObjectDataToRuntimeUpdates(runtimeUpdates, redundancyGroupId, m_PrefixConfigObject + "redundancygroup:state", groupStateData);
-		// dataClone->Set("id", objectKey); 		// redundancyGroupId
-		// dataClone->Set("redis_key", redisKey); 	// m_PrefixConfigObject + "redundancygroup:state"
-		// dataClone->Set("runtime_type", "upsert");
-		// runtimeUpdates.emplace_back(dataClone);
+			// Generate a dependency edge entry representing the connection between the Checkable and the redundancy
+			// group. This Checkable dependes on the redundancy group (is a child of it), thus the "dependency_edge_state_id"
+			// is set to the redundancy group ID. Note that if this group has multiple children, they all will have the
+			// same "dependency_edge_state_id" value.
+			auto edgeId(HashValue(new Array{checkableId, redundancyGroupId}));
+			AddDataToHmSets(hMSets, RedisKey::DependencyEdge, edgeId, data);
+
+			if (runtimeUpdates) {
+				AddObjectDataToRuntimeUpdates(*runtimeUpdates, edgeId, m_PrefixConfigObject + "dependency:edge", data);
+			}
+		}
+
+		auto dependencies(dependencyGroup->GetDependenciesForChild(checkable.get()));
+		// Sort the dependencies by their parent Checkable object to ensure that all dependency objects that share the
+		// same parent Checkable are placed next to each other in the container. See the while loop below for more info!
+		std::sort(dependencies.begin(), dependencies.end(), [](const Dependency::Ptr& lhs, const Dependency::Ptr& rhs) {
+			return lhs->GetParent() < rhs->GetParent();
+		});
+
+		// Traverse through each dependency objects within the current dependency group the provided Checkable depend
+		// on and generate a dependency edge entry. The generated dependency edge "from_node_id" may vary depending on
+		// whether the dependency group is a redundancy group or not. If it's a redundancy group, the "from_node_id"
+		// will be the redundancy group ID; otherwise, it will be the current Checkable ID. However, the "to_node_id"
+		// value will always be the parent Checkable ID of the dependency object.
+		for (auto it(dependencies.begin()); it != dependencies.end(); /* no increment */) {
+			auto dependency(*it);
+			auto parent(dependency->GetParent());
+			auto displayName(dependency->GetShortName());
+
+			// In case there are multiple Dependency objects with the same parent, these are merged into a single edge
+			// to prevent duplicate edges in the resulting graph. All objects with the same parent were placed next to
+			// each other by the sort function above.
+			//
+			// Additionally, the iterator for the surrounding loop is incremented by this loop: after it has finished,
+			// "it" will either point to the next dependency with a different parent or to the end of the container.
+			while (++it != dependencies.end() && (*it)->GetParent() == parent) {
+				displayName += ", " + (*it)->GetShortName();
+			}
+
+			Dictionary::Ptr data(new Dictionary{
+				{"environment_id", m_EnvironmentId},
+				{"from_node_id", edgeFromNodeId},
+				{"to_node_id", GetObjectIdentifier(parent)},
+				{"dependency_edge_state_id", HashValue(new Array{
+					dependencyGroup->IsRedundancyGroup()
+					? dependencyGroup->GetIcingaDBIdentifier()
+					: dependencyGroup->GetCompositeKey(),
+					GetObjectIdentifier(dependency->GetParent()),
+				})},
+				{"display_name", std::move(displayName)},
+			});
+
+			auto edgeId(HashValue(new Array{data->Get("from_node_id"), data->Get("to_node_id")}));
+			AddDataToHmSets(hMSets, RedisKey::DependencyEdge, edgeId, data);
+
+			if (runtimeUpdates) {
+				AddObjectDataToRuntimeUpdates(*runtimeUpdates, edgeId, m_PrefixConfigObject + "dependency:edge", data);
+			}
+		}
 	}
 }
 
@@ -1627,32 +1617,6 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 
 		if (expireTime > 0) {
 			attributes->Set("expire_time", TimestampToMilliseconds(expireTime));
-		}
-
-		return true;
-	}
-
-	if (type == Dependency::TypeInstance) {
-		Dependency::Ptr dependency = static_pointer_cast<Dependency>(object);
-		String redundancyGroup = dependency->GetRedundancyGroup();
-
-		attributes->Set("name", GetObjectIdentifier(dependency));
-
-		if (!redundancyGroup.IsEmpty()) {
-			Host::Ptr childHost;
-			Service::Ptr childService;
-			tie(childHost, childService) = GetHostService(dependency->GetChild());
-
-			String dependencyNodeChildId = HashValue(
-						(childService)
-						? new Array({ m_EnvironmentId, GetObjectIdentifier(childHost), GetObjectIdentifier(childService) })
-						: new Array({ m_EnvironmentId, GetObjectIdentifier(childHost) }));
-			String redundancyGroupId = HashValue(new Array({
-						m_EnvironmentId,
-						redundancyGroup,
-						dependencyNodeChildId}));
-
-			attributes->Set("redundancy_group_id", redundancyGroupId);
 		}
 
 		return true;
@@ -3181,4 +3145,36 @@ void IcingaDB::DeleteRelationship(const String& id, const String& redisKeyWithou
 	});
 
 	m_Rcon->FireAndForgetQueries(queries, Prio::Config);
+}
+
+/**
+ * Add the provided data to the Redis HMSETs map.
+ *
+ * Adds the provided data to the Redis HMSETs map for the provided Redis key. The actual Redis key is determined by
+ * the provided RedisKey enum. The data will be json encoded before being added to the Redis HMSETs map.
+ *
+ * @param hMSets The map of RedisConnection::Query you want to add the data to.
+ * @param redisKey The key of the Redis object you want to add the data to.
+ * @param id Unique Redis identifier for the provided data.
+ * @param data The actual data you want to add the Redis HMSETs map.
+ */
+void IcingaDB::AddDataToHmSets(std::map<String, RedisConnection::Query>& hMSets, RedisKey redisKey, const String& id, const Dictionary::Ptr& data) const
+{
+	RedisConnection::Query* query;
+	switch (redisKey) {
+		case RedisKey::RedundancyGroup:
+			query = &hMSets[m_PrefixConfigObject + "redundancygroup"];
+			break;
+		case RedisKey::DependencyNode:
+			query = &hMSets[m_PrefixConfigObject + "dependency:node"];
+			break;
+		case RedisKey::DependencyEdge:
+			query = &hMSets[m_PrefixConfigObject + "dependency:edge"];
+			break;
+		default:
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid RedisKey provided"));
+	}
+
+	query->emplace_back(id);
+	query->emplace_back(JsonEncode(data));
 }

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -179,7 +179,7 @@ void IcingaDB::ConfigStaticInitialize()
 void IcingaDB::UpdateAllConfigObjects()
 {
 	m_Rcon->Sync();
-	m_Rcon->FireAndForgetQuery({"XADD", "icinga:schema", "MAXLEN", "1", "*", "version", "5"}, Prio::Heartbeat);
+	m_Rcon->FireAndForgetQuery({"XADD", "icinga:schema", "MAXLEN", "1", "*", "version", "6"}, Prio::Heartbeat);
 
 	Log(LogInformation, "IcingaDB") << "Starting initial config/status dump";
 	double startTime = Utility::GetTime();

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -213,8 +213,8 @@ Dictionary::Ptr IcingaDB::SerializeRedundancyGroupState(const Checkable::Ptr& ch
 		{"id", redundancyGroup->GetIcingaDBIdentifier()},
 		{"environment_id", m_EnvironmentId},
 		{"redundancy_group_id", redundancyGroup->GetIcingaDBIdentifier()},
-		{"failed", !state.Reachable || !state.OK},
-		{"is_reachable", state.Reachable},
+		{"failed", state != DependencyGroup::State::Ok},
+		{"is_reachable", state != DependencyGroup::State::Unreachable},
 		{"last_state_change", TimestampToMilliseconds(Utility::GetTime())},
 	};
 }

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -159,6 +159,65 @@ Dictionary::Ptr IcingaDB::SerializeVars(const Dictionary::Ptr& vars)
 	return res;
 }
 
+/**
+ * Serialize a dependency edge state for Icinga DB
+ *
+ * @param dependencyGroup The state of the group the dependency is part of.
+ * @param dep The dependency object to serialize.
+ *
+ * @return A dictionary with the serialized state.
+ */
+Dictionary::Ptr IcingaDB::SerializeDependencyEdgeState(const DependencyGroup::Ptr& dependencyGroup, const Dependency::Ptr& dep)
+{
+	String edgeStateId;
+	// The edge state ID is computed a bit differently depending on whether this is for a redundancy group or not.
+	// For redundancy groups, the state ID is supposed to represent the connection state between the redundancy group
+	// and the parent Checkable of the given dependency. Hence, the outcome will always be different for each parent
+	// Checkable of the redundancy group.
+	if (dependencyGroup->IsRedundancyGroup()) {
+		edgeStateId = HashValue(new Array{
+			dependencyGroup->GetIcingaDBIdentifier(),
+			GetObjectIdentifier(dep->GetParent()),
+		});
+	} else if (dependencyGroup->GetIcingaDBIdentifier().IsEmpty()) {
+		// For non-redundant dependency groups, on the other hand, all dependency objects within that group will
+		// always have the same parent Checkable. Likewise, the state ID will be always the same as well it doesn't
+		// matter which dependency object is used to compute it. Therefore, it's sufficient to compute it only once
+		// and all the other dependency objects can reuse the cached state ID.
+		edgeStateId = HashValue(new Array{dependencyGroup->GetCompositeKey(), GetObjectIdentifier(dep->GetParent())});
+		dependencyGroup->SetIcingaDBIdentifier(edgeStateId);
+	} else {
+		// Use the already computed state ID for the dependency group.
+		edgeStateId = dependencyGroup->GetIcingaDBIdentifier();
+	}
+
+	return new Dictionary{
+		{"id", std::move(edgeStateId)},
+		{"environment_id", m_EnvironmentId},
+		{"failed", !dep->IsAvailable(DependencyState) || !dep->GetParent()->IsReachable()}
+	};
+}
+
+/**
+ * Serialize the provided redundancy group state attributes.
+ *
+ * @param redundancyGroup The redundancy group object to serialize the state for.
+ *
+ * @return A dictionary with the serialized redundancy group state.
+ */
+Dictionary::Ptr IcingaDB::SerializeRedundancyGroupState(const DependencyGroup::Ptr& redundancyGroup)
+{
+	auto state(redundancyGroup->GetState());
+	return new Dictionary{
+		{"id", redundancyGroup->GetIcingaDBIdentifier()},
+		{"environment_id", m_EnvironmentId},
+		{"redundancy_group_id", redundancyGroup->GetIcingaDBIdentifier()},
+		{"failed", !state.Reachable || !state.OK},
+		{"is_reachable", state.Reachable},
+		{"last_state_change", TimestampToMilliseconds(Utility::GetTime())},
+	};
+}
+
 const char* IcingaDB::GetNotificationTypeByEnum(NotificationType type)
 {
 	switch (type) {

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -201,13 +201,14 @@ Dictionary::Ptr IcingaDB::SerializeDependencyEdgeState(const DependencyGroup::Pt
 /**
  * Serialize the provided redundancy group state attributes.
  *
+ * @param child The child checkable object to serialize the state for.
  * @param redundancyGroup The redundancy group object to serialize the state for.
  *
  * @return A dictionary with the serialized redundancy group state.
  */
-Dictionary::Ptr IcingaDB::SerializeRedundancyGroupState(const DependencyGroup::Ptr& redundancyGroup)
+Dictionary::Ptr IcingaDB::SerializeRedundancyGroupState(const Checkable::Ptr& child, const DependencyGroup::Ptr& redundancyGroup)
 {
-	auto state(redundancyGroup->GetState());
+	auto state(redundancyGroup->GetState(child.get()));
 	return new Dictionary{
 		{"id", redundancyGroup->GetIcingaDBIdentifier()},
 		{"environment_id", m_EnvironmentId},

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -38,8 +38,6 @@ IcingaDB::IcingaDB()
 
 	m_PrefixConfigObject = "icinga:";
 	m_PrefixConfigCheckSum = "icinga:checksum:";
-
-	m_CheckablesToDependencies = new Dictionary();
 }
 
 void IcingaDB::Validate(int types, const ValidationUtils& utils)

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -38,6 +38,8 @@ IcingaDB::IcingaDB()
 
 	m_PrefixConfigObject = "icinga:";
 	m_PrefixConfigCheckSum = "icinga:checksum:";
+
+	m_CheckablesToDependencies = new Dictionary();
 }
 
 void IcingaDB::Validate(int types, const ValidationUtils& utils)

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -114,6 +114,7 @@ private:
 			std::vector<Dictionary::Ptr>* runtimeUpdates);
 	void InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
 			std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
+	void UpdateDependenciesState(const Checkable::Ptr& checkable, const DependencyGroup::Ptr& onlyDependencyGroup = nullptr) const;
 	void UpdateState(const Checkable::Ptr& checkable, StateUpdate mode);
 	void SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpdate);
 	void CreateConfigUpdate(const ConfigObject::Ptr& object, const String type, std::map<String, std::vector<String>>& hMSets,
@@ -169,6 +170,8 @@ private:
 	static String CalcEventID(const char* eventType, const ConfigObject::Ptr& object, double eventTime = 0, NotificationType nt = NotificationType(0));
 	static const char* GetNotificationTypeByEnum(NotificationType type);
 	static Dictionary::Ptr SerializeVars(const Dictionary::Ptr& vars);
+	static Dictionary::Ptr SerializeDependencyEdgeState(const DependencyGroup::Ptr& dependencyGroup, const Dependency::Ptr& dep);
+	static Dictionary::Ptr SerializeRedundancyGroupState(const DependencyGroup::Ptr& redundancyGroup);
 
 	static String HashValue(const Value& value);
 	static String HashValue(const Value& value, const std::set<String>& propertiesBlacklist, bool propertiesWhitelist = false);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -175,7 +175,7 @@ private:
 	static const char* GetNotificationTypeByEnum(NotificationType type);
 	static Dictionary::Ptr SerializeVars(const Dictionary::Ptr& vars);
 	static Dictionary::Ptr SerializeDependencyEdgeState(const DependencyGroup::Ptr& dependencyGroup, const Dependency::Ptr& dep);
-	static Dictionary::Ptr SerializeRedundancyGroupState(const DependencyGroup::Ptr& redundancyGroup);
+	static Dictionary::Ptr SerializeRedundancyGroupState(const Checkable::Ptr& child, const DependencyGroup::Ptr& redundancyGroup);
 
 	static String HashValue(const Value& value);
 	static String HashValue(const Value& value, const std::set<String>& propertiesBlacklist, bool propertiesWhitelist = false);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -103,6 +103,7 @@ private:
 	std::vector<String> GetTypeDumpSignalKeys(const Type::Ptr& type);
 	void InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
 			std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
+	void UpdateDependencyState(const Dependency::Ptr& dependency);
 	void UpdateState(const Checkable::Ptr& checkable, StateUpdate mode);
 	void SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpdate);
 	void CreateConfigUpdate(const ConfigObject::Ptr& object, const String type, std::map<String, std::vector<String>>& hMSets,
@@ -223,6 +224,8 @@ private:
 	Locked<RedisConnection::Ptr> m_RconLocked;
 	std::unordered_map<ConfigType*, RedisConnection::Ptr> m_Rcons;
 	std::atomic_size_t m_PendingRcons;
+
+	Dictionary::Ptr m_CheckablesToDependencies;
 
 	struct {
 		DumpedGlobals CustomVar, ActionUrl, NotesUrl, IconImage;

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -210,6 +210,9 @@ private:
 	static void CommandArgumentsChangedHandler(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
 	static void CustomVarsChangedHandler(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
 
+	static void ExecuteRedisTransaction(const RedisConnection::Ptr& rcon, std::map<String, RedisConnection::Query>& hMSets,
+		const std::vector<Dictionary::Ptr>& runtimeUpdates);
+
 	void AssertOnWorkQueue();
 
 	void ExceptionHandler(boost::exception_ptr exp);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -114,7 +114,8 @@ private:
 		std::vector<Dictionary::Ptr>* runtimeUpdates, const DependencyGroup::Ptr& onlyDependencyGroup = nullptr);
 	void InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
 			std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
-	void UpdateDependenciesState(const Checkable::Ptr& checkable, const DependencyGroup::Ptr& onlyDependencyGroup = nullptr) const;
+	void UpdateDependenciesState(const Checkable::Ptr& checkable, const DependencyGroup::Ptr& onlyDependencyGroup = nullptr,
+		std::set<DependencyGroup*>* seenGroups = nullptr) const;
 	void UpdateState(const Checkable::Ptr& checkable, StateUpdate mode);
 	void SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpdate);
 	void CreateConfigUpdate(const ConfigObject::Ptr& object, const String type, std::map<String, std::vector<String>>& hMSets,

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -111,7 +111,7 @@ private:
 	std::vector<String> GetTypeOverwriteKeys(const String& type);
 	std::vector<String> GetTypeDumpSignalKeys(const Type::Ptr& type);
 	void InsertCheckableDependencies(const Checkable::Ptr& checkable, std::map<String, RedisConnection::Query>& hMSets,
-			std::vector<Dictionary::Ptr>* runtimeUpdates);
+		std::vector<Dictionary::Ptr>* runtimeUpdates, const DependencyGroup::Ptr& onlyDependencyGroup = nullptr);
 	void InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
 			std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
 	void UpdateDependenciesState(const Checkable::Ptr& checkable, const DependencyGroup::Ptr& onlyDependencyGroup = nullptr) const;
@@ -124,6 +124,8 @@ private:
 	void AddObjectDataToRuntimeUpdates(std::vector<Dictionary::Ptr>& runtimeUpdates, const String& objectKey,
 			const String& redisKey, const Dictionary::Ptr& data);
 	void DeleteRelationship(const String& id, const String& redisKeyWithoutPrefix, bool hasChecksum = false);
+	void DeleteRelationship(const String& id, RedisKey redisKey, bool hasChecksum = false);
+	void DeleteState(const String& id, RedisKey redisKey, bool hasChecksum = false) const;
 	void AddDataToHmSets(std::map<String, RedisConnection::Query>& hMSets, RedisKey redisKey, const String& id, const Dictionary::Ptr& data) const;
 
 	void SendSentNotification(
@@ -149,6 +151,8 @@ private:
 	void SendCommandEnvChanged(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
 	void SendCommandArgumentsChanged(const ConfigObject::Ptr& command, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
 	void SendCustomVarsChanged(const ConfigObject::Ptr& object, const Dictionary::Ptr& oldValues, const Dictionary::Ptr& newValues);
+	void SendDependencyGroupChildRegistered(const Checkable::Ptr& child, const DependencyGroup::Ptr& dependencyGroup);
+	void SendDependencyGroupChildRemoved(const DependencyGroup::Ptr& dependencyGroup, const std::vector<Dependency::Ptr>& dependencies, bool removeGroup);
 
 	void ForwardHistoryEntries();
 
@@ -195,6 +199,8 @@ private:
 	static void FlappingChangeHandler(const Checkable::Ptr& checkable, double changeTime);
 	static void NewCheckResultHandler(const Checkable::Ptr& checkable);
 	static void NextCheckUpdatedHandler(const Checkable::Ptr& checkable);
+	static void DependencyGroupChildRegisteredHandler(const Checkable::Ptr& child, const DependencyGroup::Ptr& dependencyGroup);
+	static void DependencyGroupChildRemovedHandler(const DependencyGroup::Ptr& dependencyGroup, const std::vector<Dependency::Ptr>& dependencies, bool removeGroup);
 	static void HostProblemChangedHandler(const Service::Ptr& service);
 	static void AcknowledgementSetHandler(const Checkable::Ptr& checkable, const String& author, const String& comment, AcknowledgementType type, bool persistent, double changeTime, double expiry);
 	static void AcknowledgementClearedHandler(const Checkable::Ptr& checkable, const String& removedBy, double changeTime);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -232,6 +232,9 @@ add_boost_test(base
     icinga_checkresult/service_flapping_notification
     icinga_checkresult/suppressed_notification
     icinga_dependencies/multi_parent
+    icinga_dependencies/default_redundancy_group_registration_unregistration
+    icinga_dependencies/simple_redundancy_group_registration_unregistration
+    icinga_dependencies/mixed_redundancy_group_registration_unregsitration
     icinga_notification/strings
     icinga_notification/state_filter
     icinga_notification/type_filter

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -232,6 +232,7 @@ add_boost_test(base
     icinga_checkresult/service_flapping_notification
     icinga_checkresult/suppressed_notification
     icinga_dependencies/multi_parent
+    icinga_dependencies/push_dependency_groups_to_registry
     icinga_dependencies/default_redundancy_group_registration_unregistration
     icinga_dependencies/simple_redundancy_group_registration_unregistration
     icinga_dependencies/mixed_redundancy_group_registration_unregsitration

--- a/test/icinga-dependencies.cpp
+++ b/test/icinga-dependencies.cpp
@@ -9,6 +9,52 @@ using namespace icinga;
 
 BOOST_AUTO_TEST_SUITE(icinga_dependencies)
 
+static Host::Ptr CreateHost(const std::string& name)
+{
+	Host::Ptr host = new Host();
+	host->SetName(name);
+	return host;
+}
+
+static Dependency::Ptr CreateDependency(Checkable::Ptr parent, Checkable::Ptr child, const std::string& name)
+{
+	Dependency::Ptr dep = new Dependency();
+	dep->SetParent(parent);
+	dep->SetChild(child);
+	dep->SetName(name + "!" + child->GetName());
+	return dep;
+}
+
+static void RegisterDependency(Dependency::Ptr dep, const std::string& redundancyGroup)
+{
+	dep->SetRedundancyGroup(redundancyGroup);
+	DependencyGroup::Register(dep);
+	dep->GetParent()->AddReverseDependency(dep);
+}
+
+static void AssertCheckableRedundancyGroup(Checkable::Ptr checkable, int dependencyCount, int groupCount, int totalDependenciesCount)
+{
+	BOOST_CHECK_MESSAGE(
+		dependencyCount == checkable->GetDependencies().size(),
+		"Dependency count mismatch for '" << checkable->GetName() << "' - expected=" << dependencyCount << "; got="
+			<< checkable->GetDependencies().size()
+	);
+	auto dependencyGroups(checkable->GetDependencyGroups());
+	BOOST_CHECK_MESSAGE(
+		groupCount == dependencyGroups.size(),
+		"Dependency group count mismatch for '" << checkable->GetName() << "'" << " - expected=" << groupCount
+			<< "; got=" << dependencyGroups.size()
+	);
+	if (groupCount > 0) {
+		BOOST_REQUIRE_MESSAGE(1 <= dependencyGroups.size(), "Checkable '" << checkable->GetName() << "' should have at least one dependency group.");
+		BOOST_CHECK_MESSAGE(
+			totalDependenciesCount == dependencyGroups.begin()->get()->GetDependenciesCount(),
+			"Member count mismatch for '" << checkable->GetName() << "'" << " - expected=" << totalDependenciesCount
+				<< "; got=" <<  dependencyGroups.begin()->get()->GetDependenciesCount()
+		);
+	}
+}
+
 BOOST_AUTO_TEST_CASE(multi_parent)
 {
 	/* One child host, two parent hosts. Simulate multi-parent dependencies. */
@@ -20,53 +66,28 @@ BOOST_AUTO_TEST_CASE(multi_parent)
 	 * - Parent objects need a CheckResult object
 	 * - Dependencies need a StateFilter
 	 */
-	Host::Ptr parentHost1 = new Host();
-	parentHost1->SetActive(true);
-	parentHost1->SetMaxCheckAttempts(1);
-	parentHost1->Activate();
-	parentHost1->SetAuthority(true);
+	Host::Ptr parentHost1 = CreateHost("parentHost1");
 	parentHost1->SetStateRaw(ServiceCritical);
 	parentHost1->SetStateType(StateTypeHard);
 	parentHost1->SetLastCheckResult(new CheckResult());
 
-	Host::Ptr parentHost2 = new Host();
-	parentHost2->SetActive(true);
-	parentHost2->SetMaxCheckAttempts(1);
-	parentHost2->Activate();
-	parentHost2->SetAuthority(true);
+	Host::Ptr parentHost2 = CreateHost("parentHost2");
 	parentHost2->SetStateRaw(ServiceOK);
 	parentHost2->SetStateType(StateTypeHard);
 	parentHost2->SetLastCheckResult(new CheckResult());
 
-	Host::Ptr childHost = new Host();
-	childHost->SetActive(true);
-	childHost->SetMaxCheckAttempts(1);
-	childHost->Activate();
-	childHost->SetAuthority(true);
+	Host::Ptr childHost = CreateHost("childHost");
 	childHost->SetStateRaw(ServiceOK);
 	childHost->SetStateType(StateTypeHard);
 
 	/* Build the dependency tree. */
-	Dependency::Ptr dep1 = new Dependency();
-
-	dep1->SetParent(parentHost1);
-	dep1->SetChild(childHost);
+	Dependency::Ptr dep1 (CreateDependency(parentHost1, childHost, "dep1"));
 	dep1->SetStateFilter(StateFilterUp);
+	RegisterDependency(dep1, "");
 
-	// Reverse dependencies
-        DependencyGroup::Register(dep1);
-        parentHost1->AddReverseDependency(dep1);
-
-	Dependency::Ptr dep2 = new Dependency();
-
-	dep2->SetParent(parentHost2);
-	dep2->SetChild(childHost);
+	Dependency::Ptr dep2 (CreateDependency(parentHost2, childHost, "dep2"));
 	dep2->SetStateFilter(StateFilterUp);
-
-	// Reverse dependencies
-        DependencyGroup::Register(dep2);
-        parentHost2->AddReverseDependency(dep2);
-
+	RegisterDependency(dep2, "");
 
 	/* Test the reachability from this point.
 	 * parentHost1 is DOWN, parentHost2 is UP.
@@ -77,17 +98,41 @@ BOOST_AUTO_TEST_CASE(multi_parent)
 
 	BOOST_CHECK(childHost->IsReachable() == false);
 
+	Dependency::Ptr duplicateDep (CreateDependency(parentHost1, childHost, "dep4"));
+	duplicateDep->SetIgnoreSoftStates(false, true);
+	RegisterDependency(duplicateDep, "");
+	parentHost1->SetStateType(StateTypeSoft);
+
+	// It should still be unreachable, due to the duplicated dependency object above with ignore_soft_states set to false.
+	BOOST_CHECK(childHost->IsReachable() == false);
+	parentHost1->SetStateType(StateTypeHard);
+	DependencyGroup::Unregister(duplicateDep);
+
 	/* The only DNS server is DOWN.
 	 * Expected result: childHost is unreachable.
 	 */
-	dep1->SetRedundancyGroup("DNS");
+	DependencyGroup::Unregister(dep1); // Remove the dep and re-add it with a configured redundancy group.
+	RegisterDependency(dep1, "DNS");
 	BOOST_CHECK(childHost->IsReachable() == false);
 
 	/* 1/2 DNS servers is DOWN.
 	 * Expected result: childHost is reachable.
 	 */
-	dep2->SetRedundancyGroup("DNS");
+	DependencyGroup::Unregister(dep2);
+	RegisterDependency(dep2, "DNS");
 	BOOST_CHECK(childHost->IsReachable() == true);
+
+	auto grandParentHost(CreateHost("GrandParentHost"));
+	grandParentHost->SetLastCheckResult(new CheckResult());
+	grandParentHost->SetStateRaw(ServiceCritical);
+	grandParentHost->SetStateType(StateTypeHard);
+
+	Dependency::Ptr dep3 (CreateDependency(grandParentHost, parentHost1, "dep3"));
+	dep3->SetStateFilter(StateFilterUp);
+	RegisterDependency(dep3, "");
+	// The grandparent is DOWN but the DNS redundancy group has to be still reachable.
+	BOOST_CHECK_EQUAL(true, childHost->IsReachable());
+	DependencyGroup::Unregister(dep3);
 
 	/* Both DNS servers are DOWN.
 	 * Expected result: childHost is unreachable.
@@ -96,6 +141,180 @@ BOOST_AUTO_TEST_CASE(multi_parent)
 	parentHost2->SetStateRaw(ServiceCritical); // parent Host 2 DOWN
 
 	BOOST_CHECK(childHost->IsReachable() == false);
+}
+
+BOOST_AUTO_TEST_CASE(default_redundancy_group_registration_unregistration)
+{
+	Checkable::Ptr childHostC(CreateHost("C"));
+	Dependency::Ptr depCA(CreateDependency(CreateHost("A"), childHostC, "depCA"));
+	RegisterDependency(depCA, "");
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 1);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depCB(CreateDependency(CreateHost("B"), childHostC, "depCB"));
+	RegisterDependency(depCB, "");
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 2);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Checkable::Ptr childHostD(CreateHost("D"));
+	Dependency::Ptr depDA(CreateDependency(depCA->GetParent(), childHostD, "depDA"));
+	RegisterDependency(depDA, "");
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 1);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depDB(CreateDependency(depCB->GetParent(), childHostD, "depDB"));
+	RegisterDependency(depDB, "");
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 4);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depCA);
+	DependencyGroup::Unregister(depDA);
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 2);
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 2);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depCB);
+	DependencyGroup::Unregister(depDB);
+	AssertCheckableRedundancyGroup(childHostC, 0, 0, 0);
+	AssertCheckableRedundancyGroup(childHostD, 0, 0, 0);
+	BOOST_CHECK_EQUAL(0, DependencyGroup::GetRegistrySize());
+}
+
+BOOST_AUTO_TEST_CASE(simple_redundancy_group_registration_unregistration)
+{
+	Checkable::Ptr childHostC(CreateHost("childC"));
+
+	Dependency::Ptr depCA(CreateDependency(CreateHost("A"), childHostC, "depCA"));
+	RegisterDependency(depCA, "redundant");
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 1);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depCB(CreateDependency(CreateHost("B"), childHostC, "depCB"));
+	RegisterDependency(depCB, "redundant");
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 2);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Checkable::Ptr childHostD(CreateHost("childD"));
+	Dependency::Ptr depDA (CreateDependency(depCA->GetParent(), childHostD, "depDA"));
+	RegisterDependency(depDA, "redundant");
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 1);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depDB(CreateDependency(depCB->GetParent(), childHostD, "depDB"));
+	RegisterDependency(depDB, "redundant");
+	// Still 1 redundancy group, but there should be 4 dependencies now, i.e. 2 for each child Checkable.
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 4);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depCA);
+	// After unregistering depCA, childHostC should have a new redundancy group with only depCB as dependency, and...
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 1);
+	// ...childHostD should still have the same redundancy group as before but also with only two dependencies.
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 2);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depDA);
+	// Nothing should have changed for childHostC, but childHostD should now have a fewer group dependency, i.e.
+	// both child hosts should have the same redundancy group with only depCB and depDB as dependency.
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 2);
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 2);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Register(depDA);
+	DependencyGroup::Unregister(depDB);
+	// Nothing should have changed for childHostC, but both should now have a separate group with only depCB and depDA as dependency.
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 1);
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 1);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depCB);
+	DependencyGroup::Unregister(depDA);
+	AssertCheckableRedundancyGroup(childHostC, 0, 0, 0);
+	AssertCheckableRedundancyGroup(childHostD, 0, 0, 0);
+	BOOST_CHECK_EQUAL(0, DependencyGroup::GetRegistrySize());
+}
+
+BOOST_AUTO_TEST_CASE(mixed_redundancy_group_registration_unregsitration)
+{
+	Checkable::Ptr childHostC(CreateHost("childC"));
+	Dependency::Ptr depCA(CreateDependency(CreateHost("A"), childHostC, "depCA"));
+	RegisterDependency(depCA, "redundant");
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 1);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Checkable::Ptr childHostD(CreateHost("childD"));
+	Dependency::Ptr depDA(CreateDependency(depCA->GetParent(), childHostD, "depDA"));
+	RegisterDependency(depDA, "redundant");
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 2);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depCB(CreateDependency(CreateHost("B"), childHostC, "depCB"));
+	RegisterDependency(depCB, "redundant");
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 2);
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 1);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depDB(CreateDependency(depCB->GetParent(), childHostD, "depDB"));
+	RegisterDependency(depDB, "redundant");
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 4);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Checkable::Ptr childHostE(CreateHost("childE"));
+	Dependency::Ptr depEA(CreateDependency(depCA->GetParent(), childHostE, "depEA"));
+	RegisterDependency(depEA, "redundant");
+	AssertCheckableRedundancyGroup(childHostE, 1, 1, 1);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depEB(CreateDependency(depCB->GetParent(), childHostE, "depEB"));
+	RegisterDependency(depEB, "redundant");
+	// All 3 hosts share the same group, and each host has 2 dependencies, thus 6 dependencies in total.
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 6);
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 6);
+	AssertCheckableRedundancyGroup(childHostE, 2, 1, 6);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	Dependency::Ptr depEZ(CreateDependency(CreateHost("Z"), childHostE, "depEZ"));
+	RegisterDependency(depEZ, "redundant");
+	// Child host E should have a new redundancy group with 3 dependencies and the other two should still share the same group.
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostE, 3, 1, 3);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depEA);
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 4);
+	AssertCheckableRedundancyGroup(childHostE, 2, 1, 2);
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Register(depEA); // Re-register depEA and instead...
+	DependencyGroup::Unregister(depEZ); // ...unregister depEZ and check if all the hosts share the same group again.
+	// All 3 hosts share the same group again, and each host has 2 dependencies, thus 6 dependencies in total.
+	AssertCheckableRedundancyGroup(childHostC, 2, 1, 6);
+	AssertCheckableRedundancyGroup(childHostD, 2, 1, 6);
+	AssertCheckableRedundancyGroup(childHostE, 2, 1, 6);
+	BOOST_CHECK_EQUAL(1, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depCA);
+	DependencyGroup::Unregister(depDB);
+	DependencyGroup::Unregister(depEB);
+	// Child host C has now a separate group with only depCB as dependency, and child hosts D and E share the same group.
+	AssertCheckableRedundancyGroup(childHostC, 1, 1, 1);
+	AssertCheckableRedundancyGroup(childHostD, 1, 1, 2);
+	AssertCheckableRedundancyGroup(childHostE, 1, 1, 2);
+	// Child host C has now a separate group with only depCB as member, and child hosts D and E share the same group.
+	BOOST_CHECK_EQUAL(2, DependencyGroup::GetRegistrySize());
+
+	DependencyGroup::Unregister(depCB);
+	DependencyGroup::Unregister(depDA);
+	DependencyGroup::Unregister(depEA);
+	AssertCheckableRedundancyGroup(childHostC, 0, 0, 0);
+	AssertCheckableRedundancyGroup(childHostD, 0, 0, 0);
+	AssertCheckableRedundancyGroup(childHostE, 0, 0, 0);
+	BOOST_CHECK_EQUAL(0, DependencyGroup::GetRegistrySize());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/icinga-dependencies.cpp
+++ b/test/icinga-dependencies.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(multi_parent)
 	dep1->SetStateFilter(StateFilterUp);
 
 	// Reverse dependencies
-        childHost->AddDependency(dep1);
+        DependencyGroup::Register(dep1);
         parentHost1->AddReverseDependency(dep1);
 
 	Dependency::Ptr dep2 = new Dependency();
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(multi_parent)
 	dep2->SetStateFilter(StateFilterUp);
 
 	// Reverse dependencies
-        childHost->AddDependency(dep2);
+        DependencyGroup::Register(dep2);
         parentHost2->AddReverseDependency(dep2);
 
 


### PR DESCRIPTION
As the title of the PR already implies, this is mainly about serialising the in-memory representation of all checkable dependencies according to the specifications given by https://github.com/Icinga/icingadb/issues/347#issuecomment-2306972320 and dumping them into Redis so that they can be processed further and written to the database by https://github.com/Icinga/icingadb/pull/889. Furthermore, it should be noted that, until this point, `redundancy_group`s were merely an additional flag on the actual `Dependency` objects, but for Icinga 2 itself they didn't represent any kind of object or state and there was no grouping involved at all as one might expect from its name. However, in order to facilitate dependency management and serialisations, redundancy groups now represent a concrete Icinga 2 object. The inline comment in the code describes how and what it exactly represents, but I'll just copy and paste it here with a bit of formatting adjustment.

A `DependencyGroup` now represents a set of dependencies that are somehow related to each other. Specifically, a `DependencyGroup` is a container for `Dependency` objects of different Checkables that share the same **child -> parent** relationship config, thus forming a group of dependencies. All dependencies of a Checkable that have the same `redundancy_group` attribute value set are guaranteed to be part of the same `DependencyGroup` object, and another `Checkable` will join that group if and only if it has identical set of dependencies, that is, the same parent(s), same redundancy group name and all other dependency attributes required to form a composite key. The composite key, consisting of the `Dependency` **parent** checkable, the time `period` (if configured), the `states` filter and the `ignore_soft_states` attributes, uniquely identifies the `DependencyGroup` object to which it belongs.

More specifically, let's say we have a dependency graph like this:

```mermaid
graph BT;
pp1((PP1));
pp2((PP2));
p1((P1));
p2((P2));
c1((C1));
c2((C2));
rg1(RG1);
p1-->pp1;
p2-->pp2;
rg1-->p1;
rg1-->p2;
c1-->rg1;
c2-->rg1;
```

The arrows represent a dependency relationship from bottom to top, i.e. both `C1` and `C2` depend on their `RG1` redundancy group that depends from `P1` and `P2`, and `P1` and `P2` depend each on their respective parents (`PP1`, `PP2` - no group). Now, as one can see, both `C1` and `C2` have identical dependencies, that is, they both depend on the same redundancy group `RG1` (they might have been constructed via some Apply Rules). So, instead of having to maintain two separate copies of that dependency graph as it's the case with the master branch, we can bring that imaginary redundancy group into reality by putting both `P1` and `P2` into the new `DependencyGroup` object. However, we don't really put `P1` and `P2` objects into that group, but rather the actual Dependency objects of both child Checkables. Therefore, the group wouldn't just contain 2 dependencies, but **4** in total, i.e. **2** for each child Checkable (`C1 -> {P1, P2}` and `C2 -> {P1, P2}`). This way, both child Checkables can just refer to that very same `DependencyGroup` object.

However, since not all dependencies are part of a redundancy group, we also have to consider the case where a Checkable has dependencies that are not part of any redundancy group, like `P1 -> PP1`. In such situations, each of the child Checkables (e.g. `P1, P2`) will have their own (sharable) `DependencyGroup` object just like for RGs. This allows us to keep the implementation simple and treat redundant and non-redundant dependencies in the same way, without having to introduce any special cases everywhere. So, in the end, we'd have **3** dependency groups in total, i.e. one for the redundancy group `RG1` (shared by C1 and C2), and two distinct groups for `P1` and `P2`.

With this structure in hand, Icinga DB can now easily serialise them for each checkable if it needs to. As previously stated, a single `DependencyGroup` object may be shared by multiple checkables, and Icinga DB must only serialise such group once. To achieve this, Icinga DB now caches all the already processed DependencyGroup objects in the new [`m_DumpedGlobals#DependencyGroup`](https://github.com/Icinga/icinga2/blob/bc2c750551faed595f4983a02738022da1d9168a/lib/icingadb/icingadb.hpp#L253) for each initial config dump and resets it when it is complete.

The process of serialisation on its own works as follows, and each part of the results is dumped into Redis using the appropriate Redis keys. There're now 5 new Redis keys introduced mainly for this purposes.

- `icinga:dependency:node` contains dependency node data representing each host, service, and redundancy group in any given dependency graph.
- `icinga:dependency:edge` contains information representing all connections between the dependency nodes.
- `icinga:redundancygroup` contains the all the redundancy group data (`redundancy_group` database table) of any dependency graph.
- `icinga:redundancygroup:state` represents state information for all redundancy groups.
- `icinga:dependency:edge:state` likewise contains state information for (every) dependency edge in a dependency graph. It is noteworthy that multiple edges may share the same state, a decision that is made by the serialisation/grouping process.

Please note, as per https://github.com/Icinga/icingadb/issues/347#issuecomment-2306972320 only Checkables that are part of some dependency graph should be serialised. That's they either depend on other Checkables or others depend on it, checkables without any child or parent dependencies and `Service` objects with only implicit dependencies to their hosts are ignored. So, firstly, it produces dependency node entries according to the new Icinga DB schema for a given checkable. In cases where the checkable is also part of a **redundancy group** (note _redundancy group_ not just _dependency group_), each of its redundancy groups including their state information will also be serialised according to the Icinga DB (Go) schema spec. Subsequently, all the relevant edges are extracted from that checkable and also dumped into Redis (for more details, please refer to the inline comments). It is important to note that there are some special cases to be aware of, as of today Icinga 2 allows you to have **n** `Dependency` objects pointing from `C1` -> `P1` as long as they have different names. However, in order to render these in Icinga DB Web in a meaningful way, we needed to somehow reduce all the duplicate edges connecting `C1` and `P1` to just a single one in the database. Consequently, during the serialisation process, Icinga DB will be using all their short names separated by comma as `dependency_edge.display_name`, and querying the state of each of them and selecting only the severed one. This approach did not require us to introduce a breaking change in Icinga 2 itself, prohibiting the use of more than one dependency objects referencing the same parent, but solved it in a more convenient way.

Last but not least, as part of the restructured dependency management, a bunch of existing issues have been solved automatically, which are listed below. 

Well, that's it! This pretty much describes in general what this PR is all about, but you'll find more implementation-specific details as inline comments in the respective code blocks.

fixes #10158
fixes #10190
fixes #10227
fixes #10014
fixes #10143