### PR TITLE
Fix broken SELinux policy on Fedora `>=41` systems

### DIFF
--- a/tools/selinux/icinga2.fc
+++ b/tools/selinux/icinga2.fc
@@ -6,7 +6,8 @@
 
 /etc/icinga2/scripts(/.*)?	 --	gen_context(system_u:object_r:nagios_notification_plugin_exec_t,s0)
 
-/usr/sbin/icinga2		--	gen_context(system_u:object_r:icinga2_exec_t,s0)
+/usr/s?bin/icinga2		--	gen_context(system_u:object_r:icinga2_exec_t,s0)
+
 /usr/lib/icinga2/sbin/icinga2		--	gen_context(system_u:object_r:icinga2_exec_t,s0)
 /usr/lib/icinga2/safe-reload           --      gen_context(system_u:object_r:icinga2_exec_t,s0)
 


### PR DESCRIPTION
Since Fedora 42 the `/usr/sbin/` directory was merged into `/usr/bin/` and the sbin dir is still there but it is just a symlink to `/usr/bin/`. However, they seem to have backported [^1] all the related SELinux changes to Fedora 41 and broke our policy even on Fedora 41 systems. So, this PR adds both the`/usr/sbin/icinga2/` and `/usr/bin/icinga2` paths to the `icinga2.fc` file and either one is guaranteed to work on all supported systems.

The relevant change from the referenced SELinux changes is within the `config/file_contexts.subs_dist` file and on a Fedora VM:
```bash
$ cat /etc/selinux/targeted/contexts/files/file_contexts.subs_dist
...
/var/mnt             /mnt
/bin                 /usr/bin
/usr/sbin            /usr/bin
```

fixes #10411

[^1]: https://github.com/fedora-selinux/selinux-policy/commit/1be14f9b5a99a4eec7f9aba7fbb83bf8dde817f4