### PR TITLE
GitHub Actions: Show log files in Windows jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,3 +46,12 @@ jobs:
           if ($LastExitCode -ne 0) { throw "Error during build" }
           & powershell.exe .\tools\win32\test.ps1
           if ($LastExitCode -ne 0) { throw "Error during test" }
+
+      - name: Show Log Files
+        if: ${{ always() }}
+        run: |
+          foreach ($file in Get-ChildItem -Recurse -Filter "*.log") {
+            Write-Host "::group::$($file.FullName)"
+            Get-Content $file.FullName
+            Write-Host "::endgroup::"
+          }


### PR DESCRIPTION
If CPack fails, it may write the actual errors to a dedicated log file:
    
    EXEC : CPack error : Problem running WiX. Please check 'D:/a/icinga2/icinga2/Build/_CPack_Packages/win64/WIX/wix.log' for errors. [D:\a\icinga2\icinga2\Build\PACKAGE.vcxproj]
    
Show all `*.log` files as part of the job output so that it doesn't get lost. I've chosen that generic pattern because I don't know whether the exact name and path may change. At the moment, it additionally includes a second file containing some more verbose output from our test cases.

I've made it part of the output as in case of the WIX error log, that's where I'd have expected it in the first place. The output is [automatically grouped using some magic GitHub syntax](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines).

Preview of the [job output](https://github.com/Icinga/icinga2/actions/runs/15020262298/job/42207533603?pr=10433#step:5:14047):

![](https://github.com/user-attachments/assets/9b31fa62-77bd-4f35-a4b5-95b3fd102ab2)


refs #10383 (had a [pipeline with such an error](https://github.com/Icinga/icinga2/actions/runs/14970344893/job/42065163477?pr=10383#step:4:1715))