### PR TITLE
Refactor HttpHandlers to use fewer arguments and to stream responses

### DIFF
--- a/lib/remote/CMakeLists.txt
+++ b/lib/remote/CMakeLists.txt
@@ -27,6 +27,7 @@ set(remote_SOURCES
   eventshandler.cpp eventshandler.hpp
   filterutility.cpp filterutility.hpp
   httphandler.cpp httphandler.hpp
+  httpmessage.cpp httpmessage.hpp
   httpserverconnection.cpp httpserverconnection.hpp
   httputility.cpp httputility.hpp
   infohandler.cpp infohandler.hpp

--- a/lib/remote/actionshandler.cpp
+++ b/lib/remote/actionshandler.cpp
@@ -16,11 +16,9 @@ REGISTER_URLHANDLER("/v1/actions", ActionsHandler);
 
 bool ActionsHandler::HandleRequest(
 	const WaitGroup::Ptr& waitGroup,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/actionshandler.hpp
+++ b/lib/remote/actionshandler.hpp
@@ -17,11 +17,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/actionshandler.hpp
+++ b/lib/remote/actionshandler.hpp
@@ -18,11 +18,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -161,12 +161,12 @@ public:
 		return m_WaitGroup;
 	}
 
-protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
 	void Start(bool runtimeCreated) override;
 	void Stop(bool runtimeDeleted) override;
 
+protected:
 	void ValidateTlsProtocolmin(const Lazy<String>& lvalue, const ValidationUtils& utils) override;
 	void ValidateTlsHandshakeTimeout(const Lazy<double>& lvalue, const ValidationUtils& utils) override;
 

--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -15,11 +15,9 @@ REGISTER_URLHANDLER("/v1/config/files", ConfigFilesHandler);
 
 bool ConfigFilesHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -16,16 +16,17 @@ REGISTER_URLHANDLER("/v1/config/files", ConfigFilesHandler);
 bool ConfigFilesHandler::HandleRequest(
 	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
+	auto params = request.Params();
 
 	if (request.method() != http::verb::get)
 		return false;
@@ -44,36 +45,36 @@ bool ConfigFilesHandler::HandleRequest(
 	}
 
 	if (request[http::field::accept] == "application/json") {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid Accept header. Either remove the Accept header or set it to 'application/octet-stream'.");
+		response.SendJsonError(params, 400, "Invalid Accept header. Either remove the Accept header or set it to 'application/octet-stream'.");
 		return true;
 	}
 
 	FilterUtility::CheckPermission(user, "config/query");
 
-	String packageName = HttpUtility::GetLastParameter(params, "package");
-	String stageName = HttpUtility::GetLastParameter(params, "stage");
+	String packageName = request.GetLastParameter("package");
+	String stageName = request.GetLastParameter("stage");
 
 	if (!ConfigPackageUtility::ValidatePackageName(packageName)) {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid package name.");
+		response.SendJsonError(params, 400, "Invalid package name.");
 		return true;
 	}
 
 	if (!ConfigPackageUtility::ValidateStageName(stageName)) {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid stage name.");
+		response.SendJsonError(params, 400, "Invalid stage name.");
 		return true;
 	}
 
-	String relativePath = HttpUtility::GetLastParameter(params, "path");
+	String relativePath = request.GetLastParameter("path");
 
 	if (ConfigPackageUtility::ContainsDotDot(relativePath)) {
-		HttpUtility::SendJsonError(response, params, 400, "Path contains '..' (not allowed).");
+		response.SendJsonError(params, 400, "Path contains '..' (not allowed).");
 		return true;
 	}
 
 	String path = ConfigPackageUtility::GetPackageDir() + "/" + packageName + "/" + stageName + "/" + relativePath;
 
 	if (!Utility::PathExists(path)) {
-		HttpUtility::SendJsonError(response, params, 404, "Path not found.");
+		response.SendJsonError(params, 404, "Path not found.");
 		return true;
 	}
 
@@ -81,13 +82,11 @@ bool ConfigFilesHandler::HandleRequest(
 		std::ifstream fp(path.CStr(), std::ifstream::in | std::ifstream::binary);
 		fp.exceptions(std::ifstream::badbit);
 
-		String content((std::istreambuf_iterator<char>(fp)), std::istreambuf_iterator<char>());
 		response.result(http::status::ok);
 		response.set(http::field::content_type, "application/octet-stream");
-		response.body() = content;
-		response.content_length(response.body().size());
+		response.body() << fp.rdbuf();
 	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 500, "Could not read file.",
+		response.SendJsonError(params, 500, "Could not read file.",
 			DiagnosticInformation(ex));
 	}
 

--- a/lib/remote/configfileshandler.hpp
+++ b/lib/remote/configfileshandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/configfileshandler.hpp
+++ b/lib/remote/configfileshandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -12,11 +12,9 @@ REGISTER_URLHANDLER("/v1/config/packages", ConfigPackagesHandler);
 
 bool ConfigPackagesHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/configpackageshandler.hpp
+++ b/lib/remote/configpackageshandler.hpp
@@ -16,37 +16,16 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;
 
 private:
-	void HandleGet(
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params
-	);
-	void HandlePost(
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params
-	);
-	void HandleDelete(
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params
-	);
+	void HandleGet(const HttpRequest& request, HttpResponse& response);
+	void HandlePost(const HttpRequest& request, HttpResponse& response);
+	void HandleDelete(const HttpRequest& request, HttpResponse& response);
 
 };
 

--- a/lib/remote/configpackageshandler.hpp
+++ b/lib/remote/configpackageshandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 
 private:

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -15,11 +15,9 @@ std::atomic<bool> ConfigStagesHandler::m_RunningPackageUpdates (false);
 
 bool ConfigStagesHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/configstageshandler.hpp
+++ b/lib/remote/configstageshandler.hpp
@@ -17,37 +17,16 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;
 
 private:
-	void HandleGet(
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params
-	);
-	void HandlePost(
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params
-	);
-	void HandleDelete(
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params
-	);
+	void HandleGet(const HttpRequest& request, HttpResponse& response);
+	void HandlePost(const HttpRequest& request, HttpResponse& response);
+	void HandleDelete(const HttpRequest& request, HttpResponse& response);
 
 	static std::atomic<bool> m_RunningPackageUpdates;
 };

--- a/lib/remote/configstageshandler.hpp
+++ b/lib/remote/configstageshandler.hpp
@@ -16,11 +16,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 
 private:

--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -56,16 +56,17 @@ static void EnsureFrameCleanupTimer()
 bool ConsoleHandler::HandleRequest(
 	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
+	auto params = request.Params();
 
 	if (url->GetPath().size() != 3)
 		return false;
@@ -79,34 +80,33 @@ bool ConsoleHandler::HandleRequest(
 
 	FilterUtility::CheckPermission(user, "console");
 
-	String session = HttpUtility::GetLastParameter(params, "session");
+	String session = request.GetLastParameter("session");
 
 	if (session.IsEmpty())
 		session = Utility::NewUniqueID();
 
-	String command = HttpUtility::GetLastParameter(params, "command");
+	String command = request.GetLastParameter("command");
 
-	bool sandboxed = HttpUtility::GetLastParameter(params, "sandboxed");
+	bool sandboxed = request.GetLastParameter("sandboxed");
 
 	ConfigObjectsSharedLock lock (std::try_to_lock);
 
 	if (!lock) {
-		HttpUtility::SendJsonError(response, params, 503, "Icinga is reloading.");
+		response.SendJsonError(params, 503, "Icinga is reloading.");
 		return true;
 	}
 
 	if (methodName == "execute-script")
-		return ExecuteScriptHelper(request, response, params, command, session, sandboxed);
+		return ExecuteScriptHelper(request, response, command, session, sandboxed);
 	else if (methodName == "auto-complete-script")
-		return AutocompleteScriptHelper(request, response, params, command, session, sandboxed);
+		return AutocompleteScriptHelper(request, response, command, session, sandboxed);
 
-	HttpUtility::SendJsonError(response, params, 400, "Invalid method specified: " + methodName);
+	response.SendJsonError(params, 400, "Invalid method specified: " + methodName);
 	return true;
 }
 
-bool ConsoleHandler::ExecuteScriptHelper(boost::beast::http::request<boost::beast::http::string_body>& request,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params, const String& command, const String& session, bool sandboxed)
+bool ConsoleHandler::ExecuteScriptHelper(const HttpRequest& request, HttpResponse& response,
+	const String& command, const String& session, bool sandboxed)
 {
 	namespace http = boost::beast::http;
 
@@ -174,14 +174,13 @@ bool ConsoleHandler::ExecuteScriptHelper(boost::beast::http::request<boost::beas
 	});
 
 	response.result(http::status::ok);
-	HttpUtility::SendJsonBody(response, params, result);
+	response.SendJsonBody(result, request.IsPretty());
 
 	return true;
 }
 
-bool ConsoleHandler::AutocompleteScriptHelper(boost::beast::http::request<boost::beast::http::string_body>& request,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params, const String& command, const String& session, bool sandboxed)
+bool ConsoleHandler::AutocompleteScriptHelper(const HttpRequest& request, HttpResponse& response,
+	const String& command, const String& session, bool sandboxed)
 {
 	namespace http = boost::beast::http;
 
@@ -213,7 +212,7 @@ bool ConsoleHandler::AutocompleteScriptHelper(boost::beast::http::request<boost:
 	});
 
 	response.result(http::status::ok);
-	HttpUtility::SendJsonBody(response, params, result);
+	response.SendJsonBody(result, request.IsPretty());
 
 	return true;
 }

--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -55,11 +55,9 @@ static void EnsureFrameCleanupTimer()
 
 bool ConsoleHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/consolehandler.hpp
+++ b/lib/remote/consolehandler.hpp
@@ -25,11 +25,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;
@@ -37,12 +34,10 @@ public:
 	static std::vector<String> GetAutocompletionSuggestions(const String& word, ScriptFrame& frame);
 
 private:
-	static bool ExecuteScriptHelper(boost::beast::http::request<boost::beast::http::string_body>& request,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params, const String& command, const String& session, bool sandboxed);
-	static bool AutocompleteScriptHelper(boost::beast::http::request<boost::beast::http::string_body>& request,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params, const String& command, const String& session, bool sandboxed);
+	static bool ExecuteScriptHelper(const HttpRequest& request, HttpResponse& response,
+		const String& command, const String& session, bool sandboxed);
+	static bool AutocompleteScriptHelper(const HttpRequest& request, HttpResponse& response,
+		const String& command, const String& session, bool sandboxed);
 
 };
 

--- a/lib/remote/consolehandler.hpp
+++ b/lib/remote/consolehandler.hpp
@@ -24,11 +24,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 
 	static std::vector<String> GetAutocompletionSuggestions(const String& word, ScriptFrame& frame);

