### PR TITLE
Remove workaround for GCC 4.x

### DIFF
--- a/lib/base/atomic.hpp
+++ b/lib/base/atomic.hpp
@@ -109,7 +109,7 @@ private:
  * @ingroup base
  */
 template <typename T>
-using AtomicOrLocked = typename std::conditional<std::is_trivially_copyable<T>::value, std::atomic<T>, Locked<T>>::type;
+using AtomicOrLocked = std::conditional_t<std::is_trivially_copyable_v<T>, std::atomic<T>, Locked<T>>;
 
 }
 


### PR DESCRIPTION
Just noticed some small room for improvement while looking over another diff in that file:

The fallback implementation was added for GCC 4.x as that didn't yet implement `std::is_trivially_copyable`. However, by now we're using C++17 as our language standard and that wasn't even implemented in GCC 4.x yet[^1]:

> Some C++17 features are available since GCC 5, but support was experimental and the ABI of C++17 features was not stable until GCC 9.

Hence, this became more or less dead code and can be removed.

While at it, I also made use of [`std::conditional_t`](https://en.cppreference.com/w/cpp/types/conditional.html#Helper_types) and [`std::is_trivially_copyable_v`](https://en.cppreference.com/w/cpp/types/is_trivially_copyable.html#Helper_variable_template) available in newer C++ versions, doing the same but more compactly (if you look at their documentation, they are defined as just what we did before).

[^1]: https://gcc.gnu.org/projects/cxx-status.html#cxx17