### PR TITLE
Add a .clang-format file implementing the Icinga 2 style guide

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,147 @@
+---
+# As per the style-guide we base our settings on the LLVM style. This is closer
+# than any of the other options, but there are more conventions that differ from
+# it than the style-guide suggests.
+BasedOnStyle: LLVM
+
+# Default LLVM puts access modifiers (public: etc.) at an offset of -2, meaning
+# in the middle between the indentation level of the class and the class members.
+# A setting of -4 puts them at the same level as class definitions.
+AccessModifierOffset: -4
+
+# We don't want to align function parameters or arguments with the open bracket
+# but instead always just add a level of indentation.
+AlignAfterOpenBracket: BlockIndent
+
+# Mostly relevant for formatting preprocessor macros so that all backslashes align.
+AlignEscapedNewlines: LeftWithLastLine
+
+# Needed so assignments and if conditions don't get aligned if they're multi-line.
+# AlignOperands: DontAlign
+
+# We try to avoid having all parameters of a function declaration on a single line
+# Together with 'BinPackParameters' and 'PenaltyReturnTypeOnItsOwnLine' this leads
+# to function signatures being either all on one line, or split by argument like a
+# list.
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# Put simple getters/setters in class bodies on a single line.
+AllowShortFunctionsOnASingleLine: InlineOnly
+
+# If necessary to break function calls, preferably put each argument on its own line.
+BinPackArguments: false
+
+# If necessary to break function signatures, preferably put each parameter on its own line.
+BinPackParameters: false
+
+# Does not work with assignments. It breaks the value up and aligns it to the right.
+# BreakBeforeBinaryOperators: All
+
+# Brace-wrapping settings. Mostly should resemble BreakBeforebraces: Mozilla with a few
+# changes, mostly regarding empty classes.
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# Sets clang-format up to use the BraceWrapping setting above.
+BreakBeforeBraces: Custom
+
+# When template parameter declarations are split into multiple lines this will put
+# the closing '>' on its own line, much like the parens for a declaration list.
+BreakBeforeTemplateCloser: true
+
+# Template declarations are always on their own line.
+BreakTemplateDeclarations: Yes
+
+# Convention
+ColumnLimit: 120
+
+# Includes are sorted according to the style guide, with the additional requirement
+# from Boost.Test that the header including the test framework must go first.
+IncludeCategories:
+  - Regex: ^(<|")BoostTestTargetConfig.h
+    Priority: 1
+    CaseSensitive: false
+  - Regex: ^"(base|config|icinga|perfdata|remote|test)/
+    Priority: 2
+    CaseSensitive: false
+  - Regex: ^<boost/
+    Priority: 3
+    CaseSensitive: false
+  - Regex: ^<
+    Priority: 4
+    CaseSensitive: false
+
+# Convention
+IndentCaseLabels: true
+IndentWidth: 4
+
+# Adds braces to if/else/while blocks if they don't have one yet.
+# This is required by the current version of the style-guide.
+InsertBraces: true
+
+# This makes code like dispatching with std::visit() more bearable by keeping
+# the lambda signature on the same line with the function call and not indenting
+# the lambda body itself.
+# NOTE: This makes calls where the lambda comes after several arguments a bit
+#       more ugly, but every alternative is worse.
+# LambdaBodyIndentation: OuterScope
+
+# Break Constructor initializers to one per line (if they have to be broken up).
+PackConstructorInitializers: CurrentLine
+
+# We really want to avoid breaking assignments if we can avoid it.
+# This, together with 'BinPackArguments' leads to clang-format rather breaking at
+# constructor calls with each argument on its own line, like we want.
+PenaltyBreakAssignment: 2000
+
+# We never want to break up foo::bar.
+PenaltyBreakScopeResolution: 100000
+
+# We allow log message shift operators to start on the next line.
+PenaltyBreakFirstLessLess: 0
+
+# We usually don't want to go above the 120 column-width limit, but it's ok if the
+# alternative is worse. A setting of 500 means in relation to PenaltyIndentedWhitespace
+# that two characters over the limit are equal to one level of indentation.
+# This takes it into account that it's worse if a function call with many arguments is
+# split, than if it's only one argument that's wrapped around to the next line.
+PenaltyExcessCharacter: 20
+
+# This is needed together with 'PenaltyBreakFirstLessLess' for our preferred formatting
+# of log messages.
+PenaltyIndentedWhitespace: 10
+
+# We absolutely never want the return type on its own line.
+# Together with 'AllowAllParametersOfDeclarationOnNextLine' and 'BinPackParameters'
+# This makes it so that function signatures are always either on one line or split
+# line by line per argument.
+PenaltyReturnTypeOnItsOwnLine: 50000
+
+# Convention
+PointerAlignment: Left
+ReferenceAlignment: Left
+SpaceAfterTemplateKeyword: false
+TabWidth: 4
+UseTab: Always
+
+# This only works for matching tokens, as in parsing tokens. Matching any syntactic
+# characters is not supported. Currently we use this mostly to circumvent reformatting
+# Boost.Test's weird bullet point syntax for unit-test decorators.
+OneLineFormatOffRegex: (BOOST_FIXTURE_TEST_SUITE|BOOST_AUTO_TEST_SUITE|BOOST_FIXTURE_TEST_CASE|BOOST_AUTO_TEST_CASE|unit_test|CTestProperties|RequiresCertificate)

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,46 @@
+Checks: >
+  *,
+  -fuchsia-*,
+  -llvmlibc-*,
+  -altera-unroll-loops,
+  -altera-struct-pack-align,
+  -bugprone-narrowing-conversions,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-empty-catch,
+  -bugprone-suspicious-include,
+  -cert-err58-cpp,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -google-build-using-namespace,
+  -google-default-arguments,
+  -google-readability-braces-around-statements,
+  -google-readability-todo,
+  -google-runtime-int,
+  -hicpp-braces-around-statements,
+  -hicpp-named-parameter,
+  -hicpp-no-array-decay,
+  -hicpp-uppercase-literal-suffix,
+  -llvm-include-order,
+  -misc-non-private-member-variables-in-classes,
+  -misc-use-anonymous-namespace,
+  -modernize-use-trailing-return-type,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-implicit-bool-conversion,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-uppercase-literal-suffix
+
+CheckOptions:
+  - key:   modernize-use-override.AllowOverrideAndFinal
+    value: 'true'
+  - key:   readability-braces-around-statements.ShortStatementLines
+    value: '2'
+  - key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
+    value: 'true'

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,36 @@
+name: clang-format
+
+on:
+  pull_request: {}
+
+jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install clang-format
+        run: pip install 'clang-format==21.1.8'
+
+      - name: Check formatting of added and changed lines
+        run: |
+          if ! git-clang-format --quiet --diff --extensions c,h,cpp,hpp \
+            "$(git merge-base HEAD^1 HEAD^2)" HEAD^2 > clang-format.diff
+          then
+            cat <<'EOF' >&2
+          The lines added or changed by this pull request don't follow the Icinga 2
+          style guide. To fix this, install clang-format 21 and run the following on
+          your branch, then review and commit the result:
+
+            git clang-format --extensions c,h,cpp,hpp "$(git merge-base HEAD master)"
+
+          Don't hesitate to ask us for help if necessary.
+          EOF
+            cat clang-format.diff >&2
+            exit 1
+          fi

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request: {}
   release:
     types:
       - published

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'support/*'
-  pull_request: {}
 
 concurrency:
   group: linux-${{ github.event_name == 'push' && github.sha || github.ref }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'support/*'
-  pull_request: {}
 
 concurrency:
   group: windows-${{ github.event_name == 'push' && github.sha || github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Except those related to git and vagrant
 !.git*
+!.clang-format
 !.puppet*
 !.travis.yml
 !.mailmap

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Except those related to git and vagrant
 !.git*
 !.clang-format
+!.clang-tidy
 !.puppet*
 !.travis.yml
 !.mailmap

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -41,7 +41,7 @@ JsonRpcConnection::JsonRpcConnection(const WaitGroup::Ptr& waitGroup, const Stri
 	: m_Identity(identity), m_Authenticated(authenticated), m_Stream(stream), m_Role(role),
 	m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_IoStrand(io),
 	m_OutgoingMessagesQueued(io), m_WriterDone(io), m_ShuttingDown(false), m_WaitGroup(waitGroup),
-	m_CheckLivenessTimer(io), m_HeartbeatTimer(io)
+	m_CheckLivenessTimer(io), m_HeartbeatTimer(io) 
 {
 	if (authenticated)
 		m_Endpoint = Endpoint::GetByName(identity);


### PR DESCRIPTION
This adds my current `.clang-format` file to the project.

This tries to make a compromise between the style recommended by the style guide as well as the observed conventions in our code that sometimes (often) clash with the style guide. It's also a compromise between what `clang-format` can do and what I would consider ideal.

The file is fully commented so I'll not detail every setting and decision in the description here.

Bonus: I've added my current `.clang-tidy` file as well, but for quite some time I've only subtracted settings that seemed annoying, non-applicable to our code or duplicates, so this is still very opinionated at this point.