### PR TITLE
`Checkable::GetSeverity()`: consider reachability

### DIFF
--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -197,7 +197,6 @@ int Host::GetSeverity() const
 	}
 
 	return severity;
-
 }
 
 bool Host::IsStateOK(ServiceState state) const

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -180,17 +180,19 @@ int Host::GetSeverity() const
 	} else if (state == HostUp) {
 		severity = 0;
 	} else {
-		if (IsReachable())
+		if (IsReachable()) {
 			severity = 64;
-		else
+		} else {
 			severity = 32;
+		}
 
-		if (IsAcknowledged())
+		if (IsAcknowledged()) {
 			severity += 512;
-		else if (IsInDowntime())
+		} else if (IsInDowntime()) {
 			severity += 256;
-		else
+		} else {
 			severity += 2048;
+		}
 	}
 
 	olock.Unlock();

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -196,8 +196,6 @@ int Host::GetSeverity() const
 		severity += 2048;
 	}
 
-	olock.Unlock();
-
 	return severity;
 
 }

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -180,18 +180,14 @@ int Host::GetSeverity() const
 		return 0;
 	}
 
-	int severity = 0;
-
-	if (IsReachable()) {
-		severity = 64;
-	} else {
-		severity = 32;
-	}
+	int severity = 32; // DOWN
 
 	if (IsAcknowledged()) {
 		severity += 512;
 	} else if (IsInDowntime()) {
 		severity += 256;
+	} else if (!IsReachable()) {
+		severity += 1024;
 	} else {
 		severity += 2048;
 	}

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -170,29 +170,30 @@ HostState Host::GetLastHardState() const
  * sort by severity. It is therefore easier to keep them seperated here. */
 int Host::GetSeverity() const
 {
-	int severity = 0;
-
 	ObjectLock olock(this);
 	HostState state = GetState();
 
 	if (!HasBeenChecked()) {
-		severity = 16;
-	} else if (state == HostUp) {
-		severity = 0;
-	} else {
-		if (IsReachable()) {
-			severity = 64;
-		} else {
-			severity = 32;
-		}
+		return 16;
+	}
+	if (state == HostUp) {
+		return 0;
+	}
 
-		if (IsAcknowledged()) {
-			severity += 512;
-		} else if (IsInDowntime()) {
-			severity += 256;
-		} else {
-			severity += 2048;
-		}
+	int severity = 0;
+
+	if (IsReachable()) {
+		severity = 64;
+	} else {
+		severity = 32;
+	}
+
+	if (IsAcknowledged()) {
+		severity += 512;
+	} else if (IsInDowntime()) {
+		severity += 256;
+	} else {
+		severity += 2048;
 	}
 
 	olock.Unlock();

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -121,18 +121,14 @@ int Service::GetSeverity() const
 	} else if (state == ServiceOK) {
 		severity = 0;
 	} else {
-		switch (state) {
-			case ServiceWarning:
-				severity = 32;
-				break;
-			case ServiceUnknown:
-				severity = 64;
-				break;
-			case ServiceCritical:
-				severity = 128;
-				break;
-			default:
-				severity = 256;
+		if (state == ServiceWarning) {
+			severity = 32;
+		} else if (state == ServiceUnknown) {
+			severity = 64;
+		} else if (state == ServiceCritical) {
+			severity = 128;
+		} else {
+			severity = 256;
 		}
 
 		Host::Ptr host = GetHost();

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -111,39 +111,40 @@ Host::Ptr Service::GetHost() const
  * sort by severity. It is therefore easier to keep them seperated here. */
 int Service::GetSeverity() const
 {
-	int severity;
-
 	ObjectLock olock(this);
 	ServiceState state = GetStateRaw();
 
 	if (!HasBeenChecked()) {
-		severity = 16;
-	} else if (state == ServiceOK) {
-		severity = 0;
-	} else {
-		if (state == ServiceWarning) {
-			severity = 32;
-		} else if (state == ServiceUnknown) {
-			severity = 64;
-		} else if (state == ServiceCritical) {
-			severity = 128;
-		} else {
-			severity = 256;
-		}
-
-		Host::Ptr host = GetHost();
-		ObjectLock hlock (host);
-		if (host->GetState() != HostUp) {
-			severity += 1024;
-		} else if (IsAcknowledged()) {
-			severity += 512;
-		} else if (IsInDowntime()) {
-			severity += 256;
-		} else {
-			severity += 2048;
-		}
-		hlock.Unlock();
+		return 16;
 	}
+	if (state == ServiceOK) {
+		return 0;
+	}
+
+	int severity = 0;
+
+	if (state == ServiceWarning) {
+		severity = 32;
+	} else if (state == ServiceUnknown) {
+		severity = 64;
+	} else if (state == ServiceCritical) {
+		severity = 128;
+	} else {
+		severity = 256;
+	}
+
+	Host::Ptr host = GetHost();
+	ObjectLock hlock (host);
+	if (host->GetState() != HostUp) {
+		severity += 1024;
+	} else if (IsAcknowledged()) {
+		severity += 512;
+	} else if (IsInDowntime()) {
+		severity += 256;
+	} else {
+		severity += 2048;
+	}
+	hlock.Unlock();
 
 	olock.Unlock();
 

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -133,14 +133,12 @@ int Service::GetSeverity() const
 		severity = 256;
 	}
 
-	Host::Ptr host = GetHost();
-	ObjectLock hlock (host);
-	if (host->GetState() != HostUp) {
-		severity += 1024;
-	} else if (IsAcknowledged()) {
+	if (IsAcknowledged()) {
 		severity += 512;
 	} else if (IsInDowntime()) {
 		severity += 256;
+	} else if (!IsReachable()) {
+		severity += 1024;
 	} else {
 		severity += 2048;
 	}

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -144,9 +144,6 @@ int Service::GetSeverity() const
 	} else {
 		severity += 2048;
 	}
-	hlock.Unlock();
-
-	olock.Unlock();
 
 	return severity;
 }

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -139,13 +139,12 @@ int Service::GetSeverity() const
 		ObjectLock hlock (host);
 		if (host->GetState() != HostUp) {
 			severity += 1024;
+		} else if (IsAcknowledged()) {
+			severity += 512;
+		} else if (IsInDowntime()) {
+			severity += 256;
 		} else {
-			if (IsAcknowledged())
-				severity += 512;
-			else if (IsInDowntime())
-				severity += 256;
-			else
-				severity += 2048;
+			severity += 2048;
 		}
 		hlock.Unlock();
 	}


