### PR TITLE
Small code and performance optimizations in `Log` class

### DIFF
--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -27,6 +27,7 @@ template Log& Log::operator<<(const int&);
 template Log& Log::operator<<(const unsigned long&);
 template Log& Log::operator<<(const long&);
 template Log& Log::operator<<(const double&);
+template Log& Log::operator<<(const char*&);
 
 REGISTER_TYPE(Logger);
 
@@ -314,13 +315,4 @@ Log::~Log()
 		WindowsEventLogLogger::WriteToWindowsEventLog(entry);
 	}
 #endif /* _WIN32 */
-}
-
-Log& Log::operator<<(const char *val)
-{
-	if (!m_IsNoOp) {
-		m_Buffer << val;
-	}
-
-	return *this;
 }

--- a/lib/base/logger.cpp
+++ b/lib/base/logger.cpp
@@ -247,21 +247,25 @@ void Logger::UpdateMinLogSeverity()
 Log::Log(LogSeverity severity, String facility, const String& message)
 	: Log(severity, std::move(facility))
 {
-	if (!m_IsNoOp) {
-		m_Buffer << message;
-	}
+	*this << message;
 }
 
 Log::Log(LogSeverity severity, String facility)
-	: m_Severity(severity), m_Facility(std::move(facility)), m_IsNoOp(severity < Logger::GetMinLogSeverity())
-{ }
+{
+	// Only fully initialize the object if it's actually going to be logged.
+	if (severity >= Logger::GetMinLogSeverity()) {
+		m_Severity = severity;
+		m_Facility = std::move(facility);
+		m_Buffer.emplace();
+	}
+}
 
 /**
  * Writes the message to the application's log.
  */
 Log::~Log()
 {
-	if (m_IsNoOp) {
+	if (!m_Buffer) {
 		return;
 	}
 
@@ -271,7 +275,7 @@ Log::~Log()
 	entry.Facility = m_Facility;
 
 	{
-		auto msg (m_Buffer.str());
+		auto msg (m_Buffer->str());
 		msg.erase(msg.find_last_not_of("\n") + 1u);
 
 		entry.Message = std::move(msg);

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -6,6 +6,7 @@
 #include "base/atomic.hpp"
 #include "base/i2-base.hpp"
 #include "base/logger-ti.hpp"
+#include <optional>
 #include <set>
 #include <sstream>
 
@@ -121,8 +122,8 @@ public:
 	template<typename T>
 	Log& operator<<(T&& val)
 	{
-		if (!m_IsNoOp) {
-			m_Buffer << std::forward<T>(val);
+		if (m_Buffer) {
+			*m_Buffer << std::forward<T>(val);
 		}
 
 		return *this;
@@ -131,8 +132,11 @@ public:
 private:
 	LogSeverity m_Severity;
 	String m_Facility;
-	std::ostringstream m_Buffer;
-	bool m_IsNoOp;
+	/**
+	 * Stream for incrementally generating the log message. If the message will be discarded as it's level currently
+	 * isn't logged, it will be empty as the stream doesn't need to be initialized in this case.
+	 */
+	std::optional<std::ostringstream> m_Buffer;
 };
 
 extern template Log& Log::operator<<(const Value&);

--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -119,16 +119,14 @@ public:
 	~Log();
 
 	template<typename T>
-	Log& operator<<(const T& val)
+	Log& operator<<(T&& val)
 	{
 		if (!m_IsNoOp) {
-			m_Buffer << val;
+			m_Buffer << std::forward<T>(val);
 		}
 
 		return *this;
 	}
-
-	Log& operator<<(const char *val);
 
 private:
 	LogSeverity m_Severity;
@@ -146,6 +144,7 @@ extern template Log& Log::operator<<(const int&);
 extern template Log& Log::operator<<(const unsigned long&);
 extern template Log& Log::operator<<(const long&);
 extern template Log& Log::operator<<(const double&);
+extern template Log& Log::operator<<(const char*&);
 
 }
 


### PR DESCRIPTION
There are two pretty much independent commits in this PR:

* ef0bc8366cbdb9a11d44333d6014a231cc93ee31: There were two pretty much identical implementations of `Log::operator<<` so far. One of them was already templated for `const T&`, change this template to `T&&` and `std::forward` so that it can just handle both cases, allowing to remove the duplicate implementation. That should probably already have been done in #10177 instead of fixing the duplicated implementation :sweat_smile:
* 8d74cc631c73c6124cd0c4e85b09d3e77fb79bda: Avoids the overhead of constructing a `std::ostringstream` for log messages that will be discarded by putting it into `std::optional`. Given that `std::optional` already tracks if it contains a value, this also replaces the existing `m_IsNoOp` bool. On my machine, this reduces the time per no-op `Log()` from ~72ns to ~11ns when compiled with `-O2`.

<details>
<summary>Crude patch for benchmarking this</summary>

Adds a quick benchmark to `icinga2 daemon -C`. The explicit call to `UpdateMinLogSeverity()` is necessary as the corresponding value otherwise isn't initialized yet (it's still set to `LogDebug` which circumvents the `m_IsNoOp`/`std::optinal` optimiziation).

```diff
diff --git a/lib/base/logger.hpp b/lib/base/logger.hpp
index d7f30bcee..b2238a0de 100644
--- a/lib/base/logger.hpp
+++ b/lib/base/logger.hpp
@@ -94,9 +94,10 @@ protected:
        void Start(bool runtimeCreated) override;
        void Stop(bool runtimeRemoved) override;
 
-private:
+public:
        static void UpdateMinLogSeverity();
 
+private:
        static std::mutex m_Mutex;
        static std::set<Logger::Ptr> m_Loggers;
        static bool m_ConsoleLogEnabled;
diff --git a/lib/cli/daemoncommand.cpp b/lib/cli/daemoncommand.cpp
index 3a9ce8c0a..39a26a2cd 100644
--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -658,6 +658,16 @@ int DaemonCommand::Run(const po::variables_map& vm, const std::vector<std::strin
                }
 
                Log(LogInformation, "cli", "Finished validating the configuration file(s).");
+
+               Logger::UpdateMinLogSeverity();
+               auto start = std::chrono::steady_clock::now();
+               constexpr int iter = 1000000;
+               for (int i = 0; i < iter; ++i) {
+                       Log(LogDebug, "test") << i;
+               }
+               auto nsPerOp = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - start).count() / iter;
+               Log(LogCritical, "LogBenchmark") << nsPerOp << "ns/op";
+
                return EXIT_SUCCESS;
        }
 
```

</details>

ref/IP/59145 (This PR is not supposed to solve it, profiling there just showed the `std::ostringstream` constructor to be surprisingly expensive, sparking the idea for this PR.)