### PR TITLE
tests: fix FormatDateTime with 32-bit time_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ various documentation improvements.
 
 * Don't close anonymous connections before sending the response for a certificate request #10337
 * Performance data: Don't discard min/max values even if crit/warn thresholds aren’t given #10339
+* Fix a failing test case on systems `time_t` is only 32 bits #10343
 
 ### Documentation
 


### PR DESCRIPTION
With a 32-bit time_t, two checks in the FormatDateTime test case didn't work properly so far:

1. Every time_t value can be represented by struct tm, hence the test makes no sense on such platforms and is now disabled there similar to how it's already done with other checks in the same function.
2. std::nextafter(2147483647, +double_limit::infinity())) results in something like 2147483647.000000238 which simply results in the limit when cast back to an integer type, so it didn't actually test the overflow. This is fixed by an additional std::ceil()/std::floor().

The failing test case was introduced to the support/2.14 branch with #10145, the first affected version is 2.13.11.

This PR adds itself to the changelog for 2.14.5 as the changelog was already merged in #10341.

backport of #10342