### PR TITLE
GHA: Fetch full git history for windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout HEAD
         uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
 
       - name: Build tools
         run: |


### PR DESCRIPTION
Quote from https://github.com/actions/checkout:
> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags

Fixes the Windows GHA from #10383:
https://github.com/Icinga/icinga2/actions/runs/15064535939/job/42346335042?pr=10383

>   C:\a\icinga2\icinga2\Build\_CPack_Packages\win32\WIX\main.wxs(8) : error CNDL0108 : The Product/@Version attribute's value, '083ab56', is not a valid version.  Legal version values should look like 'x.x.x.x' where x is an integer from 0 to 65534.
> 
>  C:\a\icinga2\icinga2\Build\_CPack_Packages\win32\WIX\main.wxs(8) : error CNDL0010 : The Product/@Version attribute was not found; it is required.
