### PR TITLE
Serialize fields before queueing them to the workqueue

### DIFF
--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -272,22 +272,12 @@ void ElasticsearchWriter::InternalCheckResultHandler(const Checkable::Ptr& check
 	fields->Set("max_check_attempts", checkable->GetMaxCheckAttempts());
 
 	fields->Set("reachable", checkable->IsReachable());
+	fields->Set("check_command", checkable->GetCheckCommand()->GetName());
 
-	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
-
-	if (commandObj)
-		fields->Set("check_command", commandObj->GetName());
-
-	double ts = Utility::GetTime();
-
-	if (cr) {
-		AddCheckResult(fields, checkable, cr);
-		ts = cr->GetExecutionEnd();
-	}
-
+	AddCheckResult(fields, checkable, cr);
 	AddTemplateTags(fields, checkable, cr);
 
-	Enqueue(checkable, "checkresult", fields, ts);
+	Enqueue(checkable, "checkresult", fields, cr->GetExecutionEnd());
 }
 
 void ElasticsearchWriter::StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type)
@@ -325,21 +315,12 @@ void ElasticsearchWriter::StateChangeHandlerInternal(const Checkable::Ptr& check
 		fields->Set("last_hard_state", host->GetLastHardState());
 	}
 
-	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
+	fields->Set("check_command", checkable->GetCheckCommand()->GetName());
 
-	if (commandObj)
-		fields->Set("check_command", commandObj->GetName());
-
-	double ts = Utility::GetTime();
-
-	if (cr) {
-		AddCheckResult(fields, checkable, cr);
-		ts = cr->GetExecutionEnd();
-	}
-
+	AddCheckResult(fields, checkable, cr);
 	AddTemplateTags(fields, checkable, cr);
 
-	Enqueue(checkable, "statechange", fields, ts);
+	Enqueue(checkable, "statechange", fields, cr->GetExecutionEnd());
 }
 
 void ElasticsearchWriter::NotificationSentToAllUsersHandler(const Notification::Ptr& notification,
@@ -396,11 +377,7 @@ void ElasticsearchWriter::NotificationSentToAllUsersHandlerInternal(const Notifi
 	fields->Set("notification_type", notificationTypeString);
 	fields->Set("author", author);
 	fields->Set("text", text);
-
-	CheckCommand::Ptr commandObj = checkable->GetCheckCommand();
-
-	if (commandObj)
-		fields->Set("check_command", commandObj->GetName());
+	fields->Set("check_command", checkable->GetCheckCommand()->GetName());
 
 	double ts = Utility::GetTime();
 

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -101,13 +101,13 @@ void ElasticsearchWriter::Resume()
 		CheckResultHandler(checkable, cr);
 	});
 	m_HandleStateChanges = Checkable::OnStateChange.connect([this](const Checkable::Ptr& checkable,
-		const CheckResult::Ptr& cr, StateType type, const MessageOrigin::Ptr&) {
-		StateChangeHandler(checkable, cr, type);
+		const CheckResult::Ptr& cr, StateType, const MessageOrigin::Ptr&) {
+		StateChangeHandler(checkable, cr);
 	});
-	m_HandleNotifications = Checkable::OnNotificationSentToAllUsers.connect([this](const Notification::Ptr& notification,
+	m_HandleNotifications = Checkable::OnNotificationSentToAllUsers.connect([this](const Notification::Ptr&,
 		const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, const NotificationType& type,
 		const CheckResult::Ptr& cr, const String& author, const String& text, const MessageOrigin::Ptr&) {
-		NotificationSentToAllUsersHandler(notification, checkable, users, type, cr, author, text);
+		NotificationSentToAllUsersHandler(checkable, users, type, cr, author, text);
 	});
 }
 
@@ -280,15 +280,15 @@ void ElasticsearchWriter::InternalCheckResultHandler(const Checkable::Ptr& check
 	Enqueue(checkable, "checkresult", fields, cr->GetExecutionEnd());
 }
 
-void ElasticsearchWriter::StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type)
+void ElasticsearchWriter::StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
 {
 	if (IsPaused())
 		return;
 
-	m_WorkQueue.Enqueue([this, checkable, cr, type]() { StateChangeHandlerInternal(checkable, cr, type); });
+	m_WorkQueue.Enqueue([this, checkable, cr]() { StateChangeHandlerInternal(checkable, cr); });
 }
 
