### PR TITLE
Don't abruptly close anonymous connections

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -286,14 +286,6 @@ delayed_request:
 	Log(LogInformation, "JsonRpcConnection")
 		<< "Certificate request for CN '" << cn << "' is pending. Waiting for approval.";
 
-	if (origin) {
-		auto client (origin->FromClient);
-
-		if (client && !client->GetEndpoint()) {
-			client->Disconnect();
-		}
-	}
-
 	return result;
 }
 


### PR DESCRIPTION
This was mistakenly introduced with PR https://github.com/Icinga/icinga2/pull/7686 due to too many open connections (https://github.com/Icinga/icinga2/issues/7680). This was wrong in the sense that closing the connection is simply out of place here and should have been handled differently. After we revised the RPC connection disconnect procedure with `v2.14.4`, it becomes clear why it is wrong, because the connection is closed abruptly before the corresponding response (`result`) has even been written. Now if you remove the disconnect here, shouldn't the issue https://github.com/Icinga/icinga2/issues/7680 occur again, you ask? The answer is no, because we now also have a maximum timeout of `10s` for anonymous connections, after which they are automatically closed. Thanks to the introduction of this timeout by @julianbrost in https://github.com/Icinga/icinga2/pull/8479, this `Disconnect()` call has become superfluous.

## Tests

**Signing master:**
```bash
[2025-01-30 16:52:59 +0000] information/JsonRpcConnection: Received certificate request for CN 'satellite' which couldn't be verified: self-signed certificate (code 18)
[2025-01-30 16:52:59 +0000] information/JsonRpcConnection: Sending certificate response for CN 'satellite' to endpoint 'mbp-yhabteab' (auto-signing ticket)
```

**Non signing master:**
```bash
[2025-01-30 17:52:49 +0100] information/ApiListener: New client connection from [::1]:49696 (no client certificate)
[2025-01-30 17:52:49 +0100] information/ApiListener: No data received on new API connection from [::1]:49696. Ensure that the remote endpoints are properly configured in a cluster setup.
[2025-01-30 17:52:59 +0100] information/ApiListener: New client connection for identity 'satellite' from [::1]:49697 (certificate validation failed: code 18: self-signed certificate)
[2025-01-30 17:52:59 +0100] information/JsonRpcConnection: Received certificate request for CN 'satellite' which couldn't be verified: ok (code 0)
[2025-01-30 17:52:59 +0100] information/JsonRpcConnection: Certificate request for CN 'satellite' is pending. Waiting for approval.
[2025-01-30 17:52:59 +0100] information/JsonRpcConnection: Received certificate update message for CN 'satellite'
[2025-01-30 17:52:59 +0100] information/JsonRpcConnection: Saved certificate update for CN 'satellite'
[2025-01-30 17:52:59 +0100] warning/JsonRpcConnection: API client disconnected for identity 'satellite'
```

