### PR TITLE
SharedObject: delete unused methods

### DIFF
--- a/lib/base/shared-object.hpp
+++ b/lib/base/shared-object.hpp
@@ -31,23 +31,8 @@ protected:
 	{
 	}
 
-	inline SharedObject(const SharedObject&) : SharedObject()
-	{
-	}
-
-	inline SharedObject(SharedObject&&) : SharedObject()
-	{
-	}
-
-	inline SharedObject& operator=(const SharedObject&)
-	{
-		return *this;
-	}
-
-	inline SharedObject& operator=(SharedObject&&)
-	{
-		return *this;
-	}
+	SharedObject(const SharedObject&) = delete;
+	SharedObject& operator=(const SharedObject&) = delete;
 
 	inline virtual
 	~SharedObject() = default;


### PR DESCRIPTION
None of the derived classes use them, none shall have to explicitly delete them.