### PR TITLE
Abort connections with no valid endpoint

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -757,7 +757,8 @@ void ApiListener::NewClientHandlerInternal(
 		if (!verify_ok) {
 			log << " (certificate validation failed: " << verifyError << ")";
 		} else if (!endpoint) {
-			log << " (no Endpoint object found for identity)";
+			log << " (no Endpoint object found for identity. Closing Connection.)";
+			return;
 		}
 	} else {
 		Log(LogInformation, "ApiListener")


### PR DESCRIPTION
Aborts connections early when no endpoint is defined for the incoming connection. This is done by returning early from `ApiListener::NewClientHandlerInternal` when the certificate is validated, but no endpoint is configured for the remote.

A more complex solution that does not close the connection so abruptly for the remote (causing various errors in the log) would involve both sides of the `JsonRpcConnection` confirming the connection via an exchange of messages an should be considered in a future refactoring of the `NewClientHandler` code.

For now this closes #10405 by making the cluster checks fail reliably and keeps the parent from blindly sending requests to clients that just silently discard them.