### PR TITLE
Support json serialization into `std::ostream`

### DIFF
--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -18,6 +18,84 @@
 
 using namespace icinga;
 
+// The following code is a specialization of the nlohmann::adl_serializer<> for our Value type.
+// This allows us to serialize Icinga Values directly into JSON objects using the nlohmann::json library.
+// The specialization is defined within the nlohmann namespace, which is where the library expects it to be.
+namespace nlohmann
+{
+	template<>
+	struct adl_serializer<Value>
+	{
+		/**
+		 * Serializes an Icinga Value into a JSON object.
+		 *
+		 * @note This function is used by the JSON library to serialize the value.
+		 *
+		 * @param j The JSON object to serialize the value into.
+		 * @param value The value to serialize.
+		 */
+		static void to_json(json& j, const Value& value)
+		{
+			switch (value.GetType()) {
+				case ValueNumber:
+					if (auto ll(static_cast<long long>(value)); ll == value) {
+						j = ll;
+					} else {
+						j = value.Get<double>();
+					}
+					break;
+				case ValueBoolean:
+					j = value.ToBool();
+					break;
+				case ValueString:
+					j = Utility::ValidateUTF8(value.Get<String>());
+					break;
+				case ValueObject:
+				{
+					const Object::Ptr& obj = value.Get<Object::Ptr>();
+					if (obj->GetReflectionType() == Namespace::TypeInstance) {
+						ObjectLock olock(obj);
+						auto nsJson(json::object());
+						for (const auto& [key, value] : static_pointer_cast<Namespace>(obj)) {
+							nsJson[Utility::ValidateUTF8(key)] = value.Val;
+						}
+						j = std::move(nsJson);
+					} else if (obj->GetReflectionType() == Dictionary::TypeInstance) {
+						ObjectLock olock(obj);
+						auto dictJson(json::object());
+						for (const auto& [key, value] : static_pointer_cast<Dictionary>(obj)) {
+							dictJson[Utility::ValidateUTF8(key)] = value;
+						}
+						j = std::move(dictJson);
+					} else if (obj->GetReflectionType() == Array::TypeInstance) {
+						ObjectLock olock(obj);
+						auto arrJson(json::array());
+						for (const Value& v : static_pointer_cast<Array>(obj)) {
+							arrJson.emplace_back(v);
+						}
+						j = std::move(arrJson);
+					} else { // Some other non-serializable object type!
+						j = obj->ToString();
+					}
+					break;
+				}
+				case ValueEmpty:
+					j = nullptr;
+					break;
+				default:
+					VERIFY(!"Invalid variant type.");
+			}
+		}
+
+		// Deserializing JSON objects into Icinga Values is not supported here.
+		// For JSON deserialization, use the JsonSax class instead.
+		static void from_json(const json&, Value&)
+		{
+			throw std::runtime_error("JSON#from_json is not supported for icinga::Value");
+		}
+	};
+} // namespace nlohmann
+
 class JsonSax : public nlohmann::json_sax<nlohmann::json>
 {
 public:
@@ -45,165 +123,13 @@ private:
 	void FillCurrentTarget(Value value);
 };
 
