### PR TITLE
Ensure consistent mktime() DST behavior across different implementations

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -14,11 +14,6 @@ case "$DISTRO" in
     # https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/icinga2/APKBUILD
     apk add bison boost-dev ccache cmake flex g++ libedit-dev libressl-dev ninja-build tzdata
     ln -vs /usr/lib/ninja-build/bin/ninja /usr/local/bin/ninja
-
-    # This test fails due to some glibc/musl mismatch regarding timezone PST/PDT.
-    # - https://www.openwall.com/lists/musl/2024/03/05/2
-    # - https://gitlab.alpinelinux.org/alpine/aports/-/blob/b3ea02e2251451f9511086e1970f21eb640097f7/community/icinga2/disable-failing-tests.patch
-    sed -i '/icinga_legacytimeperiod\/dst$/d' /icinga2/test/CMakeLists.txt
     ;;
 
   amazonlinux:2)

--- a/lib/base/datetime.cpp
+++ b/lib/base/datetime.cpp
@@ -35,7 +35,7 @@ DateTime::DateTime(const std::vector<Value>& args)
 
 		tms.tm_isdst = -1;
 
-		m_Value = mktime(&tms);
+		m_Value = Utility::TmToTimestamp(&tms);
 	} else if (args.size() == 1)
 		m_Value = args[0];
 	else

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -185,6 +185,9 @@ public:
 		return in.SubStr(0, maxLength - sha1HexLength - strlen(trunc)) + trunc + SHA1(in);
 	}
 
+	static time_t NormalizeTm(tm *t);
+	static time_t TmToTimestamp(const tm *t);
+
 private:
 	Utility();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -186,6 +186,7 @@ add_boost_test(base
     base_utility/EscapeCreateProcessArg
     base_utility/TruncateUsingHash
     base_utility/FormatDateTime
+    base_utility/NormalizeTm
     base_value/scalar
     base_value/convert
     base_value/format

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,7 @@ add_boost_test(types
 
 set(base_test_SOURCES
   icingaapplication-fixture.cpp
+  utils.cpp
   base-array.cpp
   base-base64.cpp
   base-convert.cpp

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -517,13 +517,8 @@ BOOST_AUTO_TEST_CASE(dst)
 				day, "01:30-02:30",
 				{make_tm("2021-03-14 01:00:00 PST")},
 				{make_tm("2021-03-14 01:59:59 PST")},
-#ifndef _WIN32
 				// As 02:30 does not exist on this day, it is parsed as if it was 02:30 PST which is actually 03:30 PDT.
 				Segment("2021-03-14 01:30:00 PST", "2021-03-14 03:30:00 PDT"),
-#else
-				// Windows interpretes 02:30 as 01:30 PST, so it is an empty segment.
-				boost::none,
-#endif
 			});
 		}
 
@@ -533,14 +528,9 @@ BOOST_AUTO_TEST_CASE(dst)
 				day, "02:30-03:30",
 				{make_tm("2021-03-14 01:00:00 PST")},
 				{make_tm("2021-03-14 03:00:00 PDT")},
-#ifndef _WIN32
 				// As 02:30 does not exist on this day, it is parsed as if it was 02:30 PST which is actually 03:30 PDT.
 				// Therefore, the result is a segment from 03:30 PDT to 03:30 PDT with a duration of 0, i.e. no segment.
 				boost::none,
-#else
-				// Windows parses non-existing 02:30 as 01:30 PST, resulting in an 1 hour segment.
-				Segment("2021-03-14 01:30:00 PST", "2021-03-14 03:30:00 PDT"),
-#endif
 			});
 		}
 
@@ -549,13 +539,8 @@ BOOST_AUTO_TEST_CASE(dst)
 			day, "02:15-03:45",
 			{make_tm("2021-03-14 01:00:00 PST")},
 			{make_tm("2021-03-14 03:30:00 PDT")},
-#ifndef _WIN32
 			// As 02:15 does not exist on this day, it is parsed as if it was 02:15 PST which is actually 03:15 PDT.
 			Segment("2021-03-14 03:15:00 PDT", "2021-03-14 03:45:00 PDT"),
-#else
-			// Windows interprets 02:15 as 01:15 PST though.
-			Segment("2021-03-14 01:15:00 PST", "2021-03-14 03:45:00 PDT"),
-#endif
 		});
 
 		// range after DST change
@@ -587,7 +572,6 @@ BOOST_AUTO_TEST_CASE(dst)
 
 		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
 			// range existing twice during DST change (first instance)
