### PR TITLE
Avoid undefined behavior in string/vector_move test

### DIFF
--- a/test/base-string.cpp
+++ b/test/base-string.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(vector_move)
 
 	void *oldAddr = vec[0].GetData().data();
 	// Sanity check that the data buffer is actually allocated outside the icinga::String instance.
-	BOOST_CHECK(!(&vec[0] <= oldAddr && oldAddr < &vec[1]));
+	BOOST_CHECK(!(vec.data() <= oldAddr && oldAddr < vec.data() + vec.size()));
 
 	// Force the vector to grow.
 	vec.reserve(vec.capacity() + 1);


### PR DESCRIPTION
`vec[1]` is equivalent to `vec[vec.size()]` at that point and thus not a valid element of the vector, making the use of operator[] undefined behavior here. With some compiler flags (like those used in package builds on RHEL and similar), the compiler (rightfully) aborts the program on this out of bounds access:

     68/178 Test  #68: base-base_string/vector_move ............................................***Failed    0.01 sec
    /usr/include/c++/14/bits/stl_vector.h:1130: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = icinga::String; _Alloc = std::allocator<icinga::String>; reference = icinga::String&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
    Running 1 test case...
    unknown location(0): fatal error: in "base_string/vector_move": signal: SIGABRT (application abort requested)
    /builds/packages/icinga2/packaging/fedora/41/BUILD/icinga2-2.14.5+467.g206d7cda1-build/icinga2-2.14.5+467.g206d7cda1/test/base-string.cpp(120): last checkpoint
    *** 1 failure is detected in the test module "icinga2"

This commit fixes this by taking the indirection through `.data()` and using plain pointer arithmetic instead.

This problem was recently introduced with PR #10353.

closes #10363

## Tests

### Current master branch

Failed snapshot pipeline for 206d7cda1bac4950be6f574fc8a31fff41465433: https://git.icinga.com/packages/icinga2/-/pipelines/35807 (not publicly accessible)

![rpm-binary jobs failed on: Amazon Linux 2023; Fedora 39, 40, 41; RHEL 8, 9](https://github.com/user-attachments/assets/10379d87-6464-469b-8e37-4d3cbfb0c49d)

### This PR

Successful pipeline for 784867b3f7c9736e4b49b78c51de2c59df4d7fa4: https://git.icinga.com/packages/icinga2/-/pipelines/35817 (not publicly accessible)

![rpm-binary jobs are all now succeeding](https://github.com/user-attachments/assets/8e8c48d6-eb1b-4fa5-a200-371b209d45fa)
