### PR TITLE
Checkable#ProcessCheckResult(): discard🗑️ CR or delay its producers shutdown

### DIFF
--- a/lib/base/CMakeLists.txt
+++ b/lib/base/CMakeLists.txt
@@ -87,6 +87,7 @@ set(base_SOURCES
   unixsocket.cpp unixsocket.hpp
   utility.cpp utility.hpp
   value.cpp value.hpp value-operators.cpp
+  wait-group.cpp wait-group.hpp
   win32.hpp
   workqueue.cpp workqueue.hpp
 )

--- a/lib/base/wait-group.cpp
+++ b/lib/base/wait-group.cpp
@@ -1,0 +1,38 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "base/wait-group.hpp"
+
+using namespace icinga;
+
+bool StoppableWaitGroup::try_lock_shared()
+{
+	std::unique_lock lock (m_Mutex);
+
+	if (m_Stopped) {
+		return false;
+	}
+
+	++m_SharedLocks;
+	return true;
+}
+
+void StoppableWaitGroup::unlock_shared()
+{
+	std::unique_lock lock (m_Mutex);
+
+	if (!--m_SharedLocks && m_Stopped) {
+		lock.unlock();
+		m_CV.notify_all();
+	}
+}
+
+/**
+ * Disallow new shared locks, wait for all existing ones.
+ */
+void StoppableWaitGroup::Join()
+{
+	std::unique_lock lock (m_Mutex);
+
+	m_Stopped = true;
+	m_CV.wait(lock, [this] { return !m_SharedLocks; });
+}

--- a/lib/base/wait-group.hpp
+++ b/lib/base/wait-group.hpp
@@ -1,0 +1,54 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#pragma once
+
+#include "base/object.hpp"
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+
+namespace icinga
+{
+
+/**
+ * A synchronization interface that allows concurrent shared locking.
+ *
+ * @ingroup base
+ */
+class WaitGroup : public Object
+{
+public:
+	DECLARE_PTR_TYPEDEFS(WaitGroup);
+
+	virtual bool try_lock_shared() = 0;
+	virtual void unlock_shared() = 0;
+};
+
+/**
+ * A thread-safe wait group that can be stopped to prevent further shared locking.
+ *
+ * @ingroup base
+ */
+class StoppableWaitGroup : public WaitGroup
+{
+public:
+	DECLARE_PTR_TYPEDEFS(StoppableWaitGroup);
+
+	StoppableWaitGroup() = default;
+	StoppableWaitGroup(const StoppableWaitGroup&) = delete;
+	StoppableWaitGroup(StoppableWaitGroup&&) = delete;
+	StoppableWaitGroup& operator=(const StoppableWaitGroup&) = delete;
+	StoppableWaitGroup& operator=(StoppableWaitGroup&&) = delete;
+
+	bool try_lock_shared() override;
+	void unlock_shared() override;
+	void Join();
+
+private:
+	std::mutex m_Mutex;
+	std::condition_variable m_CV;
+	uint_fast32_t m_SharedLocks = 0;
+	bool m_Stopped = false;
+};
+
+}

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -81,6 +81,7 @@ void CheckerComponent::Stop(bool runtimeRemoved)
 		m_CV.notify_all();
 	}
 
+	m_WaitGroup->Join();
 	m_ResultTimer->Stop(true);
 	m_Thread.join();
 

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -232,7 +232,7 @@ void CheckerComponent::CheckThreadProc()
 void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable)
 {
 	try {
-		checkable->ExecuteCheck();
+		checkable->ExecuteCheck(m_WaitGroup);
 	} catch (const std::exception& ex) {
 		CheckResult::Ptr cr = new CheckResult();
 		cr->SetState(ServiceUnknown);
@@ -246,7 +246,7 @@ void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable)
 		cr->SetExecutionStart(now);
 		cr->SetExecutionEnd(now);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, m_WaitGroup);
 
 		Log(LogCritical, "checker", output);
 	}

--- a/lib/checker/checkercomponent.hpp
+++ b/lib/checker/checkercomponent.hpp
@@ -8,6 +8,7 @@
 #include "base/configobject.hpp"
 #include "base/timer.hpp"
 #include "base/utility.hpp"
+#include "base/wait-group.hpp"
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/key_extractors.hpp>
@@ -77,6 +78,7 @@ private:
 	CheckableSet m_IdleCheckables;
 	CheckableSet m_PendingCheckables;
 
+	StoppableWaitGroup::Ptr m_WaitGroup = new StoppableWaitGroup();
 	Timer::Ptr m_ResultTimer;
 
 	void CheckThreadProc();

--- a/lib/compat/externalcommandlistener.cpp
+++ b/lib/compat/externalcommandlistener.cpp
@@ -138,7 +138,7 @@ void ExternalCommandListener::CommandPipeThread(const String& commandPath)
 					Log(LogInformation, "ExternalCommandListener")
 						<< "Executing external command: " << command;
 