-#ifndef _WIN32
 			tests.push_back(TestData{
 				day, "01:15-01:45",
 				{make_tm("2021-11-07 01:00:00 PDT")},
@@ -595,15 +579,6 @@ BOOST_AUTO_TEST_CASE(dst)
 				// Duplicate times are interpreted as the first occurrence.
 				Segment("2021-11-07 01:15:00 PDT", "2021-11-07 01:45:00 PDT"),
 			});
-#else
-			tests.push_back(TestData{
-				day, "01:15-01:45",
-				{make_tm("2021-11-07 01:00:00 PDT")},
-				{make_tm("2021-11-07 01:30:00 PST")},
-				// However, Windows always uses the second occurrence.
-				Segment("2021-11-07 01:15:00 PST", "2021-11-07 01:45:00 PST"),
-			});
-#endif
 		}
 
 		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
@@ -612,13 +587,8 @@ BOOST_AUTO_TEST_CASE(dst)
 				day, "01:15-01:45",
 				{make_tm("2021-11-07 01:00:00 PST")},
 				{make_tm("2021-11-07 01:30:00 PST")},
-#ifndef _WIN32
 				// Interpreted as the first occurrence, so it's in the past.
 				boost::none,
-#else
-				// On Windows, it's the second occurrence, so it's still in the present/future and is found.
-				Segment("2021-11-07 01:15:00 PST", "2021-11-07 01:45:00 PST"),
-#endif
 			});
 		}
 
@@ -644,13 +614,8 @@ BOOST_AUTO_TEST_CASE(dst)
 			day, "00:30-01:30",
 			{make_tm("2021-11-07 00:00:00 PDT")},
 			{make_tm("2021-11-07 01:00:00 PDT")},
-#ifndef _WIN32
 			// Both times are interpreted as the first instance on that day (i.e both PDT).
 			Segment("2021-11-07 00:30:00 PDT", "2021-11-07 01:30:00 PDT")
-#else
-			// Windows interprets duplicate times as the second instance (i.e. both PST).
-			Segment("2021-11-07 00:30:00 PDT", "2021-11-07 01:30:00 PST")
-#endif
 		});
 
 		// range beginning during duplicate DST hour (first instance)
@@ -658,18 +623,12 @@ BOOST_AUTO_TEST_CASE(dst)
 			day, "01:30-02:30",
 			{make_tm("2021-11-07 01:00:00 PDT")},
 			{make_tm("2021-11-07 02:00:00 PST")},
-#ifndef _WIN32
 			// 01:30 is interpreted as the first occurrence (PDT) but since there's no 02:30 PDT, it's PST.
 			Segment("2021-11-07 01:30:00 PDT", "2021-11-07 02:30:00 PST")
-#else
-			// Windows interprets both as PST though.
-			Segment("2021-11-07 01:30:00 PST", "2021-11-07 02:30:00 PST")
-#endif
 		});
 
 		if (day.find("sunday") == std::string::npos) { // skip for non-absolute day specs (would find another sunday)
 			// range ending during duplicate DST hour (second instance)
-#ifndef _WIN32
 			tests.push_back(TestData{
 				day, "00:30-01:30",
 				{make_tm("2021-11-07 00:00:00 PST")},
@@ -678,15 +637,6 @@ BOOST_AUTO_TEST_CASE(dst)
 				// 01:00 PST (02:00 PDT) is after the segment.
 				boost::none,
 			});
-#else
-			tests.push_back(TestData{
-				day, "00:30-01:30",
-				{make_tm("2021-11-07 00:00:00 PDT")},
-				{make_tm("2021-11-07 01:00:00 PST")},
-				// As Windows interprets the end as PST, it's still in the future and the segment is found.
-				Segment("2021-11-07 00:30:00 PDT", "2021-11-07 01:30:00 PST"),
-			});
-#endif
 		}
 
 		// range beginning during duplicate DST hour (second instance)
@@ -694,13 +644,8 @@ BOOST_AUTO_TEST_CASE(dst)
 			day, "01:30-02:30",
 			{make_tm("2021-11-07 01:00:00 PDT")},
 			{make_tm("2021-11-07 02:00:00 PST")},
-#ifndef _WIN32
 			// As 01:30 always refers to the first occurrence (PDT), this is actually a 2 hour segment.
 			Segment("2021-11-07 01:30:00 PDT", "2021-11-07 02:30:00 PST"),