-void ElasticsearchWriter::StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type)
+void ElasticsearchWriter::StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
 {
 	AssertOnWorkQueue();
 
@@ -323,21 +323,19 @@ void ElasticsearchWriter::StateChangeHandlerInternal(const Checkable::Ptr& check
 	Enqueue(checkable, "statechange", fields, cr->GetExecutionEnd());
 }
 
-void ElasticsearchWriter::NotificationSentToAllUsersHandler(const Notification::Ptr& notification,
-	const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, NotificationType type,
-	const CheckResult::Ptr& cr, const String& author, const String& text)
+void ElasticsearchWriter::NotificationSentToAllUsersHandler(const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
+	NotificationType type, const CheckResult::Ptr& cr, const String& author, const String& text)
 {
 	if (IsPaused())
 		return;
 
-	m_WorkQueue.Enqueue([this, notification, checkable, users, type, cr, author, text]() {
-		NotificationSentToAllUsersHandlerInternal(notification, checkable, users, type, cr, author, text);
+	m_WorkQueue.Enqueue([this, checkable, users, type, cr, author, text]() {
+		NotificationSentToAllUsersHandlerInternal(checkable, users, type, cr, author, text);
 	});
 }
 
-void ElasticsearchWriter::NotificationSentToAllUsersHandlerInternal(const Notification::Ptr& notification,
-	const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, NotificationType type,
-	const CheckResult::Ptr& cr, const String& author, const String& text)
+void ElasticsearchWriter::NotificationSentToAllUsersHandlerInternal(const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
+	NotificationType type, const CheckResult::Ptr& cr, const String& author, const String& text)
 {
 	AssertOnWorkQueue();
 

--- a/lib/perfdata/elasticsearchwriter.hpp
+++ b/lib/perfdata/elasticsearchwriter.hpp
@@ -43,12 +43,8 @@ private:
 	void AddTemplateTags(const Dictionary::Ptr& fields, const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 
 	void StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void InternalCheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void NotificationSentToAllUsersHandler(const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
-		NotificationType type, const CheckResult::Ptr& cr, const String& author, const String& text);
-	void NotificationSentToAllUsersHandlerInternal(const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
 		NotificationType type, const CheckResult::Ptr& cr, const String& author, const String& text);
 
 	void Enqueue(const Checkable::Ptr& checkable, const String& type,

--- a/lib/perfdata/elasticsearchwriter.hpp
+++ b/lib/perfdata/elasticsearchwriter.hpp
@@ -42,16 +42,14 @@ private:
 	void AddCheckResult(const Dictionary::Ptr& fields, const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void AddTemplateTags(const Dictionary::Ptr& fields, const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 
-	void StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type);
-	void StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type);
+	void StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
+	void StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void InternalCheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void NotificationSentToAllUsersHandler(const Notification::Ptr& notification,
-		const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, NotificationType type,
-		const CheckResult::Ptr& cr, const String& author, const String& text);
-	void NotificationSentToAllUsersHandlerInternal(const Notification::Ptr& notification,
-		const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, NotificationType type,
-		const CheckResult::Ptr& cr, const String& author, const String& text);
+	void NotificationSentToAllUsersHandler(const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
+		NotificationType type, const CheckResult::Ptr& cr, const String& author, const String& text);
+	void NotificationSentToAllUsersHandlerInternal(const Checkable::Ptr& checkable, const std::set<User::Ptr>& users,
+		NotificationType type, const CheckResult::Ptr& cr, const String& author, const String& text);
 
 	void Enqueue(const Checkable::Ptr& checkable, const String& type,
 		const Dictionary::Ptr& fields, double ts);

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -268,18 +268,6 @@ void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const Check
 	if (IsPaused())
 		return;
 
-	m_WorkQueue.Enqueue([this, checkable, cr]() { CheckResultHandlerInternal(checkable, cr); });
-}
-
-void GelfWriter::CheckResultHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
-{
-	AssertOnWorkQueue();
-
-	CONTEXT("GELF Processing check result for '" << checkable->GetName() << "'");
-
-	Log(LogDebug, "GelfWriter")
-		<< "Processing check result for '" << checkable->GetName() << "'";
-
 	Host::Ptr host;
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
@@ -308,80 +296,72 @@ void GelfWriter::CheckResultHandlerInternal(const Checkable::Ptr& checkable, con
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 	fields->Set("_check_command", checkCommand->GetName());
 
-	fields->Set("_latency", cr->CalculateLatency());
-	fields->Set("_execution_time", cr->CalculateExecutionTime());
-	fields->Set("short_message", CompatUtility::GetCheckResultOutput(cr));
-	fields->Set("full_message", cr->GetOutput());
-	fields->Set("_check_source", cr->GetCheckSource());
+	m_WorkQueue.Enqueue([this, checkable, cr, fields = std::move(fields)]() {
+		CONTEXT("GELF Processing check result for '" << checkable->GetName() << "'");
 
-	if (GetEnableSendPerfdata()) {
-		Array::Ptr perfdata = cr->GetPerformanceData();
+		Log(LogDebug, "GelfWriter")
+			<< "Processing check result for '" << checkable->GetName() << "'";
 
-		if (perfdata) {
-			ObjectLock olock(perfdata);
-			for (const Value& val : perfdata) {
-				PerfdataValue::Ptr pdv;
+		fields->Set("_latency", cr->CalculateLatency());
+		fields->Set("_execution_time", cr->CalculateExecutionTime());
+		fields->Set("short_message", CompatUtility::GetCheckResultOutput(cr));
+		fields->Set("full_message", cr->GetOutput());
+		fields->Set("_check_source", cr->GetCheckSource());
 
-				if (val.IsObjectType<PerfdataValue>())
-					pdv = val;
-				else {
-					try {
-						pdv = PerfdataValue::Parse(val);
-					} catch (const std::exception&) {
-						Log(LogWarning, "GelfWriter")
-							<< "Ignoring invalid perfdata for checkable '"
-							<< checkable->GetName() << "' and command '"
-							<< checkCommand->GetName() << "' with value: " << val;
-						continue;
+		if (GetEnableSendPerfdata()) {
+			Array::Ptr perfdata = cr->GetPerformanceData();
+
+			if (perfdata) {
+				ObjectLock olock(perfdata);
+				for (const Value& val : perfdata) {
+					PerfdataValue::Ptr pdv;
+
+					if (val.IsObjectType<PerfdataValue>())
+						pdv = val;
+					else {
+						try {
+							pdv = PerfdataValue::Parse(val);
+						} catch (const std::exception&) {
+							Log(LogWarning, "GelfWriter")
+								<< "Ignoring invalid perfdata for checkable '"
+								<< checkable->GetName() << "' and command '"
+								<< checkable->GetCheckCommand()->GetName() << "' with value: " << val;
+							continue;
+						}
 					}
+
+					String escaped_key = pdv->GetLabel();
+					boost::replace_all(escaped_key, " ", "_");
+					boost::replace_all(escaped_key, ".", "_");
+					boost::replace_all(escaped_key, "\\", "_");
+					boost::algorithm::replace_all(escaped_key, "::", ".");
+
+					fields->Set("_" + escaped_key, pdv->GetValue());
+
+					if (!pdv->GetMin().IsEmpty())
+						fields->Set("_" + escaped_key + "_min", pdv->GetMin());
+					if (!pdv->GetMax().IsEmpty())
+						fields->Set("_" + escaped_key + "_max", pdv->GetMax());
+					if (!pdv->GetWarn().IsEmpty())
+						fields->Set("_" + escaped_key + "_warn", pdv->GetWarn());
+					if (!pdv->GetCrit().IsEmpty())
+						fields->Set("_" + escaped_key + "_crit", pdv->GetCrit());
+
+					if (!pdv->GetUnit().IsEmpty())
+						fields->Set("_" + escaped_key + "_unit", pdv->GetUnit());
 				}
-
-				String escaped_key = pdv->GetLabel();
-				boost::replace_all(escaped_key, " ", "_");
-				boost::replace_all(escaped_key, ".", "_");
-				boost::replace_all(escaped_key, "\\", "_");
-				boost::algorithm::replace_all(escaped_key, "::", ".");
-
-				fields->Set("_" + escaped_key, pdv->GetValue());
-
-				if (!pdv->GetMin().IsEmpty())
-					fields->Set("_" + escaped_key + "_min", pdv->GetMin());
-				if (!pdv->GetMax().IsEmpty())
-					fields->Set("_" + escaped_key + "_max", pdv->GetMax());
-				if (!pdv->GetWarn().IsEmpty())
-					fields->Set("_" + escaped_key + "_warn", pdv->GetWarn());
-				if (!pdv->GetCrit().IsEmpty())
-					fields->Set("_" + escaped_key + "_crit", pdv->GetCrit());
-
-				if (!pdv->GetUnit().IsEmpty())
-					fields->Set("_" + escaped_key + "_unit", pdv->GetUnit());
 			}
 		}
-	}
 
-	SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), cr->GetExecutionEnd()));
-}
-
-void GelfWriter::NotificationToUserHandler(const Checkable::Ptr& checkable, NotificationType notificationType,
-	CheckResult::Ptr const& cr, const String& author, const String& commentText, const String& commandName)
-{
-	if (IsPaused())
-		return;
-
-	m_WorkQueue.Enqueue([this, checkable, notificationType, cr, author, commentText, commandName]() {
-		NotificationToUserHandlerInternal(checkable, notificationType, cr, author, commentText, commandName);
+		SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), cr->GetExecutionEnd()));
 	});
 }
 
-void GelfWriter::NotificationToUserHandlerInternal(const Checkable::Ptr& checkable, NotificationType notificationType,
-	CheckResult::Ptr const& cr, const String& author, const String& commentText, const String& commandName)
+void GelfWriter::NotificationToUserHandler(const Checkable::Ptr& checkable, NotificationType notificationType,
+	const CheckResult::Ptr& cr, const String& author, const String& commentText, const String& commandName)
 {
-	AssertOnWorkQueue();
-
-	CONTEXT("GELF Processing notification to all users '" << checkable->GetName() << "'");
-
-	Log(LogDebug, "GelfWriter")
-		<< "Processing notification for '" << checkable->GetName() << "'";
+	if (IsPaused())
+		return;
 
 	Host::Ptr host;
 	Service::Ptr service;
@@ -423,25 +403,20 @@ void GelfWriter::NotificationToUserHandlerInternal(const Checkable::Ptr& checkab
 	fields->Set("_comment", authorComment);
 	fields->Set("_check_command", checkable->GetCheckCommand()->GetName());
 
-	SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), ts));
+	m_WorkQueue.Enqueue([this, checkable, ts, fields = std::move(fields)]() {
+		CONTEXT("GELF Processing notification to all users '" << checkable->GetName() << "'");
+
+		Log(LogDebug, "GelfWriter")
+			<< "Processing notification for '" << checkable->GetName() << "'";
+
+		SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), ts));
+	});
 }
 
 void GelfWriter::StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
 {
 	if (IsPaused())
 		return;
-
-	m_WorkQueue.Enqueue([this, checkable, cr]() { StateChangeHandlerInternal(checkable, cr); });
-}
-
-void GelfWriter::StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
-{
-	AssertOnWorkQueue();
-
-	CONTEXT("GELF Processing state change '" << checkable->GetName() << "'");
-
-	Log(LogDebug, "GelfWriter")
-		<< "Processing state change for '" << checkable->GetName() << "'";
 
 	Host::Ptr host;
 	Service::Ptr service;
@@ -470,7 +445,14 @@ void GelfWriter::StateChangeHandlerInternal(const Checkable::Ptr& checkable, con
 	fields->Set("full_message", cr->GetOutput());
 	fields->Set("_check_source", cr->GetCheckSource());
 
-	SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), cr->GetExecutionEnd()));
+	m_WorkQueue.Enqueue([this, checkable, fields = std::move(fields), ts = cr->GetExecutionEnd()]() {
+		CONTEXT("GELF Processing state change '" << checkable->GetName() << "'");
+
+		Log(LogDebug, "GelfWriter")
+			<< "Processing state change for '" << checkable->GetName() << "'";
+
+		SendLogMessage(checkable, ComposeGelfMessage(fields, GetSource(), ts));
+	});
 }
 
 String GelfWriter::ComposeGelfMessage(const Dictionary::Ptr& fields, const String& source, double ts)
