### PR TITLE
Fixed double output for timestamps in debug log

### DIFF
--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -199,7 +199,8 @@ void CheckerComponent::CheckThreadProc()
 			<< "Scheduling info for checkable '" << checkable->GetName() << "' ("
 			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", checkable->GetNextCheck()) << "): Object '"
 			<< csi.Object->GetName() << "', Next Check: "
-			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", csi.NextCheck) << "(" << csi.NextCheck << ").";
+			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", csi.NextCheck)
+			<< " (" << std::fixed << std::setprecision(0) << csi.NextCheck << ").";
 
 		m_PendingCheckables.insert(csi);
 

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -71,9 +71,11 @@ void Checkable::UpdateNextCheck(const MessageOrigin::Ptr& origin)
 	double lastCheck = GetLastCheck();
 
 	Log(LogDebug, "Checkable")
+		<< std::fixed << std::setprecision(0)
 		<< "Update checkable '" << GetName() << "' with check interval '" << GetCheckInterval()
 		<< "' from last check time at " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", (lastCheck < 0 ? 0 : lastCheck))
-		<< " (" << GetLastCheck() << ") to next check time at " << Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", nextCheck) << " (" << nextCheck << ").";
+		<< " (" << lastCheck << ") to next check time at "
+		<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", nextCheck) << " (" << nextCheck << ").";
 
 	SetNextCheck(nextCheck, false, origin);
 }


### PR DESCRIPTION
The timestamps used both in the CheckerComponent and Checkable debug logs were printed in the scientific notation, making them effectively useless.

> debug/CheckerComponent: Scheduling info for checkable 'host!service' (2025-02-26 14:53:16 +0100): Object 'host!service', Next Check: 2025-02-26 14:53:16 +0100(1.74058e+09).
> debug/Checkable: Update checkable 'host!service' with check interval '300' from last check time at 2025-02-26 14:48:47 +0100 (1.74058e+09) to next check time at 2025-02-26 14:58:12 +0100 (1.74058e+09).

Switching to std::fixed actually shows the complete Unix timestamp.

> debug/CheckerComponent: Scheduling info for checkable 'host!service' (2025-02-26 15:36:44 +0000): Object 'host!service', Next Check: 2025-02-26 15:36:44 +0000 (1740584204).
> debug/Checkable: Update checkable 'host!service' with check interval '60' from last check time at 2025-02-26 15:37:11 +0000 (1740584232) to next check time at 2025-02-26 15:38:09 +0000 (1740584290).