### PR TITLE
Send signals as Icinga user in safe-reload and logrotate

### DIFF
--- a/etc/initsystem/safe-reload.cmake
+++ b/etc/initsystem/safe-reload.cmake
@@ -43,7 +43,7 @@ if [ ! -e "$ICINGA2_PID_FILE" ]; then
 fi
 
 pid=`cat "$ICINGA2_PID_FILE"`
-if ! kill -HUP "$pid" >/dev/null 2>&1; then
+if ! "$DAEMON" internal signal --sig SIGHUP --pid "$pid" >/dev/null 2>&1; then
 	echo "Error: Icinga not running"
 	exit 7
 fi

--- a/etc/logrotate.d/icinga2.cmake
+++ b/etc/logrotate.d/icinga2.cmake
@@ -6,7 +6,7 @@
 	missingok
 	notifempty@LOGROTATE_CREATE@
 	postrotate
-		/bin/kill -USR1 $(cat @ICINGA2_INITRUNDIR@/icinga2.pid 2> /dev/null) 2> /dev/null || true
+		@CMAKE_INSTALL_FULL_SBINDIR@/icinga2 internal signal --sig SIGUSR1 --pid "$(cat @ICINGA2_INITRUNDIR@/icinga2.pid 2> /dev/null)" 2> /dev/null || true
 	endscript
 }
 

--- a/lib/cli/internalsignalcommand.cpp
+++ b/lib/cli/internalsignalcommand.cpp
@@ -57,6 +57,8 @@ int InternalSignalCommand::Run(const boost::program_options::variables_map& vm, 
 		return kill(vm["pid"].as<int>(), SIGCHLD);
 	if (signal == "SIGHUP")
 		return kill(vm["pid"].as<int>(), SIGHUP);
+	if (signal == "SIGUSR1")
+		return kill(vm["pid"].as<int>(), SIGUSR1);
 
 	Log(LogCritical, "cli") << "Unsupported signal \"" << signal << "\"";
 #else


### PR DESCRIPTION
In contrast to the regular `kill` binary, `icinga2 internal signal` drops permissions before sending the signal. This is important as the PID file can be written by the Icinga user, dropping the permissions prevents that user from using this to send signals to processes it is not supposed to signal.

SIGUSR1 wasn't among the list of signals supported by `icinga2 internal signal`, so it is added there.

> [!IMPORTANT]  
> **Mention in changelog:**
> The logrotate config is installed in /etc and may not be updated by a package update in case it was modified.

## Tests

* Installed from this branch, new CMake substitutions worked correctly.
* `systemctl reload icinga2` (and also calling `/usr/lib/icinga2/safe-reload`) still successfully reload Icinga 2.
* Expanded command from the logrotate config worked when manually executing it (triggered the "Received USR1 signal, reopening application logs." log message).
* `icinga2 internal signal` indeed drops privileges (more of a sanity check):
    ```console
    # strace -e getuid,setuid,kill icinga2 internal signal --sig SIGHUP --pid 1
    --- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=2562755, si_uid=0, si_status=0, si_utime=0, si_stime=0} ---
    getuid()                                = 0
    setuid(961)                             = 0
    kill(1, SIGHUP)                         = -1 EPERM (Operation not permitted)
    +++ exited with 255 +++
    ```

fixes #10527