### PR TITLE
Disable GitHub Actions for tests for the doc/ path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,10 +1,14 @@
 name: Docker image
 
 on:
-  pull_request: {}
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'doc/**'
   release:
     types:
       - published

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'support/*'
-  pull_request: {}
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 concurrency:
   group: linux-${{ github.event_name == 'push' && github.sha || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
       - 'support/*'
-  pull_request: {}
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 
 concurrency:
   group: windows-${{ github.event_name == 'push' && github.sha || github.ref }}


### PR DESCRIPTION
While opening some PR for the docs I noticed a lot of GH Actions started. Since changes in the documentation do not affect the code, it might make sense to not trigger all Actions.

https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-excluding-paths

Just a suggestion.