-#else
-			// On Windows, it refers t the second occurrence (PST), therefore it's an 1 hour segment.
-			Segment("2021-11-07 01:30:00 PST", "2021-11-07 02:30:00 PST"),
-#endif
 		});
 	}
 

--- a/test/icinga-legacytimeperiod.cpp
+++ b/test/icinga-legacytimeperiod.cpp
@@ -2,6 +2,7 @@
 
 #include "base/utility.hpp"
 #include "icinga/legacytimeperiod.hpp"
+#include "test/utils.hpp"
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
@@ -469,35 +470,6 @@ BOOST_AUTO_TEST_CASE(advanced)
 	AdvancedHelper("09:00:01-30:00", {{2014, 9, 24}, {9, 0, 1}}, {{2014, 9, 25}, {6, 0, 0}});
 	AdvancedHelper("09:00-30:00:02", {{2014, 9, 24}, {9, 0, 0}}, {{2014, 9, 25}, {6, 0, 2}});
 	AdvancedHelper("09:00:03-30:00:04", {{2014, 9, 24}, {9, 0, 3}}, {{2014, 9, 25}, {6, 0, 4}});
-}
-
-tm make_tm(std::string s)
-{
-	int dst = -1;
-	size_t l = strlen("YYYY-MM-DD HH:MM:SS");
-	if (s.size() > l) {
-		std::string zone = s.substr(l);
-		if (zone == " PST") {
-			dst = 0;
-		} else if (zone == " PDT") {
-			dst = 1;
-		} else {
-			// tests should only use PST/PDT (for now)
-			BOOST_CHECK_MESSAGE(false, "invalid or unknown time time: " << zone);
-		}
-	}
-
-	std::tm t = {};
-#if defined(__GNUC__) && __GNUC__ < 5
-	// GCC did not implement std::get_time() until version 5
-	strptime(s.c_str(), "%Y-%m-%d %H:%M:%S", &t);
-#else /* defined(__GNUC__) && __GNUC__ < 5 */
-	std::istringstream stream(s);
-	stream >> std::get_time(&t, "%Y-%m-%d %H:%M:%S");
-#endif /* defined(__GNUC__) && __GNUC__ < 5 */
-	t.tm_isdst = dst;
-
-	return t;
 }
 
 time_t make_time_t(const tm* t)

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -23,13 +23,8 @@ tm make_tm(std::string s)
     }
 
     std::tm t = {};
-#if defined(__GNUC__) && __GNUC__ < 5
-    // GCC did not implement std::get_time() until version 5
-    strptime(s.c_str(), "%Y-%m-%d %H:%M:%S", &t);
-#else /* defined(__GNUC__) && __GNUC__ < 5 */
     std::istringstream stream(s);
     stream >> std::get_time(&t, "%Y-%m-%d %H:%M:%S");
-#endif /* defined(__GNUC__) && __GNUC__ < 5 */
     t.tm_isdst = dst;
 
     return t;

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,0 +1,36 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "utils.hpp"
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <boost/test/unit_test.hpp>
+
+tm make_tm(std::string s)
+{
+    int dst = -1;
+    size_t l = strlen("YYYY-MM-DD HH:MM:SS");
+    if (s.size() > l) {
+        std::string zone = s.substr(l);
+        if (zone == " PST") {
+            dst = 0;
+        } else if (zone == " PDT") {
+            dst = 1;
+        } else {
+            // tests should only use PST/PDT (for now)
+            BOOST_CHECK_MESSAGE(false, "invalid or unknown time time: " << zone);
+        }
+    }
+
+    std::tm t = {};
+#if defined(__GNUC__) && __GNUC__ < 5
+    // GCC did not implement std::get_time() until version 5
+    strptime(s.c_str(), "%Y-%m-%d %H:%M:%S", &t);
+#else /* defined(__GNUC__) && __GNUC__ < 5 */
+    std::istringstream stream(s);
+    stream >> std::get_time(&t, "%Y-%m-%d %H:%M:%S");
+#endif /* defined(__GNUC__) && __GNUC__ < 5 */
+    t.tm_isdst = dst;
+
+    return t;
+}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -29,3 +29,39 @@ tm make_tm(std::string s)
 
     return t;
 }
