### PR TITLE
Rework dependency cycle detection

### DIFF
--- a/lib/base/CMakeLists.txt
+++ b/lib/base/CMakeLists.txt
@@ -38,6 +38,7 @@ set(base_SOURCES
   filelogger.cpp filelogger.hpp filelogger-ti.hpp
   function.cpp function.hpp function-ti.hpp function-script.cpp functionwrapper.hpp
   initialize.cpp initialize.hpp
+  intrusive-ptr.hpp
   io-engine.cpp io-engine.hpp
   journaldlogger.cpp journaldlogger.hpp journaldlogger-ti.hpp
   json.cpp json.hpp json-script.cpp

--- a/lib/base/configtype.hpp
+++ b/lib/base/configtype.hpp
@@ -9,11 +9,13 @@
 #include "base/dictionary.hpp"
 #include <shared_mutex>
 #include <unordered_map>
+#include <boost/signals2.hpp>
 
 namespace icinga
 {
 
 class ConfigObject;
+class ConfigItems;
 
 class ConfigType
 {
@@ -47,6 +49,13 @@ for (const auto& object : objects) {
 	}
 
 	int GetObjectCount() const;
+
+	/**
+	 * Signal that allows hooking into the config loading process just before ConfigObject::OnAllConfigLoaded() is
+	 * called for a bunch of objects. A vector of pointers to these objects is passed as an argument. All elements
+	 * are of the object type the signal is called on.
+	 */
+	boost::signals2::signal<void (const ConfigItems&)> BeforeOnAllConfigLoaded;
 
 private:
 	typedef std::unordered_map<String, intrusive_ptr<ConfigObject> > ObjectMap;

--- a/lib/base/intrusive-ptr.hpp
+++ b/lib/base/intrusive-ptr.hpp
@@ -1,0 +1,22 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#pragma once
+
+#include "base/i2-base.hpp"
+#include <memory>
+#include <boost/smart_ptr/intrusive_ptr.hpp>
+#include <boost/version.hpp>
+
+// std::hash is only implemented starting from Boost 1.74. Implement it ourselves for older version to allow using
+// boost::intrusive_ptr inside std::unordered_set<> or as the key of std::unordered_map<>.
+// https://github.com/boostorg/smart_ptr/commit/5a18ffdc5609a0e64b63e47cb81c4f0847e0c087
+#if BOOST_VERSION < 107400
+template<class T>
+struct std::hash<boost::intrusive_ptr<T>>
+{
+	std::size_t operator()(const boost::intrusive_ptr<T>& ptr) const noexcept
+	{
+		return std::hash<T*>{}(ptr.get());
+	}
+};
+#endif /* BOOST_VERSION < 107400 */

--- a/lib/base/object.hpp
+++ b/lib/base/object.hpp
@@ -5,6 +5,7 @@
 
 #include "base/i2-base.hpp"
 #include "base/debug.hpp"
+#include "base/intrusive-ptr.hpp"
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <atomic>
 #include <cstddef>

--- a/lib/base/shared.hpp
+++ b/lib/base/shared.hpp
@@ -4,6 +4,7 @@
 #define SHARED_H
 
 #include "base/atomic.hpp"
+#include "base/intrusive-ptr.hpp"
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include <cstdint>
 #include <utility>

--- a/lib/cli/daemonutility.cpp
+++ b/lib/cli/daemonutility.cpp
@@ -256,17 +256,6 @@ bool DaemonUtility::LoadConfigFiles(const std::vector<std::string>& configs,
 	upq.SetName("DaemonUtility::LoadConfigFiles");
 	bool result = ConfigItem::CommitItems(ascope.GetContext(), upq, newItems);
 
-	if (result) {
-		try {
-			Dependency::AssertNoCycles();
-		} catch (...) {
-			Log(LogCritical, "config")
-				<< DiagnosticInformation(boost::current_exception(), false);
-
-			result = false;
-		}
-	}
-
 	if (!result) {
 		ConfigCompilerContext::GetInstance()->CancelObjectsFile();
 		return false;

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -5,6 +5,7 @@
 
 #include "icinga/i2-icinga.hpp"
 #include "icinga/dependency-ti.hpp"
+#include "config/configitem.hpp"
 
 namespace icinga
 {
@@ -22,6 +23,8 @@ class Service;
 class Dependency final : public ObjectImpl<Dependency>
 {
 public:
+	static void StaticInitialize();
+
 	DECLARE_OBJECT(Dependency);
 	DECLARE_OBJECTNAME(Dependency);
 
@@ -36,9 +39,8 @@ public:
 
 	static void EvaluateApplyRules(const intrusive_ptr<Host>& host);
 	static void EvaluateApplyRules(const intrusive_ptr<Service>& service);
-	static void AssertNoCycles();
 
-	/* Note: Only use them for unit test mocks. Prefer OnConfigLoaded(). */
+	/* Note: Only use them for unit test mocks. Prefer InitChildParentReferences(). */
 	void SetParent(intrusive_ptr<Checkable> parent);
 	void SetChild(intrusive_ptr<Checkable> child);
 
@@ -46,15 +48,16 @@ protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
 	void Stop(bool runtimeRemoved) override;
+	void InitChildParentReferences();
 
 private:
 	Checkable::Ptr m_Parent;
 	Checkable::Ptr m_Child;
 
-	static bool m_AssertNoCyclesForIndividualDeps;
-
 	static bool EvaluateApplyRuleInstance(const Checkable::Ptr& checkable, const String& name, ScriptFrame& frame, const ApplyRule& rule, bool skipFilter);
 	static bool EvaluateApplyRule(const Checkable::Ptr& checkable, const ApplyRule& rule, bool skipFilter = false);
+
+	static void BeforeOnAllConfigLoadedHandler(const ConfigItems& items);
 };
 
 }


### PR DESCRIPTION
With #10290, registering a dependency to a checkable will trigger further events inside Icinga DB, so fully registering it, then checking for cycles and unregistering it if there's actually a cycle isn't really the best idea. This PR provides changes that allow to check for cycles before actually fully registering the dependencies and gives the dependency cycle check code a general makeover. The changes include:

* Grouping of related structs and previously static functions in a new `DependencyCycleChecker` helper class for a bit more structure.
* Adding a new method that allows considering extra dependencies for the cycle check that are not yet registered on the individual checkables (`DependencyCycleChecker::AddExtraDependency()`).
* Removal of the distinction between config loaded during process startup and runtime updates (`m_AssertNoCyclesForIndividualDeps`): `CommitNewItems()` already adds config objects in batches. The cycle check is now performed for each batch in one go using a newly introduced `BeforeOnAllConfigLoaded` signal.
* Improved error messages in case of cycles.

The commit messages and code comments contain more details, so please check there for all the details.

In general, expect for the different error messages, there should be no changes in user-facing behavior.

## Tests

The following config has no cycles as-is, uncommenting either of the additional blocks introduces a cycle:

```
object Host "cyclic-host-a" {
	check_command = "dummy"
}

object Service "example-service" {
	host_name = "cyclic-host-a"
	check_command = "dummy"
}

object Host "cyclic-host-b" {
	check_command = "dummy"
}

object Dependency "dep-a" {
	parent_host_name = "cyclic-host-a"
	parent_service_name = "example-service"
	child_host_name = "cyclic-host-b"
}

#object Dependency "dep-b" {
#	parent_host_name = "cyclic-host-b"
#	child_host_name = "cyclic-host-a"
#}

#apply Dependency "dep-b-apply" to Host {
#	parent_host_name = "cyclic-host-b"
#	assign where host.name != "cyclic-host-b"
#}

#object Dependency "dep-self" {
#	parent_host_name = "cyclic-host-a"
#	child_host_name = "cyclic-host-a"
#}
```

Additionally, the dependency creating the cycle can also be added as a runtime update:

```sh
curl -sSku root:icinga -X PUT 'https://localhost:5665/v1/objects/dependencies/cyclic-host-a!dep-b-runtime' \
     --json '{"attrs":{"parent_host_name":"cyclic-host-b"}, "pretty": true}'
```

### Current master branch (5c651e45a386e6ed2dcdcf542e745c3c4df11fa4)

#### Without cycle

Config validates, daemon starts successfully.

#### Cycle with object

```console
# icinga2 daemon -C 
[...]
[2025-03-07 09:14:56 +0100] critical/config: Error: Dependency cycle:
Host 'cyclic-host-a'
-> Dependency 'cyclic-host-a!dep-b'
-> Host 'cyclic-host-b'
-> Dependency 'cyclic-host-b!dep-a'
-> Service 'cyclic-host-a!example-service'
-> Host 'cyclic-host-a' (implicit)
[2025-03-07 09:14:56 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

#### Cycle with apply

```console
# icinga2 daemon -C 
[...]
[2025-03-07 09:15:54 +0100] critical/config: Error: Dependency cycle:
Host 'test-sat-a-231'
-> Dependency 'test-sat-a-231!dep-b-apply'
-> Host 'cyclic-host-b'
-> Dependency 'cyclic-host-b!dep-a'
-> Service 'cyclic-host-a!example-service'
-> Host 'cyclic-host-a' (implicit)
-> Dependency 'cyclic-host-a!dep-b-apply'
-> Host 'cyclic-host-b'
[2025-03-07 09:15:54 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

Note: I tested this by including the config in my test cluster, so this shows an unrelated host test-sat-a-231 that's also present there. It's part of the path that found the cycle but not actually part of the cycle itself (the path shown has a shape like the Greek letter ρ). The test below doesn't show that extra host, but that's only because the starting nodes for the search are picked differently, there was no change in the code that would prevent such a path from appearing.

#### Self-loop

```
# icinga2 daemon -C 
[...]
[2025-03-10 14:09:39 +0100] critical/config: Error: Dependency cycle:
Host 'cyclic-host-a'
-> Dependency 'cyclic-host-a!dep-self'
-> Host 'cyclic-host-a'
[2025-03-10 14:09:39 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

#### Cycle with runtime update

```json
{
    "results": [
        {
            "code": 500,
            "errors": [
                "Error: Dependency cycle:\nHost 'cyclic-host-b'\n-> Dependency 'cyclic-host-b!dep-a'\n-> Service 'cyclic-host-a!example-service'\n-> Host 'cyclic-host-a' (implicit)\n-> Dependency 'cyclic-host-a!dep-b-runtime'\n-> Host 'cyclic-host-b'\n"
            ],
            "status": "Object could not be created."
        }
    ]
}
```

Pretty error message from the JSON:

```
Error: Dependency cycle:
Host 'cyclic-host-b'
-> Dependency 'cyclic-host-b!dep-a'
-> Service 'cyclic-host-a!example-service'
-> Host 'cyclic-host-a' (implicit)
-> Dependency 'cyclic-host-a!dep-b-runtime'
-> Host 'cyclic-host-b'
```

### This PR (fce4775009a79f30603565e1a92b13c63cba6591)

#### Without cycle

Config validates, daemon starts successfully.

#### Cycle with object

```console
# icinga2 daemon -C 
[...]
[2025-03-12 10:36:15 +0100] critical/config: Error: Dependency cycle:
	- Service "cyclic-host-a!example-service" depends on Host "cyclic-host-a" (implicit)
	- Host "cyclic-host-a" depends on Host "cyclic-host-b" (Dependency "dep-b" in /etc/icinga2/zones.d/master/dependencies.conf: 20:1-20:25)
	- Host "cyclic-host-b" depends on Service "cyclic-host-a!example-service" (Dependency "dep-a" in /etc/icinga2/zones.d/master/dependencies.conf: 14:1-14:25)
[2025-03-12 10:36:15 +0100] critical/config: 1 error
[2025-03-12 10:36:15 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

#### Cycle with apply

```console
# icinga2 daemon -C 
[...]
[2025-03-12 10:36:39 +0100] critical/config: Error: Dependency cycle:
	- Host "cyclic-host-b" depends on Service "cyclic-host-a!example-service" (Dependency "dep-a" in /etc/icinga2/zones.d/master/dependencies.conf: 14:1-14:25)
	- Service "cyclic-host-a!example-service" depends on Host "cyclic-host-a" (implicit)
	- Host "cyclic-host-a" depends on Host "cyclic-host-b" (Dependency "dep-b-apply" in /etc/icinga2/zones.d/master/dependencies.conf: 25:1-25:38)
[2025-03-12 10:36:39 +0100] critical/config: 1 error
[2025-03-12 10:36:39 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

#### Self-loop

```console
# icinga2 daemon -C 
[...]
[2025-03-12 10:37:03 +0100] critical/config: Error: Dependency cycle:
	- Service "cyclic-host-a!example-service" depends on Host "cyclic-host-a" (implicit)
	- Host "cyclic-host-a" depends on itself (Dependency "dep-self" in /etc/icinga2/zones.d/master/dependencies.conf: 30:1-30:28)
[2025-03-12 10:37:03 +0100] critical/config: 1 error
[2025-03-12 10:37:03 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

As already noted in the old "cycle with apply" case, additional edges before the actual cycle may be shown both with and without this PR. The checkables are just picked in a different order, so the situations where this happens changed.

#### Cycle with runtime update

```json
{
    "results": [
        {
            "code": 500,
            "errors": [
                "Error: Dependency cycle:\n\t- Host \"cyclic-host-b\" depends on Service \"cyclic-host-a!example-service\" (Dependency \"dep-a\" in /etc/icinga2/zones.d/master/dependencies.conf: 14:1-14:25)\n\t- Service \"cyclic-host-a!example-service\" depends on Host \"cyclic-host-a\" (implicit)\n\t- Host \"cyclic-host-a\" depends on Host \"cyclic-host-b\" (Dependency \"dep-b-runtime\" in /var/lib/icinga2/api/packages/_api/77e78991-06d4-4589-aa0c-ee60e1d7724e/conf.d/dependencies/cyclic-host-a!dep-b-runtime.conf: 1:0-1:32)\n"
            ],
            "status": "Object could not be created."
        }
    ]
}
```

Pretty error message from the JSON:

```
Error: Dependency cycle:
	- Host "cyclic-host-b" depends on Service "cyclic-host-a!example-service" (Dependency "dep-a" in /etc/icinga2/zones.d/master/dependencies.conf: 14:1-14:25)
	- Service "cyclic-host-a!example-service" depends on Host "cyclic-host-a" (implicit)
	- Host "cyclic-host-a" depends on Host "cyclic-host-b" (Dependency "dep-b-runtime" in /var/lib/icinga2/api/packages/_api/77e78991-06d4-4589-aa0c-ee60e1d7724e/conf.d/dependencies/cyclic-host-a!dep-b-runtime.conf: 1:0-1:32)
```