### PR TITLE
GHA: AUTHORS: use sed(1), not grep(1)

### DIFF
--- a/.github/workflows/authors-file.yml
+++ b/.github/workflows/authors-file.yml
@@ -21,7 +21,7 @@ jobs:
           git add AUTHORS
           git log --format='format:%aN <%aE>' "$(
             git merge-base HEAD^1 HEAD^2
-          )..HEAD^2" | grep -vEe '^dependabot\[bot] ' >> AUTHORS
+          )..HEAD^2" | sed '/^dependabot\[bot] /d' >> AUTHORS
           sort -uo AUTHORS AUTHORS
           git diff AUTHORS >> AUTHORS.diff
 


### PR DESCRIPTION
grep(1)'s exit code causes the GHA to fail in contrast to sed(1).

Explicitly requested in https://github.com/Icinga/icinga2/pull/10383#issuecomment-2850534279.

* This outsources a subset of #10383 because dependabot has problems with rebasing PRs with multiple committers.