-					ExternalCommandProcessor::Execute(command);
+					ExternalCommandProcessor::Execute(m_WaitGroup, command);
 				} catch (const std::exception& ex) {
 					Log(LogWarning, "ExternalCommandListener")
 						<< "External command failed: " << DiagnosticInformation(ex, false);

--- a/lib/compat/externalcommandlistener.cpp
+++ b/lib/compat/externalcommandlistener.cpp
@@ -50,6 +50,8 @@ void ExternalCommandListener::Start(bool runtimeCreated)
  */
 void ExternalCommandListener::Stop(bool runtimeRemoved)
 {
+	m_WaitGroup->Join();
+
 	Log(LogInformation, "ExternalCommandListener")
 		<< "'" << GetName() << "' stopped.";
 

--- a/lib/compat/externalcommandlistener.hpp
+++ b/lib/compat/externalcommandlistener.hpp
@@ -5,6 +5,7 @@
 
 #include "compat/externalcommandlistener-ti.hpp"
 #include "base/objectlock.hpp"
+#include "base/wait-group.hpp"
 #include "base/timer.hpp"
 #include "base/utility.hpp"
 #include <thread>
@@ -29,6 +30,8 @@ protected:
 	void Stop(bool runtimeRemoved) override;
 
 private:
+	StoppableWaitGroup::Ptr m_WaitGroup = new StoppableWaitGroup();
+
 #ifndef _WIN32
 	std::thread m_CommandThread;
 

--- a/lib/db_ido/idochecktask.hpp
+++ b/lib/db_ido/idochecktask.hpp
@@ -18,7 +18,7 @@ class IdoCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	IdoCheckTask();

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -126,7 +126,8 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 	if (params->Contains("ttl"))
 		cr->SetTtl(HttpUtility::GetLastParameter(params, "ttl"));
 
-	Result result = checkable->ProcessCheckResult(cr);
+	Result result = checkable->ProcessCheckResult(cr, ApiListener::GetInstance()->GetWaitGroup());
+
 	switch (result) {
 		case Result::Ok:
 			return ApiActions::CreateResult(200, "Successfully processed check result for object '" + checkable->GetName() + "'.");
@@ -787,7 +788,7 @@ Dictionary::Ptr ApiActions::ExecuteCommand(const ConfigObject::Ptr& object, cons
 			Defer resetCheckCommandOverride([]() {
 				CheckCommand::ExecuteOverride = nullptr;
 			});
-			cmd->Execute(checkable, cr, execMacros, false);
+			cmd->Execute(checkable, cr, listener->GetWaitGroup(), execMacros, false);
 		}
 	} else if (command_type == "EventCommand") {
 		EventCommand::Ptr cmd = GetSingleObjectByNameUsingPermissions(EventCommand::GetTypeName(), resolved_command, ActionsHandler::AuthenticatedApiUser);

--- a/lib/icinga/checkable-script.cpp
+++ b/lib/icinga/checkable-script.cpp
@@ -6,6 +6,7 @@
 #include "base/function.hpp"
 #include "base/functionwrapper.hpp"
 #include "base/scriptframe.hpp"
+#include "remote/apilistener.hpp"
 
 using namespace icinga;
 
@@ -16,7 +17,9 @@ static void CheckableProcessCheckResult(const CheckResult::Ptr& cr)
 	REQUIRE_NOT_NULL(self);
 
 	if (cr) {
-		self->ProcessCheckResult(cr);
+		auto api (ApiListener::GetInstance());
+
+		self->ProcessCheckResult(cr, api ? api->GetWaitGroup() : new StoppableWaitGroup());
 	}
 }
 

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -12,6 +12,7 @@
 #include "icinga/notification.hpp"
 #include "icinga/comment.hpp"
 #include "icinga/downtime.hpp"
+#include "base/wait-group.hpp"
 #include "remote/endpoint.hpp"
 #include "remote/messageorigin.hpp"
 #include <condition_variable>
@@ -114,15 +115,17 @@ public:
 
 	static void UpdateStatistics(const CheckResult::Ptr& cr, CheckableType type);
 
-	void ExecuteRemoteCheck(const Dictionary::Ptr& resolvedMacros = nullptr);
-	void ExecuteCheck();
+	void ExecuteRemoteCheck(const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros = nullptr);
+	void ExecuteCheck(const WaitGroup::Ptr& producer);
+
 	enum class ProcessingResult
 	{
 		Ok,
 		CheckableInactive,
 		NewerCheckResultPresent,
 	};
-	ProcessingResult ProcessCheckResult(const CheckResult::Ptr& cr, const MessageOrigin::Ptr& origin = nullptr);
+
+	ProcessingResult ProcessCheckResult(const CheckResult::Ptr& cr, const WaitGroup::Ptr& producer, const MessageOrigin::Ptr& origin = nullptr);
 
 	Endpoint::Ptr GetCommandEndpoint() const;
 

--- a/lib/icinga/checkcommand.cpp
+++ b/lib/icinga/checkcommand.cpp
@@ -11,11 +11,12 @@ REGISTER_TYPE(CheckCommand);
 thread_local CheckCommand::Ptr CheckCommand::ExecuteOverride;
 
 void CheckCommand::Execute(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	GetExecute()->Invoke({
 		checkable,
 		cr,
+		producer,
 		resolvedMacros,
 		useResolvedMacros
 	});

--- a/lib/icinga/checkcommand.hpp
+++ b/lib/icinga/checkcommand.hpp
@@ -23,6 +23,7 @@ public:
 	static thread_local CheckCommand::Ptr ExecuteOverride;
 
 	void Execute(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
+		const WaitGroup::Ptr& producer,
 		const Dictionary::Ptr& resolvedMacros = nullptr,
 		bool useResolvedMacros = false);
 };

--- a/lib/icinga/clusterevents-check.cpp
+++ b/lib/icinga/clusterevents-check.cpp
@@ -279,7 +279,7 @@ void ClusterEvents::ExecuteCheckFromQueue(const MessageOrigin::Ptr& origin, cons
 
 	if (command_type == "check_command") {
 		try {
-			host->ExecuteRemoteCheck(macros);
+			host->ExecuteRemoteCheck(ApiListener::GetInstance()->GetWaitGroup(), macros);
 		} catch (const std::exception& ex) {
 			String output = "Exception occurred while checking '" + host->GetName() + "': " + DiagnosticInformation(ex);
 			ServiceState state = ServiceUnknown;

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -176,9 +176,9 @@ Value ClusterEvents::CheckResultAPIHandler(const MessageOrigin::Ptr& origin, con
 	}
 
 	if (!checkable->IsPaused() && Zone::GetLocalZone() == checkable->GetZone() && endpoint == checkable->GetCommandEndpoint())
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, ApiListener::GetInstance()->GetWaitGroup());
 	else
-		checkable->ProcessCheckResult(cr, origin);
+		checkable->ProcessCheckResult(cr, ApiListener::GetInstance()->GetWaitGroup(), origin);
 
 	return Empty;
 }

--- a/lib/icingadb/icingadbchecktask.hpp
+++ b/lib/icingadb/icingadbchecktask.hpp
@@ -18,7 +18,7 @@ class IcingadbCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	IcingadbCheckTask();

--- a/lib/livestatus/livestatuslistener.cpp
+++ b/lib/livestatus/livestatuslistener.cpp
@@ -192,7 +192,7 @@ void LivestatusListener::ClientHandler(const Socket::Ptr& client)
 			break;
 
 		LivestatusQuery::Ptr query = new LivestatusQuery(lines, GetCompatLogPath());
-		if (!query->Execute(stream))
+		if (!query->Execute(m_WaitGroup, stream))
 			break;
 	}
 

--- a/lib/livestatus/livestatuslistener.cpp
+++ b/lib/livestatus/livestatuslistener.cpp
@@ -112,6 +112,7 @@ void LivestatusListener::Stop(bool runtimeRemoved)
 		<< "'" << GetName() << "' stopped.";
 
 	m_Listener->Close();
+	m_WaitGroup->Join();
 
 	if (m_Thread.joinable())
 		m_Thread.join();

--- a/lib/livestatus/livestatuslistener.hpp
+++ b/lib/livestatus/livestatuslistener.hpp
@@ -7,6 +7,7 @@
 #include "livestatus/livestatuslistener-ti.hpp"
 #include "livestatus/livestatusquery.hpp"
 #include "base/socket.hpp"
+#include "base/wait-group.hpp"
 #include <thread>
 
 using namespace icinga;
@@ -40,6 +41,7 @@ private:
 
 	Socket::Ptr m_Listener;
 	std::thread m_Thread;
+	StoppableWaitGroup::Ptr m_WaitGroup = new StoppableWaitGroup();
 };
 
 }