+
+#ifndef _WIN32
+const char *GlobalTimezoneFixture::TestTimezoneWithDST = "America/Los_Angeles";
+#else /* _WIN32 */
+// Tests are using pacific time because Windows only really supports timezones following US DST rules with the TZ
+// environment variable. Format is "[Standard TZ][negative UTC offset][DST TZ]".
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/tzset?view=msvc-160#remarks
+const char *GlobalTimezoneFixture::TestTimezoneWithDST = "PST8PDT";
+#endif /* _WIN32 */
+
+GlobalTimezoneFixture::GlobalTimezoneFixture(const char *fixed_tz)
+{
+    tz = getenv("TZ");
+#ifdef _WIN32
+    _putenv_s("TZ", fixed_tz == "" ? "UTC" : fixed_tz);
+#else
+    setenv("TZ", fixed_tz, 1);
+#endif
+    tzset();
+}
+
+GlobalTimezoneFixture::~GlobalTimezoneFixture()
+{
+#ifdef _WIN32
+    if (tz)
+        _putenv_s("TZ", tz);
+    else
+        _putenv_s("TZ", "");
+#else
+    if (tz)
+        setenv("TZ", tz, 1);
+    else
+        unsetenv("TZ");
+#endif
+    tzset();
+}

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -6,3 +6,20 @@
 #include <string>
 
 tm make_tm(std::string s);
+
+struct GlobalTimezoneFixture
+{
+    /**
+     * Timezone used for testing DST changes.
+     *
+     * DST changes in America/Los_Angeles:
+     * 2021-03-14: 01:59:59 PST (UTC-8) -> 03:00:00 PDT (UTC-7)
+     * 2021-11-07: 01:59:59 PDT (UTC-7) -> 01:00:00 PST (UTC-8)
+     */
+    static const char *TestTimezoneWithDST;
+
+    GlobalTimezoneFixture(const char *fixed_tz = "");
+    ~GlobalTimezoneFixture();
+
+    char *tz;
+};

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -1,0 +1,8 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#pragma once
+
+#include <ctime>
+#include <string>
+
+tm make_tm(std::string s);


### PR DESCRIPTION
The PR is a bit long, but the overall goal is quite simple: If a TimePeriod says `01:30-02:30`, it should behave the same across different platforms. The tricky part are DST changes: these two times may not exist at all or could exist twice on a day where a DST change happens.

So far, Icinga 2 simply used `mktime()` with `tm_isdst = -1` (saying "figure out automatically whether DST is active at this time") and relied on whatever was returned. The exact behavior in these edge cases isn't specified and differs between libc implementations.

Tests for these edge cases already exist in the `icinga_legacytimeperiod/dst` test case which had two problems that are fixed by this PR:
1. The test had a lot of `#ifdef _WIN32` providing different expected values for Windows compared to other platforms. This is undesirable because if Icinga 2 is asked to map a time to an exact timestamp, the behavior should be consistent across platforms.
2. The non-Windows tests basically tested for the glibc behavior[^1] which is not standardized so they happened to fail on Mac OS (#9801) and Alpine with musl as libc (#10288).

This PR introduces `Utility::NormalizeTm()` (named after `struct tm`) as a wrapper around `mktime()` which calls it multiple times in a way to provide a behavior that matches the one that glibc provides. Please note that I'm not saying that this is necessarily better behavior than what's given by other implementations, but it also isn't worse and I picked it because it introduces the least possible user-visible changes: All the [platforms we fully support as server](https://icinga.com/subscriptions/support-matrix/) (and hence as master) use glibc, so for these, there is no change in behavior. Of that list, Windows is the only one that will observe a change in behavior (that was the only thing that was special-cased in the tests so far), but that change will make it consistent with the behavior of its master. Also, on a pure agent, the effect is limited anyway: the agent would need to evaluate TimePeriods (or ScheduledDowntimes) itself to make a difference, and that isn't done there when `command_endpoint` is used.

The PR also adds test cases for the newly introduced `NormalizeTm()` which are supposed to cover all relevant situations. In fact, to prove the "now it behaves like glibc" point, with glibc, the implementation can be replaced with a simple call to `mktime()` and the tests still pass. I've done so in commit 0df599b6814c0d1d5a5fc2a296aeff4859deb60c, where the the tests in the [Linux pipeline](https://github.com/Icinga/icinga2/actions/runs/14707951962) still pass everywhere except on Alpine (which is expected as it uses musl and this is exactly what this PR is fixing).

fixes #9801
fixes #10288

[^1]: I added these tests and part of their purpose was to detect if there are actually further inconsistencies except between Windows and everything else. Turns out yes: so the tests have fulfilled their purpose.