### PR TITLE
Allow to define both `[de]activation_priority` for a given type

### DIFF
--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -586,7 +586,7 @@ void ConfigObject::StopObjects()
 	std::vector<Type::Ptr> types = Type::GetAllTypes();
 
 	std::sort(types.begin(), types.end(), [](const Type::Ptr& a, const Type::Ptr& b) {
-		if (a->GetActivationPriority() > b->GetActivationPriority())
+		if (a->GetDeactivationPriority() > b->GetDeactivationPriority())
 			return true;
 		return false;
 	});

--- a/lib/base/type.cpp
+++ b/lib/base/type.cpp
@@ -202,6 +202,11 @@ int Type::GetActivationPriority() const
 	return 0;
 }
 
+int Type::GetDeactivationPriority() const
+{
+	return GetActivationPriority();
+}
+
 void Type::RegisterAttributeHandler(int fieldId, const AttributeHandler& callback)
 {
 	throw std::runtime_error("Invalid field ID.");

--- a/lib/base/type.hpp
+++ b/lib/base/type.hpp
@@ -103,6 +103,7 @@ public:
 
 	virtual const std::unordered_set<Type*>& GetLoadDependencies() const;
 	virtual int GetActivationPriority() const;
+	virtual int GetDeactivationPriority() const;
 
 	typedef std::function<void (const Object::Ptr&, const Value&)> AttributeHandler;
 	virtual void RegisterAttributeHandler(int fieldId, const AttributeHandler& callback);

--- a/tools/mkclass/class_lexer.ll
+++ b/tools/mkclass/class_lexer.ll
@@ -118,7 +118,7 @@ class				{ return T_CLASS; }
 namespace			{ return T_NAMESPACE; }
 code				{ return T_CODE; }
 load_after			{ return T_LOAD_AFTER; }
-activation_priority	{ return T_ACTIVATION_PRIORITY; }
+(activation_priority|deactivation_priority) { yylval->fieldAttributeMask = strcmp(yytext, "activation_priority") == 0 ? FAActivationPriority : FADeactivationPriority; return T_ACTIVATION_DEACTIVATION_PRIORITY; }
 library				{ return T_LIBRARY; }
 abstract			{ yylval->num = TAAbstract; return T_CLASS_ATTRIBUTE; }
 vararg_constructor		{ yylval->num = TAVarArgConstructor; return T_CLASS_ATTRIBUTE; }

--- a/tools/mkclass/class_parser.yy
+++ b/tools/mkclass/class_parser.yy
@@ -28,6 +28,7 @@ using namespace icinga;
 %union {
 	char *text;
 	int num;
+	FieldAttribute fieldAttributeMask;
 	FieldType *type;
 	Field *field;
 	std::vector<Field> *fields;
@@ -44,7 +45,7 @@ using namespace icinga;
 %token T_CLASS "class (T_CLASS)"
 %token T_CODE "code (T_CODE)"
 %token T_LOAD_AFTER "load_after (T_LOAD_AFTER)"
-%token T_ACTIVATION_PRIORITY "activation_priority (T_ACTIVATION_PRIORITY)"
+%token T_ACTIVATION_DEACTIVATION_PRIORITY "activation_deactivation_priority (T_ACTIVATION_DEACTIVATION_PRIORITY)"
 %token T_LIBRARY "library (T_LIBRARY)"
 %token T_NAMESPACE "namespace (T_NAMESPACE)"
 %token T_VALIDATOR "validator (T_VALIDATOR)"
@@ -81,6 +82,7 @@ using namespace icinga;
 %type <num> T_FIELD_ACCESSOR_TYPE
 %type <num> T_CLASS_ATTRIBUTE
 %type <num> class_attribute_list
+%type <fieldAttributeMask> T_ACTIVATION_DEACTIVATION_PRIORITY
 %type <type> field_type
 %type <field> class_field
 %type <fields> class_fields
@@ -237,7 +239,9 @@ class: class_attribute_list T_CLASS T_IDENTIFIER inherits_specifier type_base_sp
 			if (field.Attributes & FALoadDependency) {
 				$$->LoadDependencies.push_back(field.Name);
 			} else if (field.Attributes & FAActivationPriority) {
-				$$->ActivationPriority = field.Priority;
+				$$->ActivationPriority = field.ActivationPriority;
+			} else if (field.Attributes & FADeactivationPriority) {
+				$$->DeactivationPriority = field.DeactivationPriority;
 			} else
 				$$->Fields.push_back(field);
 		}
@@ -368,11 +372,15 @@ class_field: field_attribute_list field_type identifier alternative_name_specifi
 		std::free($2);
 		$$ = field;
 	}
-	| T_ACTIVATION_PRIORITY T_NUMBER ';'
+	| T_ACTIVATION_DEACTIVATION_PRIORITY T_NUMBER ';'
 	{
 		auto *field = new Field();
-		field->Attributes = FAActivationPriority;
-		field->Priority = $2;
+		field->Attributes = $1;
+		if (field->Attributes & FAActivationPriority){
+			field->ActivationPriority = $2;
+		} else {
+			field->DeactivationPriority = $2;
+		}
 		$$ = field;
 	}
 	;

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -407,6 +407,16 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 		<< "\t" << "return " << klass.ActivationPriority << ";" << std::endl
 		<< "}" << std::endl << std::endl;
 
