### PR TITLE
Prevent worst-case exponential complexity in dependency evaluation

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -3097,6 +3097,12 @@ via the [REST API](12-icinga2-api.md#icinga2-api).
 > Reachability calculation depends on fresh and processed check results. If dependencies
 > disable checks for child objects, this won't work reliably.
 
+> **Note**
+>
+> The parent of a dependency can have a parent itself and so on. The nesting depth of
+> dependencies is currently limited to 256 which should be more than enough for any practical
+> use. This is an implementation detail and may change in the future.
+
 ### Implicit Dependencies for Services on Host <a id="dependencies-implicit-host-service"></a>
 
 Icinga 2 automatically adds an implicit dependency for services on their host. That way

--- a/lib/base/object.cpp
+++ b/lib/base/object.cpp
@@ -201,14 +201,14 @@ Value icinga::GetPrototypeField(const Value& context, const String& field, bool 
 }
 
 #ifdef I2_LEAK_DEBUG
-void icinga::TypeAddObject(Object *object)
+void icinga::TypeAddObject(const Object *object)
 {
 	std::unique_lock<std::mutex> lock(l_ObjectCountLock);
 	String typeName = Utility::GetTypeName(typeid(*object));
 	l_ObjectCounts[typeName]++;
 }
 
-void icinga::TypeRemoveObject(Object *object)
+void icinga::TypeRemoveObject(const Object *object)
 {
 	std::unique_lock<std::mutex> lock(l_ObjectCountLock);
 	String typeName = Utility::GetTypeName(typeid(*object));
@@ -239,7 +239,7 @@ INITIALIZE_ONCE([]() {
 });
 #endif /* I2_LEAK_DEBUG */
 
-void icinga::intrusive_ptr_add_ref(Object *object)
+void icinga::intrusive_ptr_add_ref(const Object *object)
 {
 #ifdef I2_LEAK_DEBUG
 	if (object->m_References.fetch_add(1) == 0u)
@@ -249,7 +249,7 @@ void icinga::intrusive_ptr_add_ref(Object *object)
 #endif /* I2_LEAK_DEBUG */
 }
 
-void icinga::intrusive_ptr_release(Object *object)
+void icinga::intrusive_ptr_release(const Object *object)
 {
 	auto previous (object->m_References.fetch_sub(1));
 

--- a/lib/base/object.hpp
+++ b/lib/base/object.hpp
@@ -31,7 +31,8 @@ class ValidationUtils;
 extern const Value Empty;
 
 #define DECLARE_PTR_TYPEDEFS(klass) \
-	typedef intrusive_ptr<klass> Ptr
+	typedef intrusive_ptr<klass> Ptr; \
+	typedef intrusive_ptr<const klass> ConstPtr
 
 #define IMPL_TYPE_LOOKUP_SUPER() 					\
 
@@ -192,7 +193,7 @@ private:
 	Object(const Object& other) = delete;
 	Object& operator=(const Object& rhs) = delete;
 
-	std::atomic<uint_fast64_t> m_References;
+	mutable std::atomic<uint_fast64_t> m_References;
 	mutable std::recursive_mutex m_Mutex;
 
 #ifdef I2_DEBUG
@@ -202,17 +203,17 @@ private:
 
 	friend struct ObjectLock;
 
-	friend void intrusive_ptr_add_ref(Object *object);
-	friend void intrusive_ptr_release(Object *object);
+	friend void intrusive_ptr_add_ref(const Object *object);
+	friend void intrusive_ptr_release(const Object *object);
 };
 
 Value GetPrototypeField(const Value& context, const String& field, bool not_found_error, const DebugInfo& debugInfo);
 
-void TypeAddObject(Object *object);
-void TypeRemoveObject(Object *object);
+void TypeAddObject(const Object *object);
+void TypeRemoveObject(const Object *object);
 
-void intrusive_ptr_add_ref(Object *object);
-void intrusive_ptr_release(Object *object);
+void intrusive_ptr_add_ref(const Object *object);
+void intrusive_ptr_release(const Object *object);
 
 template<typename T>
 class ObjectImpl

--- a/lib/base/shared-object.hpp
+++ b/lib/base/shared-object.hpp
@@ -12,8 +12,8 @@ namespace icinga
 
 class SharedObject;
 
-inline void intrusive_ptr_add_ref(SharedObject *object);
-inline void intrusive_ptr_release(SharedObject *object);
+inline void intrusive_ptr_add_ref(const SharedObject *object);
+inline void intrusive_ptr_release(const SharedObject *object);
 
 /**
  * Seamless and polymorphistic base for any class to create shared pointers of.
@@ -23,8 +23,8 @@ inline void intrusive_ptr_release(SharedObject *object);
  */
 class SharedObject
 {
-	friend void intrusive_ptr_add_ref(SharedObject *object);
-	friend void intrusive_ptr_release(SharedObject *object);
+	friend void intrusive_ptr_add_ref(const SharedObject *object);
+	friend void intrusive_ptr_release(const SharedObject *object);
 
 protected:
 	inline SharedObject() : m_References(0)
@@ -38,15 +38,15 @@ protected:
 	~SharedObject() = default;
 
 private:
-	Atomic<uint_fast64_t> m_References;
+	mutable Atomic<uint_fast64_t> m_References;
 };
 
-inline void intrusive_ptr_add_ref(SharedObject *object)
+inline void intrusive_ptr_add_ref(const SharedObject *object)
 {
 	object->m_References.fetch_add(1);
 }
 
-inline void intrusive_ptr_release(SharedObject *object)
+inline void intrusive_ptr_release(const SharedObject *object)
 {
 	if (object->m_References.fetch_sub(1) == 1u) {
 		delete object;

--- a/lib/base/shared.hpp
+++ b/lib/base/shared.hpp
@@ -16,13 +16,13 @@ template<class T>
 class Shared;
 
 template<class T>
-inline void intrusive_ptr_add_ref(Shared<T> *object)
+inline void intrusive_ptr_add_ref(const Shared<T> *object)
 {
 	object->m_References.fetch_add(1);
 }
 
 template<class T>
-inline void intrusive_ptr_release(Shared<T> *object)
+inline void intrusive_ptr_release(const Shared<T> *object)
 {
 	if (object->m_References.fetch_sub(1) == 1u) {
 		delete object;
@@ -38,11 +38,12 @@ inline void intrusive_ptr_release(Shared<T> *object)
 template<class T>
 class Shared : public T
 {
-	friend void intrusive_ptr_add_ref<>(Shared<T> *object);
-	friend void intrusive_ptr_release<>(Shared<T> *object);
+	friend void intrusive_ptr_add_ref<>(const Shared<T> *object);
+	friend void intrusive_ptr_release<>(const Shared<T> *object);
 
 public:
 	typedef boost::intrusive_ptr<Shared> Ptr;
+	typedef boost::intrusive_ptr<const Shared> ConstPtr;
 
 	/**
 	 * Like std::make_shared, but for this class.
@@ -94,7 +95,7 @@ public:
 	}
 
 private:
-	Atomic<uint_fast64_t> m_References;
+	mutable Atomic<uint_fast64_t> m_References;
 };
 
 }

--- a/lib/icinga/CMakeLists.txt
+++ b/lib/icinga/CMakeLists.txt
@@ -39,7 +39,7 @@ set(icinga_SOURCES
   comment.cpp comment.hpp comment-ti.hpp
   compatutility.cpp compatutility.hpp
   customvarobject.cpp customvarobject.hpp customvarobject-ti.hpp
-  dependency.cpp dependency-group.cpp dependency.hpp dependency-ti.hpp dependency-apply.cpp
+  dependency.cpp dependency-group.cpp dependency-state.cpp dependency.hpp dependency-ti.hpp dependency-apply.cpp
   downtime.cpp downtime.hpp downtime-ti.hpp
   envresolver.cpp envresolver.hpp
   eventcommand.cpp eventcommand.hpp eventcommand-ti.hpp

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -84,7 +84,7 @@ public:
 
 	void AddGroup(const String& name);
 
-	bool IsReachable(DependencyType dt = DependencyState, int rstack = 0) const;
+	bool IsReachable(DependencyType dt = DependencyState) const;
 	bool AffectsChildren() const;
 
 	AcknowledgementType GetAcknowledgement();

--- a/lib/icinga/dependency-state.cpp
+++ b/lib/icinga/dependency-state.cpp
@@ -1,0 +1,114 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "icinga/dependency.hpp"
+#include "icinga/host.hpp"
+#include "icinga/service.hpp"
+
+using namespace icinga;
+
+/**
+ * Construct a helper for evaluating the state of dependencies.
+ *
+ * @param dt Dependency type to check for within the individual methods.
+ */
+DependencyStateChecker::DependencyStateChecker(DependencyType dt)
+	: m_DependencyType(dt)
+{
+}
+
+/**
+ * Checks whether a given checkable is currently reachable.
+ *
+ * @param checkable The checkable to check reachability for.
+ * @param rstack The recursion stack level to prevent infinite recursion, defaults to 0.
+ * @return Whether the given checkable is reachable.
+ */
+bool DependencyStateChecker::IsReachable(Checkable::ConstPtr checkable, int rstack)
+{
+	if (rstack > Dependency::MaxDependencyRecursionLevel) {
+		Log(LogWarning, "Checkable")
+			<< "Too many nested dependencies (>" << Dependency::MaxDependencyRecursionLevel << ") for checkable '"
+			<< checkable->GetName() << "': Dependency failed.";
+
+		return false;
+	}
+
+	/* implicit dependency on host if this is a service */
+	const auto* service = dynamic_cast<const Service*>(checkable.get());
+	if (service && (m_DependencyType == DependencyState || m_DependencyType == DependencyNotification)) {
+		Host::Ptr host = service->GetHost();
+
+		if (host && host->GetState() != HostUp && host->GetStateType() == StateTypeHard) {
+			return false;
+		}
+	}
+
+	for (auto& dependencyGroup : checkable->GetDependencyGroups()) {
+		if (auto state(GetState(dependencyGroup, checkable.get(), rstack + 1)); state != DependencyGroup::State::Ok) {
+			Log(LogDebug, "Checkable")
+				<< "Dependency group '" << dependencyGroup->GetRedundancyGroupName() << "' have failed for checkable '"
+				<< checkable->GetName() << "': Marking as unreachable.";
+
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Retrieve the state of the given dependency group.
+ *
+ * The state of the dependency group is determined based on the state of the parent Checkables and dependency objects
+ * of the group. A dependency group is considered unreachable when none of the parent Checkables is reachable. However,
+ * a dependency group may still be marked as failed even when it has reachable parent Checkables, but an unreachable
+ * group has always a failed state.
+ *
+ * @param group
+ * @param child The child Checkable to evaluate the state for.
+ * @param rstack The recursion stack level to prevent infinite recursion, defaults to 0.
+ *
+ * @return - Returns the state of the current dependency group.
+ */
+DependencyGroup::State DependencyStateChecker::GetState(const DependencyGroup::ConstPtr& group, const Checkable* child, int rstack)
+{
+	using State = DependencyGroup::State;
+
+	auto dependencies(group->GetDependenciesForChild(child));
+	size_t reachable = 0, available = 0;
+
+	for (const auto& dependency : dependencies) {
+		if (IsReachable(dependency->GetParent(), rstack)) {
+			reachable++;
+
+			// Only reachable parents are considered for availability. If they are unreachable and checks are
+			// disabled, they could be incorrectly treated as available otherwise.
+			if (dependency->IsAvailable(m_DependencyType)) {
+				available++;
+			}
+		}
+	}
+
+	if (group->IsRedundancyGroup()) {
+		// The state of a redundancy group is determined by the best state of any parent. If any parent ist reachable,
+		// the redundancy group is reachable, analogously for availability.
+		if (reachable == 0) {
+			return State::Unreachable;
+		} else if (available == 0) {
+			return State::Failed;
+		} else {
+			return State::Ok;
+		}
+	} else {
+		// For dependencies without a redundancy group, dependencies.size() will be 1 in almost all cases. It will only
+		// contain more elements if there are duplicate dependency config objects between two checkables. In this case,
+		// all of them have to be reachable/available as they don't provide redundancy.
+		if (reachable < dependencies.size()) {
+			return State::Unreachable;
+		} else if (available < dependencies.size()) {
+			return State::Failed;
+		} else {
+			return State::Ok;
+		}
+	}
+}

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -250,6 +250,7 @@ public:
 
 private:
 	DependencyType m_DependencyType;
+	std::unordered_map<Checkable::ConstPtr, bool> m_Cache;
 };
 
 }


### PR DESCRIPTION
So far, calling Checkable::IsReachable() traversed all possible paths to it's parents. In case a parent is reachable via multiple paths, all it's parents were evaluated multiple times, result in a worst-case exponential complexity.

With this PR, the implementation keeps track of which checkables were already visited and uses the already-computed reachability instead of repeating the computation, ensuring a worst-case linear runtime within the graph size.

For implementing this, there are two additional commits with preparations for that change:
- Add `T::ConstPtr` as a typedef for `intrusive_ptr<const T>` combined with the necessary changes to support this (changing some functions to accept a `const Object*` instead of an `Object*` as well as marking the reference counter attribute as `mutable`). This was done because `Checkable::IsReachable()` is `const`, i.e. `this` is of type `const Checkable*`, so a `Checkable::Ptr` can't be constructed from it, only the new `Checkable::ConstPtr`.
- The actual implementation of `Checkable::IsReachable()` and `DependencyGroup::GetState()` is moved to a new helper class (the original methods are kept and now transparently call the ones in the helper class), so that they can easily access common storage (i.e. a cache needed for implementing this) without having to explicitly pass the cache through a public interface or having to resort to `thread_local`.

## Test

I've prepared a config file that creates the following dependency graph that is pretty much the worst case for the old implementation. Note that this diagram is reduced to 4 levels, the actual config generates 25 levels, making the issue much more obvious when running the config.

```mermaid
graph TD;
    2-->0;
    2-->1;
    3-->0;
    3-->1;
    4-->2;
    4-->3;
    5-->2;
    5-->3;
    6-->4;
    6-->5;
    7-->4;
    7-->5;
```

<details>
<summary>bobby-little-dependencies.conf</summary>

```
include "/etc/icinga2/icinga2.conf"

var h = "bobby-little-dependencies"
object Host h {
	check_command = "dummy"
}

for (var i in range(25)) { // change this number to scale the depth of the dependency graph
	for (var j in range(2)) {
		var s = 2*i + j 
		object Service s use (h) {
			host_name = h
			check_command = "dummy"
			check_interval = 10s
			retry_interval = 10s
			vars.dummy_text = {{
				log(macro("checking $host.name$!$service.name$"))
			}}
		}
		if (i > 0) {
			for (var k in range(2)) {
				var d = 2*(i-1) + k
				log(String(s) + "-->" + String(d) + ";")
				object Dependency d use (s, d, h) {
					parent_host_name = h
					parent_service_name = d
					child_host_name = h
					child_service_name = s
				}
			}
		}
	}
}
```

</details>

This can easily be started in a container:

```shell
docker run --rm -it -v $(pwd)/bobby-little-dependencies.conf:/icinga2.conf:ro icinga/icinga2:dev icinga2 daemon -c /icinga2.conf
```

### Before

Heavy CPU usage (fluctuating somewhere between 200% and 800% on my machine), checks aren't executed every 10s as configured.

### After

Almost no CPU usage (mostly idle, peaks of around 2% on my machine), regular check execution.

ref/IP/59145
ref/IP/59671