### PR TITLE
Zone#GetEndpoints(): return endpoints in the specified order, not randomly🎲

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -932,7 +932,7 @@ Dictionary::Ptr ApiActions::ExecuteCommand(const ConfigObject::Ptr& object, cons
 		for (const Zone::Ptr& zone : ConfigType::GetObjectsByType<Zone>()) {
 			/* Fetch immediate child zone members */
 			if (zone->GetParent() == localZone && zone->CanAccessObject(endpointPtr->GetZone())) {
-				std::set<Endpoint::Ptr> endpoints = zone->GetEndpoints();
+				auto endpoints (zone->GetEndpoints());
 
 				for (const Endpoint::Ptr& childEndpoint : endpoints) {
 					if (!(childEndpoint->GetCapabilities() & (uint_fast64_t)ApiCapabilities::ExecuteArbitraryCommand)) {

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -966,7 +966,7 @@ Value ClusterEvents::ExecuteCommandAPIHandler(const MessageOrigin::Ptr& origin, 
 			for (const Zone::Ptr &zone : ConfigType::GetObjectsByType<Zone>()) {
 				/* Fetch immediate child zone members */
 				if (zone->GetParent() == localZone && zone->CanAccessObject(endpointZone)) {
-					std::set<Endpoint::Ptr> endpoints = zone->GetEndpoints();
+					auto endpoints (zone->GetEndpoints());
 
 					for (const Endpoint::Ptr &childEndpoint : endpoints) {
 						if (!(childEndpoint->GetCapabilities() & (uint_fast64_t)ApiCapabilities::ExecuteArbitraryCommand)) {

--- a/lib/livestatus/zonestable.cpp
+++ b/lib/livestatus/zonestable.cpp
@@ -70,8 +70,7 @@ Value ZonesTable::EndpointsAccessor(const Value& row)
 	if (!zone)
 		return Empty;
 
-	std::set<Endpoint::Ptr> endpoints = zone->GetEndpoints();
-
+	auto endpoints (zone->GetEndpoints());
 	ArrayData result;
 
 	for (const Endpoint::Ptr& endpoint : endpoints) {

--- a/lib/remote/zone.cpp
+++ b/lib/remote/zone.cpp
@@ -51,10 +51,9 @@ Zone::Ptr Zone::GetParent() const
 	return m_Parent;
 }
 
-std::set<Endpoint::Ptr> Zone::GetEndpoints() const
+std::vector<Endpoint::Ptr> Zone::GetEndpoints() const
 {
-	std::set<Endpoint::Ptr> result;
-
+	std::vector<Endpoint::Ptr> result;
 	Array::Ptr endpoints = GetEndpointsRaw();
 
 	if (endpoints) {
@@ -66,7 +65,7 @@ std::set<Endpoint::Ptr> Zone::GetEndpoints() const
 			if (!endpoint)
 				continue;
 
-			result.insert(endpoint);
+			result.emplace_back(std::move(endpoint));
 		}
 	}
 

--- a/lib/remote/zone.hpp
+++ b/lib/remote/zone.hpp
@@ -22,7 +22,7 @@ public:
 	void OnAllConfigLoaded() override;
 
 	Zone::Ptr GetParent() const;
-	std::set<Endpoint::Ptr> GetEndpoints() const;
+	std::vector<Endpoint::Ptr> GetEndpoints() const;
 	std::vector<Zone::Ptr> GetAllParentsRaw() const;
 	Array::Ptr GetAllParents() const override;
 


### PR DESCRIPTION
ApiListener#RelayMessageOne() relays every given message to the first connected endpoint Zone#GetEndpoints() returns. Randomness in combination with bad luck can direct more traffic (from a particular network segment) to one master than the admin wants.

This change lets the Zone#endpoints order prefer one endpoint over the other.

ref/NC/820479