### PR TITLE
Introduce --no-impersonate flag

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -298,7 +298,9 @@ static int Main()
 		("include,I", po::value<std::vector<std::string> >(), "add include search directory")
 		("log-level,x", po::value<std::string>(), "specify the log level for the console log.\n"
 			"The valid value is either debug, notice, information (default), warning, or critical")
-		("script-debugger,X", "whether to enable the script debugger");
+		("script-debugger,X", "whether to enable the script debugger")
+		("no-impersonate", ("run as current user, never impersonate " +
+							Configuration::RunAsUser + ":" + Configuration::RunAsGroup).CStr());
 
 	po::options_description hiddenDesc("Hidden options");
 

--- a/lib/cli/apisetupcommand.cpp
+++ b/lib/cli/apisetupcommand.cpp
@@ -22,11 +22,6 @@ String ApiSetupCommand::GetShortDescription() const
 	return "setup for API";
 }
 
-ImpersonationLevel ApiSetupCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
 void ApiSetupCommand::InitParameters(boost::program_options::options_description& visibleDesc,
 	boost::program_options::options_description& hiddenDesc) const
 {

--- a/lib/cli/apisetupcommand.hpp
+++ b/lib/cli/apisetupcommand.hpp
@@ -23,7 +23,6 @@ public:
 	void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 };
 
 }

