### PR TITLE
IcingaDB: Don't publish useless data to Redis

### DIFF
--- a/lib/icingadb/icingadb-stats.cpp
+++ b/lib/icingadb/icingadb-stats.cpp
@@ -12,42 +12,15 @@ using namespace icinga;
 
 Dictionary::Ptr IcingaDB::GetStats()
 {
-	Dictionary::Ptr stats = new Dictionary();
+	Dictionary::Ptr status = new Dictionary();
+	IcingaApplication::StatsFunc(status, nullptr);
 
-	//TODO: Figure out if more stats can be useful here.
-	Namespace::Ptr statsFunctions = ScriptGlobal::Get("StatsFunctions", &Empty);
-
-	if (!statsFunctions)
-		Dictionary::Ptr();
-
-	ObjectLock olock(statsFunctions);
-
-	for (auto& kv : statsFunctions)
-	{
-		Function::Ptr func = kv.second.Val;
-
-		if (!func)
-			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid status function name."));
-
-		Dictionary::Ptr status = new Dictionary();
-		Array::Ptr perfdata = new Array();
-		func->Invoke({ status, perfdata });
-
-		stats->Set(kv.first, new Dictionary({
-			{ "status", status },
-			{ "perfdata", Serialize(perfdata, FAState) }
-		}));
-	}
-
-	typedef Dictionary::Ptr DP;
-	DP app = DP(DP(DP(stats->Get("IcingaApplication"))->Get("status"))->Get("icingaapplication"))->Get("app");
-
+	Dictionary::Ptr app(Dictionary::Ptr(status->Get("icingaapplication"))->Get("app"));
 	app->Set("program_start", TimestampToMilliseconds(Application::GetStartTime()));
 
-	auto localEndpoint (Endpoint::GetLocalEndpoint());
-	if (localEndpoint) {
+	if (auto localEndpoint(Endpoint::GetLocalEndpoint()); localEndpoint) {
 		app->Set("endpoint_id", GetObjectIdentifier(localEndpoint));
 	}
 
-	return stats;
+	return new Dictionary{{ "IcingaApplication", new Dictionary{{"status", status}}}};
 }

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -143,7 +143,7 @@ private:
 	Dictionary::Ptr SerializeState(const Checkable::Ptr& checkable);
 
 	/* Stats */
-	Dictionary::Ptr GetStats();
+	static Dictionary::Ptr GetStats();
 
 	/* utilities */
 	static String FormatCheckSumBinary(const String& str);


### PR DESCRIPTION
The Icinga DB daemon processes the data from the `IcingaApplication` type only and Icinga DB Web also uses only those stats. However, before this commit, Icinga DB published all kinds of useless stats to Redis each second, like the number of (un)reachable hosts, services, and so on, which is waste of CPU and some other resources. This commit reduces the published data drastically to only those simple stats coming from the `IcingaApplication` type.

### Before

<details><summary>docker exec -i redis redis-cli -p 6380 --raw XREAD streams icinga:stats 0</summary>

```bash
icinga:stats
1741094716481-0
ApiListener
{"perfdata":[{"counter":false,"crit":null,"label":"api_num_conn_endpoints","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_endpoints","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_http_clients","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_json_rpc_anonymous_clients","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_json_rpc_relay_queue_item_rate","max":null,"min":null,"type":"PerfdataValue","unit":"","value":13.183333333333334,"warn":null},{"counter":false,"crit":null,"label":"api_num_json_rpc_relay_queue_items","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_json_rpc_sync_queue_item_rate","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_json_rpc_sync_queue_items","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_json_rpc_work_queue_item_rate","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null},{"counter":false,"crit":null,"label":"api_num_not_conn_endpoints","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null}],"status":{"api":{"conn_endpoints":[],"http":{"clients":0},"identity":"mbp-yhabteab","json_rpc":{"anonymous_clients":0,"relay_queue_item_rate":13.183333333333334,"relay_queue_items":0,"sync_queue_item_rate":0,"sync_queue_items":0,"work_queue_item_rate":0},"not_conn_endpoints":[],"num_conn_endpoints":0,"num_endpoints":0,"num_not_conn_endpoints":0,"zones":{"fooo":{"client_log_lag":0,"connected":true,"endpoints":["mbp-yhabteab"],"parent_zone":""}}}}}
CIB
{"perfdata":[],"status":{"active_host_checks":0.4166666666666667,"active_host_checks_15min":565,"active_host_checks_1min":25,"active_host_checks_5min":266,"active_service_checks":2.45,"active_service_checks_15min":13558,"active_service_checks_1min":147,"active_service_checks_5min":8352,"avg_execution_time":0.001536543679806127,"avg_latency":0.0033716023314160582,"current_concurrent_checks":0,"current_pending_callbacks":0,"max_execution_time":0.09525394439697266,"max_latency":0.10480809211730957,"min_execution_time":0.0005261898040771484,"min_latency":0.0004940032958984375,"num_hosts_acknowledged":0,"num_hosts_down":43,"num_hosts_flapping":0,"num_hosts_handled":0,"num_hosts_in_downtime":0,"num_hosts_pending":0,"num_hosts_problem":232,"num_hosts_unreachable":384,"num_hosts_up":103,"num_services_acknowledged":0,"num_services_critical":3017,"num_services_flapping":0,"num_services_handled":5485,"num_services_in_downtime":0,"num_services_ok":3428,"num_services_pending":0,"num_services_problem":8980,"num_services_unknown":2844,"num_services_unreachable":3401,"num_services_warning":3119,"passive_host_checks":0,"passive_host_checks_15min":0,"passive_host_checks_1min":0,"passive_host_checks_5min":0,"passive_service_checks":0,"passive_service_checks_15min":0,"passive_service_checks_1min":0,"passive_service_checks_5min":0,"remote_check_queue":0,"uptime":10598.02723813057}}
CheckerComponent
{"perfdata":[{"counter":false,"crit":null,"label":"checkercomponent_checker_idle","max":null,"min":null,"type":"PerfdataValue","unit":"","value":12938,"warn":null},{"counter":false,"crit":null,"label":"checkercomponent_checker_pending","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0,"warn":null}],"status":{"checkercomponent":{"checker":{"idle":12938,"pending":0}}}}
ElasticsearchWriter
{"perfdata":[],"status":{"elasticsearchwriter":{}}}
FileLogger
{"perfdata":[],"status":{"filelogger":{}}}
GelfWriter
{"perfdata":[],"status":{"gelfwriter":{}}}
GraphiteWriter
{"perfdata":[],"status":{"graphitewriter":{}}}
IcingaApplication
{"perfdata":[],"status":{"icingaapplication":{"app":{"enable_event_handlers":true,"enable_flapping":true,"enable_host_checks":true,"enable_notifications":true,"enable_perfdata":true,"enable_service_checks":true,"endpoint_id":"b344bec6e673840b76f486318c25c75fde03c8d3","environment":"","node_name":"mbp-yhabteab","pid":94203,"program_start":1741084118381,"version":"v2.14.0-481-g5a7b3ac16"}}}}
Influxdb2Writer
{"perfdata":[],"status":{"influxdb2writer":{}}}
InfluxdbWriter
{"perfdata":[],"status":{"influxdbwriter":{}}}
NotificationComponent
{"perfdata":[],"status":{"notificationcomponent":{}}}
OpenTsdbWriter
{"perfdata":[],"status":{"opentsdbwriter":{}}}
PerfdataWriter
{"perfdata":[],"status":{"perfdatawriter":{}}}
SyslogLogger
{"perfdata":[],"status":{"sysloglogger":{}}}
config_dump_in_progress
false
icingadb_environment
"07d5e33e7da4205e9f9a9d7513fed06ddf5e91a8"
timestamp
1741094716414
```

</details>

### After

<details><summary>docker exec -i redis redis-cli -p 6380 --raw XREAD streams icinga:stats 0</summary>

```bash
icinga:stats
1741105038990-0
IcingaApplication
{"perfdata":[],"status":{"icingaapplication":{"app":{"enable_event_handlers":true,"enable_flapping":true,"enable_host_checks":true,"enable_notifications":true,"enable_perfdata":true,"enable_service_checks":true,"endpoint_id":"b344bec6e673840b76f486318c25c75fde03c8d3","environment":"","node_name":"mbp-yhabteab","pid":33394,"program_start":1741104995661,"version":"v2.14.0-481-g5a7b3ac16"}}}}
config_dump_in_progress
false
icingadb_environment
"07d5e33e7da4205e9f9a9d7513fed06ddf5e91a8"
timestamp
1741105038991
```

</details> 