### PR TITLE
GHA: Unbreak Windows Tests

### DIFF
--- a/tools/win32/test.ps1
+++ b/tools/win32/test.ps1
@@ -24,7 +24,7 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
 
 cd "$env:ICINGA2_BUILDPATH"
 
-ctest.exe -C "${env:CMAKE_BUILD_TYPE}" -T test -O $env:ICINGA2_BUILDPATH/Test.xml --output-on-failure --log_level=all
+ctest.exe -C "${env:CMAKE_BUILD_TYPE}" -T test -O $env:ICINGA2_BUILDPATH/Test.xml --output-on-failure
 if ($lastexitcode -ne 0) {
   cd ..
   exit $lastexitcode


### PR DESCRIPTION
Backport of https://github.com/Icinga/icinga2/pull/10104

---
As seen in the recent GHA run for #10102, the two Windows Actions have failed. The output log contains:

> DEBUG:   27+  >>>> ctest.exe -C "${env:CMAKE_BUILD_TYPE}" -T test -O $env:ICINGA2_BUILDPATH/Test.xml
> --output-on-failure --log_level=all
> CMake Error: Unknown argument: --log_level=all
> CMake Error: Run 'ctest --help' for all supported options.

After consulting ctest(1), older versions included, I have never found a mention of the "--log_level" flag. Since the useful "--output-on-failure" flag is already set, which will "[o]utput anything outputted by the test program if the test should fail", I do not see any further reason for more logging information.

This flag was introduced in 7665143afa500dd589546665124293b9c1206265, but I have not found any reasoning for the flag in particular.