### PR TITLE
Deterministically shut down all connections on ApiListener::Stop()

### DIFF
--- a/lib/base/wait-group.cpp
+++ b/lib/base/wait-group.cpp
@@ -26,6 +26,11 @@ void StoppableWaitGroup::unlock_shared()
 	}
 }
 
+bool StoppableWaitGroup::IsLockable() const
+{
+	return !m_Stopped.load(std::memory_order_relaxed);
+}
+
 /**
  * Disallow new shared locks, wait for all existing ones.
  */
@@ -33,6 +38,6 @@ void StoppableWaitGroup::Join()
 {
 	std::unique_lock lock (m_Mutex);
 
-	m_Stopped = true;
+	m_Stopped.store(true, std::memory_order_relaxed);
 	m_CV.wait(lock, [this] { return !m_SharedLocks; });
 }

--- a/lib/base/wait-group.hpp
+++ b/lib/base/wait-group.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "base/object.hpp"
+#include "base/atomic.hpp"
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
@@ -22,6 +23,8 @@ public:
 
 	virtual bool try_lock_shared() = 0;
 	virtual void unlock_shared() = 0;
+
+	virtual bool IsLockable() const = 0;
 };
 
 /**
@@ -42,13 +45,16 @@ public:
 
 	bool try_lock_shared() override;
 	void unlock_shared() override;
+
+	bool IsLockable() const override;
+
 	void Join();
 
 private:
 	std::mutex m_Mutex;
 	std::condition_variable m_CV;
 	uint_fast32_t m_SharedLocks = 0;
-	bool m_Stopped = false;
+	Atomic<bool> m_Stopped = false;
 };
 
 }

--- a/lib/remote/actionshandler.hpp
+++ b/lib/remote/actionshandler.hpp
@@ -16,6 +16,7 @@ public:
 	static thread_local ApiUser::Ptr AuthenticatedApiUser;
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -917,7 +917,7 @@ void ApiListener::NewClientHandlerInternal(
 	} else {
 		Log(LogNotice, "ApiListener", "New HTTP client");
 
-		HttpServerConnection::Ptr aclient = new HttpServerConnection(identity, verify_ok, client);
+		HttpServerConnection::Ptr aclient = new HttpServerConnection(m_WaitGroup, identity, verify_ok, client);
 		AddHttpClient(aclient);
 		aclient->Start();
 		shutdownSslConn.Cancel();

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -368,6 +368,8 @@ void ApiListener::Stop(bool runtimeDeleted)
 	m_Timer->Stop(true);
 	m_RenewOwnCertTimer->Stop(true);
 
+	StopListener();
+
 	m_WaitGroup->Join();
 	ObjectImpl<ApiListener>::Stop(runtimeDeleted);
 
@@ -486,11 +488,36 @@ bool ApiListener::AddListener(const String& node, const String& service)
 	Log(LogInformation, "ApiListener")
 		<< "Started new listener on '[" << localEndpoint.address() << "]:" << localEndpoint.port() << "'";
 
-	IoEngine::SpawnCoroutine(io, [this, acceptor](asio::yield_context yc) { ListenerCoroutineProc(yc, acceptor); });
+	auto strand = Shared<asio::io_context::strand>::Make(io);
+
+	boost::signals2::scoped_connection closeSignal = m_OnListenerShutdown.connect([strand, acceptor]() {
+		boost::asio::post(*strand, [acceptor] {
+			try {
+				acceptor->close();
+			} catch (const std::exception& ex) {
+				Log(LogCritical, "ApiListener")
+					<< "Failed to close acceptor socket: " << ex.what();
+			}
+		});
+	});
+
+	IoEngine::SpawnCoroutine(*strand, [this, acceptor, closeSignal = std::move(closeSignal)](asio::yield_context yc) {
+		ListenerCoroutineProc(yc, acceptor);
+	});
 
 	UpdateStatusFile(localEndpoint);
 
 	return true;
+}
+
+/**
+ * Stops the listener(s).
+ */
+void ApiListener::StopListener()
+{
+	m_OnListenerShutdown();
+
+	m_ListenerWaitGroup->Join();
 }
 
 void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server)
@@ -506,7 +533,14 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 		lastModified = Utility::GetFileCreationTime(crlPath);
 	}
 
