### PR TITLE
intrusive_ptr_*(): specify memory_order explicitly

### DIFF
--- a/lib/base/object.cpp
+++ b/lib/base/object.cpp
@@ -246,13 +246,13 @@ void icinga::intrusive_ptr_add_ref(const Object *object)
 	if (object->m_References.fetch_add(1) == 0u)
 		TypeAddObject(object);
 #else /* I2_LEAK_DEBUG */
-	object->m_References.fetch_add(1);
+	object->m_References.fetch_add(1, std::memory_order_relaxed);
 #endif /* I2_LEAK_DEBUG */
 }
 
 void icinga::intrusive_ptr_release(const Object *object)
 {
-	auto previous (object->m_References.fetch_sub(1));
+	auto previous (object->m_References.fetch_sub(1, std::memory_order_acq_rel));
 
 	if (previous == 1u) {
 #ifdef I2_LEAK_DEBUG

--- a/lib/base/shared-object.hpp
+++ b/lib/base/shared-object.hpp
@@ -44,12 +44,12 @@ private:
 
 inline void intrusive_ptr_add_ref(const SharedObject *object)
 {
-	object->m_References.fetch_add(1);
+	object->m_References.fetch_add(1, std::memory_order_relaxed);
 }
 
 inline void intrusive_ptr_release(const SharedObject *object)
 {
-	if (object->m_References.fetch_sub(1) == 1u) {
+	if (object->m_References.fetch_sub(1, std::memory_order_acq_rel) == 1u) {
 		delete object;
 	}
 }

--- a/lib/base/shared.hpp
+++ b/lib/base/shared.hpp
@@ -19,13 +19,13 @@ class Shared;
 template<class T>
 inline void intrusive_ptr_add_ref(const Shared<T> *object)
 {
-	object->m_References.fetch_add(1);
+	object->m_References.fetch_add(1, std::memory_order_relaxed);
 }
 
 template<class T>
 inline void intrusive_ptr_release(const Shared<T> *object)
 {
-	if (object->m_References.fetch_sub(1) == 1u) {
+	if (object->m_References.fetch_sub(1, std::memory_order_acq_rel) == 1u) {
 		delete object;
 	}
 }


### PR DESCRIPTION
More relaxed memory_order = less safety guarantees = faster execution.

This is safe because std::shared_ptr does the same. See also: https://en.cppreference.com/w/cpp/atomic/memory_order "Typical use for relaxed memory ordering is incrementing counters, such as the reference counters of std::shared_ptr, since this only requires atomicity, but not ordering or synchronization (note that decrementing the std::shared_ptr counters requires acquire-release synchronization with the destructor)."