### PR TITLE
IcingaDB: Make Redis & DB values consistent

### DIFF
--- a/lib/compat/compatlogger.cpp
+++ b/lib/compat/compatlogger.cpp
@@ -130,7 +130,7 @@ void CompatLogger::CheckResultHandler(const Checkable::Ptr& checkable, const Che
 			<< host->GetName() << ";"
 			<< service->GetShortName() << ";"
 			<< Service::StateToString(service->GetState()) << ";"
-			<< Service::StateTypeToString(service->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(service->GetStateType()) << ";"
 			<< attempt_after << ";"
 			<< output << ""
 			<< "";
@@ -140,7 +140,7 @@ void CompatLogger::CheckResultHandler(const Checkable::Ptr& checkable, const Che
 		msgbuf << "HOST ALERT: "
 			<< host->GetName() << ";"
 			<< GetHostStateString(host) << ";"
-			<< Host::StateTypeToString(host->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(host->GetStateType()) << ";"
 			<< attempt_after << ";"
 			<< output << ""
 			<< "";
@@ -413,14 +413,14 @@ void CompatLogger::EventCommandHandler(const Checkable::Ptr& checkable)
 			<< host->GetName() << ";"
 			<< service->GetShortName() << ";"
 			<< Service::StateToString(service->GetState()) << ";"
-			<< Service::StateTypeToString(service->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(service->GetStateType()) << ";"
 			<< current_attempt << ";"
 			<< event_command_name;
 	} else {
 		msgbuf << "HOST EVENT HANDLER: "
 			<< host->GetName() << ";"
 			<< GetHostStateString(host) << ";"
-			<< Host::StateTypeToString(host->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(host->GetStateType()) << ";"
 			<< current_attempt << ";"
 			<< event_command_name;
 	}
@@ -505,7 +505,7 @@ void CompatLogger::ReopenFile(bool rotate)
 		msgbuf << "CURRENT HOST STATE: "
 			<< host->GetName() << ";"
 			<< GetHostStateString(host) << ";"
-			<< Host::StateTypeToString(host->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(host->GetStateType()) << ";"
 			<< host->GetCheckAttempt() << ";"
 			<< output << "";
 
@@ -526,7 +526,7 @@ void CompatLogger::ReopenFile(bool rotate)
 			<< host->GetName() << ";"
 			<< service->GetShortName() << ";"
 			<< Service::StateToString(service->GetState()) << ";"
-			<< Service::StateTypeToString(service->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(service->GetStateType()) << ";"
 			<< service->GetCheckAttempt() << ";"
 			<< output << "";
 

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -994,7 +994,7 @@ void DbEvents::AddCheckResultLogHistory(const Checkable::Ptr& checkable, const C
 			<< host->GetName() << ";"
 			<< service->GetShortName() << ";"
 			<< Service::StateToString(service->GetState()) << ";"
-			<< Service::StateTypeToString(service->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(service->GetStateType()) << ";"
 			<< service->GetCheckAttempt() << ";"
 			<< output << ""
 			<< "";
@@ -1021,7 +1021,7 @@ void DbEvents::AddCheckResultLogHistory(const Checkable::Ptr& checkable, const C
 		msgbuf << "HOST ALERT: "
 			<< host->GetName() << ";"
 			<< GetHostStateString(host) << ";"
-			<< Host::StateTypeToString(host->GetStateType()) << ";"
+			<< Checkable::StateTypeToString(host->GetStateType()) << ";"
 			<< host->GetCheckAttempt() << ";"
 			<< output << ""
 			<< "";

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -322,3 +322,9 @@ void Checkable::CleanDeadlinedExecutions(const Timer * const&)
 		}
 	}
 }
+
+String Checkable::StateTypeToString(StateType type)
+{
+	return type == StateTypeSoft ? "SOFT" : "HARD";
+}
+

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -105,6 +105,8 @@ public:
 
 	void UpdateNextCheck(const MessageOrigin::Ptr& origin = nullptr);
 
+	static String StateTypeToString(StateType type);
+
 	bool HasBeenChecked() const;
 	virtual bool IsStateOK(ServiceState state) const = 0;
 

--- a/lib/icinga/host.cpp
+++ b/lib/icinga/host.cpp
@@ -228,22 +228,6 @@ String Host::StateToString(HostState state)
 	}
 }
 
-StateType Host::StateTypeFromString(const String& type)
-{
-	if (type == "SOFT")
-		return StateTypeSoft;
-	else
-		return StateTypeHard;
-}
-
-String Host::StateTypeToString(StateType type)
-{
-	if (type == StateTypeSoft)
-		return "SOFT";
-	else
-		return "HARD";
-}
-
 bool Host::ResolveMacro(const String& macro, const CheckResult::Ptr&, Value *result) const
 {
 	if (macro == "state") {

--- a/lib/icinga/host.hpp
+++ b/lib/icinga/host.hpp
@@ -45,9 +45,6 @@ public:
 	static HostState StateFromString(const String& state);
 	static String StateToString(HostState state);
 
-	static StateType StateTypeFromString(const String& state);
-	static String StateTypeToString(StateType state);
-
 	bool ResolveMacro(const String& macro, const CheckResult::Ptr& cr, Value *result) const override;
 
 	void OnAllConfigLoaded() override;

--- a/lib/icinga/notification.cpp
+++ b/lib/icinga/notification.cpp
@@ -98,6 +98,16 @@ void Notification::StaticInitialize()
 	m_TypeFilterMap["Recovery"] = NotificationRecovery;
 	m_TypeFilterMap["FlappingStart"] = NotificationFlappingStart;
 	m_TypeFilterMap["FlappingEnd"] = NotificationFlappingEnd;
+
+	// Since the types and states attributes are user configurable and allowed to change at runtime, we need to
+	// hook into the OnTypesChanged and OnStatesChanged signals to update the actual filter bitsets whenever these
+	// attributes change. Otherwise, the filter bitsets would be stale and not reflect their current state.
+	OnTypesChanged.connect([](const Notification::Ptr& notification, const MessageOrigin::Ptr&) {
+		notification->SetTypeFilter(FilterArrayToInt(notification->GetTypes(), GetTypeFilterMap(), ~0));
+	});
+	OnStatesChanged.connect([](const Notification::Ptr& notification, const MessageOrigin::Ptr&) {
+		notification->SetStateFilter(FilterArrayToInt(notification->GetStates(), GetStateFilterMap(), ~0));
+	});
 }
 
 void Notification::OnConfigLoaded()

--- a/lib/icinga/service.cpp
+++ b/lib/icinga/service.cpp
@@ -195,22 +195,6 @@ String Service::StateToString(ServiceState state)
 	}
 }
 
-StateType Service::StateTypeFromString(const String& type)
-{
-	if (type == "SOFT")
-		return StateTypeSoft;
-	else
-		return StateTypeHard;
-}
-
-String Service::StateTypeToString(StateType type)
-{
-	if (type == StateTypeSoft)
-		return "SOFT";
-	else
-		return "HARD";
-}
-
 bool Service::ResolveMacro(const String& macro, const CheckResult::Ptr& cr, Value *result) const
 {
 	if (macro == "state") {

--- a/lib/icinga/service.hpp
+++ b/lib/icinga/service.hpp
@@ -39,9 +39,6 @@ public:
 	static ServiceState StateFromString(const String& state);
 	static String StateToString(ServiceState state);
 
-	static StateType StateTypeFromString(const String& state);
-	static String StateTypeToString(StateType state);
-
 	static void EvaluateApplyRules(const Host::Ptr& host);
 
 	void OnAllConfigLoaded() override;

--- a/lib/icinga/user.cpp
+++ b/lib/icinga/user.cpp
@@ -12,6 +12,21 @@ using namespace icinga;
 
 REGISTER_TYPE(User);
 
+INITIALIZE_ONCE(&User::StaticInitialize);
+
+void User::StaticInitialize()
+{
+	// Since the types and states attributes are user configurable and allowed to change at runtime, we need to
+	// hook into the OnTypesChanged and OnStatesChanged signals to update the actual filter bitsets whenever these
+	// attributes change. Otherwise, the filter bitsets would be stale and not reflect their current state.
+	OnTypesChanged.connect([](const User::Ptr& user, const MessageOrigin::Ptr&) {
+		user->SetTypeFilter(FilterArrayToInt(user->GetTypes(), Notification::GetTypeFilterMap(), ~0));
+	});
+	OnStatesChanged.connect([](const User::Ptr& user, const MessageOrigin::Ptr&) {
+		user->SetStateFilter(FilterArrayToInt(user->GetStates(), Notification::GetStateFilterMap(), ~0));
+	});
+}
+
 void User::OnConfigLoaded()
 {
 	ObjectImpl<User>::OnConfigLoaded();

--- a/lib/icinga/user.hpp
+++ b/lib/icinga/user.hpp
@@ -22,6 +22,8 @@ public:
 	DECLARE_OBJECT(User);
 	DECLARE_OBJECTNAME(User);
 
+	static void StaticInitialize();
+
 	void AddGroup(const String& name);
 
 	/* Notifications */

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1974,7 +1974,7 @@ void IcingaDB::SendStateChange(const ConfigObject::Ptr& object, const CheckResul
 		"id", HashValue(rawId),
 		"environment_id", m_EnvironmentId,
 		"host_id", GetObjectIdentifier(host),
-		"state_type", Convert::ToString(type),
+		"state_type", Checkable::StateTypeToString(type).ToLower(),
 		"soft_state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetState()) : Convert::ToLong(Host::CalculateState(cr->GetState())) : 99),
 		"hard_state", Convert::ToString(hard_state),
 		"check_attempt", Convert::ToString(checkable->GetCheckAttempt()),
@@ -2954,7 +2954,7 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	 */
 	attrs->Set("id", id);
 	attrs->Set("environment_id", m_EnvironmentId);
-	attrs->Set("state_type", checkable->HasBeenChecked() ? checkable->GetStateType() : StateTypeHard);
+	attrs->Set("state_type", Checkable::StateTypeToString(checkable->HasBeenChecked() ? checkable->GetStateType() : StateTypeHard).ToLower());
 
 	// TODO: last_hard/soft_state should be "previous".
 	if (service) {

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -3018,7 +3018,9 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	attrs->Set("is_reachable", checkable->IsReachable());
 	attrs->Set("is_flapping", checkable->IsFlapping());
 
-	attrs->Set("is_acknowledged", checkable->GetAcknowledgement());
+	attrs->Set("is_acknowledged", checkable->IsAcknowledged());
+	attrs->Set("is_sticky_acknowledgement", checkable->GetAcknowledgement() == AcknowledgementSticky);
+
 	if (checkable->IsAcknowledged()) {
 		Timestamp entry = 0;
 		Comment::Ptr AckComment;

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2047,8 +2047,9 @@ void IcingaDB::SendSentNotification(
 	auto usersAmount (users.size());
 	auto sendTs (TimestampToMilliseconds(sendTime));
 
+	auto notificationTypeStr(GetNotificationTypeByEnum(type));
 	Array::Ptr rawId = new Array({m_EnvironmentId, notification->GetName()});
-	rawId->Add(GetNotificationTypeByEnum(type));
+	rawId->Add(notificationTypeStr);
 	rawId->Add(sendTs);
 
 	auto notificationHistoryId (HashValue(rawId));
@@ -2059,7 +2060,7 @@ void IcingaDB::SendSentNotification(
 		"environment_id", m_EnvironmentId,
 		"notification_id", GetObjectIdentifier(notification),
 		"host_id", GetObjectIdentifier(host),
-		"type", Convert::ToString(type),
+		"type", notificationTypeStr,
 		"state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetState()) : Convert::ToLong(Host::CalculateState(cr->GetState())) : 99),
 		"previous_hard_state", Convert::ToString(cr ? service ? Convert::ToLong(cr->GetPreviousHardState()) : Convert::ToLong(Host::CalculateState(cr->GetPreviousHardState())) : 99),
 		"author", Utility::ValidateUTF8(author),

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1684,7 +1684,7 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 
 		attributes->Set("author", comment->GetAuthor());
 		attributes->Set("text", comment->GetText());
-		attributes->Set("entry_type", comment->GetEntryType());
+		attributes->Set("entry_type", IcingaDB::CommentTypeToString(comment->GetEntryType()));
 		attributes->Set("entry_time", TimestampToMilliseconds(comment->GetEntryTime()));
 		attributes->Set("is_persistent", comment->GetPersistent());
 		attributes->Set("is_sticky", comment->GetSticky());
@@ -2300,7 +2300,7 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 		"entry_time", Convert::ToString(TimestampToMilliseconds(comment->GetEntryTime())),
 		"author", Utility::ValidateUTF8(comment->GetAuthor()),
 		"comment", Utility::ValidateUTF8(comment->GetText()),
-		"entry_type", Convert::ToString(comment->GetEntryType()),
+		"entry_type", IcingaDB::CommentTypeToString(comment->GetEntryType()),
 		"is_persistent", Convert::ToString((unsigned short)comment->GetPersistent()),
 		"is_sticky", Convert::ToString((unsigned short)comment->GetSticky()),
 		"event_id", CalcEventID("comment_add", comment),
@@ -2372,7 +2372,7 @@ void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 		"entry_time", Convert::ToString(TimestampToMilliseconds(comment->GetEntryTime())),
 		"author", Utility::ValidateUTF8(comment->GetAuthor()),
 		"comment", Utility::ValidateUTF8(comment->GetText()),
-		"entry_type", Convert::ToString(comment->GetEntryType()),
+		"entry_type", IcingaDB::CommentTypeToString(comment->GetEntryType()),
 		"is_persistent", Convert::ToString((unsigned short)comment->GetPersistent()),
 		"is_sticky", Convert::ToString((unsigned short)comment->GetSticky()),
 		"event_id", CalcEventID("comment_remove", comment),

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1624,8 +1624,8 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 		attributes->Set("email", user->GetEmail());
 		attributes->Set("pager", user->GetPager());
 		attributes->Set("notifications_enabled", user->GetEnableNotifications());
-		attributes->Set("states", user->GetStates());
-		attributes->Set("types", user->GetTypes());
+		attributes->Set("states", StatesOrTypesFilterToRedisValue(user->GetStateFilter(), true));
+		attributes->Set("types", StatesOrTypesFilterToRedisValue(user->GetTypeFilter(), false));
 
 		if (user->GetPeriod())
 			attributes->Set("timeperiod_id", GetObjectIdentifier(user->GetPeriod()));
@@ -1673,8 +1673,8 @@ bool IcingaDB::PrepareObject(const ConfigObject::Ptr& object, Dictionary::Ptr& a
 		}
 
 		attributes->Set("notification_interval", std::max(0.0, std::round(notification->GetInterval())));
-		attributes->Set("states", notification->GetStates());
-		attributes->Set("types", notification->GetTypes());
+		attributes->Set("states", StatesOrTypesFilterToRedisValue(notification->GetStateFilter(), true));
+		attributes->Set("types", StatesOrTypesFilterToRedisValue(notification->GetTypeFilter(), false));
 
 		return true;
 	}

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -245,6 +245,21 @@ const char* IcingaDB::GetNotificationTypeByEnum(NotificationType type)
 	VERIFY(!"Invalid notification type.");
 }
 
+/**
+ * Converts the given comment type to its string representation.
+ *
+ * @ingroup icinga
+ */
+String IcingaDB::CommentTypeToString(CommentType type)
+{
+	switch (type) {
+		case CommentUser: return "comment";
+		case CommentAcknowledgement: return "ack";
+		default:
+			BOOST_THROW_EXCEPTION(std::invalid_argument("Invalid comment type specified"));
+	}
+}
+
 static const std::set<String> propertiesBlacklistEmpty;
 
 String IcingaDB::HashValue(const Value& value)

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -219,6 +219,31 @@ Dictionary::Ptr IcingaDB::SerializeRedundancyGroupState(const Checkable::Ptr& ch
 	};
 }
 
+/**
+ * Converts the given filter to its Redis value representation.
+ *
+ * Within the Icinga 2 code base, if the states and types filter bitsets are set to -1, the filter will match
+ * on all states/types. However, since sending -1 to Redis would crash the Icinga DB daemon, as both fields are
+ * of type Go's uint8/uint16, so the primary purpose of this function is to make sure that no negative values are
+ * passed to Redis.
+ *
+ * @param filter The filter to convert.
+ * @param isStatesFilter Whether the given filter is a states filter or a types filter.
+ */
+int IcingaDB::StatesOrTypesFilterToRedisValue(int filter, bool isStatesFilter)
+{
+	if (filter >= 0) {
+		return filter;
+	}
+
+	if (isStatesFilter) {
+		return StateFilterOK | StateFilterWarning | StateFilterCritical | StateFilterUnknown | StateFilterUp | StateFilterDown;
+	}
+
+	return NotificationDowntimeStart | NotificationDowntimeEnd | NotificationDowntimeRemoved | NotificationCustom |
+		NotificationAcknowledgement | NotificationProblem | NotificationRecovery | NotificationFlappingStart | NotificationFlappingEnd;
+}
+
 const char* IcingaDB::GetNotificationTypeByEnum(NotificationType type)
 {
 	switch (type) {

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -174,6 +174,7 @@ private:
 	static String GetObjectIdentifier(const ConfigObject::Ptr& object);
 	static String CalcEventID(const char* eventType, const ConfigObject::Ptr& object, double eventTime = 0, NotificationType nt = NotificationType(0));
 	static const char* GetNotificationTypeByEnum(NotificationType type);
+	static String CommentTypeToString(CommentType type);
 	static Dictionary::Ptr SerializeVars(const Dictionary::Ptr& vars);
 	static Dictionary::Ptr SerializeDependencyEdgeState(const DependencyGroup::Ptr& dependencyGroup, const Dependency::Ptr& dep);
 	static Dictionary::Ptr SerializeRedundancyGroupState(const Checkable::Ptr& child, const DependencyGroup::Ptr& redundancyGroup);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -173,6 +173,7 @@ private:
 
 	static String GetObjectIdentifier(const ConfigObject::Ptr& object);
 	static String CalcEventID(const char* eventType, const ConfigObject::Ptr& object, double eventTime = 0, NotificationType nt = NotificationType(0));
+	static int StatesOrTypesFilterToRedisValue(int filter, bool isStatesFilter);
 	static const char* GetNotificationTypeByEnum(NotificationType type);
 	static String CommentTypeToString(CommentType type);
 	static Dictionary::Ptr SerializeVars(const Dictionary::Ptr& vars);


### PR DESCRIPTION
ThisThis tries to make some of the values written to Redis and to the Database more consistent. Specifically, previously Icinga DB sent 0 or 1 for the `state_type` field, and the Icinga DB (Go) daemon mapped them to `soft` and `hard` accordingly before writing them to the database. This is not the case anymore, and the Icinga DB now writes `soft` and `hard` directly to Redis. This also applies to the `comment#entry_type`, `{user, notification}#types,states` and `notification#type` fields. They all are now serialized exactly how they're going to be written to the database, thus eliminating the need for the Go daemon to do any mappings. Apart from that, the `is_acknowledged` field is now serialized as `true` or `false` as opposed to `1` (normal) or `2` (sticky) previously. From now on that field will be set to `true` if the checkable has been acknowledged, and the new `is_sticky_acknowledgement` field will be set to `true` if the acknowledgement is sticky.

One additional bug that's been fixed by this PR but isn't related to the above topic is that the `{user, notification}#types,states` bitsets will correctly be refreshed whenever the user or notification `types,states` attributes are changed at runtime. Previously, the bitsets were only updated at startup, and never refreshed again (see 98dee18).

fixes #9427