### PR TITLE
Implement synchronous signal handling in umbrella/worker processes

### DIFF
--- a/lib/base/application.hpp
+++ b/lib/base/application.hpp
@@ -12,9 +12,14 @@
 #include <cstdint>
 #include <iosfwd>
 #include <type_traits>
+#include <chrono>
+#include <optional>
+#include <variant>
 
 namespace icinga
 {
+
+using namespace std::literals::chrono_literals;
 
 class ThreadPool;
 
@@ -63,6 +68,11 @@ public:
 
 #ifndef _WIN32
 	static void SetUmbrellaProcess(pid_t pid);
+
+	static std::optional<siginfo_t> GetPendingSignal(std::initializer_list<int> signals,
+		std::variant<bool, std::chrono::microseconds> wait = 0us);
+	static std::optional<siginfo_t> GetPendingSignal(int signal,
+		std::variant<bool, std::chrono::microseconds> wait = 0us);
 #endif /* _WIN32 */
 
 	static bool IsShuttingDown();
@@ -157,8 +167,8 @@ private:
 	static void DisplayBugMessage(std::ostream& os);
 
 	static void SigAbrtHandler(int signum);
-	static void SigUsr1Handler(int signum);
 	static void ExceptionHandler();
+	static void WorkerSignalHandler(std::chrono::microseconds timeout);
 
 	static String GetCrashReportFilename();
 


### PR DESCRIPTION
This PR is an attempt to fix #9676.

## Problem

As documented in the issue linked above, on the current master, Signal handling is done in asynchronous handlers installed with `sigaction()`. As per the POSIX standard, these handlers aren't allowed to use any functions that aren't listed as `async-signal-safe`, which we currently violate by calling functions such as `Log()` that perform allocations using `operator new()`.

I've had difficulty reproducing the original problem, even when adding multiple big allocations in the event loops. But even if we can't easily reproduce it, doing these things in signal handlers is still incorrect and should be fixed.

## Considerations

There are two potential solutions to this problem. Either remove all non-`async-signal-safe` functions from the handlers and make them as simple as possible, or make the signal handling synchronous instead, as suggested in #9676 by using `sigtimedwait()`.

Currently there is additional effort involved in setting atomic variables (which is necessary because all threads can potentially receive the signal) that get then queried in the processes main event loops.

Considering this additional effort in re-synchronizing the results from signal handling, the synchronous approach seemed simpler and actually less invasive if we want to still keep a way of logging inside of signal handlers.

The asynchronous handlers for SIGABRT will remain as its critical to what it does.

## Implementation

I moved blocking the relevant signals to earlier in `DeamonCommand::Run()` and now we leave them blocked, instead of unblocking them after forking into "umbrella" and worker processes and installing signal handlers instead. Except for SIGHUP, which gets set to be ignore (SIG_IGN) for the worker, same as before.

From there, on the "umbrella"-side, pending signals are polled individually directly where needed, removing the necessity for all of the global state variables.
https://github.com/Icinga/icinga2/blob/42999027f0c49001d37b3d97927112337458132b/lib/cli/daemoncommand.cpp#L472-L477

However on the worker side, this is not easily possible because the state variables (static members of `Application::` in this case) are shared with the WIN32 code-paths and have other input sources as part of the regular control flow. Therefore a `WorkerSignalHandler()`, similar to the old one in  `lib/cli/daemoncommand.cpp` was added to `lib/base/application.cpp` and replaces the `Utility::Sleep()` in `Application::RunEventLoop()` on non-WIN32 systems.
https://github.com/Icinga/icinga2/blob/42999027f0c49001d37b3d97927112337458132b/lib/base/application.cpp#L474-L478

The function `Application::GetPendingSignal()` contains all the platform-y ugliness to support MacOS and OpenBSD, so the rest of the code doesn't have to deal with it. It also supports being called with an infinite timeout and zero timeout.

## Testing

Manual testing has been done to verify that the signals involved in the umbrella/worker setup and termination (SIGUSR1, SIGUSR2, SIGTERM, SIGINT, SIGHUP) are processed and propagated as expected.

In the future (or pending discussion in the context of this PR), adding automated test cases may be a good idea but considering how entangled these classes and functions currently are this would be difficult without refactoring into more self-contained parts first.