### PR TITLE
Checkable: Use correct timeout for rescheduling remote checks

### DIFF
--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -624,12 +624,16 @@ void Checkable::ExecuteCheck()
 			if (service)
 				params->Set("service", service->GetShortName());
 
+			double checkTimeout = GetCheckCommand()->GetTimeout();
+
 			/*
 			 * If the host/service object specifies the 'check_timeout' attribute,
 			 * forward this to the remote endpoint to limit the command execution time.
 			 */
-			if (!GetCheckTimeout().IsEmpty())
-				params->Set("check_timeout", GetCheckTimeout());
+			if (auto ckCheckTimeout(GetCheckTimeout()); !ckCheckTimeout.IsEmpty()) {
+				checkTimeout = Convert::ToDouble(ckCheckTimeout);
+				params->Set("check_timeout", ckCheckTimeout);
+			}
 
 			params->Set("macros", macros);
 
@@ -642,7 +646,7 @@ void Checkable::ExecuteCheck()
 			 * a check result from the remote instance. The check will be re-scheduled
 			 * using the proper check interval once we've received a check result.
 			 */
-			SetNextCheck(Utility::GetTime() + GetCheckCommand()->GetTimeout() + 30);
+			SetNextCheck(Utility::GetTime() + checkTimeout + 30);
 
 		/*
 		 * Let the user know that there was a problem with the check if


### PR DESCRIPTION
Previously, the `command#timeout` which by default is `1m`, was used to reschedule the just sent remote check. However, this results into a bunch of extra checks being sent to the remote host, even though the first one is still running with a `check_timeout > command#timeout`. That's because if one want to override the default timeout of the command for a specific host/service, one has to set the `checkable#check_timeout` attribute to the desired value. So, this commit makes sure that the `checkable#check_timeout` attribute (if set) is used to reschedule the remote check.

```bash
$ cat sleep.sh
#!/bin/zsh

sleep 300
echo "Command completed after 5 minutes\n"
exit 0
```

```bash
object CheckCommand "sleepv1" {
	command = [ "/PATH/TO/sleep.sh" ]
}

object Host "test" {
        check_command = "sleepv1"
	max_check_attempts = 1
	check_timeout = 5m // <-- This overrides the default command#timeout value
        command_endpoint = "icinga-agent-endpoint-name"
        zone = "master"
}
```

fixes #10362