### PR TITLE
.mailmap: Merge Alvar email addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -35,6 +35,7 @@ Alexander A. Klimov <alexander.klimov@icinga.com> <al2klimov@gmail.com>
 <tobias.vonderkrone@profitbricks.com> <tobias@vonderkrone.info>
 <yonas.habteab@icinga.com> <yonas.habteab@netways.de>
 Alex <alexp710@hotmail.com> <alexp710@hotmail.com>
+Alvar Penning <alvar.penning@icinga.com> <8402811+oxzi@users.noreply.github.com>
 Baptiste Beauplat <lyknode@cilg.org> <lyknode@cilg.org>
 Carsten Köbke <carsten.koebke@gmx.de> Carsten Koebke <carsten.koebke@koebbes.de>
 Claudio Kuenzler <ck@claudiokuenzler.com>


### PR DESCRIPTION
Merging PRs via GitHub resulted in using the noreply email addresses. By adding a .mailmap entry, they are hidden from the git log.

Before:
> $ git shortlog -sne v2.14.0..HEAD | grep -i alvar
>     22  Alvar Penning <alvar.penning@icinga.com>
>      1  Alvar <8402811+oxzi@users.noreply.github.com>
>      1  alvar <8402811+oxzi@users.noreply.github.com>

After:
> $ git shortlog -sne v2.14.0..HEAD | grep -i alvar
>     24  Alvar Penning <alvar.penning@icinga.com>