--- a/lib/livestatus/livestatusquery.cpp
+++ b/lib/livestatus/livestatusquery.cpp
@@ -570,7 +570,7 @@ void LivestatusQuery::ExecuteGetHelper(const Stream::Ptr& stream)
 	SendResponse(stream, LivestatusErrorOK, result.str());
 }
 
-void LivestatusQuery::ExecuteCommandHelper(const Stream::Ptr& stream)
+void LivestatusQuery::ExecuteCommandHelper(const WaitGroup::Ptr& producer, const Stream::Ptr& stream)
 {
 	{
 		std::unique_lock<std::mutex> lock(l_QueryMutex);
@@ -580,7 +580,7 @@ void LivestatusQuery::ExecuteCommandHelper(const Stream::Ptr& stream)
 
 	Log(LogNotice, "LivestatusQuery")
 		<< "Executing command: " << m_Command;
-	ExternalCommandProcessor::Execute(m_Command);
+	ExternalCommandProcessor::Execute(producer, m_Command);
 	SendResponse(stream, LivestatusErrorOK, "");
 }
 
@@ -621,7 +621,7 @@ void LivestatusQuery::PrintFixed16(const Stream::Ptr& stream, int code, const St
 	}
 }
 
-bool LivestatusQuery::Execute(const Stream::Ptr& stream)
+bool LivestatusQuery::Execute(const WaitGroup::Ptr& producer, const Stream::Ptr& stream)
 {
 	try {
 		Log(LogNotice, "LivestatusQuery")
@@ -630,7 +630,7 @@ bool LivestatusQuery::Execute(const Stream::Ptr& stream)
 		if (m_Verb == "GET")
 			ExecuteGetHelper(stream);
 		else if (m_Verb == "COMMAND")
-			ExecuteCommandHelper(stream);
+			ExecuteCommandHelper(producer, stream);
 		else if (m_Verb == "ERROR")
 			ExecuteErrorHelper(stream);
 		else

--- a/lib/livestatus/livestatusquery.hpp
+++ b/lib/livestatus/livestatusquery.hpp
@@ -5,6 +5,7 @@
 
 #include "livestatus/filter.hpp"
 #include "livestatus/aggregator.hpp"
+#include "base/wait-group.hpp"
 #include "base/object.hpp"
 #include "base/array.hpp"
 #include "base/stream.hpp"
@@ -33,7 +34,7 @@ public:
 
 	LivestatusQuery(const std::vector<String>& lines, const String& compat_log_path);
 
-	bool Execute(const Stream::Ptr& stream);
+	bool Execute(const WaitGroup::Ptr& producer, const Stream::Ptr& stream);
 
 	static int GetExternalCommands();
 
@@ -76,7 +77,7 @@ private:
 	static String QuoteStringPython(const String& str);
 
 	void ExecuteGetHelper(const Stream::Ptr& stream);
-	void ExecuteCommandHelper(const Stream::Ptr& stream);
+	void ExecuteCommandHelper(const WaitGroup::Ptr& producer, const Stream::Ptr& stream);
 	void ExecuteErrorHelper(const Stream::Ptr& stream);
 
 	void SendResponse(const Stream::Ptr& stream, int code, const String& data);

--- a/lib/methods/clusterchecktask.cpp
+++ b/lib/methods/clusterchecktask.cpp
@@ -17,10 +17,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, ClusterCheck, &ClusterCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, ClusterCheck, &ClusterCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
@@ -47,7 +47,7 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 		} else {
 			cr->SetOutput(output);
 			cr->SetState(ServiceUnknown);
-			checkable->ProcessCheckResult(cr);
+			checkable->ProcessCheckResult(cr, producer);
 		}
 
 		return;
@@ -92,7 +92,7 @@ void ClusterCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRe
 		cr->SetState(state);
 		cr->SetOutput(output);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }
 

