### PR TITLE
GitHub Actions: use Windows Server 2025

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         bits: [32, 64]
 
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     env:
       BITS: '${{ matrix.bits }}'

--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -11,8 +11,8 @@ function ThrowOnNativeFailure {
 }
 
 
-$VsVersion = 2019
-$MsvcVersion = '14.2'
+$VsVersion = 2022
+$MsvcVersion = '14.3'
 $BoostVersion = @(1, 88, 0)
 $OpensslVersion = '3_0_16'
 

--- a/tools/win32/configure-dev.ps1
+++ b/tools/win32/configure-dev.ps1
@@ -1,6 +1,6 @@
 Set-PsDebug -Trace 1
 
-# Specify default targets for VS 2019 for developers.
+# Specify default targets for VS 2022 for developers.
 
 if (-not (Test-Path env:ICINGA2_BUILDPATH)) {
   $env:ICINGA2_BUILDPATH = '.\debug'
@@ -22,7 +22,7 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
   $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
 }
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
-  $env:CMAKE_GENERATOR = 'Visual Studio 16 2019'
+  $env:CMAKE_GENERATOR = 'Visual Studio 17 2022'
 }
 if (-not (Test-Path env:CMAKE_GENERATOR_PLATFORM)) {
   $env:CMAKE_GENERATOR_PLATFORM = 'x64'

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -17,7 +17,7 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
   $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
 }
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
-  $env:CMAKE_GENERATOR = 'Visual Studio 16 2019'
+  $env:CMAKE_GENERATOR = 'Visual Studio 17 2022'
 }
 if (-not (Test-Path env:BITS)) {
   $env:BITS = 64

--- a/tools/win32/load-vsenv.ps1
+++ b/tools/win32/load-vsenv.ps1
@@ -18,7 +18,7 @@ if (-not (Test-Path $BUILD)) {
 if (Test-Path env:VS_INSTALL_PATH) {
   $VSBASE = $env:VS_INSTALL_PATH
 } else {
-  $VSBASE = "C:\Program Files (x86)\Microsoft Visual Studio\2019"
+  $VSBASE = "C:\Program Files (x86)\Microsoft Visual Studio\2022"
 }
 
 if (Test-Path env:BITS) {


### PR DESCRIPTION
GitHub wants to retire the Windows Server 2019 runners by the end of the month, so we need to adapt, see also:
https://github.com/actions/runner-images/issues/12045

For the moment, this is a draft, just to see if anything interesting happens with the version bump.