-const char l_Null[] = "null";
-const char l_False[] = "false";
-const char l_True[] = "true";
-const char l_Indent[] = "    ";
-
-// https://github.com/nlohmann/json/issues/1512
-template<bool prettyPrint>
-class JsonEncoder
-{
-public:
-	void Null();
-	void Boolean(bool value);
-	void NumberFloat(double value);
-	void Strng(String value);
-	void StartObject();
-	void Key(String value);
-	void EndObject();
-	void StartArray();
-	void EndArray();
-
-	String GetResult();
-
-private:
-	std::vector<char> m_Result;
-	String m_CurrentKey;
-	std::stack<std::bitset<2>> m_CurrentSubtree;
-
-	void AppendChar(char c);
-
-	template<class Iterator>
-	void AppendChars(Iterator begin, Iterator end);
-
-	void AppendJson(nlohmann::json json);
-
-	void BeforeItem();
-
-	void FinishContainer(char terminator);
-};
-
-template<bool prettyPrint>
-void Encode(JsonEncoder<prettyPrint>& stateMachine, const Value& value);
-
-template<bool prettyPrint>
-inline
-void EncodeNamespace(JsonEncoder<prettyPrint>& stateMachine, const Namespace::Ptr& ns)
-{
-	stateMachine.StartObject();
-
-	ObjectLock olock(ns);
-	for (const Namespace::Pair& kv : ns) {
-		stateMachine.Key(Utility::ValidateUTF8(kv.first));
-		Encode(stateMachine, kv.second.Val);
-	}
-
-	stateMachine.EndObject();
-}
-
-template<bool prettyPrint>
-inline
-void EncodeDictionary(JsonEncoder<prettyPrint>& stateMachine, const Dictionary::Ptr& dict)
-{
-	stateMachine.StartObject();
-
-	ObjectLock olock(dict);
-	for (const Dictionary::Pair& kv : dict) {
-		stateMachine.Key(Utility::ValidateUTF8(kv.first));
-		Encode(stateMachine, kv.second);
-	}
-
-	stateMachine.EndObject();
-}
-
-template<bool prettyPrint>
-inline
-void EncodeArray(JsonEncoder<prettyPrint>& stateMachine, const Array::Ptr& arr)
-{
-	stateMachine.StartArray();
-
-	ObjectLock olock(arr);
-	for (const Value& value : arr) {
-		Encode(stateMachine, value);
-	}
-
-	stateMachine.EndArray();
-}
-
-template<bool prettyPrint>
-void Encode(JsonEncoder<prettyPrint>& stateMachine, const Value& value)
-{
-	switch (value.GetType()) {
-		case ValueNumber:
-			stateMachine.NumberFloat(value.Get<double>());
-			break;
-
-		case ValueBoolean:
-			stateMachine.Boolean(value.ToBool());
-			break;
-
-		case ValueString:
-			stateMachine.Strng(Utility::ValidateUTF8(value.Get<String>()));
-			break;
-
-		case ValueObject:
-			{
-				const Object::Ptr& obj = value.Get<Object::Ptr>();
-
-				{
-					Namespace::Ptr ns = dynamic_pointer_cast<Namespace>(obj);
-					if (ns) {
-						EncodeNamespace(stateMachine, ns);
-						break;
-					}
-				}
-
-				{
-					Dictionary::Ptr dict = dynamic_pointer_cast<Dictionary>(obj);
-					if (dict) {
-						EncodeDictionary(stateMachine, dict);
-						break;
-					}
-				}
-
-				{
-					Array::Ptr arr = dynamic_pointer_cast<Array>(obj);
-					if (arr) {
-						EncodeArray(stateMachine, arr);
-						break;
-					}
-				}
-
-				// obj is most likely a function => "Object of type 'Function'"
-				Encode(stateMachine, obj->ToString());
-				break;
-			}
-
-		case ValueEmpty:
-			stateMachine.Null();
-			break;
-
-		default:
-			VERIFY(!"Invalid variant type.");
-	}
-}
+// The number of spaces to use for indentation in pretty-printed JSON.
+static constexpr unsigned int l_JsonIndentSize = 4;
 
 String icinga::JsonEncode(const Value& value, bool pretty_print)
 {
-	if (pretty_print) {
-		JsonEncoder<true> stateMachine;
-
-		Encode(stateMachine, value);
-
-		return stateMachine.GetResult() + "\n";
-	} else {
-		JsonEncoder<false> stateMachine;
-
-		Encode(stateMachine, value);
-
-		return stateMachine.GetResult();
-	}
+	nlohmann::json json(value);
+	return json.dump(pretty_print ? l_JsonIndentSize : -1, ' ', true);
 }
 
 Value icinga::JsonDecode(const String& data)
