### PR TITLE
GitHub Actions: remove Ubuntu 24.10 (end of life)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,7 +54,6 @@ jobs:
 
           - ubuntu:22.04
           - ubuntu:24.04
-          - ubuntu:24.10
           - ubuntu:25.04
 
         platform:


### PR DESCRIPTION
That version [went out of support in July 2025](https://ubuntu.com/about/release-cycle) and by now the repos got archived and [causes pipelines to fail](https://github.com/Icinga/icinga2/actions/runs/17671678861/job/50224642536#step:5:25):

```
Err:5 http://security.ubuntu.com/ubuntu oracular-security Release
  404  Not Found [IP: 185.125.190.83 80]
Err:6 http://archive.ubuntu.com/ubuntu oracular Release
  404  Not Found [IP: 185.125.190.36 80]
Err:7 http://archive.ubuntu.com/ubuntu oracular-updates Release
  404  Not Found [IP: 185.125.190.36 80]
Err:8 http://archive.ubuntu.com/ubuntu oracular-backports Release
  404  Not Found [IP: 185.125.190.36 80]
```