### PR TITLE
IcingaDB: Sync downtime `cancel_time` conditionally

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2131,7 +2131,6 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 		"scheduled_end_time", Convert::ToString(TimestampToMilliseconds(downtime->GetEndTime())),
 		"has_been_cancelled", Convert::ToString((unsigned short)downtime->GetWasCancelled()),
 		"trigger_time", Convert::ToString(TimestampToMilliseconds(downtime->GetTriggerTime())),
-		"cancel_time", Convert::ToString(TimestampToMilliseconds(downtime->GetRemoveTime())),
 		"event_id", CalcEventID("downtime_start", downtime),
 		"event_type", "downtime_start"
 	});

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2221,7 +2221,6 @@ void IcingaDB::SendRemovedDowntime(const Downtime::Ptr& downtime)
 		"scheduled_end_time", Convert::ToString(TimestampToMilliseconds(downtime->GetEndTime())),
 		"has_been_cancelled", Convert::ToString((unsigned short)downtime->GetWasCancelled()),
 		"trigger_time", Convert::ToString(TimestampToMilliseconds(downtime->GetTriggerTime())),
-		"cancel_time", Convert::ToString(TimestampToMilliseconds(downtime->GetRemoveTime())),
 		"event_id", CalcEventID("downtime_end", downtime),
 		"event_type", "downtime_end"
 	});
@@ -2239,6 +2238,11 @@ void IcingaDB::SendRemovedDowntime(const Downtime::Ptr& downtime)
 	if (triggeredBy) {
 		xAdd.emplace_back("triggered_by_id");
 		xAdd.emplace_back(GetObjectIdentifier(triggeredBy));
+	}
+
+	if (downtime->GetWasCancelled()) {
+		xAdd.emplace_back("cancel_time");
+		xAdd.emplace_back(Convert::ToString(TimestampToMilliseconds(downtime->GetRemoveTime())));
 	}
 
 	if (downtime->GetFixed()) {


### PR DESCRIPTION
fixes #9612

### After

<details><summary>docker exec -i redis redis-cli -p 6380 --raw XREAD streams icinga:history:stream:downtime 0</summary>


**Downtime{Started,Ended}:**

```bash
icinga:history:stream:downtime
1741949150582-0
downtime_id
23acf3150240e0d8bbffadc1081bf433825f0763
environment_id
f4df75fa7f252696a4e21b1144feac7ebaa87d3c
host_id
a7b8326f4554643d22e8b170cc3a28392d355390
entry_time
1741949150360
author
icingaadmin
comment
IPv4 network maintenance
is_flexible
0
flexible_duration
0
scheduled_start_time
1741949150000
scheduled_end_time
1741949210000
has_been_cancelled
0
trigger_time
1741949150360
event_id
96da3797a5d99341b0cae5893b1258dda0a54a92
event_type
downtime_start
object_type
service
service_id
eac9c2dd2a67b59544e9e3ae8eeb86a4c405d566
start_time
1741949150000
end_time
1741949210000
endpoint_id
3d42be5dfd885d4e763379f6cdbbb26faf9bd2b0
1741949210340-0
downtime_id
23acf3150240e0d8bbffadc1081bf433825f0763
environment_id
f4df75fa7f252696a4e21b1144feac7ebaa87d3c
host_id
a7b8326f4554643d22e8b170cc3a28392d355390
entry_time
1741949150360
author
icingaadmin
cancelled_by

comment
IPv4 network maintenance
is_flexible
0
flexible_duration
0
scheduled_start_time
1741949150000
scheduled_end_time
1741949210000
has_been_cancelled
0
trigger_time
1741949150360
event_id
2a65d064a104a30b96b8c3fd34aa5e170ebaf48a
event_type
downtime_end
object_type
service
service_id
eac9c2dd2a67b59544e9e3ae8eeb86a4c405d566
start_time
1741949150000
end_time
1741949210000
endpoint_id
3d42be5dfd885d4e763379f6cdbbb26faf9bd2b0
```

**DowntimeRemoved:** `/v1/actions/remove-downtime`

```bash
comment
IPv4 network maintenance
is_flexible
0
flexible_duration
0
scheduled_start_time
1741949668000
scheduled_end_time
1741949968000
has_been_cancelled
1
trigger_time
1741949668024
event_id
7d069fb1c24e7478860cec668eda31f312a19aec
event_type
downtime_end
cancel_time
1741949675638
object_type
service
service_id
eac9c2dd2a67b59544e9e3ae8eeb86a4c405d566
start_time
1741949668000
end_time
1741949968000
endpoint_id
3d42be5dfd885d4e763379f6cdbbb26faf9bd2b0
```

</details> 