### PR TITLE
Notification: Clear last notified state per user on flapping end as well

### DIFF
--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -233,14 +233,17 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 		<< "notifications of type '" << notificationTypeName
 		<< "' for notification object '" << notificationName << "'.";
 
-	if (type == NotificationRecovery) {
+	Checkable::Ptr checkable = GetCheckable();
+
+	// Clear the last notified problem state per user if we're sending a recovery notification or if we're sending a
+	// flapping end notification and the checkable is already in an OK state. This is necessary since we might have
+	// missed the recovery notification due to the flapping state.
+	if (type == NotificationRecovery || (type == NotificationFlappingEnd && checkable->IsStateOK(cr->GetState()))) {
 		auto states (GetLastNotifiedStatePerUser());
 
 		states->Clear();
 		OnLastNotifiedStatePerUserCleared(this, nullptr);
 	}
-
-	Checkable::Ptr checkable = GetCheckable();
 
 	if (!force) {
 		TimePeriod::Ptr tp = GetPeriod();


### PR DESCRIPTION
While testing #10361 I've noticed that the cached `last_notified_state_per_user` doesn't get cleared when flapping state comes into play.

## Test

```bash
object NotificationCommand "send" {
	command = [ "true" ]
}

apply Notification "notify" to Service {
	command = "send"
	users = ["icingaadmin"]
	interval = 0
	types = [ Recovery, Problem, FlappingStart, FlappingEnd ]
	assign where true
}

Object Host "test" {
	check_command = "dummy"
	max_check_attempts = 1
	check_interval = 30s

	vars.dummy_state = 0
	vars.dummy_text = "I'm just testing something"
}

object Service "service" {
    check_command = "dummy"
    host_name = "test"
    max_check_attempts = 1
    enable_active_checks = false
    enable_flapping = true
}
```

Use this script to trigger the bug:
```zsh
#!/bin/zsh

set -exo pipefail

submit_check_result() {
  curl -sSk \
    -u root:icinga \
    -o /dev/null \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json' \
    -X POST 'https://localhost:5665/v1/actions/process-check-result' -d@- <<EOF &
{
    "type": "Service",
    "filter": "host.name == \"test\"",
    "exit_status": $1,
    "plugin_output": "$2"
}
EOF
}

while ; do
  for state in 1 2; do
    submit_check_result $state "WARNING/CRITICAL - flapping"
  done

  flapping=$(curl -ksSu root:icinga 'https://localhost:5665/v1/objects/services?pretty=1' | jq '.results[].attrs.flapping');
  if [ "$flapping" = true ] ; then
    echo "Service is flapping, sending recovery state\n"
    while ; do
      submit_check_result 0 "OK - flapping"

      flapping=$(curl -ksSu root:icinga 'https://localhost:5665/v1/objects/services?pretty=1' | jq '.results[].attrs.flapping')
      if [ "$flapping" = false ]; then
        echo "Service is no longer flapping\n"
        # Trigger a final state change to put the service back into a problem state 'WARNING' and Icinga won't send
        # any problem notification due to the last notified state per user cache not being cleared.
        submit_check_result 1 "WARNING - Not flapping"
        break
      fi
    done

    break # We're done here and can exit the script
  fi
  echo "Service is not flapping yet, keep trying\n"
done
```

### Before

```bash
[2025-03-12 11:00:22 +0100] debug/HttpUtility: Request body: '{    "type": "Service",    "filter": "host.name == \"test\"",    "exit_status": 1,    "plugin_output": "WARNING - Not flapping"}'
...
[2025-03-12 11:00:22 +0100] notice/Checkable: State Change: Checkable 'test!service' hard state change from OK to WARNING detected.
[2025-03-12 11:00:22 +0100] information/Checkable: Checkable 'test!service' has 1 notification(s). Checking filters for type 'Problem', sends will be logged.
...
[2025-03-12 11:00:22 +0100] notice/Notification: Attempting to send notifications of type 'Problem' for notification object 'test!service!notify'.
[2025-03-12 11:00:22 +0100] notice/ApiListener: Relaying 'event::SendNotifications' message
[2025-03-12 11:00:22 +0100] debug/Notification: Type 'Problem', TypeFilter: FlappingEnd, FlappingStart, Problem and Recovery (FType=32, TypeFilter=480)
...
[2025-03-12 11:00:22 +0100] debug/Notification: State 'Warning', StateFilter: Critical, Down, OK, Unknown, Up and Warning (FState=2, StateFilter=-1)
[2025-03-12 11:00:22 +0100] debug/Notification: User 'icingaadmin' notification 'test!service!notify', Type 'Problem', TypeFilter: Problem and Recovery (FType=32, TypeFilter=480)
[2025-03-12 11:00:22 +0100] debug/Notification: User 'icingaadmin' notification 'test!service!notify', State 'Warning', StateFilter: Critical, Down, OK, Unknown, Up and Warning (FState=2, StateFilter=-1)
[2025-03-12 11:00:22 +0100] notice/Notification: Notification object 'test!service!notify': We already notified user 'icingaadmin' for a Warning problem. Likely after that another state change notification was filtered out by config. Not sending duplicate 'Warning' notification.
```

### After

```bash
[2025-03-12 11:02:04 +0100] debug/HttpUtility: Request body: '{    "type": "Service",    "filter": "host.name == \"test\"",    "exit_status": 1,    "plugin_output": "WARNING - Not flapping"}'
[2025-03-12 11:02:04 +0100] notice/Checkable: State Change: Checkable 'test!service' hard state change from OK to WARNING detected.
[2025-03-12 11:02:04 +0100] information/Checkable: Checkable 'test!service' has 1 notification(s). Checking filters for type 'Problem', sends will be logged.
[2025-03-12 11:02:04 +0100] notice/Notification: Attempting to send notifications of type 'Problem' for notification object 'test!service!notify'.
[2025-03-12 11:02:04 +0100] debug/Notification: Type 'Problem', TypeFilter: FlappingEnd, FlappingStart, Problem and Recovery (FType=32, TypeFilter=480)
[2025-03-12 11:02:04 +0100] debug/Notification: State 'Warning', StateFilter: Critical, Down, OK, Unknown, Up and Warning (FState=2, StateFilter=-1)
[2025-03-12 11:02:04 +0100] debug/Notification: User 'icingaadmin' notification 'test!service!notify', Type 'Problem', TypeFilter: Problem and Recovery (FType=32, TypeFilter=480)
[2025-03-12 11:02:04 +0100] debug/Notification: User 'icingaadmin' notification 'test!service!notify', State 'Warning', StateFilter: Critical, Down, OK, Unknown, Up and Warning (FState=2, StateFilter=-1)
[2025-03-12 11:02:04 +0100] information/Notification: Sending 'Problem' notification 'test!service!notify' for user 'icingaadmin'
[2025-03-12 11:02:04 +0100] information/HttpServerConnection: Request POST /v1/actions/process-check-result (from [::1]:54323, user: root, agent: curl/8.7.1, status: OK) took total 11ms.
...
[2025-03-12 11:02:04 +0100] notice/Process: Running command 'true': PID 79226
[2025-03-12 11:02:04 +0100] information/Notification: Completed sending 'Problem' notification 'test!service!notify' for checkable 'test!service' and user 'icingaadmin' using command 'send'.
```