### PR TITLE
Don't abruptly close anonymous connections

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -286,14 +286,6 @@ delayed_request:
 	Log(LogInformation, "JsonRpcConnection")
 		<< "Certificate request for CN '" << cn << "' is pending. Waiting for approval.";
 
-	if (origin) {
-		auto client (origin->FromClient);
-
-		if (client && !client->GetEndpoint()) {
-			client->Disconnect();
-		}
-	}
-
 	return result;
 }
 


### PR DESCRIPTION
This was mistakenly introduced with PR #7686 due to too many open connections (#7680). This was wrong in the sense that closing the connection is simply out of place here and should have been handled differently. After we revised the RPC connection disconnect procedure with `v2.14.4`, it becomes clear why it is wrong, because the connection is closed abruptly before the corresponding response (`result`) has even been written. Now if you remove the disconnect here, shouldn't the issue #7680 occur again, you ask? The answer is no, because we now also have a maximum timeout of `10s` for anonymous connections, after which they are automatically closed. Thanks to the introduction of this timeout by @julianbrost in #8479, this `Disconnect()` call has become superfluous.

## Backport of

- https://github.com/Icinga/icinga2/pull/10332