### PR TITLE
Change ElasticsearchWriter to write perfdata as an array of objects

### DIFF
--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -369,7 +369,15 @@ attribute.
 Metric values are stored like this:
 
 ```
-check_result.perfdata.<perfdata-label>.value
+check_result.perfdata: [
+ {
+   "crit": 0,
+   "label": "example",
+   "min": 0,
+   "value": 0,
+   "warn": 0
+ }
+]
 ```
 
 The following characters are escaped in perfdata labels:
@@ -387,14 +395,7 @@ add more subsequent levels inside the tree.
 and is therefore replaced by `.`.
 
 Icinga 2 automatically adds the following threshold metrics
-if existing:
-
-```
-check_result.perfdata.<perfdata-label>.min
-check_result.perfdata.<perfdata-label>.max
-check_result.perfdata.<perfdata-label>.warn
-check_result.perfdata.<perfdata-label>.crit
-```
+if existing: min, max, warn, crit
 
 Additionally it is possible to configure custom tags that are applied to the metrics via `host_tags_template` or `service_tags_template`.
 Depending on whether the write event was triggered on a service or host object, additional tags are added to the ElasticSearch entries.

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -189,6 +189,9 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 
 	if (perfdata) {
 		ObjectLock olock(perfdata);
+
+		Array::Ptr perfdatapoints = new Array();
+
 		for (const Value& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 
@@ -212,22 +215,28 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 			boost::replace_all(escapedKey, "\\", "_");
 			boost::algorithm::replace_all(escapedKey, "::", ".");
 
-			String perfdataPrefix = prefix + "perfdata." + escapedKey;
+			Dictionary::Ptr datapoint = new Dictionary();
 
-			fields->Set(perfdataPrefix + ".value", pdv->GetValue());
+			datapoint->Set("label", escapedKey);
+			datapoint->Set("value", pdv->GetValue());
 
 			if (!pdv->GetMin().IsEmpty())
-				fields->Set(perfdataPrefix + ".min", pdv->GetMin());
+				datapoint->Set("min", pdv->GetMin());
 			if (!pdv->GetMax().IsEmpty())
-				fields->Set(perfdataPrefix + ".max", pdv->GetMax());
+				datapoint->Set("max", pdv->GetMax());
 			if (!pdv->GetWarn().IsEmpty())
-				fields->Set(perfdataPrefix + ".warn", pdv->GetWarn());
+				datapoint->Set("warn", pdv->GetWarn());
 			if (!pdv->GetCrit().IsEmpty())
-				fields->Set(perfdataPrefix + ".crit", pdv->GetCrit());
+				datapoint->Set("crit", pdv->GetCrit());
 
 			if (!pdv->GetUnit().IsEmpty())
-				fields->Set(perfdataPrefix + ".unit", pdv->GetUnit());
+				datapoint->Set("unit", pdv->GetUnit());
+
+			perfdatapoints->Add(datapoint);
 		}
+
+		String perfdataPrefix = prefix + "perfdata";
+		fields->Set(perfdataPrefix, std::move(perfdatapoints));
 	}
 }
 


### PR DESCRIPTION
Hi,

Let me preface this PR with: I'm not a C++ developer. So please excuse my C++, tried my best, feedback is welcome.

Prior to this change the ElasticsearchWriter created a new field for every metric in check command. This leads to a vast number of fields in the indices, aka a field mapping explosion.

Now, it uses an array of objects. This avoids the explosion, Makes the index fields more predictable when searching and Makes the perfdata independently searchable.

How the new output looks like:

```json
          "check_result.latency": 0.0007982254028320313,
          "check_result.output": "LOAD OK - total load average: 1.84, 1.77, 2.27",
          "check_result.perfdata": [
            {
              "crit": 10,
              "label": "load1",
              "min": 0,
              "value": 1.84,
              "warn": 5
            },
            {
              "crit": 6,
              "label": "load5",
              "min": 0,
              "value": 1.77,
              "warn": 4
            },
            {
              "crit": 4,
              "label": "load15",
              "min": 0,
              "value": 2.27,
              "warn": 3
            }
          ],
          "check_result.schedule_end": "2025-07-24T10:05:52.877+0000",
          "check_result.schedule_start": "2025-07-24T10:05:52.870+0000",
```

Fixes #10511 