--- a/lib/remote/createobjecthandler.cpp
+++ b/lib/remote/createobjecthandler.cpp
@@ -17,11 +17,9 @@ REGISTER_URLHANDLER("/v1/objects", CreateObjectHandler);
 
 bool CreateObjectHandler::HandleRequest(
 	const WaitGroup::Ptr& waitGroup,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/createobjecthandler.hpp
+++ b/lib/remote/createobjecthandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/createobjecthandler.hpp
+++ b/lib/remote/createobjecthandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/deleteobjecthandler.cpp
+++ b/lib/remote/deleteobjecthandler.cpp
@@ -17,11 +17,9 @@ REGISTER_URLHANDLER("/v1/objects", DeleteObjectHandler);
 
 bool DeleteObjectHandler::HandleRequest(
 	const WaitGroup::Ptr& waitGroup,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/deleteobjecthandler.cpp
+++ b/lib/remote/deleteobjecthandler.cpp
@@ -18,16 +18,17 @@ REGISTER_URLHANDLER("/v1/objects", DeleteObjectHandler);
 bool DeleteObjectHandler::HandleRequest(
 	const WaitGroup::Ptr& waitGroup,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
+	auto params = request.Params();
 
 	if (url->GetPath().size() < 3 || url->GetPath().size() > 4)
 		return false;
@@ -38,7 +39,7 @@ bool DeleteObjectHandler::HandleRequest(
 	Type::Ptr type = FilterUtility::TypeFromPluralName(url->GetPath()[2]);
 
 	if (!type) {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid type specified.");
+		response.SendJsonError(params, 400, "Invalid type specified.");
 		return true;
 	}
 
@@ -59,19 +60,19 @@ bool DeleteObjectHandler::HandleRequest(
 	try {
 		objs = FilterUtility::GetFilterTargets(qd, params, user);
 	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
+		response.SendJsonError(params, 404,
 			"No objects found.",
 			DiagnosticInformation(ex));
 		return true;
 	}
 
-	bool cascade = HttpUtility::GetLastParameter(params, "cascade");
-	bool verbose = HttpUtility::GetLastParameter(params, "verbose");
+	bool cascade = request.GetLastParameter("cascade");
+	bool verbose = request.IsVerbose();
 
 	ConfigObjectsSharedLock lock (std::try_to_lock);
 
 	if (!lock) {
-		HttpUtility::SendJsonError(response, params, 503, "Icinga is reloading");
+		response.SendJsonError(params, 503, "Icinga is reloading");
 		return true;
 	}
 
@@ -81,7 +82,7 @@ bool DeleteObjectHandler::HandleRequest(
 
 	std::shared_lock wgLock{*waitGroup, std::try_to_lock};
 	if (!wgLock) {
-		HttpUtility::SendJsonError(response, params, 503, "Shutting down.");
+		response.SendJsonError(params, 503, "Shutting down.");
 		return true;
 	}
 
@@ -143,7 +144,7 @@ bool DeleteObjectHandler::HandleRequest(
 	else
 		response.result(http::status::ok);
 
-	HttpUtility::SendJsonBody(response, params, result);
+	response.SendJsonBody(result, request.IsPretty());
 
 	return true;
 }

--- a/lib/remote/deleteobjecthandler.hpp
+++ b/lib/remote/deleteobjecthandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/deleteobjecthandler.hpp
+++ b/lib/remote/deleteobjecthandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -41,11 +41,9 @@ const String l_ApiQuery ("<API query>");
 
 bool EventsHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace asio = boost::asio;

--- a/lib/remote/eventshandler.hpp
+++ b/lib/remote/eventshandler.hpp
@@ -16,11 +16,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/eventshandler.hpp
+++ b/lib/remote/eventshandler.hpp
@@ -17,11 +17,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/httphandler.cpp
+++ b/lib/remote/httphandler.cpp
@@ -48,11 +48,9 @@ void HttpHandler::Register(const Url::Ptr& url, const HttpHandler::Ptr& handler)
 
 void HttpHandler::ProcessRequest(
 	const WaitGroup::Ptr& waitGroup,
-	AsioTlsStream& stream,
 	HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	Dictionary::Ptr node = m_UrlTree;
@@ -106,7 +104,7 @@ void HttpHandler::ProcessRequest(
 	 */
 	try {
 		for (const HttpHandler::Ptr& handler : handlers) {
-			if (handler->HandleRequest(waitGroup, stream, request, response, yc, server)) {
+			if (handler->HandleRequest(waitGroup, request, response, yc)) {
 				processed = true;
 				break;
 			}

--- a/lib/remote/httphandler.cpp
+++ b/lib/remote/httphandler.cpp
@@ -49,9 +49,8 @@ void HttpHandler::Register(const Url::Ptr& url, const HttpHandler::Ptr& handler)
 void HttpHandler::ProcessRequest(
 	const WaitGroup::Ptr& waitGroup,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
+	HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
@@ -59,8 +58,8 @@ void HttpHandler::ProcessRequest(
 	Dictionary::Ptr node = m_UrlTree;
 	std::vector<HttpHandler::Ptr> handlers;
 
-	Url::Ptr url = new Url(std::string(request.target()));
-	auto& path (url->GetPath());
+	request.DecodeUrl();
+	auto& path (request.Url()->GetPath());
 
 	for (std::vector<String>::size_type i = 0; i <= path.size(); i++) {
 		Array::Ptr current_handlers = node->Get("handlers");
@@ -90,12 +89,10 @@ void HttpHandler::ProcessRequest(
 
 	std::reverse(handlers.begin(), handlers.end());
 
-	Dictionary::Ptr params;
-
 	try {
-		params = HttpUtility::FetchRequestParameters(url, request.body());
+		request.DecodeParams();
 	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 400, "Invalid request body: " + DiagnosticInformation(ex, false));
+		response.SendJsonError(400, "Invalid request body: " + DiagnosticInformation(ex, false));
 		return;
 	}
 
@@ -109,12 +106,20 @@ void HttpHandler::ProcessRequest(
 	 */
 	try {
 		for (const HttpHandler::Ptr& handler : handlers) {
-			if (handler->HandleRequest(waitGroup, stream, user, request, url, response, params, yc, server)) {
+			if (handler->HandleRequest(waitGroup, stream, request, response, yc, server)) {
 				processed = true;
 				break;
 			}
 		}
 	} catch (const std::exception& ex) {
+		/* This means we can't send an error response because the exception was thrown
+		 * in the middle of a streaming response. We can't send any error response, so the
+		 * only thing we can do is propagate it up.
+		 */
+		if (response.HasSerializationStarted()) {
+			throw;
+		}
+
 		Log(LogWarning, "HttpServerConnection")
 			<< "Error while processing HTTP request: " << ex.what();
 
@@ -122,7 +127,7 @@ void HttpHandler::ProcessRequest(
 	}
 
 	if (!processed) {
-		HttpUtility::SendJsonError(response, params, 404, "The requested path '" + boost::algorithm::join(path, "/") +
+		response.SendJsonError(request.Params(), 404, "The requested path '" + boost::algorithm::join(path, "/") +
 			"' could not be found or the request method is not valid for this path.");
 		return;
 	}

--- a/lib/remote/httphandler.hpp
+++ b/lib/remote/httphandler.hpp
@@ -30,21 +30,17 @@ public:
 
 	virtual bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) = 0;
 
 	static void Register(const Url::Ptr& url, const HttpHandler::Ptr& handler);
 	static void ProcessRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	);
 
 private:

--- a/lib/remote/httphandler.hpp
+++ b/lib/remote/httphandler.hpp
@@ -4,8 +4,10 @@
 #define HTTPHANDLER_H
 
 #include "remote/i2-remote.hpp"
+#include "base/io-engine.hpp"
 #include "remote/url.hpp"
 #include "remote/httpserverconnection.hpp"
+#include "remote/httpmessage.hpp"
 #include "remote/apiuser.hpp"
 #include "base/registry.hpp"
 #include "base/tlsstream.hpp"
@@ -29,11 +31,8 @@ public:
 	virtual bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) = 0;
@@ -42,9 +41,8 @@ public:
 	static void ProcessRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
+		HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	);

--- a/lib/remote/httpmessage.cpp
+++ b/lib/remote/httpmessage.cpp
@@ -1,0 +1,235 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "remote/httpmessage.hpp"
+#include "remote/httputility.hpp"
+#include "remote/url.hpp"
+#include "base/json.hpp"
+#include "base/logger.hpp"
+#include <map>
+#include <string>
+#include <boost/beast/http.hpp>
+
+using namespace icinga;
+
+/**
+ * Adapter class for Boost Beast HTTP messages body to be used with the @c JsonEncoder.
+ *
+ * This class implements the @c nlohmann::detail::output_adapter_protocol<> interface and provides
+ * a way to write JSON data directly into the body of a Boost Beast HTTP message. The adapter is designed
+ * to work with Boost Beast HTTP messages that conform to the Beast HTTP message interface and must provide
+ * a body type that has a publicly accessible `reader` type that satisfies the Beast BodyReader [^1] requirements.
+ *
+ * @ingroup base
+ *
+ * [^1]: https://www.boost.org/doc/libs/1_85_0/libs/beast/doc/html/beast/concepts/BodyReader.html
+ */
+class HttpResponseJsonWriter : public AsyncJsonWriter
+{
+public:
+	explicit HttpResponseJsonWriter(HttpResponse& msg) : m_Reader(msg.base(), msg.body()), m_Message{msg}
+	{
+		boost::system::error_code ec;
+		// This never returns an actual error, except when overflowing the max
+		// buffer size, which we don't do here.
+		m_Reader.init(m_MinPendingBufferSize, ec);
+		ASSERT(!ec);
+	}
+
+	~HttpResponseJsonWriter() override
+	{
+		boost::system::error_code ec;
+		// Same here as in the constructor, all the standard Beast HTTP message reader implementations
+		// never return an error here, it's just there to satisfy the interface requirements.
+		m_Reader.finish(ec);
+		ASSERT(!ec);
+	}
+
+	void write_character(char c) override
+	{
+		write_characters(&c, 1);
+	}
+
+	void write_characters(const char* s, std::size_t length) override
+	{
+		boost::system::error_code ec;
+		boost::asio::const_buffer buf{s, length};
+		while (buf.size()) {
+			std::size_t w = m_Reader.put(buf, ec);
+			ASSERT(!ec);
+			buf += w;
+		}
+		m_PendingBufferSize += length;
+	}
+
+	void MayFlush(boost::asio::yield_context& yield) override
+	{
+		if (m_PendingBufferSize >= m_MinPendingBufferSize) {
+			m_Message.Flush(yield);
+			m_PendingBufferSize = 0;
+		}
+	}
+
+private:
+	HttpResponse::body_type::reader m_Reader;
+	HttpResponse& m_Message;
+	// The size of the pending buffer to avoid unnecessary writes
+	std::size_t m_PendingBufferSize{0};
+	// Minimum size of the pending buffer before we flush the data to the underlying stream
+	static constexpr std::size_t m_MinPendingBufferSize = 4096;
+};
+
+HttpRequest::HttpRequest(Shared<AsioTlsStream>::Ptr stream)
+	: m_Stream(std::forward<decltype(m_Stream)>(stream)){}
+
+void HttpRequest::ParseHeader(boost::beast::flat_buffer & buf, boost::asio::yield_context yc)
+{
+	boost::beast::http::async_read_header(*m_Stream, buf, m_Parser, yc);
+	base() = m_Parser.get().base();
+}
+
+void HttpRequest::ParseBody(boost::beast::flat_buffer & buf, boost::asio::yield_context yc)
+{
+	boost::beast::http::async_read(*m_Stream, buf, m_Parser, yc);
+	body() = std::move(m_Parser.release().body());
+}
+
+ApiUser::Ptr HttpRequest::User() const
+{
+	return m_User;
+}
+
+void HttpRequest::User(const ApiUser::Ptr& user)
+{
+	m_User = user;
+}
+
+Url::Ptr HttpRequest::Url() const
+{
+	return m_Url;
+}
+
+void HttpRequest::DecodeUrl()
+{
+	m_Url = new icinga::Url(std::string(target()));
+}
+
+Dictionary::Ptr HttpRequest::Params() const
+{
+	return m_Params;
+}
+
+void HttpRequest::DecodeParams()
+{
+	if (!body().empty()) {
+		Log(LogDebug, "HttpUtility")
+			<< "Request body: '" << body() << '\'';
+
+		m_Params = JsonDecode(body());
+	}
+
+	if (!m_Params) {
+		m_Params = new Dictionary();
+	}
+
+	if (!m_Url) {
+		DecodeUrl();
+	}
+
+	std::map<String, ArrayData> query;
+	for (const auto& kv : Url()->GetQuery()) {
+		query[kv.first].emplace_back(kv.second);
+	}
+
+	for (auto& [key, val] : query) {
+		m_Params->Set(key, new Array{std::move(val)});
+	}
+}
+
+Value HttpRequest::GetLastParameter(const String& key) const
+{
+	return HttpUtility::GetLastParameter(Params(), key);
+}
+
+bool HttpRequest::IsPretty() const
+{
+	return GetLastParameter("pretty");
+}
+
+bool HttpRequest::IsVerbose() const
+{
+	return GetLastParameter("verbose");
+}
+
+HttpResponse::HttpResponse(Shared<AsioTlsStream>::Ptr stream)
+	: m_Stream(std::move(stream))
+{
+}
+
+void HttpResponse::Flush(boost::asio::yield_context yc)
+{
+	if (!chunked()) {
+		ASSERT(!m_Serializer.is_header_done());
+		prepare_payload();
+	}
+
+	boost::system::error_code ec;
+	boost::beast::http::async_write(*m_Stream, m_Serializer, yc[ec]);
+	if (ec && ec != boost::beast::http::error::need_buffer) {
+		if (yc.ec_) {
+			*yc.ec_ = ec;
+			return;
+		} else {
+			BOOST_THROW_EXCEPTION(boost::system::system_error{ec});
+		}
+	}
+	m_Stream->async_flush(yc);
+
+	ASSERT(chunked() || m_Serializer.is_done());
+}
+
+void HttpResponse::StartStreaming()
+{
+	ASSERT(body().Size() == 0 && !m_Serializer.is_header_done());
+	body().Start();
+	chunked(true);
+}
+
+void HttpResponse::SendJsonBody(const Value& val, bool pretty)
+{
+	namespace http = boost::beast::http;
+
+	set(http::field::content_type, "application/json");
+	GetJsonEncoder().Encode(val);
+}
+
+void HttpResponse::SendJsonError(int code, String info, String diagInfo, bool pretty, bool verbose)
+{
+	ASSERT(!m_Serializer.is_header_done());
+
+	Dictionary::Ptr response = new Dictionary({ { "error", code } });
+
+	if (!info.IsEmpty()) {
+		response->Set("status", std::move(info));
+	}
+
+	if (verbose && !diagInfo.IsEmpty()) {
+		response->Set("diagnostic_information", std::move(diagInfo));
+	}
+
+	result(code);
+
+	SendJsonBody(response, pretty);
+}
+
+void HttpResponse::SendJsonError(const Dictionary::Ptr& params, int code, String info, String diagInfo)
+{
+	bool verbose = params && HttpUtility::GetLastParameter(params, "verbose");
+	bool pretty = params && HttpUtility::GetLastParameter(params, "pretty");
+	SendJsonError(code, std::move(info), std::move(diagInfo), pretty, verbose);
+}
+
+JsonEncoder HttpResponse::GetJsonEncoder(bool pretty)
+{
+	auto adapter = std::make_shared<HttpResponseJsonWriter>(*this);
+	return JsonEncoder{adapter, pretty};
+}

--- a/lib/remote/httpmessage.hpp
+++ b/lib/remote/httpmessage.hpp
@@ -1,0 +1,314 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#ifndef HTTPMESSAGE_H
+#define HTTPMESSAGE_H
+
+#include "base/dictionary.hpp"
+#include "base/tlsstream.hpp"
+#include "base/json.hpp"
+#include "remote/url.hpp"
+#include "remote/apiuser.hpp"
+#include <boost/beast/http.hpp>
+#include <boost/version.hpp>
+
+namespace icinga
+{
+
+/**
+ * A custom body_type for a  @c boost::beast::http::message
+ *
+ * It combines the memory management of @c boost::beast::http::dynamic_body,
+ * which uses a multi_buffer, with the ability to continue serialization when
+ * new data arrives of the @c boost::beast::http::buffer_body.
+ *
+ * @tparam DynamicBuffer A buffer conforming to the boost::beast interface of the same name
+ *
+ * @ingroup remote
+ */
+template<class DynamicBuffer>
+struct SerializableBody
+{
+	class reader;
+	class writer;
+
+	class value_type
+	{
+	public:
+		template <typename T>
+		value_type& operator<<(T && right)
+		{
+			/* Preferably, we would return an ostream object here instead. However
+			 * there seems to be a bug in boost::beast where if the ostream, or rather its
+			 * streambuf object is moved into the return value, the chunked encoding gets
+			 * mangled, leading to the client disconnecting.
+			 *
+			 * A workaround would have been to construct the boost::beast::detail::ostream_helper
+			 * with the last parameter set to false, indicating that the streambuf object is not
+			 * movable, but that is an implementation detail we'd rather not use directly in our
+			 * code.
+			 *
+			 * This version has a certain overhead of the ostream being constructed on every call
+			 * to the operator, which leads to an individual append for each time, whereas if the
+			 * object could be kept until the entire chain of output operators is finished, only
+			 * a single call to prepare()/commit() would have been needed.
+			 *
+			 * However, since this operator is mostly used for small error messages and the big
+			 * responses are handled via a reader instance, this shouldn't be too much of a
+			 * problem.
+			 */
+			boost::beast::ostream(m_Buffer) << std::forward<T>(right);
+			return *this;
+		}
+
+		std::size_t Size() const { return m_Buffer.size(); }
+
+		void Finish() { m_More = false; }
+		void Start() { m_More = true; }
+
+		friend class reader;
+		friend class writer;
+
+	private:
+		/* This defaults to false so the body does not require any special handling
+		 * for simple messages and can still be written with http::async_write().
+		 */
+		bool m_More = false;
+		DynamicBuffer m_Buffer;
+	};
+
+	static std::uint64_t size(const value_type& body) { return body.Size(); }
+
+	/**
+	 * Implement the boost::beast BodyReader interface for this body type
+	 *
+	 * This is used by the  @c boost::beast::http::parser (which we don't use for responses)
+	 * or in the  @c BeastHttpMessageAdapter for our own  @c JsonEncoder to write JSON directly
+	 * into the body of a HTTP response message.
+	 *
+	 * The reader automatically sets the body's `more` flag on the call to its init() function
+	 * and resets it when its finish() function is called. Regarding the usage in the
+	 * @c JsonEncoder above, this means that the message is automatically marked as complete
+	 * when the encoder object is destroyed.
+	 */
+	class reader
+	{
+	public:
+		template <bool isRequest, class Fields>
+		explicit reader(boost::beast::http::header<isRequest, Fields>& h, value_type& b) : m_Body(b)
+		{
+		}
+
+		void init(const boost::optional<std::uint64_t>& n, boost::beast::error_code& ec)
+		{
+			ec = {};
+			m_Body.Start();
+#if BOOST_VERSION >= 107000
+			if (n) {
+				m_Body.m_Buffer.reserve(*n);
+			}
+#endif /* BOOST_VERSION */
+		}
+
+		template <class ConstBufferSequence>
+		std::size_t put(const ConstBufferSequence& buffers, boost::beast::error_code& ec)
+		{
+			auto size = boost::asio::buffer_size(buffers);
+			if (size > m_Body.m_Buffer.max_size() - m_Body.Size()) {
+				ec = boost::beast::http::error::buffer_overflow;
+				return 0;
+			}
+
+			auto const wBuf = m_Body.m_Buffer.prepare(size);
+			boost::asio::buffer_copy(wBuf, buffers);
+			m_Body.m_Buffer.commit(size);
+			return size;
+		}
+
+		void finish(boost::beast::error_code& ec)
+		{
+			ec = {};
+			m_Body.Finish();
+		}
+
+	private:
+		value_type& m_Body;
+	};
+
+	/**
+	 * Implement the boost::beast BodyWriter interface for this body type
+	 *
+	 * This is used (for example) by the @c boost::beast::http::serializer to write out the
+	 * message over the TLS stream. The logic is similar to the writer of the
+	 * @c boost::beast::http::buffer_body.
+	 *
+	 * On the every call, it will free up the buffer range that has previously been written,
+	 * then return a buffer containing data the has become available in the meantime. Otherwise,
+	 * if there is more data expected in the future, for example because a corresponding reader
+	 * has not yet finished filling the body, a `need_buffer` error is returned, to inform the
+	 * serializer to abort writing for now, which in turn leads to the outer call to
+	 * `http::async_write` to call their completion handlers with a `need_buffer` error, to
+	 * notify that more data is required for another call to `http::async_write`.
+	 */
+	class writer
+	{
+	public:
+		using const_buffers_type = typename decltype(value_type::m_Buffer)::const_buffers_type;
+
+		template <bool isRequest, class Fields>
+		explicit writer(const boost::beast::http::header<isRequest, Fields>& h, value_type& b)
+			: m_Body(b)
+		{
+		}
+
+		/**
+		 * This constructor is needed specifically for boost-1.66, which was the first version
+		 * the beast library was introduced and is still used on older (supported) distros.
+		 */
+		template <bool isRequest, class Fields>
+		explicit writer(const boost::beast::http::message<isRequest, SerializableBody, Fields>& msg)
+			: m_Body(const_cast<value_type &>(msg.body()))
+		{
+		}
+
+		void init(boost::beast::error_code& ec) { ec = {}; }
+
+		boost::optional<std::pair<const_buffers_type, bool>> get(boost::beast::error_code& ec)
+		{
+			using namespace boost::beast::http;
+
+			if (m_SizeWritten > 0) {
+				m_Body.m_Buffer.consume(std::exchange(m_SizeWritten, 0));
+			}
+
+			if (m_Body.m_Buffer.size()) {
+				ec = {};
+				m_SizeWritten = m_Body.m_Buffer.size();
+				return {{m_Body.m_Buffer.data(), m_Body.m_More}};
+			}
+
+			if (m_Body.m_More) {
+				ec = {make_error_code(error::need_buffer)};
+			} else {
+				ec = {};
+			}
+			return boost::none;
+		}
+
+	private:
+		value_type& m_Body;
+		std::size_t m_SizeWritten = 0;
+	};
+};
+
+/**
+ * A wrapper class for a boost::beast HTTP request
+ *
+ * @ingroup remote
+ */
+class HttpRequest: public boost::beast::http::request<boost::beast::http::string_body>
+{
+public:
+	using ParserType = boost::beast::http::request_parser<body_type>;
+
+	explicit HttpRequest(Shared<AsioTlsStream>::Ptr stream);
+
+	/**
+	 * Parse the header of the response using the internal parser object.
+	 *
+	 * This first performs an @f async_read_header() into the parser, then copies
+	 * the parsed header into this object.
+	 */
+	void ParseHeader(boost::beast::flat_buffer& buf, boost::asio::yield_context yc);
+
+	/**
+	 * Parse the body of the response using the internal parser object.
+	 *
+	 * This first performs an async_read() into the parser, then moves the parsed body
+	 * into this object.
+	 *
+	 * @param buf The buffer used to track the state of the connection
+	 * @param yc The yield_context for this operation
+	 */
+	void ParseBody(boost::beast::flat_buffer& buf, boost::asio::yield_context yc);
+
+	ParserType& Parser() { return m_Parser; }
+
+	ApiUser::Ptr User() const;
+	void User(const ApiUser::Ptr& user);
+
+	icinga::Url::Ptr Url() const;
+	void DecodeUrl();
+
+	Dictionary::Ptr Params() const;
+	void DecodeParams();
+
+	Value GetLastParameter(const String& key) const;
+
+	/**
+	 * Return true if pretty printing was requested.
+	 */
+	bool IsPretty() const;
+
+	/**
+	 * Return true if a verbose response was requested.
+	 */
+	bool IsVerbose() const;
+
+private:
+	ApiUser::Ptr m_User;
+	Url::Ptr m_Url;
+	Dictionary::Ptr m_Params;
+
+	ParserType m_Parser;
+
+	Shared<AsioTlsStream>::Ptr m_Stream;
+};
+
+/**
+ * A wrapper class for a boost::beast HTTP response
+ *
+ * @ingroup remote
+ */
+class HttpResponse: public boost::beast::http::response<SerializableBody<boost::beast::multi_buffer>>
+{
+public:
+	explicit HttpResponse(Shared<AsioTlsStream>::Ptr stream);
+
+	/**
+	 * Writes as much of the response as is currently available.
+	 *
+	 * Uses chunk-encoding if the content_length has not been set by the time this is called
+	 * for the first time.
+	 *
+	 * The caller needs to ensure that the header is finished before calling this for the
+	 * first time as changes to the header afterwards will not have any effect.
+	 *
+	 * @param yc The yield_context for this operation
+	 */
+	void Flush(boost::asio::yield_context yc);
+
+	bool HasSerializationStarted () { return m_Serializer.is_header_done(); }
+
+	/**
+	 * Enables chunked encoding.
+	 */
+	void StartStreaming();
+
+	void SendJsonBody(const Value& val, bool pretty = false);
+	void SendJsonError(const int code, String info = String(), String diagInfo = String(),
+		bool pretty = false, bool verbose = false);
+	void SendJsonError(const Dictionary::Ptr& params, const int code,
+		String info = String(), String diagInfo = String());
+
+	JsonEncoder GetJsonEncoder(bool pretty = false);
+	
+private:
+	using Serializer = boost::beast::http::response_serializer<HttpResponse::body_type>;
+	Serializer m_Serializer{*this};
+
+	Shared<AsioTlsStream>::Ptr m_Stream;
+};
+
+}
+
+#endif /* HTTPUTILITY_H */

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -41,8 +41,7 @@ HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, cons
 }
 
 HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io)
-	: m_WaitGroup(waitGroup), m_Stream(stream), m_Seen(Utility::GetTime()), m_IoStrand(io), m_ShuttingDown(false), m_HasStartedStreaming(false),
-	m_CheckLivenessTimer(io)
+	: m_WaitGroup(waitGroup), m_Stream(stream), m_Seen(Utility::GetTime()), m_IoStrand(io), m_ShuttingDown(false), m_CheckLivenessTimer(io)
 {
 	if (authenticated) {
 		m_ApiUser = ApiUser::GetByClientCN(identity);
@@ -97,29 +96,6 @@ void HttpServerConnection::Disconnect(boost::asio::yield_context yc)
 	if (listener) {
 		listener->RemoveHttpClient(this);
 	}
-}
-
-void HttpServerConnection::StartStreaming()
-{
-	namespace asio = boost::asio;
-
-	m_HasStartedStreaming = true;
-
-	HttpServerConnection::Ptr keepAlive (this);
-
-	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) {
-		if (!m_ShuttingDown) {
-			char buf[128];
-			asio::mutable_buffer readBuf (buf, 128);
-			boost::system::error_code ec;
-
-			do {
-				m_Stream->async_read_some(readBuf, yc[ec]);
-			} while (!ec);
-
-			Disconnect(yc);
-		}
-	});
 }
 
 bool HttpServerConnection::Disconnected()
@@ -384,11 +360,8 @@ bool EnsureValidBody(
 
 static inline
 bool ProcessRequest(
-	AsioTlsStream& stream,
 	HttpRequest& request,
 	HttpResponse& response,
-	HttpServerConnection& server,
-	bool& hasStartedStreaming,
 	const WaitGroup::Ptr& waitGroup,
 	std::chrono::steady_clock::duration& cpuBoundWorkTime,
 	boost::asio::yield_context& yc
@@ -400,7 +373,7 @@ bool ProcessRequest(
 		CpuBoundWork handlingRequest (yc);
 		cpuBoundWorkTime = std::chrono::steady_clock::now() - start;
 
-		HttpHandler::ProcessRequest(waitGroup, stream, request, response, yc, server);
+		HttpHandler::ProcessRequest(waitGroup, request, response, yc);
 	} catch (const std::exception& ex) {
 		/* This means we can't do anything with the connection anymore, so we can't send
 		 * an error response. And since we don't know the state the stream is in, we have to
@@ -505,7 +478,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 
 			m_Seen = std::numeric_limits<decltype(m_Seen)>::max();
 
-			if (!ProcessRequest(*m_Stream, request, response, *this, m_HasStartedStreaming, m_WaitGroup, cpuBoundWorkTime, yc)) {
+			if (!ProcessRequest(request, response, m_WaitGroup, cpuBoundWorkTime, yc)) {
 				break;
 			}
 

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -41,7 +41,7 @@ HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, cons
 }
 
 HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io)
-	: m_WaitGroup(waitGroup), m_Stream(stream), m_Seen(Utility::GetTime()), m_IoStrand(io), m_ShuttingDown(false), m_CheckLivenessTimer(io)
+	: m_WaitGroup(waitGroup), m_Stream(stream), m_Seen(Utility::GetTime()), m_CanRead(io, true), m_IoStrand(io), m_ShuttingDown(false), m_CheckLivenessTimer(io)
 {
 	if (authenticated) {
 		m_ApiUser = ApiUser::GetByClientCN(identity);
@@ -65,6 +65,7 @@ void HttpServerConnection::Start()
 
 	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { ProcessMessages(yc); });
 	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { CheckLiveness(yc); });
+	IoEngine::SpawnCoroutine(m_IoStrand, [this, keepAlive](asio::yield_context yc) { DetectClientShutdown(yc); });
 }
 
 /**
@@ -419,6 +420,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 
 			response.set(http::field::server, l_ServerHeader);
 
+			m_CanRead.WaitForSet(yc);
 			if (!EnsureValidHeaders(buf, request, response, m_ShuttingDown, yc)) {
 				break;
 			}
@@ -477,6 +479,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 			}
 
 			m_Seen = std::numeric_limits<decltype(m_Seen)>::max();
+			m_CanRead.Clear();
 
 			if (!ProcessRequest(request, response, m_WaitGroup, cpuBoundWorkTime, yc)) {
 				break;
@@ -515,5 +518,29 @@ void HttpServerConnection::CheckLiveness(boost::asio::yield_context yc)
 			Disconnect(yc);
 			break;
 		}
+	}
+}
+
+/**
+ * Detects a shutdown initiated by the client side.
+ *
+ * @param yc The yield context for the coroutine of this function
+ */
+void HttpServerConnection::DetectClientShutdown(boost::asio::yield_context yc)
+{
+	using wait_type = boost::asio::socket_base::wait_type;
+
+	while (!m_ShuttingDown) {
+		m_CanRead.WaitForClear(yc);
+
+		boost::system::error_code ec;
+		m_Stream->async_fill(yc[ec]);
+		if (ec && !m_ShuttingDown) {
+			Log(LogInformation, "HttpServerConnection") << "Detected shutdown from client: " << m_PeerAddress << ".";
+			Disconnect(yc);
+			break;
+		}
+
+		m_CanRead.Set();
 	}
 }

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -4,6 +4,7 @@
 #define HTTPSERVERCONNECTION_H
 
 #include "remote/apiuser.hpp"
+#include "base/io-engine.hpp"
 #include "base/string.hpp"
 #include "base/tlsstream.hpp"
 #include "base/wait-group.hpp"
@@ -37,6 +38,7 @@ private:
 	ApiUser::Ptr m_ApiUser;
 	Shared<AsioTlsStream>::Ptr m_Stream;
 	double m_Seen;
+	AsioDualEvent m_CanRead;
 	String m_PeerAddress;
 	boost::asio::io_context::strand m_IoStrand;
 	bool m_ShuttingDown;
@@ -49,6 +51,7 @@ private:
 
 	void ProcessMessages(boost::asio::yield_context yc);
 	void CheckLiveness(boost::asio::yield_context yc);
+	void DetectClientShutdown(boost::asio::yield_context yc);
 };
 
 }

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -30,7 +30,6 @@ public:
 		const Shared<AsioTlsStream>::Ptr& stream);
 
 	void Start();
-	void StartStreaming();
 	bool Disconnected();
 
 private:
@@ -41,7 +40,6 @@ private:
 	String m_PeerAddress;
 	boost::asio::io_context::strand m_IoStrand;
 	bool m_ShuttingDown;
-	bool m_HasStartedStreaming;
 	boost::asio::deadline_timer m_CheckLivenessTimer;
 
 	HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated,

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -3,39 +3,9 @@
 #include "remote/httputility.hpp"
 #include "remote/url.hpp"
 #include "base/json.hpp"
-#include "base/logger.hpp"
-#include <map>
-#include <string>
-#include <vector>
 #include <boost/beast/http.hpp>
 
 using namespace icinga;
-
-Dictionary::Ptr HttpUtility::FetchRequestParameters(const Url::Ptr& url, const std::string& body)
-{
-	Dictionary::Ptr result;
-
-	if (!body.empty()) {
-		Log(LogDebug, "HttpUtility")
-			<< "Request body: '" << body << '\'';
-
-		result = JsonDecode(body);
-	}
-
-	if (!result)
-		result = new Dictionary();
-
-	std::map<String, std::vector<String>> query;
-	for (const auto& kv : url->GetQuery()) {
-		query[kv.first].emplace_back(kv.second);
-	}
-
-	for (auto& kv : query) {
-		result->Set(kv.first, Array::FromVector(kv.second));
-	}
-
-	return result;
-}
 
 Value HttpUtility::GetLastParameter(const Dictionary::Ptr& params, const String& key)
 {
@@ -50,31 +20,4 @@ Value HttpUtility::GetLastParameter(const Dictionary::Ptr& params, const String&
 		return Empty;
 	else
 		return arr->Get(arr->GetLength() - 1);
-}
-
-void HttpUtility::SendJsonBody(boost::beast::http::response<boost::beast::http::string_body>& response, const Dictionary::Ptr& params, const Value& val)
-{
-	namespace http = boost::beast::http;
-
-	response.set(http::field::content_type, "application/json");
-	response.body() = JsonEncode(val, params && GetLastParameter(params, "pretty"));
-	response.content_length(response.body().size());
-}
-
-void HttpUtility::SendJsonError(boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params, int code, const String& info, const String& diagnosticInformation)
-{
-	Dictionary::Ptr result = new Dictionary({ { "error", code } });
-
-	if (!info.IsEmpty()) {
-		result->Set("status", info);
-	}
-
-	if (params && HttpUtility::GetLastParameter(params, "verbose") && !diagnosticInformation.IsEmpty()) {
-		result->Set("diagnostic_information", diagnosticInformation);
-	}
-
-	response.result(code);
-
-	HttpUtility::SendJsonBody(response, params, result);
 }

--- a/lib/remote/httputility.hpp
+++ b/lib/remote/httputility.hpp
@@ -6,7 +6,6 @@
 #include "remote/url.hpp"
 #include "base/dictionary.hpp"
 #include <boost/beast/http.hpp>
-#include <string>
 
 namespace icinga
 {
@@ -20,12 +19,7 @@ class HttpUtility
 {
 
 public:
-	static Dictionary::Ptr FetchRequestParameters(const Url::Ptr& url, const std::string& body);
 	static Value GetLastParameter(const Dictionary::Ptr& params, const String& key);
-
-	static void SendJsonBody(boost::beast::http::response<boost::beast::http::string_body>& response, const Dictionary::Ptr& params, const Value& val);
-	static void SendJsonError(boost::beast::http::response<boost::beast::http::string_body>& response, const Dictionary::Ptr& params, const int code,
-		const String& verbose = String(), const String& diagnosticInformation = String());
 };
 
 }

--- a/lib/remote/infohandler.cpp
+++ b/lib/remote/infohandler.cpp
@@ -10,11 +10,9 @@ REGISTER_URLHANDLER("/", InfoHandler);
 
 bool InfoHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/infohandler.cpp
+++ b/lib/remote/infohandler.cpp
@@ -11,16 +11,16 @@ REGISTER_URLHANDLER("/", InfoHandler);
 bool InfoHandler::HandleRequest(
 	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
 
 	if (url->GetPath().size() > 2)
 		return false;
@@ -73,27 +73,27 @@ bool InfoHandler::HandleRequest(
 			{ "results", new Array({ result1 }) }
 		});
 
-		HttpUtility::SendJsonBody(response, params, result);
+		response.SendJsonBody(result, request.IsPretty());
 	} else {
 		response.set(http::field::content_type, "text/html");
 
-		String body = "<html><head><title>Icinga 2</title></head><h1>Hello from Icinga 2 (Version: " + Application::GetAppVersion() + ")!</h1>";
-		body += "<p>You are authenticated as <b>" + user->GetName() + "</b>. ";
+		auto & body = response.body();
+		body << "<html><head><title>Icinga 2</title></head><h1>Hello from Icinga 2 (Version: "
+			<< Application::GetAppVersion() << ")!</h1>"
+			<< "<p>You are authenticated as <b>" << user->GetName() << "</b>. ";
 
 		if (!permInfo.empty()) {
-			body += "Your user has the following permissions:</p> <ul>";
+			body << "Your user has the following permissions:</p> <ul>";
 
 			for (const String& perm : permInfo) {
-				body += "<li>" + perm + "</li>";
+				body << "<li>" << perm << "</li>";
 			}
 
-			body += "</ul>";
+			body << "</ul>";
 		} else
-			body += "Your user does not have any permissions.</p>";
+			body << "Your user does not have any permissions.</p>";
 
-		body += R"(<p>More information about API requests is available in the <a href="https://icinga.com/docs/icinga2/latest/" target="_blank">documentation</a>.</p></html>)";
-		response.body() = body;
-		response.content_length(response.body().size());
+		body << R"(<p>More information about API requests is available in the <a href="https://icinga.com/docs/icinga2/latest/" target="_blank">documentation</a>.</p></html>)";
 	}
 
 	return true;

--- a/lib/remote/infohandler.hpp
+++ b/lib/remote/infohandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/infohandler.hpp
+++ b/lib/remote/infohandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/mallocinfohandler.cpp
+++ b/lib/remote/mallocinfohandler.cpp
@@ -19,11 +19,9 @@ REGISTER_URLHANDLER("/v1/debug/malloc_info", MallocInfoHandler);
 
 bool MallocInfoHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream&,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context&,
-	HttpServerConnection&
+	boost::asio::yield_context&
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/mallocinfohandler.cpp
+++ b/lib/remote/mallocinfohandler.cpp
@@ -20,16 +20,17 @@ REGISTER_URLHANDLER("/v1/debug/malloc_info", MallocInfoHandler);
 bool MallocInfoHandler::HandleRequest(
 	const WaitGroup::Ptr&,
 	AsioTlsStream&,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context&,
 	HttpServerConnection&
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
+	auto params = request.Params();
 
 	if (url->GetPath().size() != 3) {
 		return false;
@@ -42,7 +43,7 @@ bool MallocInfoHandler::HandleRequest(
 	FilterUtility::CheckPermission(user, "debug");
 
 #ifndef HAVE_MALLOC_INFO
-	HttpUtility::SendJsonError(response, params, 501, "malloc_info(3) not available.");
+	response.SendJsonError(params, 501, "malloc_info(3) not available.");
 #else /* HAVE_MALLOC_INFO */
 	char* buf = nullptr;
 	size_t bufSize = 0;
@@ -87,8 +88,7 @@ bool MallocInfoHandler::HandleRequest(
 
 	response.result(200);
 	response.set(http::field::content_type, "application/xml");
-	response.body() = std::string(buf, bufSize);
-	response.content_length(response.body().size());
+	response.body() << std::string_view(buf, bufSize);
 #endif /* HAVE_MALLOC_INFO */
 
 	return true;

--- a/lib/remote/mallocinfohandler.hpp
+++ b/lib/remote/mallocinfohandler.hpp
@@ -15,11 +15,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/mallocinfohandler.hpp
+++ b/lib/remote/mallocinfohandler.hpp
@@ -14,11 +14,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/modifyobjecthandler.cpp
+++ b/lib/remote/modifyobjecthandler.cpp
@@ -15,11 +15,9 @@ REGISTER_URLHANDLER("/v1/objects", ModifyObjectHandler);
 
 bool ModifyObjectHandler::HandleRequest(
 	const WaitGroup::Ptr& waitGroup,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/modifyobjecthandler.hpp
+++ b/lib/remote/modifyobjecthandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/modifyobjecthandler.hpp
+++ b/lib/remote/modifyobjecthandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -1,6 +1,8 @@
 /* Icinga 2 | (c) 2012 Icinga GmbH | GPLv2+ */
 
 #include "remote/objectqueryhandler.hpp"
+#include "base/generator.hpp"
+#include "base/json.hpp"
 #include "remote/httputility.hpp"
 #include "remote/filterutility.hpp"
 #include "base/serializer.hpp"
@@ -9,6 +11,7 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <set>
 #include <unordered_map>
+#include <memory>
 
 using namespace icinga;
 
@@ -144,6 +147,16 @@ bool ObjectQueryHandler::HandleRequest(
 		return true;
 	}
 
+	if(umetas){
+		ObjectLock olock(umetas);
+		for (String meta : umetas) {
+			if (!(meta == "used_by" || meta == "location")) {
+				response.SendJsonError(params, 400, "Invalid field specified for meta: " + meta);
+				return true;
+			}
+		}
+	}
+
 	bool allJoins = request.GetLastParameter("all_joins");
 
 	params->Set("type", type->GetName());
@@ -164,9 +177,6 @@ bool ObjectQueryHandler::HandleRequest(
 			DiagnosticInformation(ex));
 		return true;
 	}
-
-	ArrayData results;
-	results.reserve(objs.size());
 
 	std::set<String> joinAttrs;
 	std::set<String> userJoinAttrs;
@@ -193,14 +203,21 @@ bool ObjectQueryHandler::HandleRequest(
 	std::unordered_map<Type*, std::pair<bool, std::unique_ptr<Expression>>> typePermissions;
 	std::unordered_map<Object*, bool> objectAccessAllowed;
 
-	for (ConfigObject::Ptr obj : objs) {
+	auto it = objs.begin();
+	auto generatorFunc = [&]() -> std::optional<Value> {
+		if (it == objs.end()) {
+			return std::nullopt;
+		}
+
+		ConfigObject::Ptr obj = *it;
+		++it;
+
 		DictionaryData result1{
 			{ "name", obj->GetName() },
 			{ "type", obj->GetReflectionType()->GetName() }
 		};
 
 		DictionaryData metaAttrs;
-
 		if (umetas) {
 			ObjectLock olock(umetas);
 			for (String meta : umetas) {
@@ -216,9 +233,6 @@ bool ObjectQueryHandler::HandleRequest(
 					}
 				} else if (meta == "location") {
 					metaAttrs.emplace_back("location", obj->GetSourceLocation());
-				} else {
-					response.SendJsonError(request.Params(), 400, "Invalid field specified for meta: " + meta);
-					return true;
 				}
 			}
 		}
@@ -228,8 +242,12 @@ bool ObjectQueryHandler::HandleRequest(
 		try {
 			result1.emplace_back("attrs", SerializeObjectAttrs(obj, String(), uattrs, false, false));
 		} catch (const ScriptError& ex) {
-			response.SendJsonError(request.Params(), 400, ex.what());
-			return true;
+			return new Dictionary{
+				{"type", type->GetName()},
+				{"name", obj->GetName()},
+				{"code", 400},
+				{"status", ex.what()}
+			};
 		}
 
 		DictionaryData joins;
@@ -238,17 +256,7 @@ bool ObjectQueryHandler::HandleRequest(
 			Object::Ptr joinedObj;
 			int fid = type->GetFieldId(joinAttr);
 
-			if (fid < 0) {
-				response.SendJsonError(request.Params(), 400, "Invalid field specified for join: " + joinAttr);
-				return true;
-			}
-
 			Field field = type->GetFieldInfo(fid);
-
-			if (!(field.Attributes & FANavigation)) {
-				response.SendJsonError(request.Params(), 400, "Not a joinable field: " + joinAttr);
-				return true;
-			}
 
 			joinedObj = obj->NavigateField(fid);
 
@@ -303,22 +311,28 @@ bool ObjectQueryHandler::HandleRequest(
 			try {
 				joins.emplace_back(prefix, SerializeObjectAttrs(joinedObj, prefix, ujoins, true, allJoins));
 			} catch (const ScriptError& ex) {
-				response.SendJsonError(request.Params(), 400, ex.what());
-				return true;
+				return new Dictionary{
+					{"type", type->GetName()},
+					{"name", obj->GetName()},
+					{"code", 400},
+					{"status", ex.what()}
+				};
 			}
 		}
 
 		result1.emplace_back("joins", new Dictionary(std::move(joins)));
 
-		results.push_back(new Dictionary(std::move(result1)));
-	}
-
-	Dictionary::Ptr result = new Dictionary({
-		{ "results", new Array(std::move(results)) }
-	});
+		return new Dictionary{std::move(result1)};
+	};
 
 	response.result(http::status::ok);
-	response.SendJsonBody(result, request.IsPretty());
+	response.set(http::field::content_type, "application/json");
+	response.StartStreaming();
+
+	Dictionary::Ptr results = new Dictionary{{"results", new ValueGenerator{generatorFunc}}};
+	results->Freeze();
+
+	response.GetJsonEncoder(request.IsPretty()).Encode(results, &yc);
 
 	return true;
 }

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -90,11 +90,9 @@ Dictionary::Ptr ObjectQueryHandler::SerializeObjectAttrs(const Object::Ptr& obje
 
 bool ObjectQueryHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/objectqueryhandler.hpp
+++ b/lib/remote/objectqueryhandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 
 private:

--- a/lib/remote/objectqueryhandler.hpp
+++ b/lib/remote/objectqueryhandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/statushandler.cpp
+++ b/lib/remote/statushandler.cpp
@@ -70,11 +70,9 @@ public:
 
 bool StatusHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/statushandler.hpp
+++ b/lib/remote/statushandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/statushandler.hpp
+++ b/lib/remote/statushandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/templatequeryhandler.cpp
+++ b/lib/remote/templatequeryhandler.cpp
@@ -77,11 +77,9 @@ public:
 
 bool TemplateQueryHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/templatequeryhandler.hpp
+++ b/lib/remote/templatequeryhandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/templatequeryhandler.hpp
+++ b/lib/remote/templatequeryhandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/typequeryhandler.cpp
+++ b/lib/remote/typequeryhandler.cpp
@@ -48,11 +48,9 @@ public:
 
 bool TypeQueryHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/typequeryhandler.cpp
+++ b/lib/remote/typequeryhandler.cpp
@@ -49,16 +49,17 @@ public:
 bool TypeQueryHandler::HandleRequest(
 	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
+	auto params = request.Params();
 
 	if (url->GetPath().size() > 3)
 		return false;
@@ -84,7 +85,7 @@ bool TypeQueryHandler::HandleRequest(
 	try {
 		objs = FilterUtility::GetFilterTargets(qd, params, user);
 	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
+		response.SendJsonError(params, 404,
 			"No objects found.",
 			DiagnosticInformation(ex));
 		return true;
@@ -151,7 +152,7 @@ bool TypeQueryHandler::HandleRequest(
 	});
 
 	response.result(http::status::ok);
-	HttpUtility::SendJsonBody(response, params, result);
+	response.SendJsonBody(result, request.IsPretty());
 
 	return true;
 }

--- a/lib/remote/typequeryhandler.hpp
+++ b/lib/remote/typequeryhandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/typequeryhandler.hpp
+++ b/lib/remote/typequeryhandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -59,16 +59,17 @@ public:
 bool VariableQueryHandler::HandleRequest(
 	const WaitGroup::Ptr&,
 	AsioTlsStream& stream,
-	const ApiUser::Ptr& user,
-	boost::beast::http::request<boost::beast::http::string_body>& request,
-	const Url::Ptr& url,
-	boost::beast::http::response<boost::beast::http::string_body>& response,
-	const Dictionary::Ptr& params,
+	const HttpRequest& request,
+	HttpResponse& response,
 	boost::asio::yield_context& yc,
 	HttpServerConnection& server
 )
 {
 	namespace http = boost::beast::http;
+
+	auto url = request.Url();
+	auto user = request.User();
+	auto params = request.Params();
 
 	if (url->GetPath().size() > 3)
 		return false;
@@ -91,7 +92,7 @@ bool VariableQueryHandler::HandleRequest(
 	try {
 		objs = FilterUtility::GetFilterTargets(qd, params, user, "variable");
 	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
+		response.SendJsonError(params, 404,
 			"No variables found.",
 			DiagnosticInformation(ex));
 		return true;
@@ -115,7 +116,7 @@ bool VariableQueryHandler::HandleRequest(
 	});
 
 	response.result(http::status::ok);
-	HttpUtility::SendJsonBody(response, params, result);
+	response.SendJsonBody(result, request.IsPretty());
 
 	return true;
 }

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -58,11 +58,9 @@ public:
 
 bool VariableQueryHandler::HandleRequest(
 	const WaitGroup::Ptr&,
-	AsioTlsStream& stream,
 	const HttpRequest& request,
 	HttpResponse& response,
-	boost::asio::yield_context& yc,
-	HttpServerConnection& server
+	boost::asio::yield_context& yc
 )
 {
 	namespace http = boost::beast::http;

--- a/lib/remote/variablequeryhandler.hpp
+++ b/lib/remote/variablequeryhandler.hpp
@@ -15,11 +15,9 @@ public:
 
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
-		AsioTlsStream& stream,
 		const HttpRequest& request,
 		HttpResponse& response,
-		boost::asio::yield_context& yc,
-		HttpServerConnection& server
+		boost::asio::yield_context& yc
 	) override;
 };
 

--- a/lib/remote/variablequeryhandler.hpp
+++ b/lib/remote/variablequeryhandler.hpp
@@ -16,11 +16,8 @@ public:
 	bool HandleRequest(
 		const WaitGroup::Ptr& waitGroup,
 		AsioTlsStream& stream,
-		const ApiUser::Ptr& user,
-		boost::beast::http::request<boost::beast::http::string_body>& request,
-		const Url::Ptr& url,
-		boost::beast::http::response<boost::beast::http::string_body>& response,
-		const Dictionary::Ptr& params,
+		const HttpRequest& request,
+		HttpResponse& response,
 		boost::asio::yield_context& yc,
 		HttpServerConnection& server
 	) override;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,7 +87,10 @@ set(base_test_SOURCES
   icinga-notification.cpp
   icinga-perfdata.cpp
   methods-pluginnotificationtask.cpp
+  remote-sslcert-fixture.cpp
   remote-configpackageutility.cpp
+  remote-httpserverconnection.cpp
+  remote-httpmessage.cpp
   remote-url.cpp
   ${base_OBJS}
   $<TARGET_OBJECTS:config>
@@ -271,6 +274,30 @@ add_boost_test(base
     icinga_perfdata/parse_edgecases
     icinga_perfdata/empty_warn_crit_min_max
     methods_pluginnotificationtask/truncate_long_output
+    remote_certs/setup_certs
+    remote_certs/cleanup_certs
+    remote_httpmessage/request_parse
+    remote_httpmessage/request_params
+    remote_httpmessage/response_flush_nothrow
+    remote_httpmessage/response_body_reader
+    remote_httpmessage/response_write_empty
+    remote_httpmessage/response_write_fixed
+    remote_httpmessage/response_write_chunked
+    remote_httpmessage/response_sendjsonbody
+    remote_httpmessage/response_sendjsonerror
+    remote_httpserverconnection/expect_100_continue
+    remote_httpserverconnection/bad_request
+    remote_httpserverconnection/error_access_control
+    remote_httpserverconnection/error_accept_header
+    remote_httpserverconnection/error_authenticate_cn
+    remote_httpserverconnection/error_authenticate_passwd
+    remote_httpserverconnection/error_authenticate_wronguser
+    remote_httpserverconnection/error_authenticate_wrongpasswd
+    remote_httpserverconnection/reuse_connection
+    remote_httpserverconnection/wg_abort
+    remote_httpserverconnection/client_shutdown
+    remote_httpserverconnection/handler_throw
+    remote_httpserverconnection/liveness_disconnect
     remote_configpackageutility/ValidateName
     remote_url/id_and_path
     remote_url/parameters
@@ -278,6 +305,43 @@ add_boost_test(base
     remote_url/format
     remote_url/illegal_legal_strings
 )
+
+if(BUILD_TESTING)
+  set_tests_properties(
+    base-remote_httpmessage/request_parse
+    base-remote_httpmessage/request_params
+    base-remote_httpmessage/response_flush_nothrow
+    base-remote_httpmessage/response_body_reader
+    base-remote_httpmessage/response_write_empty
+    base-remote_httpmessage/response_write_fixed
+    base-remote_httpmessage/response_write_chunked
+    base-remote_httpmessage/response_sendjsonbody
+    base-remote_httpmessage/response_sendjsonerror
+    base-remote_httpserverconnection/expect_100_continue
+    base-remote_httpserverconnection/bad_request
+    base-remote_httpserverconnection/error_access_control
+    base-remote_httpserverconnection/error_accept_header
+    base-remote_httpserverconnection/error_authenticate_cn
+    base-remote_httpserverconnection/error_authenticate_passwd
+    base-remote_httpserverconnection/error_authenticate_wronguser
+    base-remote_httpserverconnection/error_authenticate_wrongpasswd
+    base-remote_httpserverconnection/reuse_connection
+    base-remote_httpserverconnection/wg_abort
+    base-remote_httpserverconnection/client_shutdown
+    base-remote_httpserverconnection/handler_throw
+    base-remote_httpserverconnection/liveness_disconnect
+    PROPERTIES FIXTURES_REQUIRED ssl_certs)
+
+  set_tests_properties(
+    base-remote_certs/setup_certs
+    PROPERTIES FIXTURES_SETUP ssl_certs
+  )
+
+  set_tests_properties(
+    base-remote_certs/cleanup_certs
+    PROPERTIES FIXTURES_CLEANUP ssl_certs
+  )
+endif()
 
 if(ICINGA2_WITH_LIVESTATUS)
   set(livestatus_test_SOURCES

--- a/test/base-configuration-fixture.hpp
+++ b/test/base-configuration-fixture.hpp
@@ -1,0 +1,50 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#ifndef CONFIGURATION_FIXTURE_H
+#define CONFIGURATION_FIXTURE_H
+
+#include "base/configuration.hpp"
+#include <boost/filesystem.hpp>
+#include <BoostTestTargetConfig.h>
+
+namespace icinga {
+
+struct ConfigurationDataDirFixture
+{
+	ConfigurationDataDirFixture() : m_DataDir(boost::filesystem::current_path() / "data"), m_PrevDataDir(Configuration::DataDir.GetData())
+	{
+		Configuration::DataDir = m_DataDir.string();
+		boost::filesystem::create_directories(m_DataDir);
+	}
+
+	~ConfigurationDataDirFixture()
+	{
+		boost::filesystem::remove_all(m_DataDir);
+		Configuration::DataDir = m_PrevDataDir.string();
+	}
+
+	boost::filesystem::path m_DataDir;
+	boost::filesystem::path m_PrevDataDir;
+};
+
+struct ConfigurationCacheDirFixture
+{
+	ConfigurationCacheDirFixture() : m_CacheDir(boost::filesystem::current_path() / "data"), m_PrevCacheDir(Configuration::CacheDir.GetData())
+	{
+		Configuration::CacheDir = m_CacheDir.string();
+		boost::filesystem::create_directories(m_CacheDir);
+	}
+
+	~ConfigurationCacheDirFixture()
+	{
+		boost::filesystem::remove_all(m_CacheDir);
+		Configuration::CacheDir = m_PrevCacheDir.string();
+	}
+
+	boost::filesystem::path m_CacheDir;
+	boost::filesystem::path m_PrevCacheDir;
+};
+
+} // namespace icinga
+
+#endif // CONFIGURATION_FIXTURE_H

--- a/test/base-testloggerfixture.hpp
+++ b/test/base-testloggerfixture.hpp
@@ -1,0 +1,91 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#ifndef TEST_LOGGER_FIXTURE_H
+#define TEST_LOGGER_FIXTURE_H
+
+#include "base/logger.hpp"
+#include <boost/test/test_tools.hpp>
+#include <boost/regex.hpp>
+#include <future>
+#include <BoostTestTargetConfig.h>
+
+namespace icinga {
+
+class TestLogger : public Logger
+{
+public:
+	DECLARE_PTR_TYPEDEFS(TestLogger);
+
+	struct Expect
+	{
+		std::string pattern;
+		std::promise<bool> prom;
+		std::shared_future<bool> crutch;
+	};
+
+	auto ExpectLogPattern(const std::string& pattern, const std::chrono::milliseconds& timeout = std::chrono::seconds(0))
+	{
+		std::unique_lock lock(m_Mutex);
+		for (const auto & logEntry : m_LogEntries) {
+			if (boost::regex_match(logEntry.Message.GetData(), boost::regex(pattern))) {
+				return boost::test_tools::assertion_result{true};
+			}
+		}
+
+		if (timeout == std::chrono::seconds(0)) {
+			return boost::test_tools::assertion_result{false};
+		}
+
+		auto prom = std::promise<bool>();
+		auto fut = prom.get_future().share();
+		m_Expects.emplace_back(Expect{pattern, std::move(prom), fut});
+		lock.unlock();
+
+		auto status = fut.wait_for(timeout);
+		boost::test_tools::assertion_result ret{status == std::future_status::ready && fut.get()};
+		ret.message() << "Pattern \"" << pattern << "\" in log within " << timeout.count() << "ms";
+		return ret;
+	}
+
+private:
+	void ProcessLogEntry(const LogEntry& entry) override
+	{
+		std::unique_lock lock(m_Mutex);
+		m_LogEntries.push_back(entry);
+
+		m_Expects.erase(std::remove_if(m_Expects.begin(), m_Expects.end(), [&entry](Expect& expect) {
+			if (boost::regex_match(entry.Message.GetData(), boost::regex(expect.pattern))) {
+				expect.prom.set_value(true);
+				return true;
+			}
+			return false;
+		}), m_Expects.end());
+	}
+
+	void Flush() override {}
+
+	std::mutex m_Mutex;
+	std::vector<Expect> m_Expects;
+	std::vector<LogEntry> m_LogEntries;
+};
+
+struct TestLoggerFixture
+{
+	TestLoggerFixture()
+	{
+		testLogger->SetSeverity(testLogger->SeverityToString(LogDebug));
+		testLogger->Activate(true);
+		testLogger->SetActive(true);
+	}
+
+	auto ExpectLogPattern(const std::string& pattern, const std::chrono::milliseconds& timeout = std::chrono::seconds(0))
+	{
+		return testLogger->ExpectLogPattern(pattern, timeout);
+	}
+
+	TestLogger::Ptr testLogger = new TestLogger;
+};
+
+} // namespace icinga
+
+#endif // TEST_LOGGER_FIXTURE_H

--- a/test/base-tlsstream-fixture.hpp
+++ b/test/base-tlsstream-fixture.hpp
@@ -1,0 +1,105 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#ifndef TLSSTREAM_FIXTURE_H
+#define TLSSTREAM_FIXTURE_H
+
+#include "remote-sslcert-fixture.hpp"
+#include "base/tlsstream.hpp"
+#include "base/io-engine.hpp"
+#include <future>
+#include <BoostTestTargetConfig.h>
+
+namespace icinga {
+
+/**
+ * Creates a pair of TLS Streams on a random unused port.
+ */
+struct TlsStreamFixture: CertificateFixture
+{
+	TlsStreamFixture()
+	{
+		using namespace boost::asio::ip;
+		using handshake_type = boost::asio::ssl::stream_base::handshake_type;
+
+		auto serverCert = EnsureCertFor("server");
+		auto clientCert = EnsureCertFor("client");
+
+		auto& serverIoContext = IoEngine::Get().GetIoContext();
+
+		clientSslContext = SetupSslContext(clientCert.crtFile, clientCert.keyFile,
+			m_CaCrtFile.string(), "", DEFAULT_TLS_CIPHERS, DEFAULT_TLS_PROTOCOLMIN, DebugInfo());
+		client = Shared<AsioTlsStream>::Make(IoEngine::Get().GetIoContext(), *clientSslContext);
+
+		serverSslContext = SetupSslContext(serverCert.crtFile, serverCert.keyFile,
+			m_CaCrtFile.string(), "", DEFAULT_TLS_CIPHERS, DEFAULT_TLS_PROTOCOLMIN, DebugInfo());
+		server = Shared<AsioTlsStream>::Make(serverIoContext, *serverSslContext);
+
+		std::promise<void> p;
+
+		tcp::acceptor acceptor{serverIoContext, tcp::endpoint{address_v4::loopback(), 0}};
+		acceptor.listen();
+		acceptor.async_accept(server->lowest_layer(), [&, this](const boost::system::error_code& ec) {
+			if (ec) {
+				BOOST_TEST_MESSAGE("Server Accept Error: " + ec.message());
+				return;
+			}
+			server->next_layer().async_handshake(handshake_type::server, [&, this](const boost::system::error_code& ec) {
+				if (ec) {
+					BOOST_TEST_MESSAGE("Server Handshake Error: " + ec.message());
+					return;
+				}
+
+				p.set_value();
+			});
+		});
+
+		boost::system::error_code ec;
+		if (client->lowest_layer().connect(acceptor.local_endpoint(), ec)) {
+			BOOST_TEST_MESSAGE("Client Connect error: " + ec.message());
+		}
+
+		if (client->next_layer().handshake(handshake_type::client, ec)) {
+			BOOST_TEST_MESSAGE("Client Handshake error: " + ec.message());
+		}
+		if (!client->next_layer().IsVerifyOK()) {
+			BOOST_TEST_MESSAGE("Verify failed for connection");
+			throw;
+		}
+
+		p.get_future().wait();
+	}
+
+	auto Shutdown(const Shared<AsioTlsStream>::Ptr& stream, std::optional<boost::asio::yield_context> yc = {})
+	{
+		boost::system::error_code ec;
+		if (yc) {
+			stream->next_layer().async_shutdown((*yc)[ec]);
+		}
+		else{
+			stream->next_layer().shutdown(ec);
+		}
+#if BOOST_VERSION < 107000
+		/* On boost versions < 1.70, the end-of-file condition was propagated as an error,
+		 * even in case of a successful shutdown. This is information can be found in the
+		 * changelog for the boost Asio 1.14.0 / Boost 1.70 release.
+		 */
+		if (ec == boost::asio::error::eof) {
+			BOOST_TEST_MESSAGE("Shutdown completed successfully with 'boost::asio::error::eof'.");
+			return boost::test_tools::assertion_result{true};
+		}
+#endif
+		boost::test_tools::assertion_result ret{!ec};
+		ret.message() << "Error: " << ec.message();
+		return ret;
+	}
+
+	Shared<boost::asio::ssl::context>::Ptr clientSslContext;
+	Shared<AsioTlsStream>::Ptr client;
+
+	Shared<boost::asio::ssl::context>::Ptr serverSslContext;
+	Shared<AsioTlsStream>::Ptr server;
+};
+
+} // namespace icinga
+
+#endif // TLSSTREAM_FIXTURE_H

--- a/test/icingaapplication-fixture.cpp
+++ b/test/icingaapplication-fixture.cpp
@@ -26,6 +26,8 @@ void IcingaApplicationFixture::InitIcingaApplication()
 
 IcingaApplicationFixture::~IcingaApplicationFixture()
 {
+	BOOST_TEST_MESSAGE("Uninitializing Application...");
+	Application::UninitializeBase();
 	IcingaApplication::GetInstance().reset();
 }
 

--- a/test/remote-httpmessage.cpp
+++ b/test/remote-httpmessage.cpp
@@ -1,0 +1,258 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "test/base-tlsstream-fixture.hpp"
+#include "remote/httpmessage.hpp"
+#include "base/base64.hpp"
+#include "base/json.hpp"
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+using namespace boost::beast;
+
+BOOST_FIXTURE_TEST_SUITE(remote_httpmessage, TlsStreamFixture)
+
+BOOST_AUTO_TEST_CASE(request_parse)
+{
+	http::request<boost::beast::http::string_body> requestOut;
+	requestOut.method(http::verb::get);
+	requestOut.target("https://localhost:5665/v1/test");
+	requestOut.set(http::field::authorization, "Basic " + Base64::Encode("invalid:invalid"));
+	requestOut.set(http::field::accept, "application/json");
+	requestOut.set(http::field::connection, "close");
+	requestOut.content_length(0);
+
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		boost::beast::flat_buffer buf;
+		HttpRequest request(server);
+		server->async_fill(yc);
+		BOOST_REQUIRE_NO_THROW(request.ParseHeader(buf, yc));
+
+		for (auto & field : requestOut.base()) {
+			BOOST_REQUIRE(request.count(field.name()));
+		}
+
+		request.ParseBody(buf, yc);
+
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::write(*client, requestOut);
+	client->flush();
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(request_params)
+{
+	HttpRequest request(client);
+	request.body() = JsonEncode(new Dictionary{{"test1", false}, {"test2", true}});
+	request.target("https://localhost:1234/v1/test?test1=1&test3=0&test3=1");
+	request.DecodeParams();
+
+	BOOST_REQUIRE(!request.Params()->Get("test2").IsObjectType<Array>());
+	BOOST_REQUIRE(request.Params()->Get("test2").IsBoolean());
+	BOOST_REQUIRE(request.Params()->Get("test2").ToBool());
+	BOOST_REQUIRE(request.Params()->Get("test1").IsObjectType<Array>());
+	BOOST_REQUIRE(request.GetLastParameter("test1"));
+	BOOST_REQUIRE(request.Params()->Get("test3").IsObjectType<Array>());
+	BOOST_REQUIRE(request.GetLastParameter("test3"));
+}
+
+BOOST_AUTO_TEST_CASE(response_body_reader)
+{
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+		response.result(http::status::ok);
+		response.StartStreaming();
+
+		SerializableBody<boost::beast::multi_buffer>::reader rd{response.base(), response.body()};
+		boost::system::error_code ec;
+		rd.init(3, ec);
+		BOOST_REQUIRE(!ec);
+
+		boost::asio::const_buffer seq1("test1", 5);
+		rd.put(seq1, ec);
+		BOOST_REQUIRE(!ec);
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		boost::asio::const_buffer seq2("test2", 5);
+		rd.put(seq2, ec);
+		BOOST_REQUIRE(!ec);
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		rd.finish(ec);
+		BOOST_REQUIRE(!ec);
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::response_parser<http::string_body> parser;
+	flat_buffer buf;
+	http::read(*client, buf, parser);
+
+	BOOST_REQUIRE_EQUAL(parser.get().result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(parser.get().chunked(), true);
+	BOOST_REQUIRE_EQUAL(parser.get().body(), "test1test2");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(response_flush_nothrow)
+{
+	auto& io = IoEngine::Get();
+	std::promise<void> done;
+
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+		response.result(http::status::ok);
+
+		server->lowest_layer().close();
+
+		boost::beast::error_code ec;
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc[ec]));
+		BOOST_REQUIRE_EQUAL(ec, boost::system::errc::bad_file_descriptor);
+
+		done.set_value();
+	});
+
+	auto status = done.get_future().wait_for(std::chrono::seconds(1));
+
+	BOOST_REQUIRE(status == std::future_status::ready);
+}
+
+BOOST_AUTO_TEST_CASE(response_write_empty)
+{
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+		response.result(http::status::ok);
+
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::response_parser<http::string_body> parser;
+	flat_buffer buf;
+	http::read(*client, buf, parser);
+
+	BOOST_REQUIRE_EQUAL(parser.get().result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(parser.get().chunked(), false);
+	BOOST_REQUIRE_EQUAL(parser.get().body(), "");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(response_write_fixed)
+{
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+		response.result(http::status::ok);
+		response.body() << "test";
+
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::response_parser<http::string_body> parser;
+	flat_buffer buf;
+	http::read(*client, buf, parser);
+
+	BOOST_REQUIRE_EQUAL(parser.get().result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(parser.get().chunked(), false);
+	BOOST_REQUIRE_EQUAL(parser.get().body(), "test");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(response_write_chunked)
+{
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+		response.result(http::status::ok);
+
+		response.StartStreaming();
+		response.body() << "test" << 1;
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		response.body() << "test" << 2;
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		response.body() << "test" << 3;
+		response.body().Finish();
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::response_parser<http::string_body> parser;
+	flat_buffer buf;
+	http::read(*client, buf, parser);
+
+	BOOST_REQUIRE_EQUAL(parser.get().result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(parser.get().chunked(), true);
+	BOOST_REQUIRE_EQUAL(parser.get().body(), "test1test2test3");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(response_sendjsonbody)
+{
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+		response.result(http::status::ok);
+
+		response.SendJsonBody(new Dictionary{{"test", 1}});
+
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::response_parser<http::string_body> parser;
+	flat_buffer buf;
+	http::read(*client, buf, parser);
+
+	BOOST_REQUIRE_EQUAL(parser.get().result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(parser.get().chunked(), false);
+	Dictionary::Ptr body = JsonDecode(parser.get().body());
+	BOOST_REQUIRE_EQUAL(body->Get("test"), 1);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(response_sendjsonerror)
+{
+	auto & io = IoEngine::Get();
+	io.SpawnCoroutine(io.GetIoContext(), [&, this](boost::asio::yield_context yc) {
+		HttpResponse response(server);
+
+		// This has to be overwritten in SendJsonError.
+		response.result(http::status::ok);
+
+		response.SendJsonError(404, "Not found.");
+
+		BOOST_REQUIRE_NO_THROW(response.Flush(yc));
+		BOOST_REQUIRE(Shutdown(server, yc));
+	});
+
+	http::response_parser<http::string_body> parser;
+	flat_buffer buf;
+	http::read(*client, buf, parser);
+
+	BOOST_REQUIRE_EQUAL(parser.get().result(), http::status::not_found);
+	BOOST_REQUIRE_EQUAL(parser.get().chunked(), false);
+	Dictionary::Ptr body = JsonDecode(parser.get().body());
+	BOOST_REQUIRE_EQUAL(body->Get("error"), 404);
+	BOOST_REQUIRE_EQUAL(body->Get("status"), "Not found.");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/remote-httpserverconnection.cpp
+++ b/test/remote-httpserverconnection.cpp
@@ -1,0 +1,489 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "base-tlsstream-fixture.hpp"
+#include "icingaapplication-fixture.hpp"
+#include "base-testloggerfixture.hpp"
+#include "base/base64.hpp"
+#include "base/json.hpp"
+#include "remote/httphandler.hpp"
+#include <boost/beast/http.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/container/flat_set.hpp>
+#include <boost/version.hpp>
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+using namespace boost::beast;
+// using namespace boost::unit_test;
+using namespace boost::unit_test_framework;
+
+struct HttpServerConnectionFixture : TlsStreamFixture,
+									 IcingaApplicationFixture,
+									 ConfigurationCacheDirFixture,
+									 TestLoggerFixture
+{
+	HttpServerConnection::Ptr conn;
+	StoppableWaitGroup::Ptr wg;
+
+	HttpServerConnectionFixture()
+		: wg(new StoppableWaitGroup)
+	{
+	}
+
+	static void CreateApiListener()
+	{
+		ScriptGlobal::Set("NodeName", "server");
+		ApiListener::Ptr listener = new ApiListener;
+		listener->OnConfigLoaded();
+		listener->SetAccessControlAllowOrigin(new Array{"127.0.0.1"});
+	}
+
+	static void CreateTestUsers()
+	{
+		ApiUser::Ptr user = new ApiUser;
+		user->SetName("client");
+		user->SetClientCN("client");
+		user->SetPermissions(new Array{"*"});
+		user->Register();
+
+		user = new ApiUser;
+		user->SetName("test");
+		user->SetPassword("test");
+		user->SetPermissions(new Array{"*"});
+		user->Register();
+	}
+
+	void SetupHttpServerConnection(bool authenticated)
+	{
+		String identity = authenticated ? "client" : "invalid";
+		conn = new HttpServerConnection(wg, identity, authenticated, server);
+		conn->Start();
+	}
+
+	template <class Rep, class Period>
+	bool AssertServerDisconnected(const std::chrono::duration<Rep, Period>& timeout)
+	{
+		auto iterations = timeout / std::chrono::milliseconds(50);
+		for(std::size_t i=0; i<iterations && !conn->Disconnected(); i++){
+			Utility::Sleep(std::chrono::duration<double>(timeout).count()/iterations);
+		}
+		return conn->Disconnected();
+	}
+};
+
+class UnitTestHandler final: public HttpHandler
+{
+
+	bool HandleRequest(const WaitGroup::Ptr& waitGroup, const HttpRequest& request, HttpResponse& response,
+		boost::asio::yield_context& yc) override
+	{
+		response.result(boost::beast::http::status::ok);
+
+		if (request.GetLastParameter("stream")) {
+			response.StartStreaming();
+			response.Flush(yc);
+			for (;;) {
+				response.body() << "test";
+				response.Flush(yc);
+			}
+
+			return true;
+		}
+
+		if (request.GetLastParameter("throw")) {
+			response.StartStreaming();
+			response.body() << "test";
+			response.Flush(yc);
+			throw std::runtime_error{"The front fell off"};
+		}
+
+		response.body() << "test";
+		return true;
+	}
+};
+
+REGISTER_URLHANDLER("/v1/test", UnitTestHandler);
+
+BOOST_FIXTURE_TEST_SUITE(remote_httpserverconnection, HttpServerConnectionFixture)
+
+BOOST_AUTO_TEST_CASE(expect_100_continue)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.version(11);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::expect, "100-continue");
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::request_serializer<http::string_body> sr(request);
+	http::write_header(*client, sr);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::continue_);
+
+	http::write(*client, sr);
+	client->flush();
+
+	http::read(*client, buf, response);
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(bad_request)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.version(12);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::bad_request);
+	BOOST_REQUIRE_NE(response.body().find("<h1>Bad Request</h1>"), std::string::npos);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(error_access_control)
+{
+	CreateTestUsers();
+	CreateApiListener();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::options);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::origin, "127.0.0.1");
+	request.set(http::field::access_control_request_method, "GET");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "Preflight OK");
+
+	boost::container::flat_set<std::string> sv;
+	boost::container::flat_set options{"GET", "POST", "PUT", "DELETE", "PUSH"};
+
+	BOOST_REQUIRE_NE(response[http::field::access_control_allow_methods], "");
+	BOOST_REQUIRE_NE(response[http::field::access_control_allow_headers], "");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(error_accept_header)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::post);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "text/html");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::bad_request);
+	BOOST_REQUIRE_EQUAL(response.body(), "<h1>Accept header is missing or not set to 'application/json'.</h1>\r\n");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(error_authenticate_cn)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(error_authenticate_passwd)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(false);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::authorization, "Basic " + Base64::Encode("test:test"));
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(error_authenticate_wronguser)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(false);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::authorization, "Basic " + Base64::Encode("invalid:invalid"));
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::unauthorized);
+	Dictionary::Ptr body = JsonDecode(response.body());
+	BOOST_REQUIRE(body);
+	BOOST_REQUIRE_EQUAL(body->Get("error"), 401);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(error_authenticate_wrongpasswd)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(false);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::authorization, "Basic " + Base64::Encode("test:invalid"));
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::unauthorized);
+	Dictionary::Ptr body = JsonDecode(response.body());
+	BOOST_REQUIRE(body);
+	BOOST_REQUIRE_EQUAL(body->Get("error"), 401);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(reuse_connection)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "application/json");
+	request.keep_alive(true);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	http::read(*client, buf, response);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	request.keep_alive(false);
+	http::write(*client, request);
+	client->flush();
+
+	response.body() = "";
+	http::read(*client, buf, response);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	BOOST_REQUIRE(AssertServerDisconnected(std::chrono::seconds(5)));
+	BOOST_REQUIRE(Shutdown(client));
+	BOOST_REQUIRE(ExpectLogPattern("HTTP client disconnected .*", std::chrono::seconds(5)));
+}
+
+BOOST_AUTO_TEST_CASE(wg_abort)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "application/json");
+	request.keep_alive(true);
+	http::write(*client, request);
+	client->flush();
+
+	wg->Join();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	boost::system::error_code ec;
+	http::read(*client, buf, response, ec);
+
+	BOOST_REQUIRE_EQUAL(response.version(), 11);
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	if (!ec) {
+		/* Sometimes the call to read above already catches the end_of_stream error, sometimes
+		 * it stops just shy of that byte and we'll want to do another dummy read to catch it
+		 * here.
+		 */
+		http::read(*client, buf, response, ec);
+	}
+	BOOST_REQUIRE_EQUAL(ec, boost::system::error_code{boost::beast::http::error::end_of_stream});
+
+	BOOST_REQUIRE(AssertServerDisconnected(std::chrono::seconds(5)));
+	BOOST_REQUIRE(Shutdown(client));
+	BOOST_REQUIRE(ExpectLogPattern("HTTP client disconnected .*", std::chrono::seconds(5)));
+}
+
+BOOST_AUTO_TEST_CASE(client_shutdown)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "application/json");
+	request.keep_alive(true);
+
+	/* Instruct the test HttpHandler defined above to stream an endless response.
+	 */
+	request.body() = JsonEncode(new Dictionary{{"stream", true}});
+	request.prepare_payload();
+	http::write(*client, request);
+	client->flush();
+
+	/* Unlike the other test cases we don't require success here, because with the request
+	 * above, UnitTestHandler simulates a HttpHandler that is constantly writing.
+	 * That will cause the shutdown to fail on the client-side with "application data after
+	 * close notify", but the important part is that HttpServerConnection actually closes
+	 * the connection on its own side, which we check with the BOOST_REQUIRE() below.
+	 */
+	BOOST_WARN(Shutdown(client));
+
+	BOOST_REQUIRE(AssertServerDisconnected(std::chrono::seconds(5)));
+	BOOST_REQUIRE(ExpectLogPattern("HTTP client disconnected.*", std::chrono::seconds(5)));
+	BOOST_REQUIRE(ExpectLogPattern("Detected shutdown from client: .*"));
+}
+
+BOOST_AUTO_TEST_CASE(handler_throw)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("https://localhost:5665/v1/test");
+	request.set(http::field::accept, "application/json");
+	request.keep_alive(true);
+
+	/* Instruct the test TestHandler to throw an exception while streaming, which the
+	 * HttpHandler base should propagate up to HttpServerConnection.
+	 * The correct response is to shutdown the connection instead of trying to send a JSON
+	 * error message.
+	 */
+	request.body() = JsonEncode(new Dictionary{{"throw", true}});
+	request.prepare_payload();
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response_parser<http::string_body> parser;
+	boost::system::error_code ec;
+	http::read(*client, buf, parser, ec);
+
+	/* Since the handler threw in the middle of sending the message we shouldn't be able
+	 * to read a complete message here.
+	 */
+	BOOST_REQUIRE_EQUAL(ec, boost::system::error_code{boost::beast::http::error::partial_message});
+
+	/* The body should only contain the single "test" the handler has written, without any
+	 * attempts made to additionally write some json error message.
+	 */
+	BOOST_REQUIRE_EQUAL(parser.get().body(), "test");
+
+	/* We then expect the server to initiate a shutdown, which we then complete below.
+	 */
+	BOOST_REQUIRE(AssertServerDisconnected(std::chrono::seconds(5)));
+	BOOST_REQUIRE(Shutdown(client));
+	BOOST_REQUIRE(ExpectLogPattern("HTTP client disconnected.*", std::chrono::seconds(5)));
+	BOOST_REQUIRE(ExpectLogPattern("Exception while processing HTTP request from .+?: The front fell off"));
+}
+
+BOOST_AUTO_TEST_CASE(liveness_disconnect)
+{
+	SetupHttpServerConnection(false);
+
+	BOOST_REQUIRE(AssertServerDisconnected(std::chrono::seconds(11)));
+	BOOST_REQUIRE(ExpectLogPattern("HTTP client disconnected .*"));
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/remote-sslcert-fixture.cpp
+++ b/test/remote-sslcert-fixture.cpp
@@ -1,0 +1,26 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "remote-sslcert-fixture.hpp"
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+const boost::filesystem::path CertificateFixture::m_PersistentCertsDir = boost::filesystem::current_path() / "persistent" / "certs";
+
+BOOST_AUTO_TEST_SUITE(remote_certs)
+
+BOOST_FIXTURE_TEST_CASE(setup_certs, ConfigurationDataDirFixture)
+{
+	if (boost::filesystem::exists(CertificateFixture::m_PersistentCertsDir)) {
+		boost::filesystem::remove_all(CertificateFixture::m_PersistentCertsDir);
+	}
+}
+
+BOOST_FIXTURE_TEST_CASE(cleanup_certs, ConfigurationDataDirFixture)
+{
+	if (boost::filesystem::exists(CertificateFixture::m_PersistentCertsDir)) {
+		boost::filesystem::remove_all(CertificateFixture::m_PersistentCertsDir);
+	}
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/remote-sslcert-fixture.hpp
+++ b/test/remote-sslcert-fixture.hpp
@@ -1,0 +1,71 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#ifndef SSLCERT_FIXTURE_H
+#define SSLCERT_FIXTURE_H
+
+#include "remote/apilistener.hpp"
+#include "remote/pkiutility.hpp"
+#include "test/base-configuration-fixture.hpp"
+#include <BoostTestTargetConfig.h>
+
+namespace icinga{
+
+struct CertificateFixture: ConfigurationDataDirFixture
+{
+	CertificateFixture()
+	{
+		namespace fs = boost::filesystem;
+
+		m_CaDir = ApiListener::GetCaDir();
+		m_CertsDir = ApiListener::GetCertsDir();
+		m_CaCrtFile = m_CertsDir / "ca.crt";
+
+		fs::create_directories(m_PersistentCertsDir / "ca");
+		fs::create_directories(m_PersistentCertsDir / "certs");
+
+		if (fs::exists(m_DataDir / "ca")) {
+			fs::remove(m_DataDir / "ca");
+		}
+		if (fs::exists(m_DataDir / "certs")) {
+			fs::remove(m_DataDir / "certs");
+		}
+
+		fs::create_directory_symlink(m_PersistentCertsDir / "certs", m_DataDir / "certs");
+		fs::create_directory_symlink(m_PersistentCertsDir / "ca", m_DataDir / "ca");
+
+		if (!fs::exists(m_CaCrtFile)) {
+			PkiUtility::NewCa();
+			fs::copy_file(m_CaDir / "ca.crt", m_CaCrtFile);
+		}
+	}
+
+	auto EnsureCertFor(const std::string& name)
+	{
+		struct
+		{
+			String crtFile;
+			String keyFile;
+			String csrFile;
+		} cert;
+
+		cert.crtFile = (m_CertsDir/(name + ".crt")).string();
+		cert.keyFile = (m_CertsDir/(name + ".key")).string();
+		cert.csrFile = (m_CertsDir/(name + ".csr")).string();
+
+		if (!Utility::PathExists(cert.crtFile)) {
+			PkiUtility::NewCert(name, cert.keyFile, cert.csrFile, cert.crtFile);
+			PkiUtility::SignCsr(cert.csrFile, cert.crtFile);
+		}
+
+		return cert;
+	}
+
+	boost::filesystem::path m_CaDir;
+	boost::filesystem::path m_CertsDir;
+	boost::filesystem::path m_CaCrtFile;
+	static const boost::filesystem::path m_PersistentCertsDir;
+};
+
+} // namespace icinga
+
+#endif // SSLCERT_FIXTURE_H


### PR DESCRIPTION
This PR is a work in progress. It fixes #10142 and is a step towards #10409.

This is based on the improvements to @yhabteab's improvements to the JSON encoder in #10414.

# Description

- Added a new class `HttpRequest` that incorporates all of the derived data, like the authenticated user, url and parameters, that the handlers need, so the don't have to be passed as individual arguments, as per the suggestion in #10142.
- Added the new class `HttpResponse`, supported by a new custom message body type that makes it easy to use the `boost::beast::http::serializer` to start sending some responses with chunked encoding, before the complete data and `content_length` information is available.
- These classes derive from the respective `boost::beast:message` types and are usable in functions that require these types.
- In regard to the HttpHandler interface parameters, this leaves only the `WaitGroup`, the request and response objects and the `yield_context` being passed to the handlers.
- To support seamless disconnect in `EventsHandler` but without adding a solution specific to it (like StartStreaming did previously), I've added a third coroutine to `HttpServerConnection` that waits for the stream to be shut down by the remote side and then initiates a `Disconnect()`.
- I added unit-tests for `HttpServerConnection`, `HttpRequest` and `HttpResponse`. These add lots of functionality that can be used to extend unit-tests to other components (such as the individual HTTP handlers, JsonRpcConnection, etc.) in the future.

# Todo

- ~~The `EventsHandler` currently still blocks formally disconnecting the connection until the next event is returned by the `EventsInbox`. Before this PR, that was handled in `HttpServerConnection::StartStreaming()` by trying to read from the connection in another coroutine and calling `HttpServerConnection::Disconnect()` when the connection is closed. The handler was still sitting there, but it could simply return when it got the next event while the connection was already disconnected.~~
- ~~The signalling between the coroutines needs some more work. Possibly this can be done more implicitly. Specifically I want to get rid of `HttpResponse::Begin()` and `HttpResponse::Done()`.~~
- ~~Get distros using boost-1.66 (opensuse/leap, rockylinux:8) to build. 1.66 was the first version `boost::beast` was introduced and there are some pesky differences to the interface of the message body implementation needs to satisfy.~~
- ~~Look into adding test-cases for Http(Request|Response) and possibly HttpServerConnection (minimal version without handlers)~~
- **Look at more handlers and see if they can benefit from using these new features.**
- Some other smaller things (cleaning up commits, improving documentation, etc.)