### PR TITLE
Windows MSI build: run light.exe with -sval in GitLab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,11 @@ set(CPACK_WIX_PATCH_FILE "${CMAKE_CURRENT_BINARY_DIR}/icinga-installer/icinga2.w
 set(CPACK_WIX_EXTENSIONS "WixUtilExtension" "WixNetFxExtension")
 set(CPACK_WIX_INSTALL_SCOPE NONE)
 
+if(DEFINED ENV{ICINGA2_NO_MSI_VALIDATION})
+  # https://wixtoolset.org/docs/tools/validation/#errors-running-validation
+  set(CPACK_WIX_LIGHT_EXTRA_FLAGS "-sval")
+endif()
+
 set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION "sbin")
 set(CMAKE_INSTALL_UCRT_LIBRARIES TRUE)
 include(InstallRequiredSystemLibraries)


### PR DESCRIPTION
This is equivalent to "setting <SuppressValidation>true</SuppressValidation> in your WiX MSBuild project" **not to require the CI/CD service to run as an admin.** https://wixtoolset.org/docs/tools/validation/#errors-running-validation

* Don't get me wrong. I've even re-tested #10137 and it does what it specifies.

It's just, w/o this PR our builds **also** perform a "package validation" which involves the installer service. Non-admins can access the latter, but only if logged in via RDP. Services can't.