### PR TITLE
Change RedisConnection::Query::value_type from String to std::variant<const char*,String>

### DIFF
--- a/lib/base/string.cpp
+++ b/lib/base/string.cpp
@@ -37,6 +37,15 @@ String::String(String&& other) noexcept
 	: m_Data(std::move(other.m_Data))
 { }
 
+String::String(std::variant<const char*, String>&& data)
+{
+	if (auto str (std::get_if<String>(&data)); str) {
+		m_Data = std::move(str->m_Data);
+	} else {
+		m_Data = std::get<const char*>(data);
+	}
+}
+
 #ifndef _MSC_VER
 String::String(Value&& other)
 {

--- a/lib/base/string.hpp
+++ b/lib/base/string.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <string>
 #include <iosfwd>
+#include <variant>
 
 namespace icinga {
 
@@ -45,6 +46,7 @@ public:
 	String(String::SizeType n, char c);
 	String(const String& other);
 	String(String&& other) noexcept;
+	String(std::variant<const char*, String>&& data);
 
 #ifndef _MSC_VER
 	String(Value&& other);

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -254,17 +254,17 @@ void IcingaDB::UpdateAllConfigObjects()
 		String configObject = m_PrefixConfigObject + lcType;
 
 		// Skimmed away attributes and checksums HMSETs' keys and values by Redis key.
-		std::map<String, std::vector<std::vector<String>>> ourContentRaw {{configCheckSum, {}}, {configObject, {}}};
+		std::map<String, RedisConnection::Queries> ourContentRaw {{configCheckSum, {}}, {configObject, {}}};
 		std::mutex ourContentMutex;
 
 		upqObjectType.ParallelFor(objectChunks, [&](decltype(objectChunks)::const_reference chunk) {
-			std::map<String, std::vector<String>> hMSets;
+			std::map<String, RedisConnection::Query> hMSets;
 			// Two values are appended per object: Object ID (Hash encoded) and Object State (IcingaDB::SerializeState() -> JSON encoded)
-			std::vector<String> states = {"HMSET", m_PrefixConfigObject + lcType + ":state"};
+			RedisConnection::Query states = {"HMSET", m_PrefixConfigObject + lcType + ":state"};
 			// Two values are appended per object: Object ID (Hash encoded) and State Checksum ({ "checksum": checksum } -> JSON encoded)
-			std::vector<String> statesChksms = {"HMSET", m_PrefixConfigCheckSum + lcType + ":state"};
-			std::vector<std::vector<String> > transaction = {{"MULTI"}};
-			std::vector<String> hostZAdds = {"ZADD", "icinga:nextupdate:host"}, serviceZAdds = {"ZADD", "icinga:nextupdate:service"};
+			RedisConnection::Query statesChksms = {"HMSET", m_PrefixConfigCheckSum + lcType + ":state"};
+			RedisConnection::Queries transaction = {{"MULTI"}};
+			RedisConnection::Query hostZAdds = {"ZADD", "icinga:nextupdate:host"}, serviceZAdds = {"ZADD", "icinga:nextupdate:service"};
 
 			auto skimObjects ([&]() {
 				std::lock_guard<std::mutex> l (ourContentMutex);
@@ -346,7 +346,7 @@ void IcingaDB::UpdateAllConfigObjects()
 					zAdds->emplace_back(GetObjectIdentifier(checkable));
 
 					if (zAdds->size() >= 102u) {
-						std::vector<String> header (zAdds->begin(), zAdds->begin() + 2u);
+						RedisConnection::Query header (zAdds->begin(), zAdds->begin() + 2u);
 
 						rcon->FireAndForgetQuery(std::move(*zAdds), Prio::CheckResult);
 
@@ -417,7 +417,7 @@ void IcingaDB::UpdateAllConfigObjects()
 
 		auto& ourCheckSums (ourContent[configCheckSum]);
 		auto& ourObjects (ourContent[configObject]);
-		std::vector<String> setChecksum, setObject, delChecksum, delObject;
+		RedisConnection::Query setChecksum, setObject, delChecksum, delObject;
 
 		auto redisCurrent (redisCheckSums.begin());
 		auto redisEnd (redisCheckSums.end());
@@ -430,12 +430,12 @@ void IcingaDB::UpdateAllConfigObjects()
 			setChecksum.insert(setChecksum.begin(), {"HMSET", configCheckSum});
 			setObject.insert(setObject.begin(), {"HMSET", configObject});
 
-			std::vector<std::vector<String>> transaction;
+			RedisConnection::Queries transaction;
 
-			transaction.emplace_back(std::vector<String>{"MULTI"});
+			transaction.emplace_back(RedisConnection::Query{"MULTI"});
 			transaction.emplace_back(std::move(setChecksum));
 			transaction.emplace_back(std::move(setObject));
-			transaction.emplace_back(std::vector<String>{"EXEC"});
+			transaction.emplace_back(RedisConnection::Query{"EXEC"});
 
 			setChecksum.clear();
 			setObject.clear();
@@ -449,12 +449,12 @@ void IcingaDB::UpdateAllConfigObjects()
 			delChecksum.insert(delChecksum.begin(), {"HDEL", configCheckSum});
 			delObject.insert(delObject.begin(), {"HDEL", configObject});
 
-			std::vector<std::vector<String>> transaction;
+			RedisConnection::Queries transaction;
 
-			transaction.emplace_back(std::vector<String>{"MULTI"});
+			transaction.emplace_back(RedisConnection::Query{"MULTI"});
 			transaction.emplace_back(std::move(delChecksum));
 			transaction.emplace_back(std::move(delObject));
-			transaction.emplace_back(std::vector<String>{"EXEC"});
+			transaction.emplace_back(RedisConnection::Query{"EXEC"});
 
 			delChecksum.clear();
 			delObject.clear();
@@ -582,7 +582,7 @@ std::vector<std::vector<intrusive_ptr<ConfigObject>>> IcingaDB::ChunkObjects(std
 }
 
 void IcingaDB::DeleteKeys(const RedisConnection::Ptr& conn, const std::vector<String>& keys, RedisConnection::QueryPriority priority) {
-	std::vector<String> query = {"DEL"};
+	RedisConnection::Query query = {"DEL"};
 	for (auto& key : keys) {
 		query.emplace_back(key);
 	}
@@ -654,7 +654,7 @@ static ConfigObject::Ptr GetObjectByName(const String& name)
 	return ConfigObject::GetObject<ConfigType>(name);
 }
 
-void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
+void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, RedisConnection::Query>& hMSets,
 		std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate)
 {
 	String objectKey = GetObjectIdentifier(object);
@@ -1161,7 +1161,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, StateUpdate mode)
 	if (mode & StateUpdate::RuntimeOnly) {
 		ObjectLock olock(stateAttrs);
 
-		std::vector<String> streamadd({
+		RedisConnection::Query streamadd({
 			"XADD", "icinga:runtime:state", "MAXLEN", "~", "1000000", "*",
 			"runtime_type", "upsert",
 			"redis_key", redisStateKey,
@@ -1185,7 +1185,7 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 
 	String typeName = GetLowerCaseTypeNameDB(object);
 
-	std::map<String, std::vector<String>> hMSets;
+	std::map<String, RedisConnection::Query> hMSets;
 	std::vector<Dictionary::Ptr> runtimeUpdates;
 
 	CreateConfigUpdate(object, typeName, hMSets, runtimeUpdates, runtimeUpdate);
@@ -1194,7 +1194,7 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 		UpdateState(checkable, runtimeUpdate ? StateUpdate::Full : StateUpdate::Volatile);
 	}
 
-	std::vector<std::vector<String> > transaction = {{"MULTI"}};
+	RedisConnection::Queries transaction = {{"MULTI"}};
 
 	for (auto& kv : hMSets) {
 		if (!kv.second.empty()) {
@@ -1204,7 +1204,7 @@ void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpd
 	}
 
 	for (auto& objectAttributes : runtimeUpdates) {
-		std::vector<String> xAdd({"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*"});
+		RedisConnection::Query xAdd ({"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*"});
 		ObjectLock olock(objectAttributes);
 
 		for (const Dictionary::Pair& kv : objectAttributes) {
@@ -1547,7 +1547,7 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
  * icinga:config:object:downtime) need to be prepended. There is nothing to indicate success or failure.
  */
 void
-IcingaDB::CreateConfigUpdate(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
+IcingaDB::CreateConfigUpdate(const ConfigObject::Ptr& object, const String typeName, std::map<String, RedisConnection::Query>& hMSets,
 								std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate)
 {
 	/* TODO: This isn't essentially correct as we don't keep track of config objects ourselves. This would avoid duplicated config updates at startup.
@@ -1710,7 +1710,7 @@ void IcingaDB::SendStateChange(const ConfigObject::Ptr& object, const CheckResul
 	Array::Ptr rawId = new Array({m_EnvironmentId, object->GetName()});
 	rawId->Add(eventTs);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:state", "*",
 		"id", HashValue(rawId),
 		"environment_id", m_EnvironmentId,
@@ -1794,7 +1794,7 @@ void IcingaDB::SendSentNotification(
 
 	auto notificationHistoryId (HashValue(rawId));
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:notification", "*",
 		"id", notificationHistoryId,
 		"environment_id", m_EnvironmentId,
@@ -1858,7 +1858,7 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 	/* Update checkable state as in_downtime may have changed. */
 	UpdateState(checkable, StateUpdate::Full);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:downtime", "*",
 		"downtime_id", GetObjectIdentifier(downtime),
 		"environment_id", m_EnvironmentId,
@@ -1948,7 +1948,7 @@ void IcingaDB::SendRemovedDowntime(const Downtime::Ptr& downtime)
 	/* Update checkable state as in_downtime may have changed. */
 	UpdateState(checkable, StateUpdate::Full);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:downtime", "*",
 		"downtime_id", GetObjectIdentifier(downtime),
 		"environment_id", m_EnvironmentId,
@@ -2030,7 +2030,7 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:comment", "*",
 		"comment_id", GetObjectIdentifier(comment),
 		"environment_id", m_EnvironmentId,
@@ -2102,7 +2102,7 @@ void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:comment", "*",
 		"comment_id", GetObjectIdentifier(comment),
 		"environment_id", m_EnvironmentId,
@@ -2165,7 +2165,7 @@ void IcingaDB::SendFlappingChange(const Checkable::Ptr& checkable, double change
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:flapping", "*",
 		"environment_id", m_EnvironmentId,
 		"host_id", GetObjectIdentifier(host),
@@ -2260,7 +2260,7 @@ void IcingaDB::SendAcknowledgementSet(const Checkable::Ptr& checkable, const Str
 	/* Update checkable state as is_acknowledged may have changed. */
 	UpdateState(checkable, StateUpdate::Full);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
 		"environment_id", m_EnvironmentId,
 		"host_id", GetObjectIdentifier(host),
@@ -2318,7 +2318,7 @@ void IcingaDB::SendAcknowledgementCleared(const Checkable::Ptr& checkable, const
 	/* Update checkable state as is_acknowledged may have changed. */
 	UpdateState(checkable, StateUpdate::Full);
 
-	std::vector<String> xAdd ({
+	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
 		"environment_id", m_EnvironmentId,
 		"host_id", GetObjectIdentifier(host),
@@ -2959,7 +2959,7 @@ void IcingaDB::DeleteRelationship(const String& id, const String& redisKeyWithou
 
 	String redisKey = m_PrefixConfigObject + redisKeyWithoutPrefix;
 
-	std::vector<std::vector<String>> queries;
+	RedisConnection::Queries queries;
 
 	if (hasChecksum) {
 		queries.push_back({"HDEL", m_PrefixConfigCheckSum + redisKeyWithoutPrefix, id});

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -710,12 +710,12 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 			auto id (HashValue(new Array({m_EnvironmentId, actionUrl})));
 
 			if (runtimeUpdate || m_DumpedGlobals.ActionUrl.IsNew(id)) {
-				actionUrls.emplace_back(std::move(id));
+				actionUrls.emplace_back(id);
 				Dictionary::Ptr data = new Dictionary({{"environment_id", m_EnvironmentId}, {"action_url", actionUrl}});
 				actionUrls.emplace_back(JsonEncode(data));
 
 				if (runtimeUpdate) {
-					AddObjectDataToRuntimeUpdates(runtimeUpdates, actionUrls.at(actionUrls.size() - 2u), m_PrefixConfigObject + "action:url", data);
+					AddObjectDataToRuntimeUpdates(runtimeUpdates, id, m_PrefixConfigObject + "action:url", data);
 				}
 			}
 		}
@@ -725,12 +725,12 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 			auto id (HashValue(new Array({m_EnvironmentId, notesUrl})));
 
 			if (runtimeUpdate || m_DumpedGlobals.NotesUrl.IsNew(id)) {
-				notesUrls.emplace_back(std::move(id));
+				notesUrls.emplace_back(id);
 				Dictionary::Ptr data = new Dictionary({{"environment_id", m_EnvironmentId}, {"notes_url", notesUrl}});
 				notesUrls.emplace_back(JsonEncode(data));
 
 				if (runtimeUpdate) {
-					AddObjectDataToRuntimeUpdates(runtimeUpdates, notesUrls.at(notesUrls.size() - 2u), m_PrefixConfigObject + "notes:url", data);
+					AddObjectDataToRuntimeUpdates(runtimeUpdates, id, m_PrefixConfigObject + "notes:url", data);
 				}
 			}
 		}
@@ -740,12 +740,12 @@ void IcingaDB::InsertObjectDependencies(const ConfigObject::Ptr& object, const S
 			auto id (HashValue(new Array({m_EnvironmentId, iconImage})));
 
 			if (runtimeUpdate || m_DumpedGlobals.IconImage.IsNew(id)) {
-				iconImages.emplace_back(std::move(id));
+				iconImages.emplace_back(id);
 				Dictionary::Ptr data = new Dictionary({{"environment_id", m_EnvironmentId}, {"icon_image", iconImage}});
 				iconImages.emplace_back(JsonEncode(data));
 
 				if (runtimeUpdate) {
-					AddObjectDataToRuntimeUpdates(runtimeUpdates, iconImages.at(iconImages.size() - 2u), m_PrefixConfigObject + "icon:image", data);
+					AddObjectDataToRuntimeUpdates(runtimeUpdates, id, m_PrefixConfigObject + "icon:image", data);
 				}
 			}
 		}

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -175,7 +175,7 @@ void IcingaDB::PublishStats()
 	status->Set("timestamp", TimestampToMilliseconds(Utility::GetTime()));
 	status->Set("icingadb_environment", m_EnvironmentId);
 
-	std::vector<String> query {"XADD", "icinga:stats", "MAXLEN", "1", "*"};
+	RedisConnection::Query query {"XADD", "icinga:stats", "MAXLEN", "1", "*"};
 
 	{
 		ObjectLock statusLock (status);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -101,11 +101,11 @@ private:
 	void DeleteKeys(const RedisConnection::Ptr& conn, const std::vector<String>& keys, RedisConnection::QueryPriority priority);
 	std::vector<String> GetTypeOverwriteKeys(const String& type);
 	std::vector<String> GetTypeDumpSignalKeys(const Type::Ptr& type);
-	void InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, std::vector<String>>& hMSets,
+	void InsertObjectDependencies(const ConfigObject::Ptr& object, const String typeName, std::map<String, RedisConnection::Query>& hMSets,
 			std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
 	void UpdateState(const Checkable::Ptr& checkable, StateUpdate mode);
 	void SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpdate);
-	void CreateConfigUpdate(const ConfigObject::Ptr& object, const String type, std::map<String, std::vector<String>>& hMSets,
+	void CreateConfigUpdate(const ConfigObject::Ptr& object, const String type, std::map<String, RedisConnection::Query>& hMSets,
 			std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
 	void SendConfigDelete(const ConfigObject::Ptr& object);
 	void SendStateChange(const ConfigObject::Ptr& object, const CheckResult::Ptr& cr, StateType type);

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -99,10 +99,14 @@ void LogQuery(RedisConnection::Query& query, Log& msg)
 			break;
 		}
 
-		if (arg.GetLength() > 64) {
-			msg << " '" << arg.SubStr(0, 61) << "...'";
+		if (auto str (std::get_if<String>(&arg)); str) {
+			if (str->GetLength() > 64) {
+				msg << " '" << str->SubStr(0, 61) << "...'";
+			} else {
+				msg << " '" << *str << '\'';
+			}
 		} else {
-			msg << " '" << arg << '\'';
+			msg << " '" << std::get<const char*>(arg) << '\'';
 		}
 	}
 }

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -39,6 +39,7 @@
 #include <set>
 #include <stdexcept>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace icinga
@@ -53,7 +54,7 @@ namespace icinga
 	public:
 		DECLARE_PTR_TYPEDEFS(RedisConnection);
 
-		typedef std::vector<String> Query;
+		typedef std::vector<std::variant<const char*, String>> Query;
 		typedef std::vector<Query> Queries;
 		typedef Value Reply;
 		typedef std::vector<Reply> Replies;
@@ -667,7 +668,12 @@ void RedisConnection::WriteRESP(AsyncWriteStream& stream, const Query& query, bo
 	msg << "*" << query.size() << "\r\n";
 
 	for (auto& arg : query) {
-		msg << "$" << arg.GetLength() << "\r\n" << arg << "\r\n";
+		if (auto str (std::get_if<String>(&arg)); str) {
+			msg << "$" << str->GetLength() << "\r\n" << *str << "\r\n";
+		} else {
+			auto cstr (std::get<const char*>(arg));
+			msg << "$" << strlen(cstr) << "\r\n" << cstr << "\r\n";
+		}
 	}
 
 	asio::async_write(stream, writeBuffer, yc);


### PR DESCRIPTION
(Find TL;DR below)

![](https://github.com/user-attachments/assets/b0636f5a-0a56-4e4a-9c74-3a127f52742f)

Seriously speaking, 70ca88ae0598e8bd1352ffb675e00ab5f1335313 pollutes the diff and should be viewed on its own. It just replaces `std::vector<String>` with RedisConnection::Query. As RedisConnection::Query already was a `std::vector<String>`, this is a no-op on its own. But it allows to just change RedisConnection::Query itself and affect all its usages at once.

### Why do we have to change String to std::variant<const char*,String> at all? (efe5f22c1080ea4def2c406fd765344876a15cd1)

Especially our history messages [contain lots of hardcoded C string literals](https://github.com/Icinga/icinga2/blob/v2.14.5/lib/icingadb/icingadb-objects.cpp#L1713-L2326) "like this one". At runtime, they get translated to pointers to constant global memory, const char*. **String malloc(3)s and copies these data every time.** In contrast, std::variant<const char*,String> just stores the address if any.

## TL;DR

* The JSON RPC message processing involves Icinga DB handlers
* The Icinga DB handlers assemble Redis messages, `std::vector<T>`
* The faster T is, the better for JSON RPC message processing
* The fastest possible T is const char*, if any, which is just a pointer

fixes #10276
ref/NC/820479