@@ -484,6 +466,8 @@ String GelfWriter::ComposeGelfMessage(const Dictionary::Ptr& fields, const Strin
 
 void GelfWriter::SendLogMessage(const Checkable::Ptr& checkable, const String& gelfMessage)
 {
+	AssertOnWorkQueue();
+
 	std::ostringstream msgbuf;
 	msgbuf << gelfMessage;
 	msgbuf << '\0';

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -41,14 +41,12 @@ private:
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void CheckResultHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void NotificationToUserHandler(const Notification::Ptr& notification, const Checkable::Ptr& checkable,
-		const User::Ptr& user, NotificationType notificationType, const CheckResult::Ptr& cr,
-		const String& author, const String& commentText, const String& commandName);
-	void NotificationToUserHandlerInternal(const Notification::Ptr& notification, const Checkable::Ptr& checkable,
-		const User::Ptr& user, NotificationType notification_type, const CheckResult::Ptr& cr,
-		const String& author, const String& comment_text, const String& command_name);
-	void StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type);
-	void StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType type);
+	void NotificationToUserHandler(const Checkable::Ptr& checkable, NotificationType notificationType,
+		const CheckResult::Ptr& cr, const String& author, const String& commentText, const String& commandName);
+	void NotificationToUserHandlerInternal(const Checkable::Ptr& checkable, NotificationType notification_type,
+		const CheckResult::Ptr& cr, const String& author, const String& comment_text, const String& command_name);
+	void StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
+	void StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 
 	String ComposeGelfMessage(const Dictionary::Ptr& fields, const String& source, double ts);
 	void SendLogMessage(const Checkable::Ptr& checkable, const String& gelfMessage);

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -40,13 +40,9 @@ private:
 	Timer::Ptr m_ReconnectTimer;
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void CheckResultHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void NotificationToUserHandler(const Checkable::Ptr& checkable, NotificationType notificationType,
-		const CheckResult::Ptr& cr, const String& author, const String& commentText, const String& commandName);
-	void NotificationToUserHandlerInternal(const Checkable::Ptr& checkable, NotificationType notification_type,
-		const CheckResult::Ptr& cr, const String& author, const String& comment_text, const String& command_name);
+	void NotificationToUserHandler(const Checkable::Ptr& checkable, NotificationType notificationType, const CheckResult::Ptr& cr,
+		const String& author, const String& commentText, const String& commandName);
 	void StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void StateChangeHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 
 	String ComposeGelfMessage(const Dictionary::Ptr& fields, const String& source, double ts);
 	void SendLogMessage(const Checkable::Ptr& checkable, const String& gelfMessage);

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -45,9 +45,8 @@ private:
 	Timer::Ptr m_ReconnectTimer;
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void CheckResultHandlerInternal(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void SendMetric(const Checkable::Ptr& checkable, const String& prefix, const String& name, double value, double ts);
-	void SendPerfdata(const Checkable::Ptr& checkable, const String& prefix, const CheckResult::Ptr& cr, double ts);
+	void SendPerfdata(const Checkable::Ptr& checkable, const String& prefix, const CheckResult::Ptr& cr);
 	static String EscapeMetric(const String& str);
 	static String EscapeMetricLabel(const String& str);
 	static Value EscapeMacroMetric(const Value& value);

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -204,15 +204,6 @@ void InfluxdbCommonWriter::CheckResultHandler(const Checkable::Ptr& checkable, c
 	if (IsPaused())
 		return;
 
-	m_WorkQueue.Enqueue([this, checkable, cr]() { CheckResultHandlerWQ(checkable, cr); }, PriorityLow);
-}
-
-void InfluxdbCommonWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr)
-{
-	AssertOnWorkQueue();
-
-	CONTEXT("Processing check result for '" << checkable->GetName() << "'");
-
 	if (!IcingaApplication::GetInstance()->GetEnablePerfdata() || !checkable->GetEnablePerfdata())
 		return;
 
@@ -224,10 +215,6 @@ void InfluxdbCommonWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable,
 	if (service)
 		resolvers.emplace_back("service", service);
 	resolvers.emplace_back("host", host);
-
-	String prefix;
-
-	double ts = cr->GetExecutionEnd();
 
 	// Clone the template and perform an in-place macro expansion of measurement and tag values
 	Dictionary::Ptr tmpl_clean = service ? GetServiceTemplate() : GetHostTemplate();
@@ -253,56 +240,9 @@ void InfluxdbCommonWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable,
 		tmpl->Set("tags", tags);
 	}
 