### PR DESCRIPTION
The PR can be split in two general parts: All but the last commits are general cleanup of the code (nothing spectacular, just braces for ifs, early return instead of nesting code in an else block, and similar) in `Host::GetSeverity()` and `Service::GetSeverity()` without any change in functionality, these are split into individual commits so that the individual changes are easier to follow. Finally, the last commit implements the functional change of this PR.

So far, `Service::GetSeverity()` only considered the state of its own host, i.e. the implicit service to its own host dependency, and treated it similar to acknowledgements and downtimes. In contrast, `Host::GetSeverity()` considered reachability and treated it like a state, i.e. for the severity calculation, the host was either up, down, or unreachable.
    
This commit changes the following things:
1. Make the service severity also consider explicitly configured dependencies by using `IsReachable()`.
2. Prefer acknowledgements and downtimes over unreachability in the severity calculation so that if an already acknowledged or in-downtime services (i.e. already handled service) becomes unreachable, it shouln't become more severe.
3. To unify host and service severities a bit, hosts now use the same logic that treats reachability more like acknowledgements/downtimes instead of like a state (changing the other way around would the state from the check plugin would not affect the severity for unrachable services anymore).

### Tests

The following config snippet generates host and service objects for all the combinations of the different state attributes, i.e. hosts like `github-10399-down-indowntime-acknowledged-unreachable` where the parts of the name explain the state. For acknowledgements and downtime, API requests are listed below to bring the objects into the desired state, the rest of the state is automatically created by the config.


<details>
<summary>Icinga 2 config</summary>

