### PR TITLE
Drop Ubuntu 20.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,7 +48,6 @@ jobs:
           - registry.suse.com/suse/sle15:15.5
           - registry.suse.com/suse/sle15:15.6
 
-          - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
           - ubuntu:24.10


### PR DESCRIPTION
Is EOL by the end of May (31).