### PR TITLE
Allow UID/GID in ICINGA2_(USER|GROUP) environment variables

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -2334,12 +2334,12 @@ Also see `CMakeLists.txt` for details.
 * `ICINGA2_CONFIGDIR`: Main config directory; defaults to `CMAKE_INSTALL_SYSCONFDIR/icinga2` usually `/etc/icinga2`
 * `ICINGA2_CACHEDIR`: Directory for cache files; defaults to `CMAKE_INSTALL_LOCALSTATEDIR/cache/icinga2` usually `/var/cache/icinga2`
 * `ICINGA2_DATADIR`: Data directory  for the daemon; defaults to `CMAKE_INSTALL_LOCALSTATEDIR/lib/icinga2` usually `/var/lib/icinga2`
-* `ICINGA2_LOGDIR`: Logfiles of the daemon; defaults to `CMAKE_INSTALL_LOCALSTATEDIR/log/icinga2 usually `/var/log/icinga2`
+* `ICINGA2_LOGDIR`: Logfiles of the daemon; defaults to `CMAKE_INSTALL_LOCALSTATEDIR/log/icinga2` usually `/var/log/icinga2`
 * `ICINGA2_SPOOLDIR`: Spooling directory ; defaults to `CMAKE_INSTALL_LOCALSTATEDIR/spool/icinga2` usually `/var/spool/icinga2`
 * `ICINGA2_INITRUNDIR`: Runtime data for the init system; defaults to `CMAKE_INSTALL_LOCALSTATEDIR/run/icinga2` usually `/run/icinga2`
 * `ICINGA2_GIT_VERSION_INFO`: Whether to use Git to determine the version number; defaults to `ON`
-* `ICINGA2_USER`: The user Icinga 2 should run as; defaults to `icinga`
-* `ICINGA2_GROUP`: The group Icinga 2 should run as; defaults to `icinga`
+* `ICINGA2_USER`: The user or user-id Icinga 2 should run as; defaults to `icinga`
+* `ICINGA2_GROUP`: The group or group-id Icinga 2 should run as; defaults to `icinga`
 * `ICINGA2_COMMAND_GROUP`: The command group Icinga 2 should use; defaults to `icingacmd`
 * `ICINGA2_SYSCONFIGFILE`: Where to put the config file the initscript/systemd pulls it's dirs from;
 * defaults to `CMAKE_INSTALL_PREFIX/etc/sysconfig/icinga2`


### PR DESCRIPTION
refs #10307.
Closes #10308.
Closes #10321.

This is the third attempt at a PR that fixes this issue.

The approach in #10308 wasn't enough, because it still required an existing group and didn't allow to drop privileges from root to a user that's not in the database. Also it didn't account for other places that required valid users/groups, mostly the `Utility::SetFileOwnership()` function which is used in the `node setup` command which is especially relevant for containers.

@oxzi's solution in #10321 added a new command line argument that allowed to explicitly bypass dropping the permissions for the given command. This had the advantage over #10308 that it reliably worked for both user and group, but it also didn't allow dropping privileges (which to be fair, was the point) and also didn't account for the Utility function.

My solution allows to specify UID and GID in the `ICINGA2_USER` and `ICINGA2_GROUP` environment variables that override the defaults (corresponding to the same environment variables) set at build time. All the user has to do is additionally set these environment variables to the desired UID/GID combination and everything else should just work as expected. If the process is run as root, privileges should drop to the specified ids, if the process starts with these ids, they're validated against the environment variables and nothing else is done/attempted.

This issue got renewed interest with #10505, where users like me preferred to set custom UIDs/GIDs in their `docker-compose.yml` files for development to easier mount configuration directories. Even with this PR this is not easily possible without the `ARG ICINGA_USER_ID`, because the `/data` directory gets set up with ownership for the `icinga` user and its default UID/GID. But it's at least a step closer and maybe it would work with a mounted and manually set up /data directory.