### PR TITLE
Improvements to core dumps section in developer documentation (and some smaller stuff)

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -204,7 +204,7 @@ You can read the full story [here](https://github.com/Icinga/icinga2/issues/7309
 
 With 2.11 you'll now see 3 processes:
 
-- The umbrella process which takes care about signal handling and process spawning/stopping
+- The umbrella process which takes care of signal handling and process spawning/stopping
 - The main process with the check scheduler, notifications, etc.
 - The execution helper process
 

--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -741,7 +741,7 @@ perfdata       | Performance data related, including Graphite, Elastic, etc.
 db\_ido        | IDO database abstraction layer.
 db\_ido\_mysql | IDO database driver for MySQL.
 db\_ido\_pgsql | IDO database driver for PgSQL.
-mysql\_shin    | Library stub for linking against the MySQL client libraries.
+mysql\_shim    | Library stub for linking against the MySQL client libraries.
 pgsql\_shim    | Library stub for linking against the PgSQL client libraries.
 
 #### Class Compiler <a id="development-develop-design-patterns-class-compiler"></a>
@@ -1228,7 +1228,7 @@ every second.
 
 Avoid log messages which could irritate the user. During
 implementation, developers can change log levels to better
-see what's going one, but remember to change this back to `debug`
+see what's going on, but remember to change this back to `debug`
 or remove it entirely.
 
 
@@ -2262,7 +2262,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/icinga2
 
 ### CMake Variables <a id="development-package-builds-cmake-variables"></a>
 
-In addition to `CMAKE_INSTALL_PREFIX` here are most of the supported Icinga-specific cmake variables.
+In addition to `CMAKE_INSTALL_PREFIX` here are most of the supported Icinga-specific CMake variables.
 
 For all variables regarding defaults paths on in CMake, see
 [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html).

--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -792,17 +792,18 @@ The most common benefits:
 
 #### Unity Builds <a id="development-develop-builds-unity-builds"></a>
 
-Another thing you should be aware of: Unity builds on and off.
+You should be aware that by default unity builds are enabled. You can turn them
+off by setting the `ICINGA2_UNITY_BUILD` CMake option to `OFF`.
 
 Typically, we already use caching mechanisms to reduce recompile time with ccache.
 For release builds, there's always a new build needed as the difference is huge compared
 to a previous (major) release.
 
-Therefore we've invented the Unity builds, which basically concatenates all source files
-into one big library source code file. The compiler then doesn't need to load the many small
-files but compiles and links this huge one.
+Unity builds basically concatenate all source files into one big library source code file.
+The compiler then doesn't need to load many small files, each with all of their includes,
+but compiles and links only a few huge ones.
 
-Unity builds require more memory which is why you should disable them for development
+However, unity builds require more memory which is why you should disable them for development
 builds in small sized VMs (Linux, Windows) and also Docker containers.
 
 There's a couple of header files which are included everywhere. If you touch/edit them,

--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -683,7 +683,7 @@ these tools:
 - vim
 - CLion (macOS, Linux)
 - MS Visual Studio (Windows)
-- Atom
+- Emacs
 
 Editors differ on the functionality. The more helpers you get for C++ development,
 the faster your development workflow will be.

--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -746,7 +746,7 @@ pgsql\_shim    | Library stub for linking against the PgSQL client libraries.
 
 #### Class Compiler <a id="development-develop-design-patterns-class-compiler"></a>
 
-Another thing you will recognize are the `.ti` files which are compiled
+Something else you might notice are the `.ti` files which are compiled
 by our own class compiler into actual source code. The meta language allows
 developers to easily add object attributes and specify their behaviour.
 


### PR DESCRIPTION
## Core Dumps

Updated and added more information to set up generating core dumps, touching and expanding on systemd's coredumpctl, Ubuntu's apport and the conventional method.

This fixes #8714.

## Unity Builds

Rephrased some sentences to make them more understandably and avoid awkward claims like Icinga 'inventing' unity builds.

## Preferred Editors

Removed Atom and added Emacs. :grin:

## Typos

Also fixed a few typos and capitalization errors (maybe added a few too).

I'm happy to incorporate any further suggestions.