-	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
-
-	Array::Ptr perfdata = cr->GetPerformanceData();
-
-	if (perfdata) {
-		ObjectLock olock(perfdata);
-		for (const Value& val : perfdata) {
-			PerfdataValue::Ptr pdv;
-
-			if (val.IsObjectType<PerfdataValue>())
-				pdv = val;
-			else {
-				try {
-					pdv = PerfdataValue::Parse(val);
-				} catch (const std::exception&) {
-					Log(LogWarning, GetReflectionType()->GetName())
-						<< "Ignoring invalid perfdata for checkable '"
-						<< checkable->GetName() << "' and command '"
-						<< checkCommand->GetName() << "' with value: " << val;
-					continue;
-				}
-			}
-
-			Dictionary::Ptr fields = new Dictionary();
-			fields->Set("value", pdv->GetValue());
-
-			if (GetEnableSendThresholds()) {
-				if (!pdv->GetCrit().IsEmpty())
-					fields->Set("crit", pdv->GetCrit());
-				if (!pdv->GetWarn().IsEmpty())
-					fields->Set("warn", pdv->GetWarn());
-				if (!pdv->GetMin().IsEmpty())
-					fields->Set("min", pdv->GetMin());
-				if (!pdv->GetMax().IsEmpty())
-					fields->Set("max", pdv->GetMax());
-			}
-			if (!pdv->GetUnit().IsEmpty()) {
-				fields->Set("unit", pdv->GetUnit());
-			}
-
-			SendMetric(checkable, tmpl, pdv->GetLabel(), fields, ts);
-		}
-	}
-
+	Dictionary::Ptr fields;
 	if (GetEnableSendMetadata()) {
-		Host::Ptr host;
-		Service::Ptr service;
-		tie(host, service) = GetHostService(checkable);
-
-		Dictionary::Ptr fields = new Dictionary();
+		fields = new Dictionary();
 
 		if (service)
 			fields->Set("state", new InfluxdbInteger(service->GetState()));
@@ -317,9 +257,57 @@ void InfluxdbCommonWriter::CheckResultHandlerWQ(const Checkable::Ptr& checkable,
 		fields->Set("acknowledgement", new InfluxdbInteger(checkable->GetAcknowledgement()));
 		fields->Set("latency", cr->CalculateLatency());
 		fields->Set("execution_time", cr->CalculateExecutionTime());
-
-		SendMetric(checkable, tmpl, Empty, fields, ts);
 	}
+
+	m_WorkQueue.Enqueue([this, checkable, cr, tmpl = std::move(tmpl), metadataFields = std::move(fields)]() {
+		CONTEXT("Processing check result for '" << checkable->GetName() << "'");
+
+		double ts = cr->GetExecutionEnd();
+
+		if (Array::Ptr perfdata = cr->GetPerformanceData()) {
+			ObjectLock olock(perfdata);
+			for (const Value& val : perfdata) {
+				PerfdataValue::Ptr pdv;
+
+				if (val.IsObjectType<PerfdataValue>())
+					pdv = val;
+				else {
+					try {
+						pdv = PerfdataValue::Parse(val);
+					} catch (const std::exception&) {
+						Log(LogWarning, GetReflectionType()->GetName())
+							<< "Ignoring invalid perfdata for checkable '"
+							<< checkable->GetName() << "' and command '"
+							<< checkable->GetCheckCommand()->GetName() << "' with value: " << val;
+						continue;
+					}
+				}
+
+				Dictionary::Ptr fields = new Dictionary();
+				fields->Set("value", pdv->GetValue());
+
+				if (GetEnableSendThresholds()) {
+					if (!pdv->GetCrit().IsEmpty())
+						fields->Set("crit", pdv->GetCrit());
+					if (!pdv->GetWarn().IsEmpty())
+						fields->Set("warn", pdv->GetWarn());
+					if (!pdv->GetMin().IsEmpty())
+						fields->Set("min", pdv->GetMin());
+					if (!pdv->GetMax().IsEmpty())
+						fields->Set("max", pdv->GetMax());
+				}
+				if (!pdv->GetUnit().IsEmpty()) {
+					fields->Set("unit", pdv->GetUnit());
+				}
+
+				SendMetric(checkable, tmpl, pdv->GetLabel(), fields, ts);
+			}
+		}
+
+		if (metadataFields) {
+			SendMetric(checkable, tmpl, Empty, metadataFields, ts);
+		}
+	}, PriorityLow);
 }
 
 String InfluxdbCommonWriter::EscapeKeyOrTagValue(const String& str)
