### PR TITLE
Add a hint for upgrading docs to the release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,6 +13,7 @@ assignees: ''
 - [ ] Update bundled Windows dependencies
 - [ ] Harden global TLS defaults (consult https://ssl-config.mozilla.org)
 - [ ] Update `CHANGELOG.md`
+- [ ] Update `doc/16-upgrading-icinga-2.md` if applicable
 - [ ] Create and push a signed tag for the version
 - [ ] Build and release DEB and RPM packages
 - [ ] Build and release Windows packages


### PR DESCRIPTION
Was missing from the release checklist and it's missing in the `v2.15.0` tag. I'll also create a separate PR to add the upgrading docs.