### PR TITLE
Fix PerfdataValue Counter Parsing

### DIFF
--- a/lib/base/perfdatavalue.cpp
+++ b/lib/base/perfdatavalue.cpp
@@ -270,6 +270,11 @@ PerfdataValue::Ptr PerfdataValue::Parse(const String& perfdata)
 	if (pos != String::NPos)
 		unit = tokens[0].SubStr(pos, String::NPos);
 
+	// UoM.Out is an empty string for "c". So set counter before parsing.
+	if (unit == "c") {
+		counter = true;
+	}
+
 	double base;
 
 	{
@@ -293,10 +298,6 @@ PerfdataValue::Ptr PerfdataValue::Parse(const String& perfdata)
 			unit = uom->second.Out;
 			base = uom->second.Factor;
 		}
-	}
-
-	if (unit == "c") {
-		counter = true;
 	}
 
 	warn = ParseWarnCritMinMaxToken(tokens, 1, "warning");

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -285,6 +285,19 @@ BOOST_AUTO_TEST_CASE(uom)
 
 	str = pv->Format();
 	BOOST_CHECK_EQUAL(str, "test=1W");
+
+	pv = PerfdataValue::Parse("test=42c");
+	BOOST_CHECK(pv);
+	BOOST_CHECK_EQUAL(pv->GetValue(), 42);
+	BOOST_CHECK(pv->GetCounter());
+	BOOST_CHECK_EQUAL(pv->GetUnit(), "");
+	BOOST_CHECK_EQUAL(pv->GetCrit(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetWarn(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMin(), Empty);
+	BOOST_CHECK_EQUAL(pv->GetMax(), Empty);
+
+	str = pv->Format();
+	BOOST_CHECK_EQUAL(str, "test=42c");
 }
 
 BOOST_AUTO_TEST_CASE(warncritminmax)


### PR DESCRIPTION
Ensure that the counter unit of measurement, "c", is parsed correctly for performance data values again.

A prior refactoring in 720a88c29a489cec91815af49755413202802d7a changed the parsing logic, resulting in an incorrect behavior for counter units. By passing the raw input into the l_CsUoMs map first, the "c" UoM is removed. Moving the explicit counter check before passing the raw unit into the map resolves this issue.

Fixes #9540.