### PR TITLE
Include Nagios in the migration docs

### DIFF
--- a/doc/23-migrating-from-icinga-1x.md
+++ b/doc/23-migrating-from-icinga-1x.md
@@ -1,4 +1,8 @@
-# Migration from Icinga 1.x <a id="migration"></a>
+# Migration from Icinga 1.x or Nagios <a id="migration"></a>
+
+!!! note
+
+    Icinga 1.x was originally a fork of Nagios. The information provided here also applies to Nagios.
 
 ## Configuration Migration <a id="configuration-migration"></a>
 


### PR DESCRIPTION
Described details about migrating from Icinga 1.x apply to migrations from Nagios in the same way. Pointing this out will help users coming from Nagios to Icinga. Would be great if you could merge this to the support/v2.14 branch so we can have it in the online docs asap!