### PR TITLE
Handle concurrent config package updates gracefully

### DIFF
--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -12,7 +12,10 @@ using namespace icinga;
 
 REGISTER_URLHANDLER("/v1/config/stages", ConfigStagesHandler);
 
-std::atomic<bool> ConfigStagesHandler::m_RunningPackageUpdates (false);
+static bool l_RunningPackageUpdates(false);
+// A timestamp that indicates the last time an Icinga 2 reload failed.
+static double l_LastReloadFailedTime(0);
+static std::mutex l_RunningPackageUpdatesMutex; // Protects the above two variables.
 
 bool ConfigStagesHandler::HandleRequest(
 	const WaitGroup::Ptr&,
@@ -132,12 +135,36 @@ void ConfigStagesHandler::HandlePost(
 		if (reload && !activate)
 			BOOST_THROW_EXCEPTION(std::invalid_argument("Parameter 'reload' must be false when 'activate' is false."));
 
-		if (m_RunningPackageUpdates.exchange(true)) {
-			return HttpUtility::SendJsonError(response, params, 423,
-				"Conflicting request, there is already an ongoing package update in progress. Please try it again later.");
+		{
+			std::lock_guard runningPackageUpdatesLock(l_RunningPackageUpdatesMutex);
+			double currentReloadFailedTime = Application::GetLastReloadFailed();
+
+			/**
+			 * Once the m_RunningPackageUpdates flag is set, it typically remains set until the current worker process is
+			 * terminated, in which case the new worker will have its own m_RunningPackageUpdates flag set to false.
+			 * However, if the reload fails for any reason, the m_RunningPackageUpdates flag will remain set to true
+			 * in the current worker process, which will prevent any further package updates from being processed until
+			 * the next Icinga 2 restart.
+			 *
+			 * So, in order to prevent such a situation, we are additionally tracking the last time a reload failed
+			 * and allow to bypass the m_RunningPackageUpdates flag only if the last reload failed time was changed
+			 * since the previous request.
+			 */
+			if (l_RunningPackageUpdates && l_LastReloadFailedTime == currentReloadFailedTime) {
+				return HttpUtility::SendJsonError(
+					response, params, 423,
+					"Conflicting request, there is already an ongoing package update in progress. Please try it again later."
+				);
+			}
+
+			l_RunningPackageUpdates = true;
+			l_LastReloadFailedTime = currentReloadFailedTime;
 		}
 
-		auto resetPackageUpdates (Shared<Defer>::Make([]() { ConfigStagesHandler::m_RunningPackageUpdates.store(false); }));
+		auto resetPackageUpdates (Shared<Defer>::Make([]() {
+			std::lock_guard lock(l_RunningPackageUpdatesMutex);
+			l_RunningPackageUpdates = false;
+		}));
 
 		std::unique_lock<std::mutex> lock(ConfigPackageUtility::GetStaticPackageMutex());
 

--- a/lib/remote/configstageshandler.hpp
+++ b/lib/remote/configstageshandler.hpp
@@ -4,7 +4,6 @@
 #define CONFIGSTAGESHANDLER_H
 
 #include "remote/httphandler.hpp"
-#include <atomic>
 
 namespace icinga
 {
@@ -48,8 +47,6 @@ private:
 		boost::beast::http::response<boost::beast::http::string_body>& response,
 		const Dictionary::Ptr& params
 	);
-
-	static std::atomic<bool> m_RunningPackageUpdates;
 };
 
 }


### PR DESCRIPTION
Previously, we used a simple boolean to track the state of the package updates, and didn't reset it back when the config validation was successful because it was assumed that if we successfully validated the config beforehand, then the worker would also successfully reload the config afterwards, and that the old worker would be terminated. However, this assumption is not always true due to a number of reasons that I can't even think of right now, but the most obvious one is that after we successfully validated the config, the config  might have changed again before the worker was able to reload it. If that happens, then the new worker might fail to successfully validate the config due to the recent changes, in which case the old worker would remain active, and this flag would still be set to true, causing any subsequent requests to fail with a `423` until you manually restart the Icinga 2 service.

So, in order to prevent such a situation, we are additionally tracking the last time a reload failed and allow to bypass the `m_RunningPackageUpdates` flag only if the last reload failed time was changed since the previous request.

Additionally, this PR uses AtomicFile to write some of the important files in ConfigPackageUtility, such as the `active.conf` file.

This additional commit [abf08d0](https://github.com/Icinga/icinga2/pull/10476/commits/abf08d04612987d48f65057a8c99c7737defeb16) fixes the following strange looking error from a customer.

```bash
[2025-06-29 18:02:18 +0200] critical/config: Error: Include file '../active.conf' does not exist
Location: in /var/lib/icinga2/api/packages/director/df4d559a-1f5f-4a58-8aab-ebb6b745f640/include.conf: 1:0-1:23
[2025-06-29 18:02:18 +0200] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
[2025-06-29 18:02:18 +0200] critical/Application: Found error in config: reloading aborted
```

## Tests

Use this to generate a broken config, so that the package update succeeds but the actual worker fails due to an error.

```diff
diff --git a/lib/remote/configpackageutility.cpp b/lib/remote/configpackageutility.cpp
index 0c3356099..8e5776175 100644
--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -131,7 +131,7 @@ void ConfigPackageUtility::WritePackageConfig(const String& packageName)
                << "  globals.ActiveStages = {}\n"
                << "}\n"
                << "\n"
-               << "if (globals.contains(\"ActiveStageOverride\")) {\n"
+               << "if (global.contains(\"ActiveStageOverride\")) {\n"
                << "  var arr = ActiveStageOverride.split(\":\")\n"
                << "  if (arr[0] == \"" << packageName << "\") {\n"
                << "    if (arr.len() < 2) {\n"
```

### Before

```bash
$ while :; do curl -ksSu root:icinga -H 'Accept: application/json' -X POST 'https://10.27.0.22:5665/v1/config/stages/example-cmdb' -d '{ "files": { "conf.d/test.conf": "object Host \"cmdb-hosts\" { check_command = \"dummy\" }" }, "pretty": true }'; done
{
    "results": [
        {
            "code": 200,
            "package": "example-cmdb",
            "stage": "06ec0ab0-a36b-4b34-971a-00a9a819177b",
            "status": "Created stage. Reload triggered."
        }
    ]
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
---
```

Will never accept new package updates after this until you manually restart the Icinga 2 service.

### After

```bash
$ curl -k -s -S -i -u root:icinga -H 'Accept: application/json' -X POST 'https://localhost:5665/v1/config/packages/example-cmdb?pretty=1'
$ while :; do curl -ksSu root:icinga -H 'Accept: application/json' -X POST 'https://10.27.0.22:5665/v1/config/stages/example-cmdb' -d '{ "files": { "conf.d/test.conf": "object Host \"cmdb-hosts\" { check_command = \"dummy\" }" }, "pretty": true }'; done
---
{
    "results": [
        {
            "code": 200,
            "package": "example-cmdb",
            "stage": "c58b6e5e-4f6c-4029-8981-29d0e2647f36",
            "status": "Created stage. Reload triggered."
        }
    ]
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "results": [
        {
            "code": 200,
            "package": "example-cmdb",
            "stage": "05f72333-5d70-4142-9f23-d2e3b443b89c",
            "status": "Created stage. Reload triggered."
        }
    ]
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "error": 423,
    "status": "Conflicting request, there is already an ongoing package update in progress. Please try it again later."
}
{
    "results": [
        {
            "code": 200,
            "package": "example-cmdb",
            "stage": "d155a90a-5d59-48a1-ae49-41649a3786e6",
            "status": "Created stage. Reload triggered."
        }
    ]
}
```

Since the above diff will always generate a broken config after the config update request successfully validated the config, the only error you'll see (unless you've started the Icinga 2 systemd service without the `--close-stdio` option) is the one from the `Status` entry of the `systemctl` command:

```bash
$ systemctl status icinga2
● icinga2.service - Icinga host/service/network monitoring system
     Loaded: loaded (/usr/lib/systemd/system/icinga2.service; disabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf, 50-keep-warm.conf
     Active: active (running) since Mon 2025-06-16 08:37:46 UTC; 10min ago
 Invocation: d9a34569c78f462bb40c24afb9341d42
    Process: 74429 ExecStartPre=/usr/local/icinga2/lib/icinga2/prepare-dirs /usr/local/icinga2/etc/sysconfig/icinga2 (code=exited, status=0/SUCCESS)
   Main PID: 74438 (icinga2)
     Status: "Config validation failed."
```

To trigger the newly introduced `503` error case, you can run the following loop:

```bash
$ while :; do curl -ksSu root:icinga -H 'Accept: application/json' -X POST 'https://10.27.0.22:5665/v1/config/stages/example-cmdb' -d '{ "files": { "conf.d/test.conf": "object Host \"cmdb-hosts\" { check_command = \"dummy\"; sleep(10); }" }, "pretty": true }'; sleep 11; done
{
    "results": [
        {
            "code": 200,
            "package": "example-cmdb",
            "stage": "896ccbcd-d53f-4210-b2cb-b2210f6c36f0",
            "status": "Created stage. Reload triggered."
        }
    ]
}
{
    "error": 503,
    "status": "Icinga is reloading."
}
{
    "results": [
        {
            "code": 200,
            "package": "example-cmdb",
            "stage": "c73ebadb-3ce7-4e15-8f79-946121b0bfb3",
            "status": "Created stage. Reload triggered."
        }
    ]
}
```

ref/IP/58256
fixes #10055