@@ -348,178 +274,4 @@ void JsonSax::FillCurrentTarget(Value value)
 			node.second->Add(value);
 		}
 	}
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::Null()
-{
-	BeforeItem();
-	AppendChars((const char*)l_Null, (const char*)l_Null + 4);
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::Boolean(bool value)
-{
-	BeforeItem();
-
-	if (value) {
-		AppendChars((const char*)l_True, (const char*)l_True + 4);
-	} else {
-		AppendChars((const char*)l_False, (const char*)l_False + 5);
-	}
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::NumberFloat(double value)
-{
-	BeforeItem();
-
-	// Make sure 0.0 is serialized as 0, so e.g. Icinga DB can parse it as int.
-	if (value < 0) {
-		long long i = value;
-
-		if (i == value) {
-			AppendJson(i);
-		} else {
-			AppendJson(value);
-		}
-	} else {
-		unsigned long long i = value;
-
-		if (i == value) {
-			AppendJson(i);
-		} else {
-			AppendJson(value);
-		}
-	}
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::Strng(String value)
-{
-	BeforeItem();
-	AppendJson(std::move(value));
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::StartObject()
-{
-	BeforeItem();
-	AppendChar('{');
-
-	m_CurrentSubtree.push(2);
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::Key(String value)
-{
-	m_CurrentKey = std::move(value);
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::EndObject()
-{
-	FinishContainer('}');
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::StartArray()
-{
-	BeforeItem();
-	AppendChar('[');
-
-	m_CurrentSubtree.push(0);
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::EndArray()
-{
-	FinishContainer(']');
-}
-
-template<bool prettyPrint>
-inline
-String JsonEncoder<prettyPrint>::GetResult()
-{
-	return String(m_Result.begin(), m_Result.end());
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::AppendChar(char c)
-{
-	m_Result.emplace_back(c);
-}
-
-template<bool prettyPrint>
-template<class Iterator>
-inline
-void JsonEncoder<prettyPrint>::AppendChars(Iterator begin, Iterator end)
-{
-	m_Result.insert(m_Result.end(), begin, end);
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::AppendJson(nlohmann::json json)
-{
-	nlohmann::detail::serializer<nlohmann::json>(nlohmann::detail::output_adapter<char>(m_Result), ' ').dump(std::move(json), prettyPrint, true, 0);
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::BeforeItem()
-{
-	if (!m_CurrentSubtree.empty()) {
-		auto& node (m_CurrentSubtree.top());
-
-		if (node[0]) {
-			AppendChar(',');
-		} else {
-			node[0] = true;
-		}
-
-		if (prettyPrint) {
-			AppendChar('\n');
-
-			for (auto i (m_CurrentSubtree.size()); i; --i) {
-				AppendChars((const char*)l_Indent, (const char*)l_Indent + 4);
-			}
-		}
-
-		if (node[1]) {
-			AppendJson(std::move(m_CurrentKey));
-			AppendChar(':');
-
-			if (prettyPrint) {
-				AppendChar(' ');
-			}
-		}
-	}
-}
-
-template<bool prettyPrint>
-inline
-void JsonEncoder<prettyPrint>::FinishContainer(char terminator)
-{
-	if (prettyPrint && m_CurrentSubtree.top()[0]) {
-		AppendChar('\n');
-
-		for (auto i (m_CurrentSubtree.size() - 1u); i; --i) {
-			AppendChars((const char*)l_Indent, (const char*)l_Indent + 4);
-		}
-	}
-
-	AppendChar(terminator);
-
-	m_CurrentSubtree.pop();
 }

--- a/lib/base/json.cpp
+++ b/lib/base/json.cpp
@@ -132,6 +132,20 @@ String icinga::JsonEncode(const Value& value, bool pretty_print)
 	return json.dump(pretty_print ? l_JsonIndentSize : -1, ' ', true);
 }
 
+/**
+ * Serializes an Icinga Value into a JSON object and writes it to the given output stream.
+ *
+ * @param value The value to be JSON serialized.
+ * @param os The output stream to write the JSON data to.
+ * @param pretty_print Whether to pretty print the JSON data.
+ */
+void icinga::JsonEncode(const Value& value, std::ostream& os, bool pretty_print)
+{
+	using namespace nlohmann;
+	detail::serializer<json> s(nlohmann::detail::output_adapter(os), ' ', json::error_handler_t::strict);
+	s.dump(json(value), pretty_print, true, pretty_print ? l_JsonIndentSize : 0);
+}
+
 Value icinga::JsonDecode(const String& data)
 {
 	String sanitized (Utility::ValidateUTF8(data));

--- a/lib/base/json.hpp
+++ b/lib/base/json.hpp
@@ -12,6 +12,7 @@ class String;
 class Value;
 
 String JsonEncode(const Value& value, bool pretty_print = false);
+void JsonEncode(const Value& value, std::ostream& os, bool pretty_print = false);
 Value JsonDecode(const String& data);
 
 }

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -9,9 +9,9 @@
 #include "base/io-engine.hpp"
 #include "base/objectlock.hpp"
 #include "base/json.hpp"
-#include <boost/asio/buffer.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/asio/streambuf.hpp>
 #include <map>
 #include <set>
 
@@ -110,21 +110,18 @@ bool EventsHandler::HandleRequest(
 	http::async_write(stream, response, yc);
 	stream.async_flush(yc);
 
-	asio::const_buffer newLine ("\n", 1);
+	asio::streambuf eventsBuf;
+	std::ostream eventsOS(&eventsBuf);
 
 	for (;;) {
-		auto event (subscriber.GetInbox()->Shift(yc));
+		if (auto event(subscriber.GetInbox()->Shift(yc)); event) {
+			JsonEncode(event, eventsOS);
+			// Put a newline at the end of each event to render them on a separate line.
+			eventsOS << '\n';
 
-		if (event) {
-			String body = JsonEncode(event);
-
-			boost::algorithm::replace_all(body, "\n", "");
-
-			asio::const_buffer payload (body.CStr(), body.GetLength());
-
-			asio::async_write(stream, payload, yc);
-			asio::async_write(stream, newLine, yc);
+			asio::async_write(stream, eventsBuf, yc);
 			stream.async_flush(yc);
+			eventsBuf.consume(eventsBuf.size()); // Remove already sent data from the buffer.
 		} else if (server.Disconnected()) {
 			return true;
 		}

--- a/test/base-json.cpp
+++ b/test/base-json.cpp
@@ -44,6 +44,10 @@ BOOST_AUTO_TEST_CASE(encode)
 	auto got(JsonEncode(input, true));
 	BOOST_CHECK_MESSAGE(output == got, "expected=" << output << "\ngot=" << got);
 
+	std::ostringstream oss;
+	JsonEncode(input, oss, true);
+	BOOST_CHECK_MESSAGE(oss.str() == output, "expected=" << output << "\ngot=" << oss.str());
+
 	boost::algorithm::replace_all(output, " ", "");
 	boost::algorithm::replace_all(output, "Objectoftype'Function'", "Object of type 'Function'");
 	boost::algorithm::replace_all(output, "\n", "");

--- a/test/base-json.cpp
+++ b/test/base-json.cpp
@@ -39,10 +39,10 @@ BOOST_AUTO_TEST_CASE(encode)
     "string": "LF\nTAB\tAUml\u00e4Ill\ufffd",
     "true": true,
     "uint": 23
-}
-)EOF");
+})EOF");
 
-	BOOST_CHECK(JsonEncode(input, true) == output);
+	auto got(JsonEncode(input, true));
+	BOOST_CHECK_MESSAGE(output == got, "expected=" << output << "\ngot=" << got);
 
 	boost::algorithm::replace_all(output, " ", "");
 	boost::algorithm::replace_all(output, "Objectoftype'Function'", "Object of type 'Function'");


### PR DESCRIPTION
This PR introduces an overload of the existing `JsonEncode()` function that allows to directly serialize JSON into a `std::iostream`. Initially, I was thinking to add another overload that allows to directly write the JSON into an Asio stream, but since the json library we use doesn't provide such an implementation we'd have to implement quite a lot of unusual things. Even then, it wouldn't make any sense, I mean, why would we ever want to (async)write every and each of the JSON tokens individually into an Asio stream? Instead, we can just serialize the JSON into an `asio::streambuf` and pass that to any Asio write methods (see 4cfde50 for example usages). Additionally, this PR removes our custom `JsonEncoder` and its utilities, and provides a `nlohmann::adl_serializer<Value>` specialization instead, that does all the low level JSON serialization stuff.

Test cases for 4cfde50:

```bash
$ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' \
 -X POST 'https://localhost:5667/v1/events' \
 -d '{ "queue": "myqueue", "types": [ "CheckResult" ] }'
HTTP/1.1 200 OK
Server: Icinga/v2.14.0-580-g4d1a2a95e
Content-Type: application/json

{"acknowledgement":false,"check_result":{"active":true,"check_source":"mbp-yhabteab","command":"random","execution_end":1744878369.045693,"execution_start":1744878369.044834,"exit_status":0,"output":"Hello from mbp-yhabteab. Icinga 2 has been running for 863 milliseconds. Version: v2.14.0-580-g4d1a2a95e","performance_data":[{"counter":false,"crit":null,"label":"time","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1744878369.045537,"warn":null},{"counter":false,"crit":null,"label":"value","max":null,"min":null,"type":"PerfdataValue","unit":"","value":554,"warn":null},{"counter":false,"crit":null,"label":"value_1m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":498.6,"warn":null},{"counter":false,"crit":null,"label":"value_5m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":443.20000000000005,"warn":null},{"counter":false,"crit":null,"label":"uptime","max":null,"min":null,"type":"PerfdataValue","unit":"","value":0.863487958908081,"warn":null}],"previous_hard_state":2,"schedule_end":1744878369.045693,"schedule_start":1744878369.0384912,"scheduling_source":"mbp-yhabteab","state":3,"ttl":0,"type":"CheckResult","vars_after":{"attempt":1,"reachable":true,"state":3,"state_type":1},"vars_before":{"attempt":1,"reachable":false,"state":2,"state_type":1}},"downtime_depth":0,"host":"big-switch-server-334","service":"agent-check-17","timestamp":1744878369.046833,"type":"CheckResult"}
{"acknowledgement":false,"check_result":{"active":true,"check_source":"mbp-yhabteab","command":"random","execution_end":1744878369.28083,"execution_start":1744878369.279451,"exit_status":0,"output":"Hello from mbp-yhabteab. Icinga 2 has been running for 1 second. Version: v2.14.0-580-g4d1a2a95e","performance_data":[{"counter":false,"crit":null,"label":"time","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1744878369.280713,"warn":null},{"counter":false,"crit":null,"label":"value","max":null,"min":null,"type":"PerfdataValue","unit":"","value":554,"warn":null},{"counter":false,"crit":null,"label":"value_1m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":498.6,"warn":null},{"counter":false,"crit":null,"label":"value_5m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":443.20000000000005,"warn":null},{"counter":false,"crit":null,"label":"uptime","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1.0986640453338623,"warn":null}],"previous_hard_state":2,"schedule_end":1744878369.28083,"schedule_start":1744878369.27222,"scheduling_source":"mbp-yhabteab","state":3,"ttl":0,"type":"CheckResult","vars_after":{"attempt":1,"reachable":true,"state":3,"state_type":1},"vars_before":{"attempt":1,"reachable":false,"state":2,"state_type":1}},"downtime_depth":0,"host":"big-switch-server-27","service":"agent-check-5","timestamp":1744878369.282143,"type":"CheckResult"}
{"acknowledgement":false,"check_result":{"active":true,"check_source":"mbp-yhabteab","command":"random","execution_end":1744878369.477017,"execution_start":1744878369.475539,"exit_status":0,"output":"Hello from mbp-yhabteab. Icinga 2 has been running for 1 second. Version: v2.14.0-580-g4d1a2a95e","performance_data":[{"counter":false,"crit":null,"label":"time","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1744878369.476928,"warn":null},{"counter":false,"crit":null,"label":"value","max":null,"min":null,"type":"PerfdataValue","unit":"","value":554,"warn":null},{"counter":false,"crit":null,"label":"value_1m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":498.6,"warn":null},{"counter":false,"crit":null,"label":"value_5m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":443.20000000000005,"warn":null},{"counter":false,"crit":null,"label":"uptime","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1.2948789596557617,"warn":null}],"previous_hard_state":0,"schedule_end":1744878369.477017,"schedule_start":1744878369.4682555,"scheduling_source":"mbp-yhabteab","state":3,"ttl":0,"type":"CheckResult","vars_after":{"attempt":2,"reachable":true,"state":3,"state_type":0},"vars_before":{"attempt":1,"reachable":true,"state":1,"state_type":0}},"downtime_depth":0,"host":"big-switch-server-373","service":"agent-check-12","timestamp":1744878369.478105,"type":"CheckResult"}
{"acknowledgement":false,"check_result":{"active":true,"check_source":"mbp-yhabteab","command":"random","execution_end":1744878369.579804,"execution_start":1744878369.578383,"exit_status":0,"output":"Hello from mbp-yhabteab. Icinga 2 has been running for 1 second. Version: v2.14.0-580-g4d1a2a95e","performance_data":[{"counter":false,"crit":null,"label":"time","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1744878369.57971,"warn":null},{"counter":false,"crit":null,"label":"value","max":null,"min":null,"type":"PerfdataValue","unit":"","value":554,"warn":null},{"counter":false,"crit":null,"label":"value_1m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":498.6,"warn":null},{"counter":false,"crit":null,"label":"value_5m","max":null,"min":null,"type":"PerfdataValue","unit":"","value":443.20000000000005,"warn":null},{"counter":false,"crit":null,"label":"uptime","max":null,"min":null,"type":"PerfdataValue","unit":"","value":1.3976609706878662,"warn":null}],"previous_hard_state":1,"schedule_end":1744878369.579804,"schedule_start":1744878369.5709357,"scheduling_source":"mbp-yhabteab","state":3,"ttl":0,"type":"CheckResult","vars_after":{"attempt":1,"reachable":true,"state":3,"state_type":1},"vars_before":{"attempt":1,"reachable":false,"state":1,"state_type":1}},"downtime_depth":0,"host":"big-switch-server-247","service":"sshd","timestamp":1744878369.581242,"type":"CheckResult"}
...
```

fixes #10408