### PR TITLE
Update 02-installation.md

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -105,7 +105,7 @@ dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OSVER}.n
 ```bash
 subscription-manager repos --enable rhel-7-server-optional-rpms
 
-yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install --nogpgcheck https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm
 ```
 <!-- {% endif %} -->
 


### PR DESCRIPTION
https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm has been moved to archives.

New Link:
https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm

Added --nogpgcheck flag to prevent following error:

Downloading packages:
warning: /home/user/epel-release-7-14.noarch.rpm: Header V4 RSA/SHA256 Signature, key ID 352c64e5: NOKEY


Public key for epel-release-7-14.noarch.rpm is not installed