+	// Provide an override for the deactivation priority only if it's explicitly provided, otherwise the
+	// default implementation of this will fall back to the activation priority of that type instead.
+	if (klass.DeactivationPriority != INT_MAX) {
+		m_Header << "\t" << "int GetDeactivationPriority() const override;" << std::endl;
+		m_Impl << "int TypeImpl<" << klass.Name << ">::GetDeactivationPriority() const" << std::endl
+			<< "{" << std::endl
+			<< "\t" << "return " << klass.DeactivationPriority << ";" << std::endl
+			<< "}" << std::endl << std::endl;
+	}
+
 	/* RegisterAttributeHandler */
 	m_Header << "public:" << std::endl
 			<< "\t" << "void RegisterAttributeHandler(int fieldId, const Type::AttributeHandler& callback) override;" << std::endl;

--- a/tools/mkclass/classcompiler.hpp
+++ b/tools/mkclass/classcompiler.hpp
@@ -3,6 +3,7 @@
 #ifndef CLASSCOMPILER_H
 #define CLASSCOMPILER_H
 
+#include <climits>
 #include <string>
 #include <istream>
 #include <utility>
@@ -60,8 +61,9 @@ enum FieldAttribute
 	FADeprecated = 4096,
 	FAGetVirtual = 8192,
 	FASetVirtual = 16384,
-	FAActivationPriority = 32768,
-	FASignalWithOldValue = 65536,
+	FAActivationPriority = 1ull << 15,
+	FADeactivationPriority = 1ull << 16,
+	FASignalWithOldValue = 1ull << 17,
 };
 
 struct FieldType
@@ -107,7 +109,8 @@ struct Field
 	std::string NavigationName;
 	std::string NavigateAccessor;
 	bool PureNavigateAccessor{false};
-	int Priority{0};
+	int ActivationPriority{0};
+	int DeactivationPriority{0};
 
 	inline std::string GetFriendlyName() const
 	{
@@ -154,6 +157,7 @@ struct Klass
 	std::vector<Field> Fields;
 	std::vector<std::string> LoadDependencies;
 	int ActivationPriority{0};
+	int DeactivationPriority{INT_MAX};
 };
 
 enum RuleAttribute


### PR DESCRIPTION
As the title implies, this PR allows us to optionally define both `deactivation_priority` and `activation_priority` for a given type.  Currently all config objects have a sort of fixed order in which they are started and stopped, and in both cases we use the existing `activation_priority` field. Essentially, they're deactivated in the reverse order as they're activated. Below is a startup log snippet with the current master branch, but the output is the same with this PR as well:

```bash
[2025-03-18 15:01:48 +0100] information/ConfigItem: Triggering Start signal for config items
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'app' of type 'IcingaApplication' with priority -50
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'fooo' of type 'Zone' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'test!service' of type 'Service' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'icingaadmin' of type 'User' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'mbp-yhabteab' of type 'Endpoint' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'test_event' of type 'EventCommand' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'test' of type 'Host' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'root' of type 'ApiUser' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'send' of type 'CheckCommand' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'test!service!notify' of type 'Notification' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'send' of type 'NotificationCommand' with priority 0
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'api' of type 'ApiListener' with priority 50
[2025-03-18 15:01:48 +0100] information/ApiListener: 'api' started.
[2025-03-18 15:01:48 +0100] information/ApiListener: Started new listener on '[::]:5667'
[2025-03-18 15:01:48 +0100] information/IcingaDB: 'icingadb' started.
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'notification' of type 'NotificationComponent' with priority 200
[2025-03-18 15:01:48 +0100] information/NotificationComponent: 'notification' started.
[2025-03-18 15:01:48 +0100] debug/ConfigItem: Activating object 'checker' of type 'CheckerComponent' with priority 300
[2025-03-18 15:01:48 +0100] information/CheckerComponent: 'checker' started.
[2025-03-18 15:01:48 +0100] information/ConfigItem: Activated all objects.
```

In the current implementation, the higher priority an object has, the later it gets activated, and as you can see above, the `IcingaDB` feature is delayed until all the other objects have been activated, but for some reason still before the `NotificationComponent` and the `CheckerComponent`. There's an obvious reason why IcingaDB is being enabled so late, namely on Icinga 2 startup Icinga DB doesn't just hook on to the bunch of object signals, instead it waits until all of them are properly initialised and started and then starts a series of [Redis connections to dump them all to Redis](https://github.com/Icinga/icinga2/blob/master/lib/icingadb/icingadb-objects.cpp#L174) without any delay. Now, if we were to let `IcingaDB` start with an activation priority of `-50` as suggested in #10191, it will pretty much be the first thing to get activated and listen and react to pretty much each and every signal from the other objects, making the [parallel config dumps](https://github.com/Icinga/icinga2/blob/master/lib/icingadb/icingadb-objects.cpp#L174) essentially useless, i.e. there won't be any config dump at all as the objects will be synchronised sequentially.

However, what's the reason for #10191 to set the activation priority so low, you ask? As I mentioned above, when Icinga 2 is stopped, the objects will be deactivated in reverse order, and as for `IcingaDB`, it will be the third object to be deactivated. However, there is a potential drawback to this, in that while Icinga DB gets deactivated so early, the other components remain active and capable of generating all kinds of relevant events, which Icinga DB will not be able to process at that point. As you can see, it is impossible to get this to work in both cases using just the `activation_priority` without tweaking around and introducing some hard coded checks of some specific types.

Fortunately, this PR comes to the rescue 😄! This PR now suggests introducing an additional `deactivation_priority` field that can optionally be defined by some types if they need to. Even with this PR, any object that doesn't explicitly define a `deactivation_priority` will behave the same way as with the master branch, namely automatically using its `activation_priority` for the deactivation process as well.

refs #10191