### PR TITLE
Fix SIGABRT not causing a core dump

### DIFF
--- a/lib/base/application.cpp
+++ b/lib/base/application.cpp
@@ -776,6 +776,12 @@ void Application::SigAbrtHandler(int)
 	}
 
 	AttachDebugger(fname, interactive_debugger);
+	
+#ifdef __linux__
+	prctl(PR_SET_DUMPABLE, 1);
+#endif /* __linux __ */
+	
+	abort();
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
A second abort() is needed at the end of `SigAbrtHandler()` to trigger the SIG_DFL action (in this case the core dump).

Also since `AttachDebugger()` disables the ability to dump core, so it gets reenabled after returning from it.

I've tested and verified that the backtraces generated with `gdb` in `AttachDebugger()` still appear in the crash-log file.

This fixes #8908.
I will address the documentation changes for #8714 in a second PR.