```
for (var dep_reachable in [true, false]) {
	for (var acknowledged in [true, false]) {
		for (var in_downtime in [true, false]) {
			for (var state in [null /* pending */, HostUp, HostDown]) {
				var name = "github-10399"

				if (state == HostUp) {
					name += "-up"
				} else if (state == HostDown) {
					name += "-down"
				} else {
					name += "-pending"
				}

				if (in_downtime) {
					name += "-indowntime"
				}

				if (acknowledged) {
					name += "-acknowledged"
				}

				if (!dep_reachable) {
					name += "-unreachable"
				}

				log("Host: " + name)
				object Host name use (state, in_downtime, acknowledged) {
					check_command = "dummy"
					check_interval = 15m
					retry_interval = 15m

					if (state == HostDown) {
						vars.dummy_state = ServiceCritical
					} else if (state == HostUp) {
						vars.dummy_state = ServiceOK
					} else {
						// keep it pending
						enable_active_checks = false
						enable_passive_checks = false
					}

					vars.github_10399_in_downtime = in_downtime
					vars.github_10399_acknowledged = acknowledged
				}

				if (!dep_reachable) {
					object Dependency "unreachable" use (name) {
						child_host_name = name
						parent_host_name = "github-10399-down"
					}
				}
			}

			for (var state in [null /* pending */, ServiceOK, ServiceWarning, ServiceCritical, ServiceUnknown]) {
				for (var host_up in [true, false]) {
					var name = "github-10399"

					if (state == ServiceOK) {
						name += "-ok"
					} else if (state == ServiceWarning) {
						name += "-warning"
					} else if (state == ServiceCritical) {
						name += "-critical"
					} else if (state == ServiceUnknown) {
						name += "-unknown"
					} else {
						name += "-pending"
					}

					if (in_downtime) {
						name += "-indowntime"
					}

					if (acknowledged) {
						name += "-acknowledged"
					}

					if (!dep_reachable) {
						name += "-unreachable"
					}

					if (host_up) {
						var host = "github-10399-up"
					} else {
						name += "-hostdown"
						var host = "github-10399-down"
					}

					log("Service: " + name)
					object Service name use (host, state, in_downtime, acknowledged) {
						host_name = host
						check_command = "dummy"
						check_interval = 15m
						retry_interval = 15m

						if (state != null) {
							vars.dummy_state = state		
						} else {
							// keep it pending
							enable_active_checks = false
							enable_passive_checks = false
						}

						vars.github_10399_in_downtime = in_downtime
						vars.github_10399_acknowledged = acknowledged
					}

					if (!dep_reachable) {
						object Dependency "unreachable" use (host, name) {
							child_host_name = host
							child_service_name = name
							parent_host_name = "github-10399-down"
						}
					}
				}
			} 
		}
	}
}
```
</details>

<details>
<summary>Icinga 2 API requests for adding acknowledgements and downtimes</summary>

```
curl -sSku root:icinga 'https://localhost:5665/v1/actions/acknowledge-problem' --json '{"type": "Host", "filter": "host.vars.github_10399_acknowledged", "author": "dummy", "comment": "dummy", "pretty": true}'

curl -sSku root:icinga 'https://localhost:5665/v1/actions/acknowledge-problem' --json '{"type": "Service", "filter": "service.vars.github_10399_acknowledged", "author": "dummy", "comment": "dummy", "pretty": true}'

curl -sSku root:icinga 'https://localhost:5665/v1/actions/schedule-downtime' --json '{"type": "Host", "filter": "host.vars.github_10399_in_downtime", "start_time": '"$(date +%s)"', "end_time": '"$(date -d +1day +%s)"', "author": "dummy", "comment": "dummy", "pretty": true}'

curl -sSku root:icinga 'https://localhost:5665/v1/actions/schedule-downtime' --json '{"type": "Service", "filter": "service.vars.github_10399_in_downtime", "start_time": '"$(date +%s)"', "end_time": '"$(date -d +1day +%s)"', "author": "dummy", "comment": "dummy", "pretty": true}'
```
</details>

#### Current master (061338156c71457397f4127a6c9479cdddc9f0e9)

![Host list sorted by severity](https://github.com/user-attachments/assets/e77a050f-3995-49d3-ace7-bced4d9ca80d)
![Service list sorted by severity](https://github.com/user-attachments/assets/9d787e0c-dea1-4678-a13c-27304c1bae11)

#### This PR (31a224c5095bc7918b2ca84875c8e54415ab2550)

Ordering still looks reasonable overall. The notable change is that in the service list, you can see how all completely unhandled services (i.e. problem and not faded out with some pictogram) are moved to the top of the list.

![Host list sorted by severity](https://github.com/user-attachments/assets/3e51ad62-f1aa-4b31-bd1b-9b275a819885)
![Service list sorted by severity](https://github.com/user-attachments/assets/5db49ffd-dc7c-47d4-85c8-30ccdb2cdcae)

fixes #10340