### PR TITLE
ApiActions: Remove child downtimes recursively

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -494,7 +494,7 @@ Dictionary::Ptr ApiActions::ScheduleDowntime(const ConfigObject::Ptr& object,
 				<< "Scheduling downtime for child object " << child->GetName();
 
 			Downtime::Ptr childDowntime = Downtime::AddDowntime(child, author, comment, startTime, endTime,
-				fixed, trigger, duration);
+				fixed, trigger, duration, String(), String(), downtimeName);
 			String childDowntimeName = childDowntime->GetName();
 
 			Log(LogNotice, "ApiActions")


### PR DESCRIPTION
Services downtimes scheduled via the `all_services` flag get already removed automatically when removing their parent downtimes (introduced with #8913). Now, this commit makes it possible to perform the same actions for all child downtimes, i.e. not only for those of service objects, but for all child objects represented in the dependency tree.

## Config

```bash
template Host "default" default {
	check_command = "dummy"
	check_interval = 120s
	vars.dummy_text = "I'm just testing something"
	vars.dummy_state = 2
}

object Host "father" {}
object Host "mother" {}
object Host "grandfather" {}
object Host "sister" {}
object Host "brother" {}

apply Dependency "father" to Host {
	parent_host_name = "father"
	redundancy_group = "Parents"
	assign where host.name == "sister" || host.name == "brother"
}

apply Dependency "mother" to Host {
 	parent_host_name = "mother"
 	redundancy_group = "Parents"
 	assign where host.name == "sister" || host.name == "brother"
}

apply Dependency "grandfather" to Host {
 	parent_host_name = "grandfather"
 	redundancy_group = "Grand Parents"
 	assign where host.name == "mother" || host.name == "father"
}
```

```bash
$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/downtimes' | jq '.results | length'
0
$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/hosts' | jq '.results | length'
5
$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/dependencies' | jq '.results | length'
6
```

## Tests

**Before:**

```bash
$ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5667/v1/actions/schedule-downtime' \
 -d @<(cat <<EOF
{ "type": "Host", "filter": "host.name == \"grandfather\"", "start_time": $(date +%s), "end_time": $(date -v+30M +%s), "child_options": "DowntimeTriggeredChildren", "author": "icingaadmin", "comment": "IPv4 network maintenance", "pretty": true }
EOF
)
HTTP/1.1 200 OK
...
$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/downtimes' | jq '.results | length'
5
$ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5667/v1/actions/remove-downtime' \
 -d '{ "filter": "host.name == \"grandfather\"", "pretty": true, "type": "Host" }'
{
    "results": [
        {
            "code": 200,
            "status": "Successfully removed all downtimes for object 'grandfather' and 0 child downtimes."
        }
    ]
}
$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/downtimes' | jq '.results | length'
4
```

**After:**

```bash
$ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5667/v1/actions/schedule-downtime' \
 -d @<(cat <<EOF
{ "type": "Host", "filter": "host.name == \"grandfather\"", "start_time": $(date +%s), "end_time": $(date -v+30M +%s), "child_options": "DowntimeTriggeredChildren", "author": "icingaadmin", "comment": "IPv4 network maintenance", "pretty": true }
EOF
)

$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/downtimes' | jq '.results | length'
5
$ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5667/v1/actions/remove-downtime' \
 -d '{ "filter": "host.name == \"grandfather\"", "pretty": true, "type": "Host" }'
{
    "results": [
        {
            "code": 200,
            "status": "Successfully removed all downtimes for object 'grandfather' and 4 child downtimes."
        }
    ]
}
$ curl -ksSu root:icinga 'https://localhost:5667/v1/objects/downtimes' | jq '.results | length'
0
```

fixes #10333