### PR TITLE
ApiListener#RelayMessageOne(): log🪵 to which Endpoint messages are relayed

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1220,11 +1220,12 @@ bool ApiListener::RelayMessageOne(const Zone::Ptr& targetZone, const MessageOrig
 	ASSERT(targetZone);
 
 	Zone::Ptr localZone = Zone::GetLocalZone();
+	auto parentZone (localZone->GetParent());
 
 	/* only relay the message to a) the same local zone, b) the parent zone and c) direct child zones. Exception is a global zone. */
 	if (!targetZone->GetGlobal() &&
 		targetZone != localZone &&
-		targetZone != localZone->GetParent() &&
+		targetZone != parentZone &&
 		targetZone->GetParent() != localZone) {
 		return true;
 	}
@@ -1303,11 +1304,25 @@ bool ApiListener::RelayMessageOne(const Zone::Ptr& targetZone, const MessageOrig
 			bool isMaster = (currentZoneMaster == localEndpoint);
 
 			if (!isMaster && targetEndpoint != currentZoneMaster) {
+				if (currentTargetZone == parentZone) {
+					if (m_CurrentParentEndpoint.exchange(currentZoneMaster.get()) != currentZoneMaster.get()) {
+						Log(LogInformation, "ApiListener") << "Relaying messages for parent Zone '"
+							<< parentZone->GetName() << "' to Endpoint '" << currentZoneMaster->GetName() << "' now";
+					}
+				}
+
 				skippedEndpoints.push_back(targetEndpoint);
 				continue;
 			}
 
 			relayed = true;
+
+			if (currentTargetZone == parentZone) {
+				if (m_CurrentParentEndpoint.exchange(targetEndpoint.get()) != targetEndpoint.get()) {
+					Log(LogInformation, "ApiListener") << "Relaying messages for parent Zone '"
+						<< parentZone->GetName() << "' to Endpoint '" << targetEndpoint->GetName() << "' now";
+				}
+			}
 
 			SyncSendMessage(targetEndpoint, message);
 		}

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -8,6 +8,7 @@
 #include "remote/httpserverconnection.hpp"
 #include "remote/endpoint.hpp"
 #include "remote/messageorigin.hpp"
+#include "base/atomic.hpp"
 #include "base/configobject.hpp"
 #include "base/process.hpp"
 #include "base/shared.hpp"
@@ -177,6 +178,7 @@ private:
 	Timer::Ptr m_RenewOwnCertTimer;
 
 	Endpoint::Ptr m_LocalEndpoint;
+	Atomic<Endpoint*> m_CurrentParentEndpoint {nullptr};
 
 	static ApiListener::Ptr m_Instance;
 	static std::atomic<bool> m_UpdatedObjectAuthority;


### PR DESCRIPTION
if they're for our parent Zone.

ref/NC/820479

## Tests

### Config

```
object Endpoint "akzl1" {
  host = "10.27.1.87"
}

object Endpoint "akzl2" {
  host = "10.27.1.90"
}

object Endpoint "akzl3" {
  host = "10.27.3.6"
}

object Endpoint "akzl4" {
  host = "10.27.0.129"
}

object Zone "master" {
  endpoints = [ "akzl1", "akzl2" ]
}

object Zone "sat" {
  parent = "master"
  endpoints = [ "akzl3", "akzl4" ]
}

include <itl>

object CheckerComponent "checker" { }

object ApiListener "api" {
  accept_config = true
  accept_commands = true
}

object ApiUser "root" {
  password = "123456"
  permissions = [ "*" ]
}

object Host "master" {
  check_command = "dummy"
  zone = "master"
}

object Host "sat" {
  check_command = "dummy"
  zone = "sat"
}

for (i in range(1000)) {
  apply Service i {
    check_command = "dummy"
    assign where true
  }
}
```

### Starting point

<img width="1920" alt="Bildschirmfoto 2025-03-27 um 12 32 56" src="https://github.com/user-attachments/assets/f2de5e2b-a845-4810-946d-d70aa6b00db3" />

sat's member akzl4 relays stuff to its zone-master akzl3 which relays it to the parent akzl1.

### Let's break something... 😈

If we stop akzl1...

<img width="1920" alt="Bildschirmfoto 2025-03-27 um 12 35 31" src="https://github.com/user-attachments/assets/8fe2aca7-65ac-49f4-b51f-4dfff5248f07" />

... akzl3 switches its parent from akzl1 to akzl2.

### Let's break something... 😈 II

If we also stop akzl3...

<img width="1920" alt="Bildschirmfoto 2025-03-27 um 12 36 28" src="https://github.com/user-attachments/assets/f224266f-5a53-432d-abf4-4308f1f3dccd" />

... akzl4 switches from zone-master akzl3 to parent akzl2.

### OK, the downtime is over... 👿

Likewise, whichever preferred nodes come back online...

![Bildschirmfoto 2025-03-27 um 12 37 01](https://github.com/user-attachments/assets/0ee832c8-9564-4db3-a332-cea383db28b4)

... they're used again! 👍

![Bildschirmfoto 2025-03-27 um 12 37 21](https://github.com/user-attachments/assets/df3f79d4-d289-4e69-97da-858f5fdfe1ec)