### PR TITLE
Fix two low-hanging fruit compiler warnings

### DIFF
--- a/lib/icinga/comment.ti
+++ b/lib/icinga/comment.ti
@@ -24,8 +24,8 @@ enum CommentType
 class CommentNameComposer : public NameComposer
 {
 public:
-	virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
-	virtual Dictionary::Ptr ParseName(const String& name) const;
+	virtual String MakeName(const String& shortName, const Object::Ptr& context) const override;
+	virtual Dictionary::Ptr ParseName(const String& name) const override;
 };
 }}}
 

--- a/lib/icinga/dependency.ti
+++ b/lib/icinga/dependency.ti
@@ -13,8 +13,8 @@ code {{{
 class DependencyNameComposer : public NameComposer
 {
 public:
-	virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
-	virtual Dictionary::Ptr ParseName(const String& name) const;
+	virtual String MakeName(const String& shortName, const Object::Ptr& context) const override;
+	virtual Dictionary::Ptr ParseName(const String& name) const override;
 };
 }}}
 

--- a/lib/icinga/downtime.ti
+++ b/lib/icinga/downtime.ti
@@ -13,8 +13,8 @@ code {{{
 class DowntimeNameComposer : public NameComposer
 {
 public:
-	virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
-	virtual Dictionary::Ptr ParseName(const String& name) const;
+	virtual String MakeName(const String& shortName, const Object::Ptr& context) const override;
+	virtual Dictionary::Ptr ParseName(const String& name) const override;
 };
 }}}
 

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -472,7 +472,8 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		if (type == NotificationProblem && !reminder && !checkable->GetVolatile()) {
 			auto [host, service] = GetHostService(checkable);
-			uint_fast8_t state = service ? service->GetState() : host->GetState();
+			uint_fast8_t state = service ? static_cast<uint_fast8_t>(service->GetState())
+				: static_cast<uint_fast8_t>(host->GetState());
 
 			if (state == (uint_fast8_t)GetLastNotifiedStatePerUser()->Get(userName)) {
 				auto stateStr (service ? NotificationServiceStateToString(service->GetState()) : NotificationHostStateToString(host->GetState()));
@@ -501,7 +502,8 @@ void Notification::BeginExecuteNotification(NotificationType type, const CheckRe
 
 		if (type == NotificationProblem) {
 			auto [host, service] = GetHostService(checkable);
-			uint_fast8_t state = service ? service->GetState() : host->GetState();
+			uint_fast8_t state = service ? static_cast<uint_fast8_t>(service->GetState())
+				: static_cast<uint_fast8_t>(host->GetState());
 
 			if (state != (uint_fast8_t)GetLastNotifiedStatePerUser()->Get(userName)) {
 				GetLastNotifiedStatePerUser()->Set(userName, state);

--- a/lib/icinga/notification.ti
+++ b/lib/icinga/notification.ti
@@ -13,8 +13,8 @@ code {{{
 class NotificationNameComposer : public NameComposer
 {
 public:
-	virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
-	virtual Dictionary::Ptr ParseName(const String& name) const;
+	virtual String MakeName(const String& shortName, const Object::Ptr& context) const override;
+	virtual Dictionary::Ptr ParseName(const String& name) const override;
 };
 }}}
 

--- a/lib/icinga/scheduleddowntime.ti
+++ b/lib/icinga/scheduleddowntime.ti
@@ -12,8 +12,8 @@ code {{{
 class ScheduledDowntimeNameComposer : public NameComposer
 {
 public:
-	virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
-	virtual Dictionary::Ptr ParseName(const String& name) const;
+	virtual String MakeName(const String& shortName, const Object::Ptr& context) const override;
+	virtual Dictionary::Ptr ParseName(const String& name) const override;
 };
 }}}
 

--- a/lib/icinga/service.ti
+++ b/lib/icinga/service.ti
@@ -15,8 +15,8 @@ code {{{
 class ServiceNameComposer : public NameComposer
 {
 public:
-	virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
-	virtual Dictionary::Ptr ParseName(const String& name) const;
+	virtual String MakeName(const String& shortName, const Object::Ptr& context) const override;
+	virtual Dictionary::Ptr ParseName(const String& name) const override;
 };
 }}}
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2061,7 +2061,7 @@ void IcingaDB::SendSentNotification(
 		"host_id", GetObjectIdentifier(host),
 		"type", Convert::ToString(type),
 		"state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetState()) : Convert::ToLong(Host::CalculateState(cr->GetState())) : 99),
-		"previous_hard_state", Convert::ToString(cr ? Convert::ToLong(service ? cr->GetPreviousHardState() : Host::CalculateState(cr->GetPreviousHardState())) : 99),
+		"previous_hard_state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetPreviousHardState()) : Convert::ToLong(Host::CalculateState(cr->GetPreviousHardState())) : 99),
 		"author", Utility::ValidateUTF8(author),
 		"text", Utility::ValidateUTF8(finalText),
 		"users_notified", Convert::ToString(usersAmount),


### PR DESCRIPTION
This fixes two compiler warnings that are spamming the compile log on my system.

```
build/icinga2/lib/icinga/notification-ti.hpp:21:24: warning: ‘virtual icinga::String icinga::NotificationNameComposer::MakeName(const icinga::String&, const icinga::Object::Ptr&) const’ can be marked override [-Wsuggest-override]
   21 |         virtual String MakeName(const String& shortName, const Object::Ptr& context) const;
      |                        ^~~~~~~~
build/icinga2/lib/icinga/notification-ti.hpp:22:33: warning: ‘virtual icinga::Dictionary::Ptr icinga::NotificationNameComposer::ParseName(const icinga::String&) const’ can be marked override [-Wsuggest-override]
   22 |         virtual Dictionary::Ptr ParseName(const String& name) const;
      |                                 ^~~~~~~~~
```
This one affects the generated files but as the warning suggests, they should easily be able to be marked as override without any negative effects.

```
icinga2/lib/icinga/notification.cpp: In member function ‘void icinga::Notification::BeginExecuteNotification(icinga::NotificationType, const icinga::CheckResult::Ptr&, bool, bool, const icinga::String&, const icinga::String&)’:
icinga2/lib/icinga/notification.cpp:475:54: warning: enumerated mismatch in conditional expression: ‘icinga::ServiceState’ vs ‘icinga::HostState’ [-Wenum-compare]
  475 |                         uint_fast8_t state = service ? service->GetState() : host->GetState();
      |                                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
icinga2/lib/icinga/notification.cpp:504:54: warning: enumerated mismatch in conditional expression: ‘icinga::ServiceState’ vs ‘icinga::HostState’ [-Wenum-compare]
  504 |                         uint_fast8_t state = service ? service->GetState() : host->GetState();
      |                                              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This one stems from using the ternary operator to assign values of different types (HostState and ServiceState) to an integer or string. The solution is to first convert/cast the values, then assign them via the switch in the ternary operator.