### PR TITLE
Let ipv4-or-ipv6 prefer IPv6 instead of ipv4

### DIFF
--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -5,10 +5,10 @@ template CheckCommand "ipv4-or-ipv6" {
 		var addr_v4 = macro("$address$")
 		var addr_v6 = macro("$address6$")
 
-		if (addr_v4 && !macro("$check_ipv6$") || macro("$check_ipv4$")) {
-			return addr_v4
-		} else {
+		if (addr_v6 && !macro("$check_ipv4$") || macro("$check_ipv6$")) {
 			return addr_v6
+		} else {
+			return addr_v4
 		}
 	}}
 


### PR DESCRIPTION
Previously the magical "ipv4-or-ipv6" CheckCommand template preferred the IPv4 address (`address` field of a Host object) to the IPv6 address (`address6` field of a Host object).

This commit reverses the behaviour to favor IPv6 as it is common among different applications in order to further the transition to IPv6.

This is a breakout PR related to #10494 where the idea originated.

Practically speaking this change will not affect many setups, since the
common enterprise network setup still relies on legacy IP only.
For some setups with dual-stack though this will change the behaviour quite
suddenly although the impact should be inconsiderable and go unnoticed
if the the network setup was done properly.