### PR TITLE
tests: Fix `std::vector` out-of-range access

### DIFF
--- a/test/base-string.cpp
+++ b/test/base-string.cpp
@@ -113,6 +113,7 @@ BOOST_AUTO_TEST_CASE(vector_move)
 		// copied even by the move constructor. Using sizeof() ensures that the string is long enough so that it must
 		// be allocated separately and can be used to test for the desired move to happen.
 		std::string(sizeof(String) + 1, 'A'),
+		"Icinga 2",
 	};
 
 	void *oldAddr = vec[0].GetData().data();


### PR DESCRIPTION
Apparently, the standard compilers on all platforms seem to silently ignore out of range access to `std::vector` except on RHEL. Tracing the `std::vector` out-of-bounds assertion on my Mac, it seems that it relies on `__builtin_assume` which doesn't seem to be available. Thus, the assertion is essentially a no-op on MacOS and all other systems.

Edit: `__builtin_assume` is available on my Mac, but has been purposefully disabled!
<img width="948" alt="Bildschirmfoto 2025-03-10 um 09 34 30" src="https://github.com/user-attachments/assets/74488acb-defa-404d-9d55-d1a356222cda" />