### PR TITLE
GHA: Fix rockylinux:9 by install compression libs

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -73,7 +73,7 @@ case "$DISTRO" in
     esac
 
     dnf install -y bison ccache cmake gcc-c++ flex ninja-build redhat-rpm-config \
-      {boost,libedit,mariadb,ncurses,openssl,postgresql,systemd}-devel
+      {boost,bzip2,libedit,mariadb,ncurses,openssl,postgresql,systemd,xz,libzstd}-devel
     ;;
 esac
 


### PR DESCRIPTION
    Since recently, rockylinux:9 failed with linker errors against bz2, lzma
    and zstd. Installing the relevant devel packages fixed the builds.

    For reasons, cmake has started to add the -lbz2, -llzma, and -lzstd
    linker flags. Since Icinga 2 usually does not need those, the relevant
    devel packages were not installed. This may be due to some other
    transitively linked dependency.

    > 2025-06-05T13:12:59.5866282Z : && /usr/lib64/ccache/c++ -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wsuggest-override -Wrange-loop-construct -g -pthread -Winvalid-pch -O2 -g -DNDEBUG -Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1   -Wl,--export-dynamic -rdynamic third-party/mmatch/CMakeFiles/mmatch.dir/mmatch.c.o third-party/socketpair/CMakeFiles/socketpair.dir/socketpair.c.o lib/base/CMakeFiles/base.dir/application-version.cpp.o lib/base/CMakeFiles/base.dir/journaldlogger.cpp.o lib/base/CMakeFiles/base.dir/base_unity.cpp.o third-party/execvpe/CMakeFiles/execvpe.dir/execvpe.c.o lib/config/CMakeFiles/config.dir/config_lexer.cc.o lib/config/CMakeFiles/config.dir/config_parser.cc.o lib/config/CMakeFiles/config.dir/config_unity.cpp.o lib/remote/CMakeFiles/remote.dir/remote_unity.cpp.o plugins/CMakeFiles/check_nscp_api.dir/check_nscp_api.cpp.o -o Bin/RelWithDebInfo/check_nscp_api  -Wl,-rpath,::::::::::::::::::::::::  -ldl  /usr/lib64/libboost_coroutine.so.1.75.0  /usr/lib64/libboost_context.so.1.75.0  /usr/lib64/libboost_date_time.so.1.75.0  /usr/lib64/libboost_filesystem.so.1.75.0  /usr/lib64/libboost_iostreams.so.1.75.0  /usr/lib64/libboost_thread.so.1.75.0  /usr/lib64/libboost_system.so.1.75.0  /usr/lib64/libboost_program_options.so.1.75.0  /usr/lib64/libboost_regex.so.1.75.0  /usr/lib64/libssl.so  /usr/lib64/libcrypto.so  -lsystemd  /lib64/libedit.so  -ltermcap  /usr/lib64/libboost_chrono.so.1.75.0  -lbz2  -llzma  -lz  -lzstd  -licudata  -licui18n  -licuuc && :
    > 2025-06-05T13:12:59.5872347Z /usr/bin/ld: cannot find -lbz2
    > 2025-06-05T13:12:59.5872577Z /usr/bin/ld: cannot find -llzma
    > 2025-06-05T13:12:59.5872802Z /usr/bin/ld: cannot find -lzstd
    > 2025-06-05T13:12:59.5873039Z collect2: error: ld returned 1 exit status

    Hopefully, this issue may resolve itself in the near future, but for the
    time being this satisfies our CI run on Rocky Linux 9.
