### PR TITLE
Load Notification objects after User and UserGroup

### DIFF
--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -22,6 +22,8 @@ class Notification : CustomVarObject < NotificationNameComposer
 {
 	load_after Host;
 	load_after Service;
+	load_after User;
+	load_after UserGroup;
 
 	[config, protected, required, navigation] name(NotificationCommand) command (CommandRaw) {
 		navigate {{{


### PR DESCRIPTION
Notification objects can refer User and Group objects similar to how they can refer Host and Service objects, so that dependency feels quite natural. Note that for evaluating most configuration, this order doesn't really matter, the configuration will successfully evaluate in either case, the difference can be noticed mainly in more advanced configurations, for example when dynamically assigning user based on their groups. When accessing user objects from the Notification object definition (like in the following example), without this change, only groups configured directly in groups attribute of User objects are visible and those added via assign clauses in UserGroup objects are missing. With this commit, these are also visible.

    apply Notification "n" to Host {
        for (var u in get_objects(User)) {
            log(u.name + " -> " + Json.encode(u.groups))
        }

        # [...]
    }

This was reported by a customer. Their configuration no longer worked as expected with snapshot packages compared to already released versions. I can't share their config here, but in summary, they are populating the `users` attribute with users that are both member of a group and are configured to receive notifications via a specific communication channel.

### Tests

<details>
<summary>Self-contained Icinga 2 config that adds a User to the UserGroup "g-attr" via its `groups` attribute and adds it to a second UserGroup "g-assign" via the `assign` clause in the group definition. It logs the groups of the user visible from within the Notification definition.</summary>

```
include <itl>

object UserGroup "g-attr" {
}

object UserGroup "g-assign" {
	assign where true
}

object User "u" {
	groups = ["g-attr"]
}

object Host "h" {
	check_command = "dummy"
}

object NotificationCommand "dummy" {
	command = ["true"]
}

apply Notification "n" to Host {
	for (var u in get_objects(User)) {
		log(u.name + " -> " + Json.encode(u.groups))
	}

	command = "dummy"
	users = ["u"]
	assign where true
}
```
</details>

#### Current master

```
[2025-04-29 10:28:44 +0000] information/config: u -> ["g-attr"]
```

#### This PR

```
[2025-04-29 10:30:37 +0000] information/config: u -> ["g-attr","g-assign"]
```

ref/IP/59088
refs #10148 (This behavior was changed by 467e8b18e7ca9b246ca2e8b5afeaa7b5cc6392b3, this PR restores the previous behavior)