### PR TITLE
docs: Fix Fedora Repository, Icinga DB, SELinux

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -106,9 +106,10 @@ dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OSVER}.n
 ### Fedora Repository <a id="fedora-repository"></a>
 
 ```bash
-dnf install -y 'dnf-command(config-manager)'
-dnf config-manager --add-repo https://packages.icinga.com/fedora/$(. /etc/os-release; echo "$VERSION_ID")/release
+rpm --import https://packages.icinga.com/icinga.key
+curl -o /etc/yum.repos.d/ICINGA-release.repo https://packages.icinga.com/fedora/ICINGA-release.repo
 ```
+
 <!-- {% endif %} -->
 
 <!-- {% if sles %} -->
@@ -368,7 +369,7 @@ Restart Icinga 2 for these changes to take effect.
 systemctl restart icinga2
 ```
 
-<!-- {% if amazon_linux or debian or rhel or sles or ubuntu %} -->
+<!-- {% if amazon_linux or debian or fedora or rhel or sles or ubuntu %} -->
 ## Set up Icinga DB <a id="set-up-icinga-db"></a>
 
 Icinga DB is a set of components for publishing, synchronizing and
@@ -409,7 +410,13 @@ A Redis server from version 6.2 is required.
 
 #### Install Icinga DB Redis Package <a id="install-icinga-db-redis-package"></a>
 
-Use your distribution's package manager to install the `icingadb-redis` package as follows:
+Use your distribution's package manager to install the `icingadb-redis` package.
+
+<!-- {% if amazon_linux or fedora or rhel or opensuse or sles %} -->
+!!! tip
+
+    If you have [SELinux](22-selinux.md) enabled, the package `icingadb-redis-selinux` is also required.
+<!-- {% endif %} -->
 
 <!-- {% if amazon_linux %} -->
 <!-- {% if not icingaDocs %} -->


### PR DESCRIPTION
With Fedora 41, DNF was upgraded to version 5, breaking the command line API of "dnf config-manager"[^0]. Unfortunately, DNF 5's addrepo does not work with a simple URL anymore, but requires to construct a .repo file.

Furthermore, no information about trusting the Icinga signing key was available, resulting in one being unable to install packages. This was already the case for Fedora 40, still using DNF 4.

Since we are building Icinga DB for Fedora, I have included Icinga DB documentation for Fedora. Otherwise, this section was empty.

Finally, the icingadb-redis-selinux package was mentioned for distributions were we started to build SELinux packages for[^1].

[^0]: https://docs.fedoraproject.org/en-US/quick-docs/adding-or-removing-software-repositories-in-fedora/#_adding_repositories
[^1]: Icinga/icingadb#580