### PR TITLE
Remove unused ProcessingResult::NoCheckResult

### DIFF
--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -130,8 +130,6 @@ Dictionary::Ptr ApiActions::ProcessCheckResult(const ConfigObject::Ptr& object,
 	switch (result) {
 		case Result::Ok:
 			return ApiActions::CreateResult(200, "Successfully processed check result for object '" + checkable->GetName() + "'.");
-		case Result::NoCheckResult:
-			return ApiActions::CreateResult(400, "Could not process check result for object '" + checkable->GetName() + "' because no check result was passed.");
 		case Result::CheckableInactive:
 			return ApiActions::CreateResult(503, "Could not process check result for object '" + checkable->GetName() + "' because the object is inactive.");
 		case Result::NewerCheckResultPresent:

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -100,13 +100,12 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 {
 	using Result = Checkable::ProcessingResult;
 
+	VERIFY(cr);
+
 	{
 		ObjectLock olock(this);
 		m_CheckRunning = false;
 	}
-
-	if (!cr)
-		return Result::NoCheckResult;
 
 	double now = Utility::GetTime();
 

--- a/lib/icinga/checkable-script.cpp
+++ b/lib/icinga/checkable-script.cpp
@@ -14,7 +14,10 @@ static void CheckableProcessCheckResult(const CheckResult::Ptr& cr)
 	ScriptFrame *vframe = ScriptFrame::GetCurrentFrame();
 	Checkable::Ptr self = vframe->Self;
 	REQUIRE_NOT_NULL(self);
-	self->ProcessCheckResult(cr);
+
+	if (cr) {
+		self->ProcessCheckResult(cr);
+	}
 }
 
 Object::Ptr Checkable::GetPrototype()

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -119,7 +119,6 @@ public:
 	enum class ProcessingResult
 	{
 		Ok,
-		NoCheckResult,
 		CheckableInactive,
 		NewerCheckResultPresent,
 	};


### PR DESCRIPTION
No one passes a NULL CR to Checkable#ProcessCheckResult() anymore.

Stumbled over this due to https://github.com/Icinga/icinga2/pull/10397#discussion_r2095056094.