### PR TITLE
Process: Clean up process table entry even when `kill(2)` fails with `ESRCH`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -242,6 +242,7 @@ pv2b <pvz@pvz.pp.se>
 Ralph Breier <ralph.breier@roedl.com>
 Reto Zeder <reto.zeder@arcade.ch>
 Ricardo Bartels <ricardo@bitchbrothers.com>
+Richard Mortimer <richm@oldelvet.org.uk>
 Rinck H. Sonnenberg <r.sonnenberg@netson.nl>
 Robert Lindgren <robert.lindgren@gmail.com>
 Robert Scheck <robert@fedoraproject.org>

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -1087,7 +1087,9 @@ bool Process::DoEvents()
 				Log(LogWarning, "Process")
 					<< "Couldn't kill the process group " << m_PID << " (" << PrettyPrintArguments(m_Arguments)
 					<< "): [errno " << error << "] " << strerror(error);
-				could_not_kill = true;
+				if (error != ESRCH) {
+					could_not_kill = true;
+				}
 			}
 #endif /* _WIN32 */
 


### PR DESCRIPTION
On a very heavily loaded system the process group kill can be delayed until after the regular TERM signal has caused the process to exit. In this situation the waitpid call is valid and reaps the zombie process that would otherwise be left behind.

fixes #10355