--- a/lib/cli/caremovecommand.cpp
+++ b/lib/cli/caremovecommand.cpp
@@ -41,16 +41,6 @@ int CARemoveCommand::GetMinArguments() const
 }
 
 /**
- * Impersonate as Icinga user.
- *
- * @return impersonate level
- */
-ImpersonationLevel CARemoveCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
-/**
  * The entry point for the "ca remove" CLI command.
  *
  * @returns An exit status.

--- a/lib/cli/caremovecommand.hpp
+++ b/lib/cli/caremovecommand.hpp
@@ -21,7 +21,6 @@ public:
 	String GetDescription() const override;
 	String GetShortDescription() const override;
 	int GetMinArguments() const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 };
 

--- a/lib/cli/carestorecommand.cpp
+++ b/lib/cli/carestorecommand.cpp
@@ -41,16 +41,6 @@ int CARestoreCommand::GetMinArguments() const
 }
 
 /**
- * Impersonate as Icinga user.
- *
- * @return impersonate level
- */
-ImpersonationLevel CARestoreCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
-/**
  * The entry point for the "ca restore" CLI command.
  *
  * @returns An exit status.

--- a/lib/cli/carestorecommand.hpp
+++ b/lib/cli/carestorecommand.hpp
@@ -21,7 +21,6 @@ public:
 	String GetDescription() const override;
 	String GetShortDescription() const override;
 	int GetMinArguments() const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 };
 

--- a/lib/cli/casigncommand.cpp
+++ b/lib/cli/casigncommand.cpp
@@ -41,16 +41,6 @@ int CASignCommand::GetMinArguments() const
 }
 
 /**
- * Impersonate as Icinga user.
- *
- * @return impersonate level
- */
-ImpersonationLevel CASignCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
-/**
  * The entry point for the "ca sign" CLI command.
  *
  * @return An exit status.

--- a/lib/cli/casigncommand.hpp
+++ b/lib/cli/casigncommand.hpp
@@ -21,7 +21,6 @@ public:
 	String GetDescription() const override;
 	String GetShortDescription() const override;
 	int GetMinArguments() const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 };
 

--- a/lib/cli/clicommand.cpp
+++ b/lib/cli/clicommand.cpp
@@ -147,7 +147,7 @@ void CLICommand::InitParameters(boost::program_options::options_description& vis
 
 ImpersonationLevel CLICommand::GetImpersonationLevel() const
 {
-	return ImpersonateIcinga;
+	return m_ImpersonationLevel;
 }
 
 bool CLICommand::ParseCommand(int argc, char **argv, po::options_description& visibleDesc,
@@ -215,6 +215,10 @@ found_command:
 
 	po::store(po::command_line_parser(argc - arg_end, argv + arg_end).options(adesc).positional(positionalDesc).run(), vm);
 	po::notify(vm);
+
+	if (vm.count("no-impersonate")) {
+		command->m_ImpersonationLevel = ImpersonateNone;
+	}
 
 	return true;
 }

--- a/lib/cli/clicommand.hpp
+++ b/lib/cli/clicommand.hpp
@@ -64,6 +64,8 @@ public:
 		bool autocomplete = false, int autoindex = -1);
 
 private:
+	ImpersonationLevel m_ImpersonationLevel = ImpersonateIcinga;
+
 	static std::mutex& GetRegistryMutex();
 	static std::map<std::vector<String>, CLICommand::Ptr>& GetRegistry();
 };

--- a/lib/cli/featuredisablecommand.cpp
+++ b/lib/cli/featuredisablecommand.cpp
@@ -34,11 +34,6 @@ int FeatureDisableCommand::GetMaxArguments() const
 	return -1;
 }
 
-ImpersonationLevel FeatureDisableCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
 /**
  * The entry point for the "feature disable" CLI command.
  *

--- a/lib/cli/featuredisablecommand.hpp
+++ b/lib/cli/featuredisablecommand.hpp
@@ -23,7 +23,6 @@ public:
 	int GetMinArguments() const override;
 	int GetMaxArguments() const override;
 	std::vector<String> GetPositionalSuggestions(const String& word) const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 
 };

--- a/lib/cli/featureenablecommand.cpp
+++ b/lib/cli/featureenablecommand.cpp
@@ -34,11 +34,6 @@ int FeatureEnableCommand::GetMaxArguments() const
 	return -1;
 }
 
-ImpersonationLevel FeatureEnableCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
 /**
  * The entry point for the "feature enable" CLI command.
  *

--- a/lib/cli/featureenablecommand.hpp
+++ b/lib/cli/featureenablecommand.hpp
@@ -23,7 +23,6 @@ public:
 	int GetMinArguments() const override;
 	int GetMaxArguments() const override;
 	std::vector<String> GetPositionalSuggestions(const String& word) const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 };
 

--- a/lib/cli/internalsignalcommand.cpp
+++ b/lib/cli/internalsignalcommand.cpp
@@ -19,11 +19,6 @@ String InternalSignalCommand::GetShortDescription() const
 	return "Send signal as Icinga user";
 }
 
-ImpersonationLevel InternalSignalCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
 bool InternalSignalCommand::IsHidden() const
 {
 	return true;

--- a/lib/cli/internalsignalcommand.hpp
+++ b/lib/cli/internalsignalcommand.hpp
@@ -20,7 +20,6 @@ public:
 
 	String GetDescription() const override;
 	String GetShortDescription() const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	bool IsHidden() const override;
 	void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const override;

--- a/lib/cli/nodesetupcommand.cpp
+++ b/lib/cli/nodesetupcommand.cpp
@@ -70,11 +70,6 @@ std::vector<String> NodeSetupCommand::GetArgumentSuggestions(const String& argum
 		return CLICommand::GetArgumentSuggestions(argument, word);
 }
 
-ImpersonationLevel NodeSetupCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
 /**
  * The entry point for the "node setup" CLI command.
  *

--- a/lib/cli/nodesetupcommand.hpp
+++ b/lib/cli/nodesetupcommand.hpp
@@ -23,7 +23,6 @@ public:
 	void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const override;
 	std::vector<String> GetArgumentSuggestions(const String& argument, const String& word) const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
 
 private:

--- a/lib/cli/nodewizardcommand.cpp
+++ b/lib/cli/nodewizardcommand.cpp
@@ -36,11 +36,6 @@ String NodeWizardCommand::GetShortDescription() const
 	return "wizard for node setup";
 }
 
-ImpersonationLevel NodeWizardCommand::GetImpersonationLevel() const
-{
-	return ImpersonateIcinga;
-}
-
 int NodeWizardCommand::GetMaxArguments() const
 {
 	return -1;

--- a/lib/cli/nodewizardcommand.hpp
+++ b/lib/cli/nodewizardcommand.hpp
@@ -22,7 +22,6 @@ public:
 	String GetShortDescription() const override;
 	int GetMaxArguments() const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;
-	ImpersonationLevel GetImpersonationLevel() const override;
 	void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const override;
 


### PR DESCRIPTION
- Remove unnecessary GetImpersonationLevel in childs

  The base class CLICommand implements the GetImpersonationLevel method to always return ImpersonateIcinga. This method was overridden in some child classes with the exact same implementation.

  As this is both unnecessary and I am planning to rewrite the base class implementation, these overridden methods were removed. Now there is only the base implementation and one child with another ImpersonationLevel
  left.
- Dynamic ImpersonationLevel via --no-impersonate flag

  By default, icinga2 uses icinga:icinga as user and group, or whatever is configured via ICINGA2_USER and ICINGA2_GROUP. Thus, it is required to launch icinga2 as this user or as a privileged user, allowed to setuid.

  The only command where no user impersonation is necessary is "icinga2 console".

  However, in certain scenarios one cannot switch to a static user. There might also be the case that privileges are already dropped, e.g., by an init manager. Therefore, the "--no-impersonate" flag was introduced, skipping all impersonation logic.

  > $ icinga2 daemon
  critical/cli: Invalid group specified: icinga
  > $ icinga2 daemon --no-impersonate
  [2025-01-24 10:42:41 +0100] information/cli: Icinga application loader (version: v2.14.0-439-ga5980d362)

Closes #10307.
Closes #10308.