**Satellite (node wizard command is executed on):**
```bash
~/Workspace/icinga2# prefix/sbin/icinga2 node wizard -DInternal.DebugJsonRpc=1
Welcome to the Icinga 2 Setup Wizard!

We will guide you through all required configuration details.

Please specify if this is an agent/satellite setup ('n' installs a master setup) [Y/n]:

Starting the Agent/Satellite setup routine...

Please specify the common name (CN) [mbp-yhabteab.local]: satellite

Please specify the parent endpoint(s) (master or satellite) where this node should connect to:
Master/Satellite Common Name (CN from your master/satellite node): mbp-yhabteab

Do you want to establish a connection to the parent node from this node? [Y/n]:
Please specify the master/satellite connection information:
Master/Satellite endpoint host (IP address or FQDN): localhost
Master/Satellite endpoint port [5665]: 5667

Add more master/satellite endpoints? [y/N]:
Parent certificate information:

 Version:             3
 Subject:             CN = mbp-yhabteab
 Issuer:              CN = Icinga CA
 Valid From:          Jan 30 08:58:12 2025 GMT
 Valid Until:         Mar  3 08:58:12 2026 GMT
 Serial:              42:c7:91:bf:2d:09:58:e5:eb:c4:45:b2:78:82:c6:2e:8a:af:75:8a

 Signature Algorithm: sha256WithRSAEncryption
 Subject Alt Names:   mbp-yhabteab
 Fingerprint:         87 89 37 3D B9 11 32 51 B1 F6 3A B0 B0 BA BC A8 8A 87 3A 52 F6 37 BA 1A AA C4 1C B4 48 1E C8 12

Is this information correct? [y/N]: y

Please specify the request ticket generated on your Icinga 2 master (optional).
 (Hint: # icinga2 pki ticket --cn 'satellite'): 0423ae25f7230e5a8c4bcc0654be449a4216da42
>> {"id":"fb387c20-c79e-44fb-95ef-fd05b3c6a5d4","jsonrpc":"2.0","method":"pki::RequestCertificate","params":{"ticket":"0423ae25f7230e5a8c4bcc0654be449a4216da42"}}
<< {"jsonrpc":"2.0","method":"icinga::Hello","params":{"capabilities":3,"version":21400}}
<< {"id":"fb387c20-c79e-44fb-95ef-fd05b3c6a5d4","jsonrpc":"2.0","result":{"ca":"-----BEGIN CERTIFICATE-----\nMIIEyjCCArKgAwIBAgIVAO75wyVH/YcRL8KSHg+yOPAfzQ/6MA0GCSqGSIb3DQEB\nCwUAMBQxEjAQBgNVBAMMCUljaW5nYSBDQTAeFw0yNTAxMjkxMTI3NDhaFw00MDAx\nMjYxMTI3NDhaMBQxEjAQBgNVBAMMCUljaW5nYSBDQTCCAiIwDQYJKoZIhvcNAQEB\nBQADggIPADCCAgoCggIBAKsRkvPZL69suNnbIBqBDn9yW5fQAKBcfTc/9/vP8SrA\nlsva3eEXncX6quti58HLSWSks70po0SGpYrofEzSFpNhWfti2/yD3HCiQPYze2oZ\niss3oU/NL54N0Etl+jX9SV7j3t5lUbgLVhtmaHpDWsnKHXDmIVjsLL/aqo9wrpTi\n+Fkf8E9cw1E9iWkyNElzHofUChxpq/LrydzO/1VPMs+IXlW8V9oqxCw2TRZl5QJg\n0n5Pej52dEivgdKi84WaPXaSB+EHO3FPp4QhKpZMUIqbx3sw7cR4dGH6a8ZiHbWC\nR8rFbPROm4+fk71xrVeDxrsg6eEXppqxSTz2zxm20l1HSicxTv/Y19Ym8ldhv1Zh\nVVlmN7jeczGlhiu49t0Zc0Nq7f221VVL0fSNjwPMz7+U4xU31tjTWEmEej/BjgID\njlpQW6BDIgu+atQrGsk3UXNqyLTwM7Fn/umq229IAG2GzzYkjLf/Bm8Nz3L1D10M\nVyGku0M+P/pry9s6rWiE4F+vwbIo6WgJgW/75uw9aIGm8LwvRBwF6X78Gx284cKh\nkkK8qDqQ/ySgPROMrsiOR7rDwgMXjZz/I7ckIMRI9vr0tkJM7nPbdVyRC6/P2S+p\nO9ucqjXQZ42TjzuoA9GVpGTA75yJtcIHbkouSnUMewj1naFsJz/Fgb9SPLhm+c85\nAgMBAAGjEzARMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBAHdR\n/GijMJ2y7xFqa9gYiRAvuOTy8cUhORDiJ9VLJ7L3BUM151i1Jc5wnplF0TX2o47I\ntBTWoB+S5ZRoaitnuOavJp3gig8mnHmhNOQwi9ZovghRsbh1URAJLVjHdWR3D+jz\nIwpm9JT0rPFdC0dhbE5FBjq6BKKlb39cnxOuGfqqnrULMIosAJPOCXnQr6jAs7zS\nvwY9D2iREcH/s3tHox2RwA7NA2ofEhitcu65IfuIVOuG1XSM+DjSkGlYfnQclFMa\nZcbUCfWTI/Eap1mZp9QgTyUiR450wpyRNqijUebdotnCbeHqhP0KQRCEwyymAYud\nsN+kyzm0dMYTvofRFaH4+/sqjeHZw3xoHYaImZnBWB58ln2Rg68akIgOtYSVbirf\nMFCPnNODIw5aYH5ZzjHhxoyuiTnqdpn4dHL+IWUu8bSdZIPrqkK4Trx2lf24zPpD\ndZ2KAZ58ApDTGevUcbga2698SXaiHDcwnm2NlYz2KRvQbs61lVIsbl9+lNRrVxVy\n+wocKA6itWn5zH1BeZ23Dldj/bWr1Ecjcuryb8n8GsBKOEKU6cA99h+rJpmwz0rj\nC40IHRKoN+XNXgv0cQdA7fhCVMeIjBeDVDIvS8g8fFqCZ1G6jLqlwuxZaF3PSOjQ\nhCPKGHjqOCRQ+ogEWIMO08qUso8gAGhOkkYEG5Az\n-----END CERTIFICATE-----\n","error":"Certificate request for CN 'satellite' is pending. Waiting for approval from the parent Icinga instance.","fingerprint_request":"3e4fee2556b1c22a0477baa9075b7476fe7401c1081011698e40b489cf8ee00c","status_code":2}}
Please specify the API bind host/port (optional):
Bind Host []:
Bind Port []: 5666

Accept config from parent node? [y/N]: y
Accept commands from parent node? [y/N]: y

Reconfiguring Icinga...
Disabling feature notification. Make sure to restart Icinga 2 for these changes to take effect.

Local zone name [satellite]:
Parent zone name [master]:

Default global zones: global-templates director-global
Do you want to specify additional global zones? [y/N]:

Do you want to disable the inclusion of the conf.d directory [Y/n]:
Disabling the inclusion of the conf.d directory...

Done.

Now restart your Icinga 2 daemon to finish the installation!
```

**Edit:** Using `-DInternal.DebugJsonRpc=1` was a neat trick that I didn't even know ever existed, thanks @julianbrost for the tip!

fixes #10330 