@@ -364,6 +352,8 @@ String InfluxdbCommonWriter::EscapeValue(const Value& value)
 void InfluxdbCommonWriter::SendMetric(const Checkable::Ptr& checkable, const Dictionary::Ptr& tmpl,
 	const String& label, const Dictionary::Ptr& fields, double ts)
 {
+	AssertOnWorkQueue();
+
 	std::ostringstream msgbuf;
 	msgbuf << EscapeKeyOrTagValue(tmpl->Get("measurement"));
 

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -54,7 +54,6 @@ private:
 	std::atomic_size_t m_DataBufferSize{0};
 
 	void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
-	void CheckResultHandlerWQ(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr);
 	void SendMetric(const Checkable::Ptr& checkable, const Dictionary::Ptr& tmpl,
 		const String& label, const Dictionary::Ptr& fields, double ts);
 	void FlushTimeout();


### PR DESCRIPTION
Previously, all the event handlers of our perfdata writers were directly enqueued into their own work queue, which then extracted all the required metrics from the checkable object. However, since this is done a differently different thread than the one that is used to process the check result, the checkable could change its state in the meantime leading to an inconsistent state. Therefore, all the required metrics are now extracted within the same thread that triggered the event and then enqueued into the work queue. Apart from that, I've removed a lot of useless `if (cr) ...` statements, since a `CheckResult` handler is never going to be called without a valid `CheckResult`.

fixes #10406 