### PR TITLE
Introduce Endpoint#messages_received_per_type

### DIFF
--- a/lib/remote/apifunction.cpp
+++ b/lib/remote/apifunction.cpp
@@ -5,8 +5,8 @@
 
 using namespace icinga;
 
-ApiFunction::ApiFunction(Callback function)
-	: m_Callback(std::move(function))
+ApiFunction::ApiFunction(const char* name, Callback function)
+	: m_Name(name), m_Callback(std::move(function))
 { }
 
 Value ApiFunction::Invoke(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& arguments)

--- a/lib/remote/apifunction.hpp
+++ b/lib/remote/apifunction.hpp
@@ -25,7 +25,12 @@ public:
 
 	typedef std::function<Value(const MessageOrigin::Ptr& origin, const Dictionary::Ptr&)> Callback;
 
-	ApiFunction(Callback function);
+	ApiFunction(const char* name, Callback function);
+
+	const char* GetName() const noexcept
+	{
+		return m_Name;
+	}
 
 	Value Invoke(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& arguments);
 
@@ -33,6 +38,7 @@ public:
 	static void Register(const String& name, const ApiFunction::Ptr& function);
 
 private:
+	const char* m_Name;
 	Callback m_Callback;
 };
 
@@ -49,7 +55,7 @@ public:
 
 #define REGISTER_APIFUNCTION(name, ns, callback) \
 	INITIALIZE_ONCE([]() { \
-		ApiFunction::Ptr func = new ApiFunction(callback); \
+		ApiFunction::Ptr func = new ApiFunction(#ns "::" #name, callback); \
 		ApiFunctionRegistry::GetInstance()->Register(#ns "::" #name, func); \
 	})
 

--- a/lib/remote/endpoint.cpp
+++ b/lib/remote/endpoint.cpp
@@ -149,3 +149,16 @@ double Endpoint::GetBytesReceivedPerSecond() const
 {
 	return m_BytesReceived.CalculateRate(Utility::GetTime(), 60);
 }
+
+Dictionary::Ptr Endpoint::GetMessagesReceivedPerType() const
+{
+	DictionaryData result;
+
+	for (auto& [afunc, cnt] : m_MessageCounters) {
+		if (auto v (cnt.load(std::memory_order_relaxed)); v) {
+			result.emplace_back(afunc->GetName(), v);
+		}
+	}
+
+	return new Dictionary(std::move(result));
+}

--- a/lib/remote/endpoint.hpp
+++ b/lib/remote/endpoint.hpp
@@ -56,6 +56,8 @@ public:
 	double GetBytesSentPerSecond() const override;
 	double GetBytesReceivedPerSecond() const override;
 
+	Dictionary::Ptr GetMessagesReceivedPerType() const override;
+
 protected:
 	void OnAllConfigLoaded() override;
 

--- a/lib/remote/endpoint.ti
+++ b/lib/remote/endpoint.ti
@@ -54,6 +54,10 @@ class Endpoint : ConfigObject
 	[no_user_modify, no_storage] double bytes_received_per_second {
 		get;
 	};
+
+	[no_user_modify, no_storage] Dictionary::Ptr messages_received_per_type {
+		get;
+	};
 };
 
 }

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -351,6 +351,10 @@ void JsonRpcConnection::MessageHandler(const Dictionary::Ptr& message)
 			Log(LogNotice, "JsonRpcConnection")
 				<< "Call to non-existent function '" << method << "' from endpoint '" << m_Identity << "'.";
 		} else {
+			if (m_Endpoint) {
+				m_Endpoint->AddMessageReceived(afunc);
+			}
+
 			Dictionary::Ptr params = message->Get("params");
 			if (params)
 				resultMessage->Set("result", afunc->Invoke(origin, params));


### PR DESCRIPTION
Counts incoming messages per type and endpoint. Queryable via API:

## Test

```
> GET /v1/objects/endpoints?pretty=1 HTTP/1.1
> Host: 127.0.0.1:5665
> Authorization: Basic cm9vdDoxMjM0NTY=
> User-Agent: curl/8.7.1
> Accept: application/json
> Content-Length: 40
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 40 bytes
< HTTP/1.1 200 OK
< Server: Icinga/v2.14.0-488-gbf0a2d4c3
< Content-Type: application/json
< Content-Length: 317
<
{
    "results": [
        {
            "attrs": {
                "messages_received_per_type": {
                    "icinga::Hello": 1
                }
            },
            "joins": {},
            "meta": {},
            "name": "ws-aklimov7777777.local",
            "type": "Endpoint"
        }
    ]
}
```

# 👍