### PR TITLE
Fix double-free error in posix_error::what()

### DIFF
--- a/lib/base/exception.hpp
+++ b/lib/base/exception.hpp
@@ -118,12 +118,10 @@ String DiagnosticInformation(const boost::exception_ptr& eptr, bool verbose = tr
 
 class posix_error : virtual public std::exception, virtual public boost::exception {
 public:
-	~posix_error() throw() override;
-
-	const char *what(void) const throw() final;
+	const char* what() const noexcept final;
 
 private:
-	mutable char *m_Message{nullptr};
+	mutable String m_Message;
 };
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes #10557

The issue came up when the directory `/etc/icinga2/features-enabled/` was not accessible, for example because the permissions were changed via `chmod 111 /etc/icinga2/features-enabled`. This then led `Utility::Glob()` to throw a `posix_error` exception, that is then caught in `Expression::Evaluate()` and incorporated into a `ScriptError` as part of a `boost::errinfo_nested_exception`. Somewhere in the rats nest of `boost::exception_ptr` it then gets copied and that's where the issue starts.

`icinga::posix_error` keeps a raw pointer to a message allocated via `strdup()` copying a string::c_str() obtained from a ostringstream::str().

https://github.com/Icinga/icinga2/blob/2063d2bdbc237b32c7cc835340005c3d931e18ce/lib/base/exception.hpp#L119-L127

https://github.com/Icinga/icinga2/blob/2063d2bdbc237b32c7cc835340005c3d931e18ce/lib/base/exception.cpp#L367-L371

Since only the pointer, not the allocated string gets copied, the `posix_error` destructor calls `free()` on that pointer once for each copy.

https://github.com/Icinga/icinga2/blob/2063d2bdbc237b32c7cc835340005c3d931e18ce/lib/base/exception.cpp#L338-L341

Why was this implemented with `free`/`strdup` and not std::string? even if you wanted a pointer, this is why we have copy constructors or better yet smart pointers. Also constructing the string in `what()` without a try/catch block is also pretty terrible.

I've though about better ways to construct this error string, but I didn't have any great ideas how to do it without changing every usage of `posix_error`. This PR fixes the problem and cleans up the code a bit, but I still don't like this is done in what(). There should be some `SetMessageFromErrinfo()` or something, but that wouldn't work elegantly with boost's `operator<<`.