-	for (;;) {
+	std::shared_lock wgLock(*m_ListenerWaitGroup, std::try_to_lock);
+	if (!wgLock) {
+		Log(LogCritical, "ApiListener")
+			<< "Could not lock the listener wait group.";
+		return;
+	}
+
+	while (server->is_open()) {
 		try {
 			asio::ip::tcp::socket socket (io);
 
@@ -546,6 +580,12 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 				NewClientHandler(yc, strand, sslConn, String(), RoleServer);
 			});
 		} catch (const std::exception& ex) {
+			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
+
+			if (se && se->code() == boost::asio::error::operation_aborted) {
+				return;
+			}
+
 			Log(LogCritical, "ApiListener")
 				<< "Cannot accept new connection: " << ex.what();
 		}
@@ -826,6 +866,11 @@ void ApiListener::NewClientHandlerInternal(
 		}
 
 		throw;
+	}
+
+	std::shared_lock wgLock(*m_ListenerWaitGroup, std::try_to_lock);
+	if (!wgLock) {
+		return;
 	}
 
 	if (ctype == ClientJsonRpc) {

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -114,6 +114,7 @@ public:
 	bool AddAnonymousClient(const JsonRpcConnection::Ptr& aclient);
 	void RemoveAnonymousClient(const JsonRpcConnection::Ptr& aclient);
 	std::set<JsonRpcConnection::Ptr> GetAnonymousClients() const;
+	void DisconnectJsonRpcConnections();
 
 	void AddHttpClient(const HttpServerConnection::Ptr& aclient);
 	void RemoveHttpClient(const HttpServerConnection::Ptr& aclient);

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -191,12 +191,16 @@ private:
 	static ApiListener::Ptr m_Instance;
 	static std::atomic<bool> m_UpdatedObjectAuthority;
 
+	boost::signals2::signal<void()> m_OnListenerShutdown;
+	StoppableWaitGroup::Ptr m_ListenerWaitGroup = new StoppableWaitGroup();
+
 	void ApiTimerHandler();
 	void ApiReconnectTimerHandler();
 	void CleanupCertificateRequestsTimerHandler();
 	void CheckApiPackageIntegrity();
 
 	bool AddListener(const String& node, const String& service);
+	void StopListener();
 	void AddConnection(const Endpoint::Ptr& endpoint);
 
 	void NewClientHandler(

--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -14,6 +14,7 @@ using namespace icinga;
 REGISTER_URLHANDLER("/v1/config/files", ConfigFilesHandler);
 
 bool ConfigFilesHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/configfileshandler.hpp
+++ b/lib/remote/configfileshandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(ConfigFilesHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -11,6 +11,7 @@ using namespace icinga;
 REGISTER_URLHANDLER("/v1/config/packages", ConfigPackagesHandler);
 
 bool ConfigPackagesHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/configpackageshandler.hpp
+++ b/lib/remote/configpackageshandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(ConfigPackagesHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -15,6 +15,7 @@ REGISTER_URLHANDLER("/v1/config/stages", ConfigStagesHandler);
 std::atomic<bool> ConfigStagesHandler::m_RunningPackageUpdates (false);
 
 bool ConfigStagesHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/configstageshandler.hpp
+++ b/lib/remote/configstageshandler.hpp
@@ -15,6 +15,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(ConfigStagesHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -54,6 +54,7 @@ static void EnsureFrameCleanupTimer()
 }
 
 bool ConsoleHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/consolehandler.hpp
+++ b/lib/remote/consolehandler.hpp
@@ -23,6 +23,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(ConsoleHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/createobjecthandler.hpp
+++ b/lib/remote/createobjecthandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(CreateObjectHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/deleteobjecthandler.hpp
+++ b/lib/remote/deleteobjecthandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(DeleteObjectHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/endpoint.cpp
+++ b/lib/remote/endpoint.cpp
@@ -60,7 +60,7 @@ void Endpoint::RemoveClient(const JsonRpcConnection::Ptr& client)
 		std::unique_lock<std::mutex> lock(m_ClientsLock);
 		m_Clients.erase(client);
 
-		Log(LogWarning, "ApiListener")
+		Log(LogInformation, "ApiListener")
 			<< "Removing API client for endpoint '" << GetName() << "'. " << m_Clients.size() << " API clients left.";
 
 		SetConnecting(false);

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -40,6 +40,7 @@ const std::map<String, EventType> l_EventTypes ({
 const String l_ApiQuery ("<API query>");
 
 bool EventsHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/eventshandler.hpp
+++ b/lib/remote/eventshandler.hpp
@@ -15,6 +15,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(EventsHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/httphandler.cpp
+++ b/lib/remote/httphandler.cpp
@@ -47,6 +47,7 @@ void HttpHandler::Register(const Url::Ptr& url, const HttpHandler::Ptr& handler)
 }
 
 void HttpHandler::ProcessRequest(
+	const WaitGroup::Ptr& waitGroup,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,
@@ -108,7 +109,7 @@ void HttpHandler::ProcessRequest(
 	 */
 	try {
 		for (const HttpHandler::Ptr& handler : handlers) {
-			if (handler->HandleRequest(stream, user, request, url, response, params, yc, server)) {
+			if (handler->HandleRequest(waitGroup, stream, user, request, url, response, params, yc, server)) {
 				processed = true;
 				break;
 			}

--- a/lib/remote/httphandler.hpp
+++ b/lib/remote/httphandler.hpp
@@ -27,6 +27,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(HttpHandler);
 
 	virtual bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,
@@ -39,6 +40,7 @@ public:
 
 	static void Register(const Url::Ptr& url, const HttpHandler::Ptr& handler);
 	static void ProcessRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -6,6 +6,7 @@
 #include "remote/apiuser.hpp"
 #include "base/string.hpp"
 #include "base/tlsstream.hpp"
+#include "base/wait-group.hpp"
 #include <memory>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_context.hpp>
@@ -25,14 +26,15 @@ class HttpServerConnection final : public Object
 public:
 	DECLARE_PTR_TYPEDEFS(HttpServerConnection);
 
-	HttpServerConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream);
+	HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated,
+		const Shared<AsioTlsStream>::Ptr& stream);
 
 	void Start();
 	void StartStreaming();
-
 	bool Disconnected();
 
 private:
+	WaitGroup::Ptr m_WaitGroup;
 	ApiUser::Ptr m_ApiUser;
 	Shared<AsioTlsStream>::Ptr m_Stream;
 	double m_Seen;
@@ -42,7 +44,8 @@ private:
 	bool m_HasStartedStreaming;
 	boost::asio::deadline_timer m_CheckLivenessTimer;
 
-	HttpServerConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io);
+	HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated,
+		const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io);
 
 	void Disconnect(boost::asio::yield_context yc);
 

--- a/lib/remote/infohandler.cpp
+++ b/lib/remote/infohandler.cpp
@@ -9,6 +9,7 @@ using namespace icinga;
 REGISTER_URLHANDLER("/", InfoHandler);
 
 bool InfoHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/infohandler.hpp
+++ b/lib/remote/infohandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(InfoHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/jsonrpcconnection.hpp
+++ b/lib/remote/jsonrpcconnection.hpp
@@ -8,6 +8,7 @@
 #include "base/atomic.hpp"
 #include "base/io-engine.hpp"
 #include "base/tlsstream.hpp"
+#include "base/wait-group.hpp"
 #include "base/timer.hpp"
 #include "base/workqueue.hpp"
 #include <memory>
@@ -43,7 +44,8 @@ class JsonRpcConnection final : public Object
 public:
 	DECLARE_PTR_TYPEDEFS(JsonRpcConnection);
 
-	JsonRpcConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role);
+	JsonRpcConnection(const WaitGroup::Ptr& waitgroup, const String& identity, bool authenticated,
+		const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role);
 
 	void Start();
 
@@ -78,9 +80,11 @@ private:
 	AsioEvent m_OutgoingMessagesQueued;
 	AsioEvent m_WriterDone;
 	Atomic<bool> m_ShuttingDown;
+	WaitGroup::Ptr m_WaitGroup;
 	boost::asio::deadline_timer m_CheckLivenessTimer, m_HeartbeatTimer;
 
-	JsonRpcConnection(const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role, boost::asio::io_context& io);
+	JsonRpcConnection(const WaitGroup::Ptr& waitgroup, const String& identity, bool authenticated,
+		const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role, boost::asio::io_context& io);
 
 	void HandleIncomingMessages(boost::asio::yield_context yc);
 	void WriteOutgoingMessages(boost::asio::yield_context yc);

--- a/lib/remote/mallocinfohandler.cpp
+++ b/lib/remote/mallocinfohandler.cpp
@@ -18,6 +18,7 @@ using namespace icinga;
 REGISTER_URLHANDLER("/v1/debug/malloc_info", MallocInfoHandler);
 
 bool MallocInfoHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream&,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/mallocinfohandler.hpp
+++ b/lib/remote/mallocinfohandler.hpp
@@ -13,6 +13,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(MallocInfoHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/modifyobjecthandler.hpp
+++ b/lib/remote/modifyobjecthandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(ModifyObjectHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -89,6 +89,7 @@ Dictionary::Ptr ObjectQueryHandler::SerializeObjectAttrs(const Object::Ptr& obje
 }
 
 bool ObjectQueryHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/objectqueryhandler.hpp
+++ b/lib/remote/objectqueryhandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(ObjectQueryHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/statushandler.cpp
+++ b/lib/remote/statushandler.cpp
@@ -69,6 +69,7 @@ public:
 };
 
 bool StatusHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/statushandler.hpp
+++ b/lib/remote/statushandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(StatusHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/templatequeryhandler.cpp
+++ b/lib/remote/templatequeryhandler.cpp
@@ -76,6 +76,7 @@ public:
 };
 
 bool TemplateQueryHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/templatequeryhandler.hpp
+++ b/lib/remote/templatequeryhandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(TemplateQueryHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/typequeryhandler.cpp
+++ b/lib/remote/typequeryhandler.cpp
@@ -47,6 +47,7 @@ public:
 };
 
 bool TypeQueryHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/typequeryhandler.hpp
+++ b/lib/remote/typequeryhandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(TypeQueryHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -57,6 +57,7 @@ public:
 };
 
 bool VariableQueryHandler::HandleRequest(
+	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
 	const ApiUser::Ptr& user,
 	boost::beast::http::request<boost::beast::http::string_body>& request,

--- a/lib/remote/variablequeryhandler.hpp
+++ b/lib/remote/variablequeryhandler.hpp
@@ -14,6 +14,7 @@ public:
 	DECLARE_PTR_TYPEDEFS(VariableQueryHandler);
 
 	bool HandleRequest(
+		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
 		const ApiUser::Ptr& user,
 		boost::beast::http::request<boost::beast::http::string_body>& request,


### PR DESCRIPTION
# Deterministically shut down all connections on ApiListener::Stop()

Currently, while the shutdown order is determined by icinga2 object priorities, the connection objects on the backend can continue to have effects on the state of the program, even after seemingly having been shut down (i.e. the `Stop()` method of ApiListener has been called). In practice, the connection objects will mostly stay alive until the very end when icinga2 exits and will answer all kinds of requests until then.

To mitigate some of the effects from `ApiListener`'s associated objects after `Stop()` has returned, with this PR, these additional steps will be performed (in order):

+ Exit from `ListenerCoroutineProc`
+ Disconnect remaining endpoint and anonymous `JsonRpcConnections`
+ Abort HTTP API requests that are modifying the program state and reply with `503: Service unavailable`

This PR relates to #10179 and implements one of the TODOs in @Al2Klimov's [comment](https://github.com/Icinga/icinga2/issues/10179#issuecomment-2751552284).

## Exiting from `ListnerCoroutineProc`

`ListenerCoroutineProc` is stopped by closing the acceptor socket, then waiting for the completion of outstanding `NewClientHandler`s using a separate wait group.

## Shutting down the remaining endpoint and anonymous JsonRpcConnections

Since the ListenerCoroutineProc will not take any new connections now, and `m_ReconnectTimer` has already been stopped, we can be sure that no endpoints are currently connecting and we can simply iterate over all endpoint objects and `Disconnect()` those that are still connected.

This means that some check results are still discarded when the wait group is stopped. A solution to this will require a message to be passed between the nodes and could be addressed in a future PR.

## Aborting HTTP API requests

In API requests that modify or have the potential to modify the program state, the wait group will be locked and in case of potentially longer running requests, the stopped condition will be used to abort loops that iterate over config objects early and return with a 503 error code:

```
{
    "error": 503,
    "status": "Shutting down."
}
```

fixes #10179