--- a/lib/methods/clusterchecktask.hpp
+++ b/lib/methods/clusterchecktask.hpp
@@ -17,7 +17,7 @@ class ClusterCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	ClusterCheckTask();

--- a/lib/methods/clusterzonechecktask.cpp
+++ b/lib/methods/clusterzonechecktask.cpp
@@ -12,10 +12,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, ClusterZoneCheck, &ClusterZoneCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, ClusterZoneCheck, &ClusterZoneCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
@@ -42,7 +42,7 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 			cr->SetCommand(commandName);
 			cr->SetOutput(output);
 			cr->SetState(state);
-			checkable->ProcessCheckResult(cr);
+			checkable->ProcessCheckResult(cr, producer);
 		}
 
 		return;
@@ -97,7 +97,7 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 			cr->SetCommand(commandName);
 			cr->SetOutput(output);
 			cr->SetState(state);
-			checkable->ProcessCheckResult(cr);
+			checkable->ProcessCheckResult(cr, producer);
 		}
 
 		return;
@@ -123,7 +123,7 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 			cr->SetCommand(commandName);
 			cr->SetOutput(output);
 			cr->SetState(state);
-			checkable->ProcessCheckResult(cr);
+			checkable->ProcessCheckResult(cr, producer);
 		}
 		return;
 	}
@@ -213,6 +213,6 @@ void ClusterZoneCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const Che
 			new PerfdataValue("sum_bytes_received_per_second", bytesReceivedPerSecond)
 		}));
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }

--- a/lib/methods/clusterzonechecktask.hpp
+++ b/lib/methods/clusterzonechecktask.hpp
@@ -17,7 +17,7 @@ class ClusterZoneCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	ClusterZoneCheckTask();

--- a/lib/methods/dummychecktask.cpp
+++ b/lib/methods/dummychecktask.cpp
@@ -13,10 +13,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, DummyCheck, &DummyCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, DummyCheck, &DummyCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void DummyCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
@@ -70,6 +70,6 @@ void DummyCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResu
 		cr->SetExecutionEnd(now);
 		cr->SetCommand(commandName);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }

--- a/lib/methods/dummychecktask.hpp
+++ b/lib/methods/dummychecktask.hpp
@@ -19,7 +19,7 @@ class DummyCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	DummyCheckTask();

--- a/lib/methods/exceptionchecktask.cpp
+++ b/lib/methods/exceptionchecktask.cpp
@@ -12,10 +12,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, ExceptionCheck, &ExceptionCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, ExceptionCheck, &ExceptionCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void ExceptionCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr&, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);

--- a/lib/methods/exceptionchecktask.hpp
+++ b/lib/methods/exceptionchecktask.hpp
@@ -18,7 +18,7 @@ class ExceptionCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	ExceptionCheckTask();

--- a/lib/methods/icingachecktask.cpp
+++ b/lib/methods/icingachecktask.cpp
@@ -17,10 +17,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, IcingaCheck, &IcingaCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, IcingaCheck, &IcingaCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
@@ -204,6 +204,6 @@ void IcingaCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		cr->SetOutput(output);
 		cr->SetCommand(commandName);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }

--- a/lib/methods/icingachecktask.hpp
+++ b/lib/methods/icingachecktask.hpp
@@ -18,7 +18,7 @@ class IcingaCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	IcingaCheckTask();

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -31,7 +31,7 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, IfwApiCheck, &IfwApiCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, IfwApiCheck, &IfwApiCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 static const char* GetUnderstandableError(const std::exception& ex)
 {
@@ -194,7 +194,7 @@ static void DoIfwNetIo(
 }
 
 void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	namespace asio = boost::asio;
 	namespace http = boost::beast::http;
@@ -213,7 +213,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 			if (!(commandEndpoint->GetCapabilities() & (uint_fast64_t)ApiCapabilities::IfwApiCheckCommand)) {
 				// Assume "ifw-api-check-command" has been imported into a check command which can also work
 				// based on "plugin-check-command", delegate respectively and hope for the best
-				PluginCheckTask::ScriptFunc(checkable, cr, resolvedMacros, useResolvedMacros);
+				PluginCheckTask::ScriptFunc(checkable, cr, producer, resolvedMacros, useResolvedMacros);
 				return;
 			}
 		}
