### PR TITLE
Update command-plugins.conf to ensure compatibility with nagios-plugins' check_disk

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -434,6 +434,7 @@ disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB.
 disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.\*" (only Monitoring Plugins support this so far), "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fuse.sshfs", "fdescfs", "overlay", "nsfs", "squashfs".
 disk\_include\_type       | **Optional.** Check only filesystems of indicated type. Multiple regular expression strings must be defined as array.
 disk\_inode\_perfdata     | **Optional.** Display inode usage in perfdata
+disk\_np\_inode\_perfdata | **Optional.** Enable performance data for inode-based statistics (nagios-plugins)
 disk\_extra\_opts         | **Optional.** Read extra plugin options from an ini file.
 
 ### disk_smb <a id="plugin-check-command-disk-smb"></a>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -434,7 +434,7 @@ disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB.
 disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.\*" (only Monitoring Plugins support this so far), "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fuse.sshfs", "fdescfs", "overlay", "nsfs", "squashfs".
 disk\_include\_type       | **Optional.** Check only filesystems of indicated type. Multiple regular expression strings must be defined as array.
 disk\_inode\_perfdata     | **Optional.** Display inode usage in perfdata
-disk\_np\_inode\_perfdata | **Optional.** Enable performance data for inode-based statistics (nagios-plugins)
+disk\_np\_inode\_perfdata | **Optional.** Enable performance data for inode-based statistics (Requires: nagios-plugins >= 2.3.0)
 disk\_extra\_opts         | **Optional.** Read extra plugin options from an ini file.
 
 ### disk_smb <a id="plugin-check-command-disk-smb"></a>

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1659,6 +1659,10 @@ object CheckCommand "disk" {
 			description = "Display inode usage in perfdata"
 			set_if = "$disk_inode_perfdata$"
 		}
+		"--inode-perfdata" = {
+			description = "Enable performance data for inode-based statistics (nagios-plugins)"
+			set_if = "$disk_np_inode_perfdata$"
+		}
 		"-p" = {
 			value = "$disk_partitions$"
 			description = "Path or partition (may be repeated)"


### PR DESCRIPTION
Since nagios-plugins >= 2.3.0 a new command line argument is added to print inode-perfdata.
nagios-plugins Changelog: https://nagios-plugins.org/nagios-plugins-2-3-0-released/

As I believe many icinga-users still use nagios-plugins packages and it is included in most distributions (e.g. RHEL) I would like to add this parameter to ensure higher compatibility.