### PR TITLE
ClusterEvents: Sync & process notification `notified_problem_users`

### DIFF
--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -1281,6 +1281,7 @@ void ClusterEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& n
 	params->Set("notification_number", notification->GetNotificationNumber());
 	params->Set("last_problem_notification", notification->GetLastProblemNotification());
 	params->Set("no_more_notifications", notification->GetNoMoreNotifications());
+	params->Set("notified_problem_users", notification->GetNotifiedProblemUsers());
 
 	Dictionary::Ptr message = new Dictionary();
 	message->Set("jsonrpc", "2.0");
@@ -1373,12 +1374,16 @@ Value ClusterEvents::NotificationSentToAllUsersAPIHandler(const MessageOrigin::P
 	notification->SetLastProblemNotification(params->Get("last_problem_notification"));
 	notification->SetNoMoreNotifications(params->Get("no_more_notifications"));
 
-	ArrayData notifiedProblemUsers;
-	for (const User::Ptr& user : users) {
-		notifiedProblemUsers.push_back(user->GetName());
-	}
+	if (params->Contains("notified_problem_users")) {
+		notification->SetNotifiedProblemUsers(params->Get("notified_problem_users"));
+	} else {
+		ArrayData notifiedProblemUsers;
+		for (const User::Ptr& user : users) {
+			notifiedProblemUsers.push_back(user->GetName());
+		}
 
-	notification->SetNotifiedProblemUsers(new Array(std::move(notifiedProblemUsers)));
+		notification->SetNotifiedProblemUsers(new Array(std::move(notifiedProblemUsers)));
+	}
 
 	Checkable::OnNotificationSentToAllUsers(notification, checkable, users, type, cr, author, text, origin);
 


### PR DESCRIPTION
fixes #9813

### After

I've used the exact config given in #9813.

**OK -> Critical:**

```bash
[2025-03-14 12:27:01 +0100] information/Checkable: Checkable 'test!missing-recovery' has 1 notification(s). Checking filters for type 'Problem', sends will be logged.
[2025-03-14 12:27:01 +0100] information/Notification: Sending 'Problem' notification 'test!missing-recovery!missing-recovery' for user 'u2'
[2025-03-14 12:27:01 +0100] information/Notification: Sending 'Problem' notification 'test!missing-recovery!missing-recovery' for user 'u1'
[2025-03-14 12:27:01 +0100] information/Notification: Completed sending 'Problem' notification 'test!missing-recovery!missing-recovery' for checkable 'test!missing-recovery' and user 'u2' using command 'send'.
[2025-03-14 12:27:01 +0100] information/Notification: Completed sending 'Problem' notification 'test!missing-recovery!missing-recovery' for checkable 'test!missing-recovery' and user 'u1' using command 'send'.
```

```bash
$ curl -ksSu root:icinga 'https://config-master:5665/v1/objects/notifications/test!missing-recovery!missing-recovery?pretty=1' | jq '.results[].attrs.notified_problem_users'
[
  "u2",
  "u1"
]

$ curl -ksSu root:icinga 'https://master2:5667/v1/objects/notifications/test!missing-recovery!missing-recovery?pretty=1' | jq '.results[].attrs.notified_problem_users'
[
  "u2",
  "u1"
]
```

**Critical -> Warning:**

```bash
[2025-03-14 12:28:54 +0100] information/Checkable: Checkable 'test!missing-recovery' has 1 notification(s). Checking filters for type 'Problem', sends will be logged.
[2025-03-14 12:28:54 +0100] information/Notification: Sending 'Problem' notification 'test!missing-recovery!missing-recovery' for user 'u1'
[2025-03-14 12:28:54 +0100] information/Notification: Completed sending 'Problem' notification 'test!missing-recovery!missing-recovery' for checkable 'test!missing-recovery' and user 'u1' using command 'send'.
```

```bash
$ curl -ksSu root:icinga 'https://master2:5667/v1/objects/notifications/test!missing-recovery!missing-recovery?pretty=1' | jq '.results[].attrs.notified_problem_users'
[
  "u2",
  "u1"
]
$ curl -ksSu root:icinga 'https://config-master:5665/v1/objects/notifications/test!missing-recovery!missing-recovery?pretty=1' | jq '.results[].attrs.notified_problem_users'
[
  "u2",
  "u1"
]
```