@@ -275,7 +275,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 			callback(cr->GetCommand(), pr);
 		};
 	} else {
-		reportResult = [checkable, cr]() { checkable->ProcessCheckResult(cr); };
+		reportResult = [checkable, cr, producer] { checkable->ProcessCheckResult(cr, producer); };
 	}
 
 	// Set the default check result state and exit code to unknown for the moment!

--- a/lib/methods/ifwapichecktask.hpp
+++ b/lib/methods/ifwapichecktask.hpp
@@ -18,7 +18,7 @@ class IfwApiCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	IfwApiCheckTask();

--- a/lib/methods/nullchecktask.cpp
+++ b/lib/methods/nullchecktask.cpp
@@ -13,10 +13,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, NullCheck, &NullCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, NullCheck, &NullCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void NullCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
@@ -45,6 +45,6 @@ void NullCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResul
 		}));
 		cr->SetState(state);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }

--- a/lib/methods/nullchecktask.hpp
+++ b/lib/methods/nullchecktask.hpp
@@ -19,7 +19,7 @@ class NullCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	NullCheckTask();

--- a/lib/methods/pluginchecktask.hpp
+++ b/lib/methods/pluginchecktask.hpp
@@ -19,13 +19,13 @@ class PluginCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	PluginCheckTask();
 
-	static void ProcessFinishedHandler(const Checkable::Ptr& service,
-		const CheckResult::Ptr& cr, const Value& commandLine, const ProcessResult& pr);
+	static void ProcessFinishedHandler(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
+		const WaitGroup::Ptr& producer, const Value& commandLine, const ProcessResult& pr);
 };
 
 }

--- a/lib/methods/randomchecktask.cpp
+++ b/lib/methods/randomchecktask.cpp
@@ -13,10 +13,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, RandomCheck, &RandomCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, RandomCheck, &RandomCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void RandomCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-	const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
 	REQUIRE_NOT_NULL(checkable);
 	REQUIRE_NOT_NULL(cr);
@@ -60,6 +60,6 @@ void RandomCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 		cr->SetState(state);
 		cr->SetCommand(commandName);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }

--- a/lib/methods/randomchecktask.hpp
+++ b/lib/methods/randomchecktask.hpp
@@ -18,7 +18,7 @@ class RandomCheckTask
 {
 public:
 	static void ScriptFunc(const Checkable::Ptr& service, const CheckResult::Ptr& cr,
-		const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
 	RandomCheckTask();

--- a/lib/methods/sleepchecktask.cpp
+++ b/lib/methods/sleepchecktask.cpp
@@ -9,10 +9,10 @@
 
 using namespace icinga;
 
-REGISTER_FUNCTION_NONCONST(Internal, SleepCheck, &SleepCheckTask::ScriptFunc, "checkable:cr:resolvedMacros:useResolvedMacros");
+REGISTER_FUNCTION_NONCONST(Internal, SleepCheck, &SleepCheckTask::ScriptFunc, "checkable:cr:producer:resolvedMacros:useResolvedMacros");
 
 void SleepCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-        const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
+	const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros)
 {
     REQUIRE_NOT_NULL(checkable);
     REQUIRE_NOT_NULL(cr);
@@ -62,6 +62,6 @@ void SleepCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckResu
 		cr->SetExecutionEnd(now);
 		cr->SetCommand(commandName);
 
-		checkable->ProcessCheckResult(cr);
+		checkable->ProcessCheckResult(cr, producer);
 	}
 }

--- a/lib/methods/sleepchecktask.hpp
+++ b/lib/methods/sleepchecktask.hpp
@@ -19,7 +19,7 @@ class SleepCheckTask
 {
 public:
     static void ScriptFunc(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr,
-            const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
+		const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros, bool useResolvedMacros);
 
 private:
     SleepCheckTask();

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -368,6 +368,7 @@ void ApiListener::Stop(bool runtimeDeleted)
 	m_Timer->Stop(true);
 	m_RenewOwnCertTimer->Stop(true);
 
+	m_WaitGroup->Join();
 	ObjectImpl<ApiListener>::Stop(runtimeDeleted);
 
 	Log(LogInformation, "ApiListener")

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -16,6 +16,7 @@
 #include "base/tcpsocket.hpp"
 #include "base/tlsstream.hpp"
 #include "base/threadpool.hpp"
+#include "base/wait-group.hpp"
 #include <atomic>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
@@ -177,6 +178,7 @@ private:
 	Timer::Ptr m_RenewOwnCertTimer;
 
 	Endpoint::Ptr m_LocalEndpoint;
+	StoppableWaitGroup::Ptr m_WaitGroup = new StoppableWaitGroup();
 
 	static ApiListener::Ptr m_Instance;
 	static std::atomic<bool> m_UpdatedObjectAuthority;

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -152,6 +152,11 @@ public:
 	double GetTlsHandshakeTimeout() const override;
 	void SetTlsHandshakeTimeout(double value, bool suppress_events, const Value& cookie) override;
 
+	WaitGroup::Ptr GetWaitGroup() const
+	{
+		return m_WaitGroup;
+	}
+
 protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;

--- a/test/icinga-checkable-flapping.cpp
+++ b/test/icinga-checkable-flapping.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(host_not_flapping)
 	int i = 0;
 	while (i++ < 10) {
 		// For some reason, elusive to me, the first check is a state change
-		host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+		host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 
 		LogFlapping(host);
 		LogHostStatus(host);
@@ -107,9 +107,9 @@ BOOST_AUTO_TEST_CASE(host_flapping)
 	int i = 0;
 	while (i++ < 25) {
 		if (i % 2)
-			host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+			host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 		else
-			host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
+			host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
 
 		LogFlapping(host);
 		LogHostStatus(host);
@@ -144,18 +144,18 @@ BOOST_AUTO_TEST_CASE(host_flapping_recover)
 	Utility::SetTime(0);
 
 	// A few warning
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
 
 	LogFlapping(host);
 	LogHostStatus(host);
 	for (int i = 0; i <= 7; i++) {
 		if (i % 2)
-			host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+			host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 		else
-			host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
+			host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
 	}
 
 	LogFlapping(host);
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(host_flapping_recover)
 		BOOST_CHECK(host->GetFlappingCurrent() > 25.0);
 		BOOST_CHECK(host->IsFlapping());
 
-		host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
+		host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
 		LogFlapping(host);
 		LogHostStatus(host);
 		count++;
@@ -203,40 +203,40 @@ BOOST_AUTO_TEST_CASE(host_flapping_docs_example)
 
 	Utility::SetTime(0);
 
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceWarning));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceWarning), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 
 	LogFlapping(host);
 	LogHostStatus(host);
 	BOOST_CHECK(host->GetFlappingCurrent() == 39.1);
 	BOOST_CHECK(host->IsFlapping());
 
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 
 	LogFlapping(host);
 	LogHostStatus(host);

