### PR TITLE
Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
Some of our [GitHub workflows](https://github.com/Icinga/icinga2/blob/master/.github/workflows/windows.yml#L32) use way to old checkout versions. So enable dependabot to regularly bump those dependencies automatically.