### PR TITLE
doc/08-advanced-topics.md: Reference CheckResult state

### DIFF
--- a/doc/08-advanced-topics.md
+++ b/doc/08-advanced-topics.md
@@ -1181,7 +1181,7 @@ to represent its internal state. The following types are exposed via the [API](1
   performance\_data         | Array                 | Array of [performance data values](08-advanced-topics.md#advanced-value-types-perfdatavalue).
   check\_source             | String                | Name of the node executing the check.
   scheduling\_source        | String                | Name of the node scheduling the check.
-  state                     | Number                | The current state (0 = OK, 1 = WARNING, 2 = CRITICAL, 3 = UNKNOWN).
+  state                     | Number                | Current state according to the [check result state mapping](03-monitoring-basics.md#check-result-state-mapping).
   command                   | Value                 | Array of command with shell-escaped arguments or command line string.
   execution\_start          | Timestamp             | Check execution start time (as a UNIX timestamp).
   execution\_end            | Timestamp             | Check execution end time (as a UNIX timestamp).


### PR DESCRIPTION
Reference the Check Result State Mapping table for the CheckResult state field. This table covers both Service and Host states while the prior documentation string only covered Services.

This change is useful since there are different kinds of states for Hosts when using the Icinga 2 API. For one, there is a "normalized" version of 0 for UP and 1 for DOWN. Then there is the exit code version for 0/1 for UP and 2/3 for DOWN. Unfortunately, often this depends on the context and sometimes even intermingles.

To make it obvious which kind of state one can expect for a CheckResult object, I have linked to the already existing documentation section.