--- a/test/icinga-checkresult.cpp
+++ b/test/icinga-checkresult.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(host_1attempt)
 	CheckNotification(host, false);
 
 	std::cout << "First check result (unknown)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceUnknown));
+	host->ProcessCheckResult(MakeCheckResult(ServiceUnknown), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(host_1attempt)
 	CheckNotification(host, true, NotificationProblem);
 
 	std::cout << "Second check result (ok)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostUp);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(host_1attempt)
 	CheckNotification(host, true, NotificationRecovery);
 
 	std::cout << "Third check result (critical)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(host_1attempt)
 	CheckNotification(host, true, NotificationProblem);
 
 	std::cout << "Fourth check result (ok)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostUp);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(host_2attempts)
 	CheckNotification(host, false);
 
 	std::cout << "First check result (unknown)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceUnknown));
+	host->ProcessCheckResult(MakeCheckResult(ServiceUnknown), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(host_2attempts)
 	CheckNotification(host, false);
 
 	std::cout << "Second check result (critical)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(host_2attempts)
 	CheckNotification(host, true, NotificationProblem);
 
 	std::cout << "Third check result (ok)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostUp);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(host_2attempts)
 	CheckNotification(host, true, NotificationRecovery);
 
 	std::cout << "Fourth check result (critical)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(host_2attempts)
 	CheckNotification(host, false);
 
 	std::cout << "Fifth check result (ok)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostUp);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	CheckNotification(host, false);
 
 	std::cout << "First check result (unknown)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceUnknown));
+	host->ProcessCheckResult(MakeCheckResult(ServiceUnknown), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	CheckNotification(host, false);
 
 	std::cout << "Second check result (critical)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(host->GetCheckAttempt() == 2);
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	CheckNotification(host, false);
 
 	std::cout << "Third check result (critical)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	CheckNotification(host, true, NotificationProblem);
 
 	std::cout << "Fourth check result (ok)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostUp);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	CheckNotification(host, true, NotificationRecovery);
 
 	std::cout << "Fifth check result (critical)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	host->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostDown);
 	BOOST_CHECK(host->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(host_3attempts)
 	CheckNotification(host, false);
 
 	std::cout << "Sixth check result (ok)" << std::endl;
-	host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(host->GetState() == HostUp);
 	BOOST_CHECK(host->GetStateType() == StateTypeHard);
 	BOOST_CHECK(host->GetCheckAttempt() == 1);
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(service_1attempt)
 	CheckNotification(service, false);
 
 	std::cout << "First check result (unknown)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceUnknown));
+	service->ProcessCheckResult(MakeCheckResult(ServiceUnknown), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceUnknown);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(service_1attempt)
 	CheckNotification(service, true, NotificationProblem);
 
 	std::cout << "Second check result (ok)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceOK);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(service_1attempt)
 	CheckNotification(service, true, NotificationRecovery);
 
 	std::cout << "Third check result (critical)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceCritical);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(service_1attempt)
 	CheckNotification(service, true, NotificationProblem);
 
 	std::cout << "Fourth check result (ok)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceOK);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(service_2attempts)
 	CheckNotification(service, false);
 
 	std::cout << "First check result (unknown)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceUnknown));
+	service->ProcessCheckResult(MakeCheckResult(ServiceUnknown), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceUnknown);
 	BOOST_CHECK(service->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(service_2attempts)
 	CheckNotification(service, false);
 
 	std::cout << "Second check result (critical)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceCritical);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(service_2attempts)
 	CheckNotification(service, true, NotificationProblem);
 
 	std::cout << "Third check result (ok)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceOK);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(service_2attempts)
 	CheckNotification(service, true, NotificationRecovery);
 
 	std::cout << "Fourth check result (critical)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceCritical);
 	BOOST_CHECK(service->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(service_2attempts)
 	CheckNotification(service, false);
 
 	std::cout << "Fifth check result (ok)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceOK);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	CheckNotification(service, false);
 
 	std::cout << "First check result (unknown)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceUnknown));
+	service->ProcessCheckResult(MakeCheckResult(ServiceUnknown), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceUnknown);
 	BOOST_CHECK(service->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	CheckNotification(service, false);
 
 	std::cout << "Second check result (critical)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceCritical);
 	BOOST_CHECK(service->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(service->GetCheckAttempt() == 2);
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	CheckNotification(service, false);
 
 	std::cout << "Third check result (critical)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceCritical);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	CheckNotification(service, true, NotificationProblem);
 
 	std::cout << "Fourth check result (ok)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceOK);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -418,7 +418,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	CheckNotification(service, true, NotificationRecovery);
 
 	std::cout << "Fifth check result (critical)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceCritical);
 	BOOST_CHECK(service->GetStateType() == StateTypeSoft);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(service_3attempts)
 	CheckNotification(service, false);
 
 	std::cout << "Sixth check result (ok)" << std::endl;
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	BOOST_CHECK(service->GetState() == ServiceOK);
 	BOOST_CHECK(service->GetStateType() == StateTypeHard);
 	BOOST_CHECK(service->GetCheckAttempt() == 1);
@@ -470,7 +470,7 @@ BOOST_AUTO_TEST_CASE(host_flapping_notification)
 
 	for (int i = 0; i < 10; i++) {
 		ServiceState state = (i % 2 == 0 ? ServiceOK : ServiceCritical);
-		host->ProcessCheckResult(MakeCheckResult(state));
+		host->ProcessCheckResult(MakeCheckResult(state), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -481,7 +481,7 @@ BOOST_AUTO_TEST_CASE(host_flapping_notification)
 	std::cout << "Now calm down..." << std::endl;
 
 	for (int i = 0; i < 20; i++) {
-		host->ProcessCheckResult(MakeCheckResult(ServiceOK));
+		host->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_notification)
 
 	for (int i = 0; i < 10; i++) {
 		ServiceState state = (i % 2 == 0 ? ServiceOK : ServiceCritical);
-		service->ProcessCheckResult(MakeCheckResult(state));
+		service->ProcessCheckResult(MakeCheckResult(state), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -540,7 +540,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_notification)
 	std::cout << "Now calm down..." << std::endl;
 
 	for (int i = 0; i < 20; i++) {
-		service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+		service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_problem_notifications)
 
 	for (int i = 0; i < 10; i++) {
 		ServiceState state = (i % 2 == 0 ? ServiceOK : ServiceCritical);
-		service->ProcessCheckResult(MakeCheckResult(state));
+		service->ProcessCheckResult(MakeCheckResult(state), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -595,11 +595,11 @@ BOOST_AUTO_TEST_CASE(service_flapping_problem_notifications)
 
 	//Insert enough check results to get into hard problem state but staying flapping
 
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
 
 
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_problem_notifications)
 
 	// Calm down
 	while (service->IsFlapping()) {
-		service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+		service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -641,7 +641,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_problem_notifications)
 	// Known failure, see #5713
 	// CheckNotification(service, true, NotificationProblem);
 
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
 
 	// Known failure, see #5713
@@ -686,7 +686,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_into_bad)
 
 	for (int i = 0; i < 10; i++) {
 		ServiceState state = (i % 2 == 0 ? ServiceOK : ServiceCritical);
-		service->ProcessCheckResult(MakeCheckResult(state));
+		service->ProcessCheckResult(MakeCheckResult(state), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -696,11 +696,11 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_into_bad)
 
 	//Insert enough check results to get into hard problem state but staying flapping
 
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
 
 
@@ -712,13 +712,13 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_into_bad)
 
 	// Calm down
 	while (service->IsFlapping()) {
-		service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+		service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
 	CheckNotification(service, true, NotificationFlappingEnd);
 
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
 
 	BOOST_CHECK(service->IsFlapping() == false);
@@ -767,7 +767,7 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_over_bad_into_ok)
 
 	for (int i = 0; i < 10; i++) {
 		ServiceState state = (i % 2 == 0 ? ServiceOK : ServiceCritical);
-		service->ProcessCheckResult(MakeCheckResult(state));
+		service->ProcessCheckResult(MakeCheckResult(state), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
@@ -777,11 +777,11 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_over_bad_into_ok)
 
 	//Insert enough check results to get into hard problem state but staying flapping
 
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
-	service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+	service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
 
 
@@ -793,13 +793,13 @@ BOOST_AUTO_TEST_CASE(service_flapping_ok_over_bad_into_ok)
 
 	// Calm down
 	while (service->IsFlapping()) {
-		service->ProcessCheckResult(MakeCheckResult(ServiceCritical));
+		service->ProcessCheckResult(MakeCheckResult(ServiceCritical), new StoppableWaitGroup());
 		Utility::IncrementTime(timeStepInterval);
 	}
 
 	CheckNotification(service, true, NotificationFlappingEnd);
 
-	service->ProcessCheckResult(MakeCheckResult(ServiceOK));
+	service->ProcessCheckResult(MakeCheckResult(ServiceOK), new StoppableWaitGroup());
 	Utility::IncrementTime(timeStepInterval);
 
 	BOOST_CHECK(service->IsFlapping() == false);
@@ -894,7 +894,7 @@ BOOST_AUTO_TEST_CASE(suppressed_notification)
 					for (int i = 0; i < checkAttempts; i++) {
 						std::cout << "  ProcessCheckResult("
 							<< Service::StateToString(initialState) << ")" << std::endl;
-						service->ProcessCheckResult(MakeCheckResult(initialState));
+						service->ProcessCheckResult(MakeCheckResult(initialState), new StoppableWaitGroup());
 					}
 
 					BOOST_CHECK(service->GetState() == initialState);
@@ -972,7 +972,7 @@ BOOST_AUTO_TEST_CASE(suppressed_notification)
 					// Process check results for the state sequence.
 					for (ServiceState s : sequence) {
 						std::cout << "  ProcessCheckResult(" << Service::StateToString(s) << ")" << std::endl;
-						service->ProcessCheckResult(MakeCheckResult(s));
+						service->ProcessCheckResult(MakeCheckResult(s), new StoppableWaitGroup());
 						BOOST_CHECK(service->GetState() == s);
 						if (checkAttempts == 1) {
 							BOOST_CHECK(service->GetStateType() == StateTypeHard);
@@ -1002,7 +1002,7 @@ BOOST_AUTO_TEST_CASE(suppressed_notification)
 						for (int i = 0; i < checkAttempts && service->GetStateType() == StateTypeSoft; i++) {
 							std::cout << "  ProcessCheckResult(" << Service::StateToString(sequence.back()) << ")"
 									  << std::endl;
-							service->ProcessCheckResult(MakeCheckResult(sequence.back()));
+							service->ProcessCheckResult(MakeCheckResult(sequence.back()), new StoppableWaitGroup());
 							BOOST_CHECK(service->GetState() == sequence.back());
 						}
 					}

--- a/test/livestatus.cpp
+++ b/test/livestatus.cpp
@@ -15,7 +15,7 @@ String LivestatusQueryHelper(const std::vector<String>& lines)
 	std::stringstream stream;
 	StdioStream::Ptr sstream = new StdioStream(&stream, false);
 
-	query->Execute(sstream);
+	query->Execute(new StoppableWaitGroup(), sstream);
 
 	String output;
 	String result;


### PR DESCRIPTION
This PR is the first step in the process of making the shutdown order of our components less unpredictable. Specifically, the goal is to ensure that components that produce any kind of events (e.g. notifications) or check results are stopped in a determined order, and they don't cause any post-stop events to be triggered. The problem this PR specifically addresses is that e.g. stopping the `CheckerComponent` does prevent new checks from being scheduled, but it does not wait for already started (so can't be cancelled) checks to finish. This can lead to a situation where the e.g. `IcingaDB` component is stopped before such checks complete and causing all the resulted events to be lost, because `IcingaDB` is not able to process them anymore. How does this PR solve this?

It introduces a new `CheckResultProducer` interface that is implemented only by types that actually produce check results, which as of now are `CheckerComponent` (for local checks) and `ApiListener` (for remote checks). Each of such instance maintains a simple counter of the number of ongoing checks results it produces. However, they don't just increment the counter after e.g. `Checkable::ExecuteCheck()` is called, but only after the check execution produces a result and enters the `Checkable::ProcessCheckResult()` method, and decremented when leaving it. This way, we don't have to worry about the fact that check execution time can be very long and block the shutdown of the component indefinitely (credit goes to @Al2Klimov). Ok, but how does this prevent triggering post-factum events, you ask? Well, the `Checkable::ProcessCheckResult` requires now the `CheckResultProducer` be passed in as an argument, and is only allowed to actually process that result after locking the producer, otherwise the `cr` is discarded.

But what does locking the producer mean? It doesn't mean acquiring the `ObjectLock` on that object, but rather acquiring a shared lock[^1] on it. However, here's the catch: the producer is only shared lockable if its `Stop()` method hasn't been already called. Meaning, whenever `CheckerComponent::Stop()` is called, any thread that tries to acquire a shared lock on it in `Checkable::ProcessCheckResult()` will ultimately fail and discard the `cr` without ever processing it. On the other hand, if the checker was stopped after some threads have successfully acquired a shared lock on it (remember that when a thread acquires a shared lock, the producer automatically increments its counter), it will wait for all of them to finish while preventing any new threads from acquiring the lock until its counter goes back to `0`.

The only remaining problem that this PR doesn't solve is that `ApiListener::Stop()` implementation doesn't gracefully disconnect all active connections, which means that we might still lose some important check results received from remote endpoints. However, since this is a completely different issue, it will be addressed in a separate PR.

Edit (yhabteab) end:
---
This is the very first and hardest step of the https://github.com/Icinga/icinga2/issues/10179#issuecomment-2751552284 plan.

Checkable#ProcessCheckResult() now takes a CheckResultProducer::Ptr:

* 23c236511 Checkable#ProcessCheckResult(): discard CR or delay its producers shutdown

It tries to shared-lock the CheckResultProducer:

* Failure means the CheckResultProducer indicates it's already shutting down, so the not yet really started Checkable#ProcessCheckResult() fails and discards the CR
* Success means Checkable#ProcessCheckResult() can continue and on shutdown CheckResultProducer will wait for that

This implies that every component producing checks needs to implement CheckResultProducer:

* f86b8bacd *#Stop(): wait for own Checkable#ProcessCheckResult()s to finish
* 84cb9d837 mkclass: inherit from Object like this: class T : virtual public Object

Finally, the CheckResultProducer::Ptr has "just" to be passed through from the CheckResultProducer itself to Checkable#ProcessCheckResult():

[^1]: The new `CheckResultProducer` interface satisfies the [`std::SharedLockable`](https://en.cppreference.com/w/cpp/named_req/SharedLockable) requirements.