### PR TITLE
GHA: Fix amazonlinux:2023 MariaDB package

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -30,7 +30,7 @@ case "$DISTRO" in
 
   amazonlinux:20*)
     dnf install -y bison cmake flex gcc-c++ ninja-build \
-      {boost,libedit,mariadb1\*,ncurses,openssl,postgresql,systemd}-devel
+      {boost,libedit,mariadb-connector-c,ncurses,openssl,postgresql,systemd}-devel
     ;;
 
   debian:*|ubuntu:*)


### PR DESCRIPTION
Backport of https://github.com/Icinga/icinga2/pull/10430

---
Since recently, the amazonlinux:2023 job in the Linux action fails due to conflichting 'mariadb1*-devel' packages.

> package mariadb1011-devel-3:10.11.11-1.amzn2023.0.1.x86_64 from amazonlinux conflicts with mariadb105-devel provided by mariadb105-devel-3:10.5.16-1.amzn2023.0.7.x86_64 from amazonlinux

It seems like Amazon Linux added mariadb1011 packages next to mariadb105 packages, resulting in a conflict due to the wildcard. On prior runs, the mariadb105 packages was installed.

This change installs mariadb-connector-c-devel instead of a specific mariadb1*-devel package, as suggested by the package description.