### PR TITLE
Fix overdue state doesn't account for timeperiods in HA cluster

### DIFF
--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -136,16 +136,13 @@ void CheckerComponent::CheckThreadProc()
 
 		bool forced = checkable->GetForceNextCheck();
 		bool check = true;
-		bool notifyNextCheck = false;
 		double nextCheck = -1;
 
 		if (!forced) {
 			if (!checkable->IsReachable(DependencyCheckExecution)) {
 				Log(LogNotice, "CheckerComponent")
 					<< "Skipping check for object '" << checkable->GetName() << "': Dependency failed.";
-
 				check = false;
-				notifyNextCheck = true;
 			}
 
 			Host::Ptr host;
@@ -182,7 +179,6 @@ void CheckerComponent::CheckThreadProc()
 						<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", nextCheck);
 
 					check = false;
-					notifyNextCheck = true;
 				}
 			}
 		}
@@ -199,11 +195,6 @@ void CheckerComponent::CheckThreadProc()
 					<< "Checks for checkable '" << checkable->GetName() << "' are disabled. Rescheduling check.";
 
 				checkable->UpdateNextCheck();
-			}
-
-			if (notifyNextCheck) {
-				// Trigger update event for Icinga DB
-				Checkable::OnNextCheckUpdated(checkable);
 			}
 
 			lock.lock();

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -56,6 +56,9 @@ void CheckerComponent::OnConfigLoaded()
 	Checkable::OnNextCheckChanged.connect([this](const Checkable::Ptr& checkable, const Value&) {
 		NextCheckChangedHandler(checkable);
 	});
+	Checkable::OnRescheduleCheck.connect([this](const Checkable::Ptr& checkable, double nextCheck) {
+		NextCheckChangedHandler(checkable, nextCheck);
+	});
 }
 
 void CheckerComponent::Start(bool runtimeCreated)
@@ -333,7 +336,7 @@ CheckableScheduleInfo CheckerComponent::GetCheckableScheduleInfo(const Checkable
 	return csi;
 }
 
-void CheckerComponent::NextCheckChangedHandler(const Checkable::Ptr& checkable)
+void CheckerComponent::NextCheckChangedHandler(const Checkable::Ptr& checkable, double nextCheck)
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);
 
@@ -348,7 +351,13 @@ void CheckerComponent::NextCheckChangedHandler(const Checkable::Ptr& checkable)
 
 	idx.erase(checkable);
 
-	CheckableScheduleInfo csi = GetCheckableScheduleInfo(checkable);
+	CheckableScheduleInfo csi;
+	if (nextCheck < 0) {
+		csi = GetCheckableScheduleInfo(checkable);
+	} else {
+		csi.NextCheck = nextCheck;
+		csi.Object = checkable;
+	}
 	idx.insert(csi);
 
 	m_CV.notify_all();

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -72,7 +72,7 @@ void CheckerComponent::Start(bool runtimeCreated)
 	m_Thread = std::thread([this]() { CheckThreadProc(); });
 
 	m_ResultTimer = Timer::Create();
-	m_ResultTimer->SetInterval(5);
+	m_ResultTimer->SetInterval(m_ResultTimerInterval);
 	m_ResultTimer->OnTimerExpired.connect([this](const Timer * const&) { ResultTimerHandler(); });
 	m_ResultTimer->Start();
 }
@@ -375,4 +375,19 @@ unsigned long CheckerComponent::GetPendingCheckables()
 	std::unique_lock<std::mutex> lock(m_Mutex);
 
 	return m_PendingCheckables.size();
+}
+
+/**
+ * Sets the interval in seconds for the result timer.
+ *
+ * The result timer periodically logs the number of pending and idle checkables
+ * as well as the checks per second rate. The default interval is 5 seconds.
+ *
+ * Note, this method must be called before the component is started to have an effect on the timer.
+ *
+ * @param interval Interval in seconds for the result timer.
+ */
+void CheckerComponent::SetResultTimerInterval(double interval)
+{
+	m_ResultTimerInterval = interval;
 }

--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -205,13 +205,10 @@ void CheckerComponent::CheckThreadProc()
 			continue;
 		}
 
-
-		csi = GetCheckableScheduleInfo(checkable);
-
 		Log(LogDebug, "CheckerComponent")
 			<< "Scheduling info for checkable '" << checkable->GetName() << "' ("
 			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", checkable->GetNextCheck()) << "): Object '"
-			<< csi.Object->GetName() << "', Next Check: "
+			<< checkable->GetName() << "', Next Check: "
 			<< Utility::FormatDateTime("%Y-%m-%d %H:%M:%S %z", csi.NextCheck)
 			<< " (" << std::fixed << std::setprecision(0) << csi.NextCheck << ").";
 
@@ -235,16 +232,16 @@ void CheckerComponent::CheckThreadProc()
 		 */
 		CheckerComponent::Ptr checkComponent(this);
 
-		Utility::QueueAsyncCallback([this, checkComponent, checkable]() { ExecuteCheckHelper(checkable); });
+		Utility::QueueAsyncCallback([this, checkComponent, checkable, csi]() { ExecuteCheckHelper(checkable, csi); });
 
 		lock.lock();
 	}
 }
 
-void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable)
+void CheckerComponent::ExecuteCheckHelper(const Checkable::Ptr& checkable, const CheckableScheduleInfo& csi)
 {
 	try {
-		checkable->ExecuteCheck(m_WaitGroup);
+		checkable->ExecuteCheck(m_WaitGroup, csi.NextCheck);
 	} catch (const std::exception& ex) {
 		CheckResult::Ptr cr = new CheckResult();
 		cr->SetState(ServiceUnknown);

--- a/lib/checker/checkercomponent.hpp
+++ b/lib/checker/checkercomponent.hpp
@@ -27,21 +27,25 @@ struct CheckableScheduleInfo
 {
 	Checkable::Ptr Object;
 	double NextCheck;
-};
-
-/**
- * @ingroup checker
- */
-struct CheckableNextCheckExtractor
-{
-	typedef double result_type;
 
 	/**
-	 * @threadsafety Always.
+	 * Get the index value for ordering in the multi-index container.
+	 *
+	 * This function returns a very large value for checkables that have a running check, effectively pushing
+	 * them to the end of the ordering. This ensures that checkables with running checks are not prioritized
+	 * for scheduling ahead of others. Rescheduling of such checkables is unnecessary because the checkable
+	 * is going to reject this anyway if it notices that a check is already running, so avoiding unnecessary
+	 * CPU load. Once the running check is finished, the checkable will be re-inserted into the set with its
+	 * actual next check time as the index value.
+	 *
+	 * @return The index value for ordering in the multi-index container.
 	 */
-	double operator()(const CheckableScheduleInfo& csi)
+	[[nodiscard]] double Index() const
 	{
-		return csi.NextCheck;
+		if (Object->HasRunningCheck()) {
+			return std::numeric_limits<double>::max();
+		}
+		return NextCheck;
 	}
 };
 
@@ -58,7 +62,7 @@ public:
 		CheckableScheduleInfo,
 		boost::multi_index::indexed_by<
 			boost::multi_index::ordered_unique<boost::multi_index::member<CheckableScheduleInfo, Checkable::Ptr, &CheckableScheduleInfo::Object> >,
-			boost::multi_index::ordered_non_unique<CheckableNextCheckExtractor>
+			boost::multi_index::ordered_non_unique<boost::multi_index::const_mem_fun<CheckableScheduleInfo, double, &CheckableScheduleInfo::Index>>
 		>
 	> CheckableSet;
 

--- a/lib/checker/checkercomponent.hpp
+++ b/lib/checker/checkercomponent.hpp
@@ -93,7 +93,7 @@ private:
 	void CheckThreadProc();
 	void ResultTimerHandler();
 
-	void ExecuteCheckHelper(const Checkable::Ptr& checkable);
+	void ExecuteCheckHelper(const Checkable::Ptr& checkable, const CheckableScheduleInfo& csi);
 
 	void ObjectHandler(const ConfigObject::Ptr& object);
 	void NextCheckChangedHandler(const Checkable::Ptr& checkable, double nextCheck = -1);

--- a/lib/checker/checkercomponent.hpp
+++ b/lib/checker/checkercomponent.hpp
@@ -94,7 +94,7 @@ private:
 	void AdjustCheckTimer();
 
 	void ObjectHandler(const ConfigObject::Ptr& object);
-	void NextCheckChangedHandler(const Checkable::Ptr& checkable);
+	void NextCheckChangedHandler(const Checkable::Ptr& checkable, double nextCheck = -1);
 
 	void RescheduleCheckTimer();
 

--- a/lib/checker/checkercomponent.hpp
+++ b/lib/checker/checkercomponent.hpp
@@ -74,11 +74,15 @@ public:
 	unsigned long GetIdleCheckables();
 	unsigned long GetPendingCheckables();
 
+	void SetResultTimerInterval(double interval);
+
 private:
 	std::mutex m_Mutex;
 	std::condition_variable m_CV;
 	bool m_Stopped{false};
 	std::thread m_Thread;
+
+	double m_ResultTimerInterval{5.0}; // Interval in seconds for the result timer.
 
 	CheckableSet m_IdleCheckables;
 	CheckableSet m_PendingCheckables;
@@ -91,12 +95,8 @@ private:
 
 	void ExecuteCheckHelper(const Checkable::Ptr& checkable);
 
-	void AdjustCheckTimer();
-
 	void ObjectHandler(const ConfigObject::Ptr& object);
 	void NextCheckChangedHandler(const Checkable::Ptr& checkable, double nextCheck = -1);
-
-	void RescheduleCheckTimer();
 
 	static CheckableScheduleInfo GetCheckableScheduleInfo(const Checkable::Ptr& checkable);
 };

--- a/lib/db_ido/dbevents.cpp
+++ b/lib/db_ido/dbevents.cpp
@@ -41,7 +41,7 @@ void DbEvents::StaticInitialize()
 		DbEvents::RemoveAcknowledgement(checkable);
 	});
 
-	Checkable::OnNextCheckUpdated.connect([](const Checkable::Ptr& checkable) { NextCheckUpdatedHandler(checkable); });
+	Checkable::OnNextCheckChanged.connect([](const Checkable::Ptr& checkable, const Value&) { NextCheckChangedHandler(checkable); });
 	Checkable::OnFlappingChanged.connect([](const Checkable::Ptr& checkable, const Value&) { FlappingChangedHandler(checkable); });
 	Checkable::OnNotificationSentToAllUsers.connect([](const Notification::Ptr& notification, const Checkable::Ptr& checkable,
 		const std::set<User::Ptr>&, const NotificationType&, const CheckResult::Ptr&, const String&, const String&,
@@ -119,7 +119,7 @@ void DbEvents::StaticInitialize()
 }
 
 /* check events */
-void DbEvents::NextCheckUpdatedHandler(const Checkable::Ptr& checkable)
+void DbEvents::NextCheckChangedHandler(const Checkable::Ptr& checkable)
 {
 	Host::Ptr host;
 	Service::Ptr service;

--- a/lib/db_ido/dbevents.hpp
+++ b/lib/db_ido/dbevents.hpp
@@ -53,7 +53,7 @@ public:
 	static void AddLogHistory(const Checkable::Ptr& checkable, const String& buffer, LogEntryType type);
 
 	/* Status */
-	static void NextCheckUpdatedHandler(const Checkable::Ptr& checkable);
+	static void NextCheckChangedHandler(const Checkable::Ptr& checkable);
 	static void FlappingChangedHandler(const Checkable::Ptr& checkable);
 	static void LastNotificationChangedHandler(const Notification::Ptr& notification, const Checkable::Ptr& checkable);
 

--- a/lib/icinga/apiactions.cpp
+++ b/lib/icinga/apiactions.cpp
@@ -166,9 +166,6 @@ Dictionary::Ptr ApiActions::RescheduleCheck(
 
 	checkable->SetNextCheck(nextCheck);
 
-	/* trigger update event for DB IDO */
-	Checkable::OnNextCheckUpdated(checkable);
-
 	return ApiActions::CreateResult(200, "Successfully rescheduled check for object '" + checkable->GetName() + "'.");
 }
 

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -46,7 +46,7 @@ void Checkable::SetSchedulingOffset(long offset)
 	m_SchedulingOffset = offset;
 }
 
-long Checkable::GetSchedulingOffset()
+long Checkable::GetSchedulingOffset() const
 {
 	return m_SchedulingOffset;
 }
@@ -87,6 +87,11 @@ bool Checkable::HasBeenChecked() const
 	return GetLastCheckResult() != nullptr;
 }
 
+bool Checkable::HasRunningCheck() const
+{
+	return m_CheckRunning.load(std::memory_order_acquire);
+}
+
 double Checkable::GetLastCheck() const
 {
 	CheckResult::Ptr cr = GetLastCheckResult();
@@ -106,7 +111,7 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	VERIFY(producer);
 
 	ObjectLock olock(this);
-	m_CheckRunning = false;
+	m_CheckRunning.store(false, std::memory_order_release);
 
 	double now = Utility::GetTime();
 
@@ -562,6 +567,11 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 {
 	CONTEXT("Executing check for object '" << GetName() << "'");
 
+	/* don't run another check if there is one pending */
+	if (m_CheckRunning.exchange(true, std::memory_order_acq_rel)) {
+		return; // Should never happen as the checker already takes care of this.
+	}
+
 	/* keep track of scheduling info in case the check type doesn't provide its own information */
 	double scheduled_start = GetNextCheck();
 	double before_check = Utility::GetTime();
@@ -578,12 +588,6 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 
 	{
 		ObjectLock olock(this);
-
-		/* don't run another check if there is one pending */
-		if (m_CheckRunning)
-			return;
-
-		m_CheckRunning = true;
 
 		SetLastStateRaw(GetStateRaw());
 		SetLastStateType(GetLastStateType());
@@ -670,10 +674,13 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 			ProcessCheckResult(cr, producer);
 		}
 
-		{
-			ObjectLock olock(this);
-			m_CheckRunning = false;
-		}
+		/**
+		 * If this is a remote check, we don't know when the check result will be received and processed.
+		 * Therefore, we must mark the check as no longer running here, otherwise, no further checks
+		 * would be executed for this checkable as it would always appear as having a running check
+		 * (see the check at the start of this function).
+		 */
+		m_CheckRunning.store(false, std::memory_order_release);
 	}
 }
 

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -23,7 +23,6 @@ boost::signals2::signal<void (const Checkable::Ptr&, const CheckResult::Ptr&, co
 boost::signals2::signal<void (const Checkable::Ptr&, const CheckResult::Ptr&, StateType, const MessageOrigin::Ptr&)> Checkable::OnStateChange;
 boost::signals2::signal<void (const Checkable::Ptr&, const CheckResult::Ptr&, std::set<Checkable::Ptr>, const MessageOrigin::Ptr&)> Checkable::OnReachabilityChanged;
 boost::signals2::signal<void (const Checkable::Ptr&, NotificationType, const CheckResult::Ptr&, const String&, const String&, const MessageOrigin::Ptr&)> Checkable::OnNotificationsRequested;
-boost::signals2::signal<void (const Checkable::Ptr&)> Checkable::OnNextCheckUpdated;
 boost::signals2::signal<void (const Checkable::Ptr&, double)> Checkable::OnRescheduleCheck;
 
 Atomic<uint_fast64_t> Checkable::CurrentConcurrentChecks (0);

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -578,12 +578,6 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 
 	SetLastCheckStarted(Utility::GetTime());
 
-	/* This calls SetNextCheck() which updates the CheckerComponent's idle/pending
-	 * queues and ensures that checks are not fired multiple times. ProcessCheckResult()
-	 * is called too late. See #6421.
-	 */
-	UpdateNextCheck();
-
 	bool reachable = IsReachable();
 
 	{
@@ -645,11 +639,16 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 			if (listener)
 				listener->SyncSendMessage(endpoint, message);
 
-			/* Re-schedule the check so we don't run it again until after we've received
-			 * a check result from the remote instance. The check will be re-scheduled
-			 * using the proper check interval once we've received a check result.
+			/*
+			 * Let the checker use a dummy next check time until we actually receive the check result from the
+			 * remote endpoint. This should be sufficiently far in the future to avoid excessive CPU load by
+			 * constantly re-running the check, but not too far in the future to avoid that the check is not
+			 * re-run for too long in case the remote endpoint never responds. We add a small grace period
+			 * to the check command timeout to account for network latency and processing time on the remote
+			 * endpoint. So, we only need to silently update this without notifying any listeners, and once
+			 * this function returns, the checker is going access it via GetNextCheck() again.
 			 */
-			SetNextCheck(Utility::GetTime() + checkTimeout + 30);
+			SetNextCheck(Utility::GetTime() + checkTimeout + 30, true);
 
 		/*
 		 * Let the user know that there was a problem with the check if
@@ -672,6 +671,13 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 			cr->SetOutput(output);
 
 			ProcessCheckResult(cr, producer);
+		} else {
+			/**
+			 * The endpoint is currently either syncing its state or not connected yet and we are within
+			 * the magical 5min cold startup window. In both cases, we just don't do anything and wait for
+			 * the next check interval to re-try the check again. So, this check is effectively skipped.
+			 */
+			UpdateNextCheck();
 		}
 
 		/**

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -566,7 +566,7 @@ void Checkable::ExecuteRemoteCheck(const WaitGroup::Ptr& producer, const Diction
 	GetCheckCommand()->Execute(this, cr, producer, resolvedMacros, true);
 }
 
-void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
+void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer, double scheduleStart)
 {
 	CONTEXT("Executing check for object '" << GetName() << "'");
 
@@ -576,7 +576,6 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 	}
 
 	/* keep track of scheduling info in case the check type doesn't provide its own information */
-	double scheduled_start = GetNextCheck();
 	double before_check = Utility::GetTime();
 
 	SetLastCheckStarted(Utility::GetTime());
@@ -593,7 +592,7 @@ void Checkable::ExecuteCheck(const WaitGroup::Ptr& producer)
 
 	CheckResult::Ptr cr = new CheckResult();
 
-	cr->SetScheduleStart(scheduled_start);
+	cr->SetScheduleStart(scheduleStart);
 	cr->SetExecutionStart(before_check);
 
 	Endpoint::Ptr endpoint = GetCommandEndpoint();

--- a/lib/icinga/checkable-check.cpp
+++ b/lib/icinga/checkable-check.cpp
@@ -24,6 +24,7 @@ boost::signals2::signal<void (const Checkable::Ptr&, const CheckResult::Ptr&, St
 boost::signals2::signal<void (const Checkable::Ptr&, const CheckResult::Ptr&, std::set<Checkable::Ptr>, const MessageOrigin::Ptr&)> Checkable::OnReachabilityChanged;
 boost::signals2::signal<void (const Checkable::Ptr&, NotificationType, const CheckResult::Ptr&, const String&, const String&, const MessageOrigin::Ptr&)> Checkable::OnNotificationsRequested;
 boost::signals2::signal<void (const Checkable::Ptr&)> Checkable::OnNextCheckUpdated;
+boost::signals2::signal<void (const Checkable::Ptr&, double)> Checkable::OnRescheduleCheck;
 
 Atomic<uint_fast64_t> Checkable::CurrentConcurrentChecks (0);
 
@@ -519,12 +520,15 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 	if (recovery) {
 		for (auto& child : children) {
 			if (child->GetProblem() && child->GetEnableActiveChecks()) {
-				auto nextCheck (now + Utility::Random() % 60);
-
-				ObjectLock oLock (child);
-
-				if (nextCheck < child->GetNextCheck()) {
-					child->SetNextCheck(nextCheck);
+				if (auto nextCheck{now + Utility::Random() % 60}; nextCheck < child->GetNextCheck()) {
+					/**
+					 * We only want to enforce the checker to pick this up sooner, and no need to actually change
+					 * the timesatmp. Plus, no other listeners should be informed about this other than the checker,
+					 * so we emit this signal directly. In case our checker isn't responsible for this child object,
+					 * we've already broadcasted the `CheckResult` event which will cause on the responsible node to
+					 * enter this exact branch and do the rescheduling for its own checker.
+					 */
+					OnRescheduleCheck(child, nextCheck);
 				}
 			}
 		}
@@ -540,8 +544,8 @@ Checkable::ProcessingResult Checkable::ProcessCheckResult(const CheckResult::Ptr
 				continue;
 
 			if (parent->GetNextCheck() >= now + parent->GetRetryInterval()) {
-				ObjectLock olock(parent);
-				parent->SetNextCheck(now);
+				// See comment above for children. We want to just enforce an immediate check by our checker.
+				OnRescheduleCheck(parent, now);
 			}
 		}
 	}

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -89,14 +89,25 @@ void Checkable::Start(bool runtimeCreated)
 		auto cr (GetLastCheckResult());
 
 		if (GetLastCheckStarted() > (cr ? cr->GetExecutionEnd() : 0.0)) {
-			SetNextCheck(GetLastCheckStarted());
+			/**
+			 * Each node performs a check immediately after startup before the object authority is determined.
+			 * Meaning, for runtime created objects we should not enter this branch and for non-runtime created
+			 * objects we're going to call `ApiListener::UpdateObjectAuthority()` after all objects have been
+			 * started, so we can safely assume that this timestamp is only relevant for our own checker.
+			 *
+			 * However, until the authority is determined, by default all objects are paused and thus triggering
+			 * `OnRescheduleCheck` would have no effect, as the checker component ignores paused objects. Therefore,
+			 * our only option is to set this dummy ts silently here, so that when the object is unpaused later,
+			 * the checker component will pick it up and schedule the next check properly.
+			 */
+			SetNextCheck(GetLastCheckStarted(), true);
 		}
 	}
 
 	if (GetNextCheck() < now + 60) {
 		double delta = std::min(GetCheckInterval(), 60.0);
 		delta *= (double)std::rand() / RAND_MAX;
-		SetNextCheck(now + delta);
+		SetNextCheck(now + delta, true); // Same as the above `SetNextCheck` call.
 	}
 
 	ObjectImpl<Checkable>::Start(runtimeCreated);

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -102,7 +102,7 @@ public:
 	intrusive_ptr<CheckCommand> GetCheckCommand() const;
 	TimePeriod::Ptr GetCheckPeriod() const;
 
-	long GetSchedulingOffset();
+	long GetSchedulingOffset() const;
 	void SetSchedulingOffset(long offset);
 
 	void UpdateNextCheck(const MessageOrigin::Ptr& origin = nullptr);
@@ -110,6 +110,7 @@ public:
 	static String StateTypeToString(StateType type);
 
 	bool HasBeenChecked() const;
+	bool HasRunningCheck() const;
 	virtual bool IsStateOK(ServiceState state) const = 0;
 
 	double GetLastCheck() const final;
@@ -224,7 +225,7 @@ protected:
 
 private:
 	mutable std::mutex m_CheckableMutex;
-	bool m_CheckRunning{false};
+	std::atomic_bool m_CheckRunning{false};
 	long m_SchedulingOffset;
 
 	static std::mutex m_StatsMutex;

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -149,6 +149,15 @@ public:
 	static boost::signals2::signal<void (const Checkable::Ptr&, const String&, double, const MessageOrigin::Ptr&)> OnAcknowledgementCleared;
 	static boost::signals2::signal<void (const Checkable::Ptr&, double)> OnFlappingChange;
 	static boost::signals2::signal<void (const Checkable::Ptr&)> OnNextCheckUpdated;
+	/**
+	 * This signal is a very special and noisy one. It is emitted whenever someone wants to enforce the LOCAL
+	 * scheduler to reschedule the next check of a checkable at the given timestamp. This can be due to a number
+	 * of reasons, for example: Icinga 2 was interrupted while a check was being executed, and the checkable needs
+	 * to be rescheduled on startup; or a parent host changed its state and all its children need to be rescheduled
+	 * to reflect the new reachability state. There are other cases as well, but the point is: this signal is meant
+	 * to only be used by the local @c CheckerComponent to update its internal queues.
+	 */
+	static boost::signals2::signal<void (const Checkable::Ptr&, double)> OnRescheduleCheck;
 	static boost::signals2::signal<void (const Checkable::Ptr&)> OnEventCommandExecuted;
 
 	static Atomic<uint_fast64_t> CurrentConcurrentChecks;

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -148,7 +148,6 @@ public:
 		bool, bool, double, double, const MessageOrigin::Ptr&)> OnAcknowledgementSet;
 	static boost::signals2::signal<void (const Checkable::Ptr&, const String&, double, const MessageOrigin::Ptr&)> OnAcknowledgementCleared;
 	static boost::signals2::signal<void (const Checkable::Ptr&, double)> OnFlappingChange;
-	static boost::signals2::signal<void (const Checkable::Ptr&)> OnNextCheckUpdated;
 	/**
 	 * This signal is a very special and noisy one. It is emitted whenever someone wants to enforce the LOCAL
 	 * scheduler to reschedule the next check of a checkable at the given timestamp. This can be due to a number

--- a/lib/icinga/checkable.hpp
+++ b/lib/icinga/checkable.hpp
@@ -120,7 +120,7 @@ public:
 	static void UpdateStatistics(const CheckResult::Ptr& cr, CheckableType type);
 
 	void ExecuteRemoteCheck(const WaitGroup::Ptr& producer, const Dictionary::Ptr& resolvedMacros = nullptr);
-	void ExecuteCheck(const WaitGroup::Ptr& producer);
+	void ExecuteCheck(const WaitGroup::Ptr& producer, double scheduleStart);
 
 	enum class ProcessingResult
 	{

--- a/lib/icinga/clusterevents.cpp
+++ b/lib/icinga/clusterevents.cpp
@@ -47,7 +47,9 @@ REGISTER_APIFUNCTION(SetRemovalInfo, event, &ClusterEvents::SetRemovalInfoAPIHan
 void ClusterEvents::StaticInitialize()
 {
 	Checkable::OnNewCheckResult.connect(&ClusterEvents::CheckResultHandler);
-	Checkable::OnNextCheckChanged.connect(&ClusterEvents::NextCheckChangedHandler);
+	Checkable::OnNextCheckChanged.connect([](const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin) {
+		NextCheckChangedHandler(checkable, origin);
+	});
 	Checkable::OnLastCheckStartedChanged.connect(&ClusterEvents::LastCheckStartedChangedHandler);
 	Checkable::OnStateBeforeSuppressionChanged.connect(&ClusterEvents::StateBeforeSuppressionChangedHandler);
 	Checkable::OnSuppressedNotificationsChanged.connect(&ClusterEvents::SuppressedNotificationsChangedHandler);
@@ -184,7 +186,7 @@ Value ClusterEvents::CheckResultAPIHandler(const MessageOrigin::Ptr& origin, con
 	return Empty;
 }
 
-void ClusterEvents::NextCheckChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin)
+void ClusterEvents::NextCheckChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin, uint_fast64_t originClientCapabilities)
 {
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 
@@ -200,6 +202,10 @@ void ClusterEvents::NextCheckChangedHandler(const Checkable::Ptr& checkable, con
 	if (service)
 		params->Set("service", service->GetShortName());
 	params->Set("next_check", checkable->GetNextCheck());
+
+	if (originClientCapabilities > 0) {
+		params->Set("origin_client_caps", originClientCapabilities);
+	}
 
 	Dictionary::Ptr message = new Dictionary();
 	message->Set("jsonrpc", "2.0");
@@ -246,7 +252,29 @@ Value ClusterEvents::NextCheckChangedAPIHandler(const MessageOrigin::Ptr& origin
 	if (nextCheck < Application::GetStartTime() + 60)
 		return Empty;
 
-	checkable->SetNextCheck(params->Get("next_check"), false, origin);
+	auto capabilities = endpoint->GetCapabilities();
+	if (params->Contains("origin_client_caps")) {
+		capabilities &= static_cast<uint_fast64_t>(params->Get("origin_client_caps"));
+	}
+
+	if (capabilities & static_cast<uint_fast64_t>(ApiCapabilities::GranularNextCheckInvocation)) {
+		// Peer/original client has the expected Icinga 2 capability, so we can just do the normal flow.
+		// The `Checkable::OnNextCheckChanged` signal will be emitted as usual and all subscribers will
+		// be informed about this change.
+		checkable->SetNextCheck(nextCheck, false, origin);
+	} else {
+		// All older Icinga 2 versions trigger the `event::SetNextCheck` event endlessly, so we can't let the
+		// `Checkable::OnNextCheckChanged` know about this change, as it would cause too much noise in Icinga DB
+		// and the like. So, we just update the timestamp silently and manually call `Checkable::OnRescheduleCheck`
+		// to inform the checker about this change.
+		checkable->SetNextCheck(nextCheck, true, origin);
+		Checkable::OnRescheduleCheck(checkable, nextCheck);
+		// In case this message has to be relayed to other cluster nodes we directly call the `NextCheckChangedHandler`.
+		// The `originClientCapabilities` flag is necessary e.g. in a 3-level cluster setup where a very old agent
+		// sends the message to its satellite that then relays it to the master. The master then needs to know the
+		// capabilities of the original sender to decide whether to trigger the normal flow or not.
+		NextCheckChangedHandler(checkable, origin, capabilities);
+	}
 
 	return Empty;
 }

--- a/lib/icinga/clusterevents.hpp
+++ b/lib/icinga/clusterevents.hpp
@@ -24,7 +24,7 @@ public:
 	static void CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr& origin);
 	static Value CheckResultAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
-	static void NextCheckChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);
+	static void NextCheckChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin, uint_fast64_t originClientCapabilities = 0);
 	static Value NextCheckChangedAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params);
 
 	static void LastCheckStartedChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr& origin);

--- a/lib/icinga/dependency.hpp
+++ b/lib/icinga/dependency.hpp
@@ -58,9 +58,10 @@ public:
 	 */
 	static constexpr int MaxDependencyRecursionLevel{256};
 
-protected:
 	void OnConfigLoaded() override;
 	void OnAllConfigLoaded() override;
+
+protected:
 	void Stop(bool runtimeRemoved) override;
 	void InitChildParentReferences();
 

--- a/lib/icinga/externalcommandprocessor.cpp
+++ b/lib/icinga/externalcommandprocessor.cpp
@@ -393,9 +393,6 @@ void ExternalCommandProcessor::ScheduleHostCheck(double, const std::vector<Strin
 		planned_check = Utility::GetTime();
 
 	host->SetNextCheck(planned_check);
-
-	/* trigger update event for DB IDO */
-	Checkable::OnNextCheckUpdated(host);
 }
 
 void ExternalCommandProcessor::ScheduleForcedHostCheck(double, const std::vector<String>& arguments)
@@ -410,9 +407,6 @@ void ExternalCommandProcessor::ScheduleForcedHostCheck(double, const std::vector
 
 	host->SetForceNextCheck(true);
 	host->SetNextCheck(Convert::ToDouble(arguments[1]));
-
-	/* trigger update event for DB IDO */
-	Checkable::OnNextCheckUpdated(host);
 }
 
 void ExternalCommandProcessor::ScheduleSvcCheck(double, const std::vector<String>& arguments)
@@ -438,9 +432,6 @@ void ExternalCommandProcessor::ScheduleSvcCheck(double, const std::vector<String
 		planned_check = Utility::GetTime();
 
 	service->SetNextCheck(planned_check);
-
-	/* trigger update event for DB IDO */
-	Checkable::OnNextCheckUpdated(service);
 }
 
 void ExternalCommandProcessor::ScheduleForcedSvcCheck(double, const std::vector<String>& arguments)
@@ -455,9 +446,6 @@ void ExternalCommandProcessor::ScheduleForcedSvcCheck(double, const std::vector<
 
 	service->SetForceNextCheck(true);
 	service->SetNextCheck(Convert::ToDouble(arguments[2]));
-
-	/* trigger update event for DB IDO */
-	Checkable::OnNextCheckUpdated(service);
 }
 
 void ExternalCommandProcessor::EnableHostCheck(double, const std::vector<String>& arguments)
@@ -539,9 +527,6 @@ void ExternalCommandProcessor::ScheduleForcedHostSvcChecks(double, const std::ve
 
 		service->SetNextCheck(planned_check);
 		service->SetForceNextCheck(true);
-
-		/* trigger update event for DB IDO */
-		Checkable::OnNextCheckUpdated(service);
 	}
 }
 
@@ -569,9 +554,6 @@ void ExternalCommandProcessor::ScheduleHostSvcChecks(double, const std::vector<S
 			<< "Rescheduling next check for service '" << service->GetName() << "'";
 
 		service->SetNextCheck(planned_check);
-
-		/* trigger update event for DB IDO */
-		Checkable::OnNextCheckUpdated(service);
 	}
 }
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1322,19 +1322,19 @@ void IcingaDB::InsertCheckableDependencies(
  * Update the state information of a checkable in Redis.
  *
  * What is updated exactly depends on the mode parameter:
- *  - Volatile: Update the volatile state information stored in icinga:host:state or icinga:service:state as well as
- *    the corresponding checksum stored in icinga:checksum:host:state or icinga:checksum:service:state.
- *  - RuntimeOnly: Write a runtime update to the icinga:runtime:state stream. It is up to the caller to ensure that
+ *  - VolatileState: Update the volatile state information stored in icinga:host:state or icinga:service:state as well
+ *    as the corresponding checksum stored in icinga:checksum:host:state or icinga:checksum:service:state.
+ *  - RuntimeState: Write a runtime update to the icinga:runtime:state stream. It is up to the caller to ensure that
  *    identical volatile state information was already written before to avoid inconsistencies. This mode is only
  *    useful to upgrade a previous Volatile to a Full operation, otherwise Full should be used.
- *  - Full: Perform an update of all state information in Redis, that is updating the volatile information and sending
- *    a corresponding runtime update so that this state update gets written through to the persistent database by a
- *    running icingadb process.
+ *  - FullState: Perform an update of all state information in Redis, that is updating the volatile information and
+ *    sending a corresponding runtime update so that this state update gets written through to the persistent database
+ *    by a running icingadb process.
  *
  * @param checkable State of this checkable is updated in Redis
- * @param mode Mode of operation (StateUpdate::Volatile, StateUpdate::RuntimeOnly, or StateUpdate::Full)
+ * @param mode Mode of operation (DirtyBits:VolatileState, DirtyBits::RuntimeState, or DirtyBits::FullState)
  */
-void IcingaDB::UpdateState(const Checkable::Ptr& checkable, StateUpdate mode)
+void IcingaDB::UpdateState(const Checkable::Ptr& checkable, uint32_t mode)
 {
 	if (!m_RconWorker || !m_RconWorker->IsConnected())
 		return;
@@ -1344,7 +1344,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, StateUpdate mode)
 	String checksum = HashValue(stateAttrs);
 
 	auto [redisStateKey, redisChecksumKey] = GetCheckableStateKeys(checkable->GetReflectionType());
-	if (mode & StateUpdate::Volatile) {
+	if (mode & VolatileState) {
 		String objectKey = GetObjectIdentifier(checkable);
 		m_RconWorker->FireAndForgetQueries({
 			{"HSET", redisStateKey, objectKey, JsonEncode(stateAttrs)},
@@ -1352,7 +1352,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, StateUpdate mode)
 		}, Prio::RuntimeStateSync);
 	}
 
-	if (mode & StateUpdate::RuntimeOnly) {
+	if (mode & RuntimeState) {
 		ObjectLock olock(stateAttrs);
 
 		RedisConnection::Query streamadd({
@@ -1443,28 +1443,6 @@ void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const De
 
 		m_RconWorker->FireAndForgetQueries(std::move(queries), Prio::RuntimeStateSync);
 		m_RconWorker->FireAndForgetQueries(std::move(streamStates), Prio::RuntimeStateStream, {0, 1});
-	}
-}
-
-// Used to update a single object, used for runtime updates
-void IcingaDB::SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpdate)
-{
-	if (!m_RconWorker || !m_RconWorker->IsConnected())
-		return;
-
-	std::map<RedisConnection::QueryArg, RedisConnection::Query> hMSets;
-	std::vector<Dictionary::Ptr> runtimeUpdates;
-
-	CreateConfigUpdate(object, GetSyncableTypeRedisKeys(object->GetReflectionType()), hMSets, runtimeUpdates, runtimeUpdate);
-	Checkable::Ptr checkable = dynamic_pointer_cast<Checkable>(object);
-	if (checkable) {
-		UpdateState(checkable, runtimeUpdate ? StateUpdate::Full : StateUpdate::Volatile);
-	}
-
-	ExecuteRedisTransaction(m_RconWorker, hMSets, runtimeUpdates);
-
-	if (checkable) {
-		SendNextUpdate(checkable);
 	}
 }
 
@@ -1833,26 +1811,11 @@ void IcingaDB::SendConfigDelete(const ConfigObject::Ptr& object)
 	if (!m_RconWorker || !m_RconWorker->IsConnected())
 		return;
 
-	Type::Ptr type = object->GetReflectionType();
-	String objectKey = GetObjectIdentifier(object);
-	auto redisKeyPair = GetSyncableTypeRedisKeys(type);
-
-	m_RconWorker->FireAndForgetQueries({
-		{"HDEL", redisKeyPair.ObjectKey, objectKey},
-		{"HDEL", redisKeyPair.ChecksumKey, objectKey},
-		{
-			"XADD", "icinga:runtime", "MAXLEN", "~", "1000000", "*",
-			"redis_key", redisKeyPair.ObjectKey, "id", objectKey, "runtime_type", "delete"
-		}
-   	}, Prio::Config);
-
-	CustomVarObject::Ptr customVarObject = dynamic_pointer_cast<CustomVarObject>(object);
-
-	if (customVarObject) {
-		Dictionary::Ptr vars = customVarObject->GetVars();
-		SendCustomVarsChanged(object, vars, nullptr);
+	if (auto customVarObject = dynamic_pointer_cast<CustomVarObject>(object); customVarObject) {
+		SendCustomVarsChanged(object, customVarObject->GetVars(), nullptr);
 	}
 
+	Type::Ptr type = object->GetReflectionType();
 	if (type == Host::TypeInstance || type == Service::TypeInstance) {
 		Checkable::Ptr checkable = static_pointer_cast<Checkable>(object);
 
@@ -1860,17 +1823,9 @@ void IcingaDB::SendConfigDelete(const ConfigObject::Ptr& object)
 		Service::Ptr service;
 		tie(host, service) = GetHostService(checkable);
 
-		m_RconWorker->FireAndForgetQuery({
-			"ZREM",
-			service ? "icinga:nextupdate:service" : "icinga:nextupdate:host",
-			GetObjectIdentifier(checkable)
-		}, Prio::CheckResult);
-
 		auto [configStateKey, checksumStateKey] = GetCheckableStateKeys(checkable->GetReflectionType());
-		m_RconWorker->FireAndForgetQueries({
-			{"HDEL", configStateKey, objectKey},
-			{"HDEL", checksumStateKey, objectKey}
-		}, Prio::RuntimeStateSync);
+		EnqueueRelationsDeletion(GetObjectIdentifier(checkable), {{configStateKey, checksumStateKey}});
+		EnqueueConfigObject(object, ConfigDelete | NextUpdate); // Send also ZREM for next update
 
 		if (service) {
 			SendGroupsChanged<ServiceGroup>(checkable, service->GetGroups(), nullptr);
@@ -1880,6 +1835,8 @@ void IcingaDB::SendConfigDelete(const ConfigObject::Ptr& object)
 
 		return;
 	}
+
+	EnqueueConfigObject(object, ConfigDelete);
 
 	if (type == TimePeriod::TypeInstance) {
 		TimePeriod::Ptr timeperiod = static_pointer_cast<TimePeriod>(object);
@@ -1941,7 +1898,7 @@ void IcingaDB::SendStateChange(const ConfigObject::Ptr& object, const CheckResul
 
 	tie(host, service) = GetHostService(checkable);
 
-	UpdateState(checkable, StateUpdate::RuntimeOnly);
+	EnqueueConfigObject(checkable, RuntimeState);
 
 	int hard_state{};
 	if (!cr) {
@@ -2122,7 +2079,7 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 		return;
 	}
 
-	SendConfigUpdate(downtime, true);
+	EnqueueConfigObject(downtime, ConfigUpdate);
 
 	auto checkable (downtime->GetCheckable());
 	auto triggeredBy (Downtime::GetByName(downtime->GetTriggeredBy()));
@@ -2132,7 +2089,7 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 	tie(host, service) = GetHostService(checkable);
 
 	/* Update checkable state as in_downtime may have changed. */
-	UpdateState(checkable, StateUpdate::Full);
+	EnqueueConfigObject(checkable, FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:downtime", "*",
@@ -2221,7 +2178,7 @@ void IcingaDB::SendRemovedDowntime(const Downtime::Ptr& downtime)
 		return;
 
 	/* Update checkable state as in_downtime may have changed. */
-	UpdateState(checkable, StateUpdate::Full);
+	EnqueueConfigObject(checkable, FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:downtime", "*",
@@ -2309,6 +2266,9 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
 
+	// Update the checkable state to so that the "last_comment_id" is correctly reflected.
+	EnqueueConfigObject(checkable, FullState);
+
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:comment", "*",
 		"comment_id", GetObjectIdentifier(comment),
@@ -2351,7 +2311,6 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 	}
 
 	m_HistoryBulker.ProduceOne(std::move(xAdd));
-	UpdateState(checkable, StateUpdate::Full);
 }
 
 void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
@@ -2380,6 +2339,9 @@ void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 	Host::Ptr host;
 	Service::Ptr service;
 	tie(host, service) = GetHostService(checkable);
+
+	// Update the checkable state to so that the "last_comment_id" is correctly reflected.
+	EnqueueConfigObject(checkable, FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:comment", "*",
@@ -2431,7 +2393,6 @@ void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 	}
 
 	m_HistoryBulker.ProduceOne(std::move(xAdd));
-	UpdateState(checkable, StateUpdate::Full);
 }
 
 void IcingaDB::SendFlappingChange(const Checkable::Ptr& checkable, double changeTime, double flappingLastChange)
@@ -2506,7 +2467,7 @@ void IcingaDB::SendNextUpdate(const Checkable::Ptr& checkable)
 	if (!m_RconWorker || !m_RconWorker->IsConnected())
 		return;
 
-	if (checkable->GetEnableActiveChecks()) {
+	if (checkable->GetEnableActiveChecks() && checkable->IsActive()) {
 		m_RconWorker->FireAndForgetQuery(
 			{
 				"ZADD",
@@ -2516,7 +2477,7 @@ void IcingaDB::SendNextUpdate(const Checkable::Ptr& checkable)
 			},
 			Prio::CheckResult
 		);
-	} else {
+	} else if (!checkable->GetEnableActiveChecks() || checkable->GetExtension("ConfigObjectDeleted")) {
 		m_RconWorker->FireAndForgetQuery(
 			{
 				"ZREM",
@@ -2539,7 +2500,7 @@ void IcingaDB::SendAcknowledgementSet(const Checkable::Ptr& checkable, const Str
 	tie(host, service) = GetHostService(checkable);
 
 	/* Update checkable state as is_acknowledged may have changed. */
-	UpdateState(checkable, StateUpdate::Full);
+	EnqueueConfigObject(checkable, FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
@@ -2597,7 +2558,7 @@ void IcingaDB::SendAcknowledgementCleared(const Checkable::Ptr& checkable, const
 	tie(host, service) = GetHostService(checkable);
 
 	/* Update checkable state as is_acknowledged may have changed. */
-	UpdateState(checkable, StateUpdate::Full);
+	EnqueueConfigObject(checkable, FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
@@ -2722,8 +2683,10 @@ void IcingaDB::SendNotificationUsersChanged(const Notification::Ptr& notificatio
 
 	for (const auto& userName : deletedUsers) {
 		String id = HashValue(new Array({m_EnvironmentId, "user", userName, notification->GetName()}));
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "notification:user");
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "notification:recipient");
+		EnqueueRelationsDeletion(id,{
+			{CONFIG_REDIS_KEY_PREFIX "notification:user", ""},
+			{CONFIG_REDIS_KEY_PREFIX "notification:recipient", ""},
+		});
 	}
 }
 
@@ -2737,12 +2700,14 @@ void IcingaDB::SendNotificationUserGroupsChanged(const Notification::Ptr& notifi
 	for (const auto& userGroupName : deletedUserGroups) {
 		UserGroup::Ptr userGroup = UserGroup::GetByName(userGroupName);
 		String id = HashValue(new Array({m_EnvironmentId, "usergroup", userGroupName, notification->GetName()}));
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "notification:usergroup");
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "notification:recipient");
+		EnqueueRelationsDeletion(id, {
+			{CONFIG_REDIS_KEY_PREFIX "notification:usergroup", ""},
+			{CONFIG_REDIS_KEY_PREFIX "notification:recipient", ""}
+		});
 
 		for (const User::Ptr& user : userGroup->GetMembers()) {
 			String userId = HashValue(new Array({m_EnvironmentId, "usergroupuser", user->GetName(), userGroupName, notification->GetName()}));
-			DeleteRelationship(userId, CONFIG_REDIS_KEY_PREFIX "notification:recipient");
+			EnqueueRelationsDeletion(userId, {{CONFIG_REDIS_KEY_PREFIX "notification:recipient", ""}});
 		}
 	}
 }
@@ -2756,7 +2721,7 @@ void IcingaDB::SendTimePeriodRangesChanged(const TimePeriod::Ptr& timeperiod, co
 
 	for (const auto& rangeKey : deletedKeys) {
 		String id = HashValue(new Array({m_EnvironmentId, rangeKey, oldValues->Get(rangeKey), timeperiod->GetName()}));
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "timeperiod:range");
+		EnqueueRelationsDeletion(id, {{CONFIG_REDIS_KEY_PREFIX "timeperiod:range", ""}});
 	}
 }
 
@@ -2769,7 +2734,7 @@ void IcingaDB::SendTimePeriodIncludesChanged(const TimePeriod::Ptr& timeperiod, 
 
 	for (const auto& includeName : deletedIncludes) {
 		String id = HashValue(new Array({m_EnvironmentId, includeName, timeperiod->GetName()}));
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "timeperiod:override:include");
+		EnqueueRelationsDeletion(id, {{CONFIG_REDIS_KEY_PREFIX "timeperiod:override:include", ""}});
 	}
 }
 
@@ -2782,7 +2747,7 @@ void IcingaDB::SendTimePeriodExcludesChanged(const TimePeriod::Ptr& timeperiod, 
 
 	for (const auto& excludeName : deletedExcludes) {
 		String id = HashValue(new Array({m_EnvironmentId, excludeName, timeperiod->GetName()}));
-		DeleteRelationship(id, CONFIG_REDIS_KEY_PREFIX "timeperiod:override:exclude");
+		EnqueueRelationsDeletion(id, {{CONFIG_REDIS_KEY_PREFIX "timeperiod:override:exclude", ""}});
 	}
 }
 
@@ -2806,14 +2771,14 @@ void IcingaDB::SendGroupsChanged(const ConfigObject::Ptr& object, const Array::P
 	for (const auto& groupName : deletedGroups) {
 		typename T::Ptr group = ConfigObject::GetObject<T>(groupName);
 		String id = HashValue(new Array({m_EnvironmentId, group->GetName(), object->GetName()}));
-		DeleteRelationship(id, keyType);
+		EnqueueRelationsDeletion(id, {{keyType, ""}});
 
-		if (std::is_same<T, UserGroup>::value) {
+		if constexpr (std::is_same_v<T, UserGroup>) {
 			UserGroup::Ptr userGroup = dynamic_pointer_cast<UserGroup>(group);
 
 			for (const auto& notification : userGroup->GetNotifications()) {
 				String userId = HashValue(new Array({m_EnvironmentId, "usergroupuser", object->GetName(), groupName, notification->GetName()}));
-				DeleteRelationship(userId, CONFIG_REDIS_KEY_PREFIX "notification:recipient");
+				EnqueueRelationsDeletion(userId, {{CONFIG_REDIS_KEY_PREFIX "notification:recipient", ""}});
 			}
 		}
 	}
@@ -2832,7 +2797,7 @@ void IcingaDB::SendCommandEnvChanged(
 
 	for (const auto& envvarKey : GetDictionaryDeletedKeys(oldValues, newValues)) {
 		String id = HashValue(new Array({m_EnvironmentId, envvarKey, command->GetName()}));
-		DeleteRelationship(id, cmdRedisKeys.EnvObjectKey, cmdRedisKeys.EnvChecksumKey);
+		EnqueueRelationsDeletion(id, {{cmdRedisKeys.EnvObjectKey, cmdRedisKeys.EnvChecksumKey}});
 	}
 }
 
@@ -2849,7 +2814,7 @@ void IcingaDB::SendCommandArgumentsChanged(
 
 	for (const auto& argumentKey : GetDictionaryDeletedKeys(oldValues, newValues)) {
 		String id = HashValue(new Array({m_EnvironmentId, argumentKey, command->GetName()}));
-		DeleteRelationship(id, cmdRedisKeys.ArgObjectKey, cmdRedisKeys.ArgChecksumKey);
+		EnqueueRelationsDeletion(id, {{cmdRedisKeys.ArgObjectKey, cmdRedisKeys.ArgChecksumKey}});
 	}
 }
 
@@ -2869,7 +2834,7 @@ void IcingaDB::SendCustomVarsChanged(const ConfigObject::Ptr& object, const Dict
 
 	for (const auto& varId : GetDictionaryDeletedKeys(oldVars, newVars)) {
 		String id = HashValue(new Array({m_EnvironmentId, varId, object->GetName()}));
-		DeleteRelationship(id, customvarKey);
+		EnqueueRelationsDeletion(id, {{customvarKey, ""}});
 	}
 }
 
@@ -3041,7 +3006,6 @@ IcingaDB::UpdateObjectAttrs(const ConfigObject::Ptr& object, int fieldType,
 		typeName = typeNameOverride.ToLower();
 
 	return {GetObjectIdentifier(object), JsonEncode(attrs)};
-	//m_Rcon->FireAndForgetQuery({"HSET", keyPrefix + typeName, GetObjectIdentifier(object), JsonEncode(attrs)});
 }
 
 void IcingaDB::StateChangeHandler(const ConfigObject::Ptr& object, const CheckResult::Ptr& cr, StateType type)
@@ -3055,7 +3019,7 @@ void IcingaDB::ReachabilityChangeHandler(const std::set<Checkable::Ptr>& childre
 {
 	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		for (auto& checkable : children) {
-			rw->UpdateState(checkable, StateUpdate::Full);
+			rw->EnqueueConfigObject(checkable, FullState);
 			for (const auto& dependencyGroup : checkable->GetDependencyGroups()) {
 				rw->EnqueueDependencyGroupStateUpdate(dependencyGroup);
 			}
@@ -3074,17 +3038,13 @@ void IcingaDB::VersionChangedHandler(const ConfigObject::Ptr& object)
 	}
 
 	if (object->IsActive()) {
-		// Create or update the object config
 		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-			if (rw)
-				rw->SendConfigUpdate(object, true);
+			// A runtime config change triggers also a full state update as well as next update event.
+			rw->EnqueueConfigObject(object, ConfigUpdate | FullState | NextUpdate);
 		}
-	} else if (!object->IsActive() &&
-			   object->GetExtension("ConfigObjectDeleted")) { // same as in apilistener-configsync.cpp
-		// Delete object config
+	} else if (!object->IsActive() && object->GetExtension("ConfigObjectDeleted")) { // same as in apilistener-configsync.cpp
 		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-			if (rw)
-				rw->SendConfigDelete(object);
+			rw->SendConfigDelete(object);
 		}
 	}
 }
@@ -3144,16 +3104,14 @@ void IcingaDB::FlappingChangeHandler(const Checkable::Ptr& checkable, double cha
 void IcingaDB::NewCheckResultHandler(const Checkable::Ptr& checkable)
 {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-		rw->UpdateState(checkable, StateUpdate::Volatile);
-		rw->SendNextUpdate(checkable);
+		rw->EnqueueConfigObject(checkable, VolatileState);
 	}
 }
 
 void IcingaDB::NextCheckUpdatedHandler(const Checkable::Ptr& checkable)
 {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-		rw->UpdateState(checkable, StateUpdate::Volatile);
-		rw->SendNextUpdate(checkable);
+		rw->EnqueueConfigObject(checkable, VolatileState | NextUpdate);
 	}
 }
 
@@ -3186,7 +3144,7 @@ void IcingaDB::DependencyGroupChildRemovedHandler(const DependencyGroup::Ptr& de
 void IcingaDB::HostProblemChangedHandler(const Service::Ptr& service) {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		/* Host state changes affect is_handled and severity of services. */
-		rw->UpdateState(service, StateUpdate::Full);
+		rw->EnqueueConfigObject(service, FullState);
 	}
 }
 
@@ -3322,7 +3280,7 @@ void IcingaDB::DeleteState(const String& id, RedisConnection::QueryArg redisObjK
 }
 
 /**
- * Add the provided data to the Redis HMSETs map.
+ * Add the provided data to the provided map of HMSET queries.
  *
  * @param hMSets The map of HMSETs to add the provided data to.
  * @param redisKey The Redis key to which the HMSET query should be added.

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -42,8 +42,6 @@
 
 using namespace icinga;
 
-using Prio = RedisConnection::QueryPriority;
-
 INITIALIZE_ONCE(&IcingaDB::ConfigStaticInitialize);
 
 // A list of all types for which we want to sync custom variables, along with their corresponding Redis key.
@@ -212,7 +210,9 @@ void IcingaDB::ConfigStaticInitialize()
 
 void IcingaDB::UpdateAllConfigObjects()
 {
-	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:schema", "MAXLEN", "1", "*", "version", "6"}, Prio::Heartbeat);
+	// This function performs an initial dump of all configuration objects into Redis, thus there are no
+	// previously enqueued queries on m_RconWorker that we need to wait for. So, no Sync() call is necessary here.
+	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:schema", "MAXLEN", "1", "*", "version", "6"}, {}, true);
 
 	Log(LogInformation, "IcingaDB") << "Starting initial config/status dump";
 	double startTime = Utility::GetTime();
@@ -228,7 +228,7 @@ void IcingaDB::UpdateAllConfigObjects()
 	upq.SetName("IcingaDB:ConfigDump");
 
 	// Add a new type=* state=wip entry to the stream and remove all previous entries (MAXLEN 1).
-	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "MAXLEN", "1", "*", "key", "*", "state", "wip"}, Prio::Config);
+	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "MAXLEN", "1", "*", "key", "*", "state", "wip"});
 
 	const std::vector<RedisConnection::QueryArg> globalKeys = {
 		CONFIG_REDIS_KEY_PREFIX "customvar",
@@ -245,8 +245,8 @@ void IcingaDB::UpdateAllConfigObjects()
 		CONFIG_REDIS_KEY_PREFIX "redundancygroup",
 		CONFIG_REDIS_KEY_PREFIX "redundancygroup:state",
 	};
-	DeleteKeys(m_RconWorker, globalKeys, Prio::Config);
-	DeleteKeys(m_RconWorker, {"icinga:nextupdate:host", "icinga:nextupdate:service"}, Prio::Config);
+	DeleteKeys(m_RconWorker, globalKeys);
+	DeleteKeys(m_RconWorker, {"icinga:nextupdate:host", "icinga:nextupdate:service"});
 	m_RconWorker->Sync();
 
 	Defer resetDumpedGlobals ([this]() {
@@ -268,7 +268,7 @@ void IcingaDB::UpdateAllConfigObjects()
 
 		auto& rcon (m_Rcons.at(ctype));
 
-		DeleteKeys(rcon, GetTypeOverwriteKeys(type), Prio::Config);
+		DeleteKeys(rcon, GetTypeOverwriteKeys(type));
 
 		WorkQueue upqObjectType(25000, Configuration::Concurrency, LogNotice);
 		upqObjectType.SetName("IcingaDB:ConfigDump:" + type->GetName().ToLower());
@@ -279,9 +279,7 @@ void IcingaDB::UpdateAllConfigObjects()
 			String cursor = "0";
 
 			do {
-				Array::Ptr res = rcon->GetResultOfQuery({
-					"HSCAN", redisKeyPair.ChecksumKey, cursor, "COUNT", "1000"
-				}, Prio::Config);
+				Array::Ptr res = rcon->GetResultOfQuery({"HSCAN", redisKeyPair.ChecksumKey, cursor, "COUNT", "1000"});
 
 				AddKvsToMap(res->Get(1), redisCheckSums);
 
@@ -424,7 +422,7 @@ void IcingaDB::UpdateAllConfigObjects()
 			setChecksum.clear();
 			setObject.clear();
 
-			rcon->FireAndForgetQueries(std::move(transaction), Prio::Config, {affectedConfig});
+			rcon->FireAndForgetQueries(std::move(transaction), {affectedConfig});
 		});
 
 		auto flushDels ([&]() {
@@ -443,7 +441,7 @@ void IcingaDB::UpdateAllConfigObjects()
 			delChecksum.clear();
 			delObject.clear();
 
-			rcon->FireAndForgetQueries(std::move(transaction), Prio::Config, {affectedConfig});
+			rcon->FireAndForgetQueries(std::move(transaction), {affectedConfig});
 		});
 
 		auto setOne ([&]() {
@@ -506,7 +504,7 @@ void IcingaDB::UpdateAllConfigObjects()
 		auto keys = GetTypeOverwriteKeys(type, true);
 		keys.emplace_back(redisKeyPair.ObjectKey);
 		for (auto& key : keys) {
-			rcon->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", key, "state", "done"}, Prio::Config);
+			rcon->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", key, "state", "done"});
 		}
 		rcon->Sync();
 	});
@@ -527,14 +525,14 @@ void IcingaDB::UpdateAllConfigObjects()
 	}
 
 	for (auto& key : globalKeys) {
-		m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", key, "state", "done"}, Prio::Config);
+		m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", key, "state", "done"});
 	}
 
-	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", "*", "state", "done"}, Prio::Config);
+	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", "*", "state", "done"});
 
 	// enqueue a callback that will notify us once all previous queries were executed and wait for this event
 	std::promise<void> p;
-	m_RconWorker->EnqueueCallback([&p](boost::asio::yield_context&) { p.set_value(); }, Prio::Config);
+	m_RconWorker->EnqueueCallback([&p](boost::asio::yield_context&) { p.set_value(); });
 	p.get_future().wait();
 
 	auto endTime (Utility::GetTime());
@@ -567,13 +565,13 @@ std::vector<std::vector<intrusive_ptr<ConfigObject>>> IcingaDB::ChunkObjects(std
 	return chunks;
 }
 
-void IcingaDB::DeleteKeys(const RedisConnection::Ptr& conn, const std::vector<RedisConnection::QueryArg>& keys, RedisConnection::QueryPriority priority) {
+void IcingaDB::DeleteKeys(const RedisConnection::Ptr& conn, const std::vector<RedisConnection::QueryArg>& keys) {
 	RedisConnection::Query query = {"DEL"};
 	for (auto& key : keys) {
 		query.emplace_back(key);
 	}
 
-	conn->FireAndForgetQuery(std::move(query), priority);
+	conn->FireAndForgetQuery(std::move(query));
 }
 
 /**
@@ -1341,7 +1339,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, uint32_t mode)
 		m_RconWorker->FireAndForgetQueries({
 			{"HSET", redisStateKey, objectKey, JsonEncode(stateAttrs)},
 			{"HSET", redisChecksumKey, objectKey, JsonEncode(new Dictionary({{"checksum", checksum}}))},
-		}, Prio::RuntimeStateSync);
+		});
 	}
 
 	if (mode & RuntimeState) {
@@ -1359,7 +1357,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, uint32_t mode)
 			streamadd.emplace_back(IcingaToStreamValue(kv.second));
 		}
 
-		m_RconWorker->FireAndForgetQuery(std::move(streamadd), Prio::RuntimeStateStream, {0, 1});
+		m_RconWorker->FireAndForgetQuery(std::move(streamadd), {0, 1});
 	}
 }
 
@@ -1433,8 +1431,8 @@ void IcingaDB::UpdateDependenciesState(const Checkable::Ptr& checkable, const De
 			queries.emplace_back(std::move(query));
 		}
 
-		m_RconWorker->FireAndForgetQueries(std::move(queries), Prio::RuntimeStateSync);
-		m_RconWorker->FireAndForgetQueries(std::move(streamStates), Prio::RuntimeStateStream, {0, 1});
+		m_RconWorker->FireAndForgetQueries(std::move(queries));
+		m_RconWorker->FireAndForgetQueries(std::move(streamStates), {0, 1});
 	}
 }
 
@@ -2466,8 +2464,7 @@ void IcingaDB::SendNextUpdate(const Checkable::Ptr& checkable)
 				dynamic_pointer_cast<Service>(checkable) ? "icinga:nextupdate:service" : "icinga:nextupdate:host",
 				Convert::ToString(checkable->GetNextUpdate()),
 				GetObjectIdentifier(checkable)
-			},
-			Prio::CheckResult
+			}
 		);
 	} else if (!checkable->GetEnableActiveChecks() || checkable->GetExtension("ConfigObjectDeleted")) {
 		m_RconWorker->FireAndForgetQuery(
@@ -2475,8 +2472,7 @@ void IcingaDB::SendNextUpdate(const Checkable::Ptr& checkable)
 				"ZREM",
 				dynamic_pointer_cast<Service>(checkable) ? "icinga:nextupdate:service" : "icinga:nextupdate:host",
 				GetObjectIdentifier(checkable)
-			},
-			Prio::CheckResult
+			}
 		);
 	}
 }
@@ -2642,7 +2638,7 @@ void IcingaDB::ForwardHistoryEntries()
 
 			if (m_Rcon && m_Rcon->IsConnected()) {
 				try {
-					m_Rcon->GetResultsOfQueries(haystack, Prio::History, {0, 0, haystack.size()});
+					m_Rcon->GetResultsOfQueries(haystack, {0, 0, haystack.size()});
 					break;
 				} catch (const std::exception& ex) {
 					logFailure(ex.what());
@@ -3249,7 +3245,7 @@ void IcingaDB::DeleteRelationship(const String& id, RedisConnection::QueryArg re
 		"redis_key", std::move(redisObjKey), "id", id, "runtime_type", "delete"
 	});
 
-	m_RconWorker->FireAndForgetQueries(queries, Prio::Config);
+	m_RconWorker->FireAndForgetQueries(queries);
 }
 
 void IcingaDB::DeleteState(const String& id, RedisConnection::QueryArg redisObjKey, RedisConnection::QueryArg redisChecksumKey) const
@@ -3262,7 +3258,7 @@ void IcingaDB::DeleteState(const String& id, RedisConnection::QueryArg redisObjK
 		hdels.push_back({"HDEL", std::move(redisChecksumKey), id});
 	}
 
-	m_RconWorker->FireAndForgetQueries(std::move(hdels), Prio::RuntimeStateSync);
+	m_RconWorker->FireAndForgetQueries(std::move(hdels));
 	// TODO: This is currently purposefully commented out due to how Icinga DB (Go) handles runtime state
 	//       upsert and delete events. See https://github.com/Icinga/icingadb/pull/894 for more details.
 	/*m_Rcon->FireAndForgetQueries({{
@@ -3331,11 +3327,11 @@ void IcingaDB::ExecuteRedisTransaction(const RedisConnection::Ptr& rcon,
 	if (transaction.size() > 1) {
 		transaction.emplace_back(RedisConnection::Query{"EXEC"});
 		if (!runtimeUpdates.empty()) {
-			rcon->FireAndForgetQueries(std::move(transaction), Prio::Config, {1});
+			rcon->FireAndForgetQueries(std::move(transaction), {1});
 		} else {
 			// This is likely triggered by the initial Redis config dump, so a) we don't need to record the number of
 			// affected objects and b) we don't really know how many objects are going to be affected by this tx.
-			rcon->FireAndForgetQueries(std::move(transaction), Prio::Config);
+			rcon->FireAndForgetQueries(std::move(transaction));
 		}
 	}
 }

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2954,48 +2954,6 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	return attrs;
 }
 
-std::vector<String>
-IcingaDB::UpdateObjectAttrs(const ConfigObject::Ptr& object, int fieldType,
-							   const String& typeNameOverride)
-{
-	Type::Ptr type = object->GetReflectionType();
-	Dictionary::Ptr attrs(new Dictionary);
-
-	for (int fid = 0; fid < type->GetFieldCount(); fid++) {
-		Field field = type->GetFieldInfo(fid);
-
-		if ((field.Attributes & fieldType) == 0)
-			continue;
-
-		Value val = object->GetField(fid);
-
-		/* hide attributes which shouldn't be user-visible */
-		if (field.Attributes & FANoUserView)
-			continue;
-
-		/* hide internal navigation fields */
-		if (field.Attributes & FANavigation && !(field.Attributes & (FAConfig | FAState)))
-			continue;
-
-		attrs->Set(field.Name, Serialize(val));
-	}
-
-	/* Downtimes require in_effect, which is not an attribute */
-	Downtime::Ptr downtime = dynamic_pointer_cast<Downtime>(object);
-	if (downtime) {
-		attrs->Set("in_effect", Serialize(downtime->IsInEffect()));
-		attrs->Set("trigger_time", Serialize(TimestampToMilliseconds(downtime->GetTriggerTime())));
-	}
-
-
-	/* Use the name checksum as unique key. */
-	String typeName = type->GetName().ToLower();
-	if (!typeNameOverride.IsEmpty())
-		typeName = typeNameOverride.ToLower();
-
-	return {GetObjectIdentifier(object), JsonEncode(attrs)};
-}
-
 void IcingaDB::StateChangeHandler(const ConfigObject::Ptr& object, const CheckResult::Ptr& cr, StateType type)
 {
 	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -165,8 +165,8 @@ void IcingaDB::ConfigStaticInitialize()
 		IcingaDB::NewCheckResultHandler(checkable);
 	});
 
-	Checkable::OnNextCheckUpdated.connect([](const Checkable::Ptr& checkable) {
-		IcingaDB::NextCheckUpdatedHandler(checkable);
+	Checkable::OnNextCheckChanged.connect([](const Checkable::Ptr& checkable, const Value&) {
+		IcingaDB::NextCheckChangedHandler(checkable);
 	});
 
 	Service::OnHostProblemChanged.connect([](const Service::Ptr& service, const CheckResult::Ptr&, const MessageOrigin::Ptr&) {
@@ -3096,7 +3096,7 @@ void IcingaDB::NewCheckResultHandler(const Checkable::Ptr& checkable)
 	}
 }
 
-void IcingaDB::NextCheckUpdatedHandler(const Checkable::Ptr& checkable)
+void IcingaDB::NextCheckChangedHandler(const Checkable::Ptr& checkable)
 {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		rw->EnqueueConfigObject(checkable, VolatileState | NextUpdate);

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -354,7 +354,7 @@ void IcingaDB::UpdateAllConfigObjects()
 				auto checkable (dynamic_pointer_cast<Checkable>(object));
 
 				if (checkable && checkable->GetEnableActiveChecks()) {
-					EnqueueConfigObject(checkable, NextUpdate);
+					EnqueueConfigObject(checkable, icingadb::task_queue::NextUpdate);
 				}
 			}
 
@@ -1334,7 +1334,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, uint32_t mode)
 	String checksum = HashValue(stateAttrs);
 
 	auto [redisStateKey, redisChecksumKey] = GetCheckableStateKeys(checkable->GetReflectionType());
-	if (mode & VolatileState) {
+	if (mode & icingadb::task_queue::VolatileState) {
 		String objectKey = GetObjectIdentifier(checkable);
 		m_RconWorker->FireAndForgetQueries({
 			{"HSET", redisStateKey, objectKey, JsonEncode(stateAttrs)},
@@ -1342,7 +1342,7 @@ void IcingaDB::UpdateState(const Checkable::Ptr& checkable, uint32_t mode)
 		});
 	}
 
-	if (mode & RuntimeState) {
+	if (mode & icingadb::task_queue::RuntimeState) {
 		ObjectLock olock(stateAttrs);
 
 		RedisConnection::Query streamadd({
@@ -1815,7 +1815,7 @@ void IcingaDB::SendConfigDelete(const ConfigObject::Ptr& object)
 
 		auto [configStateKey, checksumStateKey] = GetCheckableStateKeys(checkable->GetReflectionType());
 		EnqueueRelationsDeletion(GetObjectIdentifier(checkable), {{configStateKey, checksumStateKey}});
-		EnqueueConfigObject(object, ConfigDelete | NextUpdate); // Send also ZREM for next update
+		EnqueueConfigObject(object, icingadb::task_queue::ConfigDelete | icingadb::task_queue::NextUpdate); // Send also ZREM for next update
 
 		if (service) {
 			SendGroupsChanged<ServiceGroup>(checkable, service->GetGroups(), nullptr);
@@ -1826,7 +1826,7 @@ void IcingaDB::SendConfigDelete(const ConfigObject::Ptr& object)
 		return;
 	}
 
-	EnqueueConfigObject(object, ConfigDelete);
+	EnqueueConfigObject(object, icingadb::task_queue::ConfigDelete);
 
 	if (type == TimePeriod::TypeInstance) {
 		TimePeriod::Ptr timeperiod = static_pointer_cast<TimePeriod>(object);
@@ -1888,7 +1888,7 @@ void IcingaDB::SendStateChange(const ConfigObject::Ptr& object, const CheckResul
 
 	tie(host, service) = GetHostService(checkable);
 
-	EnqueueConfigObject(checkable, RuntimeState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::RuntimeState);
 
 	int hard_state{};
 	if (!cr) {
@@ -2069,7 +2069,7 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 		return;
 	}
 
-	EnqueueConfigObject(downtime, ConfigUpdate);
+	EnqueueConfigObject(downtime, icingadb::task_queue::ConfigUpdate);
 
 	auto checkable (downtime->GetCheckable());
 	auto triggeredBy (Downtime::GetByName(downtime->GetTriggeredBy()));
@@ -2079,7 +2079,7 @@ void IcingaDB::SendStartedDowntime(const Downtime::Ptr& downtime)
 	tie(host, service) = GetHostService(checkable);
 
 	/* Update checkable state as in_downtime may have changed. */
-	EnqueueConfigObject(checkable, FullState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:downtime", "*",
@@ -2168,7 +2168,7 @@ void IcingaDB::SendRemovedDowntime(const Downtime::Ptr& downtime)
 		return;
 
 	/* Update checkable state as in_downtime may have changed. */
-	EnqueueConfigObject(checkable, FullState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:downtime", "*",
@@ -2257,7 +2257,7 @@ void IcingaDB::SendAddedComment(const Comment::Ptr& comment)
 	tie(host, service) = GetHostService(checkable);
 
 	// Update the checkable state to so that the "last_comment_id" is correctly reflected.
-	EnqueueConfigObject(checkable, FullState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:comment", "*",
@@ -2331,7 +2331,7 @@ void IcingaDB::SendRemovedComment(const Comment::Ptr& comment)
 	tie(host, service) = GetHostService(checkable);
 
 	// Update the checkable state to so that the "last_comment_id" is correctly reflected.
-	EnqueueConfigObject(checkable, FullState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:comment", "*",
@@ -2488,7 +2488,7 @@ void IcingaDB::SendAcknowledgementSet(const Checkable::Ptr& checkable, const Str
 	tie(host, service) = GetHostService(checkable);
 
 	/* Update checkable state as is_acknowledged may have changed. */
-	EnqueueConfigObject(checkable, FullState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
@@ -2546,7 +2546,7 @@ void IcingaDB::SendAcknowledgementCleared(const Checkable::Ptr& checkable, const
 	tie(host, service) = GetHostService(checkable);
 
 	/* Update checkable state as is_acknowledged may have changed. */
-	EnqueueConfigObject(checkable, FullState);
+	EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 
 	RedisConnection::Query xAdd ({
 		"XADD", "icinga:history:stream:acknowledgement", "*",
@@ -2965,7 +2965,7 @@ void IcingaDB::ReachabilityChangeHandler(const std::set<Checkable::Ptr>& childre
 {
 	for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		for (auto& checkable : children) {
-			rw->EnqueueConfigObject(checkable, FullState);
+			rw->EnqueueConfigObject(checkable, icingadb::task_queue::FullState);
 			for (const auto& dependencyGroup : checkable->GetDependencyGroups()) {
 				rw->EnqueueDependencyGroupStateUpdate(dependencyGroup);
 			}
@@ -2986,7 +2986,7 @@ void IcingaDB::VersionChangedHandler(const ConfigObject::Ptr& object)
 	if (object->IsActive()) {
 		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 			// A runtime config change triggers also a full state update as well as next update event.
-			rw->EnqueueConfigObject(object, ConfigUpdate | FullState | NextUpdate);
+			rw->EnqueueConfigObject(object, icingadb::task_queue::ConfigUpdate | icingadb::task_queue::FullState | icingadb::task_queue::NextUpdate);
 		}
 	} else if (!object->IsActive() && object->GetExtension("ConfigObjectDeleted")) { // same as in apilistener-configsync.cpp
 		for (const IcingaDB::Ptr& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
@@ -3050,21 +3050,21 @@ void IcingaDB::FlappingChangeHandler(const Checkable::Ptr& checkable, double cha
 void IcingaDB::NewCheckResultHandler(const Checkable::Ptr& checkable)
 {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-		rw->EnqueueConfigObject(checkable, VolatileState);
+		rw->EnqueueConfigObject(checkable, icingadb::task_queue::VolatileState);
 	}
 }
 
 void IcingaDB::NextCheckChangedHandler(const Checkable::Ptr& checkable)
 {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-		rw->EnqueueConfigObject(checkable, VolatileState | NextUpdate);
+		rw->EnqueueConfigObject(checkable, icingadb::task_queue::VolatileState | icingadb::task_queue::NextUpdate);
 	}
 }
 
 void IcingaDB::DependencyGroupChildRegisteredHandler(const Checkable::Ptr& child, const DependencyGroup::Ptr& dependencyGroup)
 {
 	for (const auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
-		rw->EnqueueConfigObject(child, FullState); // Child requires a full state update.
+		rw->EnqueueConfigObject(child, icingadb::task_queue::FullState); // Child requires a full state update.
 		rw->EnqueueDependencyChildRegistered(dependencyGroup, child);
 		rw->EnqueueDependencyGroupStateUpdate(dependencyGroup);
 
@@ -3075,7 +3075,7 @@ void IcingaDB::DependencyGroupChildRegisteredHandler(const Checkable::Ptr& child
 			// Checkable as well. The grandparent Checkable may still have wrong numbers of total children, though it's
 			// not worth traversing the whole tree way up and sending config updates for each one of them, as the next
 			// Redis config dump is going to fix it anyway.
-			rw->EnqueueConfigObject(parent, ConfigUpdate | FullState);
+			rw->EnqueueConfigObject(parent, icingadb::task_queue::ConfigUpdate | icingadb::task_queue::FullState);
 		}
 	}
 }
@@ -3090,7 +3090,7 @@ void IcingaDB::DependencyGroupChildRemovedHandler(const DependencyGroup::Ptr& de
 void IcingaDB::HostProblemChangedHandler(const Service::Ptr& service) {
 	for (auto& rw : ConfigType::GetObjectsByType<IcingaDB>()) {
 		/* Host state changes affect is_handled and severity of services. */
-		rw->EnqueueConfigObject(service, FullState);
+		rw->EnqueueConfigObject(service, icingadb::task_queue::FullState);
 	}
 }
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -227,14 +227,6 @@ void IcingaDB::UpdateAllConfigObjects()
 	WorkQueue upq(25000, Configuration::Concurrency, LogNotice);
 	upq.SetName("IcingaDB:ConfigDump");
 
-	m_RconWorker->SuppressQueryKind(Prio::CheckResult);
-	m_RconWorker->SuppressQueryKind(Prio::RuntimeStateSync);
-
-	Defer unSuppress ([this]() {
-		m_RconWorker->UnsuppressQueryKind(Prio::RuntimeStateSync);
-		m_RconWorker->UnsuppressQueryKind(Prio::CheckResult);
-	});
-
 	// Add a new type=* state=wip entry to the stream and remove all previous entries (MAXLEN 1).
 	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "MAXLEN", "1", "*", "key", "*", "state", "wip"}, Prio::Config);
 

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -47,7 +47,7 @@ void IcingaDB::PendingItemsThreadProc()
 	// Redis queries when the Redis connection is saturated.
 	constexpr std::size_t maxPendingQueries = 128;
 	// The minimum age an item must have before it can be processed.
-	constexpr ch::milliseconds minItemAge{1000};
+	constexpr ch::milliseconds minItemAge{300};
 
 	std::unique_lock lock(m_PendingItemsMutex);
 	// Wait until the initial config dump is done. IcingaDB::OnConnectedHandler will notify us once it's finished.

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -85,6 +85,7 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 {
 	using namespace std::chrono_literals;
 	namespace ch = std::chrono;
+	namespace queue = icingadb::task_queue;
 
 	bool madeProgress = false; // Did we make any progress in this iteration?
 	ch::duration<double> retryAfter{0}; // If we can't process anything right now, how long to wait before retrying?
@@ -93,7 +94,7 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 	auto& seqView = m_PendingItems.get<1>();
 	for (auto it(seqView.begin()); it != seqView.end(); ++it) {
 		if (it != seqView.begin()) {
-			if (dynamic_cast<const icingadb::task_queue::RelationsDeletionItem*>(it->get())) {
+			if (std::holds_alternative<queue::RelationsDeletionItem>(it->Item)) {
 				// We don't know whether the previous items are related to this deletion item or not,
 				// thus we can't just process this right now when there are older items in the queue.
 				// Otherwise, we might delete something that is going to be updated/created.
@@ -101,14 +102,19 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 			}
 		}
 
-		if (auto age = now - (*it)->EnqueueTime; 1000ms > age) {
+		if (auto age = now - it->EnqueueTime; 1000ms > age) {
 			if (it == seqView.begin()) {
 				retryAfter = 1000ms - age;
 			}
 			break;
 		}
 
-		ConfigObject::Ptr cobj = (*it)->GetObjectToLock();
+		ConfigObject::Ptr cobj;
+		if (auto confPtr = std::get_if<queue::PendingConfigItem>(&it->Item); confPtr) {
+			cobj = confPtr->Object;
+		} else if (auto edgePtr = std::get_if<queue::PendingDependencyEdgeItem>(&it->Item)) {
+			cobj = edgePtr->Child;
+		}
 		ObjectLock olock(cobj, std::defer_lock);
 		if (cobj && !olock.TryLock()) {
 			continue; // Can't lock the object right now, try the next one.
@@ -119,14 +125,15 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 		madeProgress = true;
 
 		lock.unlock();
-		try {
-			itemToProcess->Execute(*this);
-		} catch (const std::exception& ex) {
-			icingadb::task_queue::PendingQueueItem& itemRef = *itemToProcess; // For typeid(operand of typeid must not have any side effects).
-			Log(LogCritical, "IcingaDB")
-				<< "Exception while processing pending item of type '" << typeid(itemRef).name() << "': "
-				<< DiagnosticInformation(ex, GetActive());
-		}
+		std::visit([this](auto &item) {
+			try {
+				ProcessQueueItem(item);
+			} catch (const std::exception& ex) {
+				Log(LogCritical, "IcingaDB")
+					<< "Exception while processing pending item of type '" << typeid(decltype(item)).name() << "': "
+					<< DiagnosticInformation(ex, GetActive());
+			}
+		}, itemToProcess.Item);
 		lock.lock();
 		break;
 	}
@@ -138,11 +145,6 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 	return retryAfter;
 }
 
-ConfigObject::Ptr icingadb::task_queue::PendingConfigItem::GetObjectToLock() const
-{
-	return Object;
-}
-
 /**
  * Execute the pending configuration item.
  *
@@ -150,15 +152,18 @@ ConfigObject::Ptr icingadb::task_queue::PendingConfigItem::GetObjectToLock() con
  * on the dirty bits set for the associated configuration object. It handles configuration deletions, updates,
  * and state updates for checkable objects.
  *
- * @param icingadb The IcingaDB instance to use for executing Redis queries.
+ * @param item The queue item to process.
  */
-void icingadb::task_queue::PendingConfigItem::Execute(IcingaDB& icingadb) const {
-	if (DirtyBits & ConfigDelete) {
-		auto redisKeyPair = icingadb.GetSyncableTypeRedisKeys(Object->GetReflectionType());
-		icingadb.m_RconWorker->FireAndForgetQueries(
+void IcingaDB::ProcessQueueItem(const icingadb::task_queue::PendingConfigItem& item)
+{
+	namespace queue = icingadb::task_queue;
+
+	if (item.DirtyBits & queue::ConfigDelete) {
+		auto redisKeyPair = GetSyncableTypeRedisKeys(item.Object->GetReflectionType());
+		m_RconWorker->FireAndForgetQueries(
 			{
-				{"HDEL", redisKeyPair.ObjectKey, icingadb.GetObjectIdentifier(Object)},
-				{"HDEL", redisKeyPair.ChecksumKey, icingadb.GetObjectIdentifier(Object)},
+				{"HDEL", redisKeyPair.ObjectKey, GetObjectIdentifier(item.Object)},
+				{"HDEL", redisKeyPair.ChecksumKey, GetObjectIdentifier(item.Object)},
 				{
 					"XADD",
 					"icinga:runtime",
@@ -169,7 +174,7 @@ void icingadb::task_queue::PendingConfigItem::Execute(IcingaDB& icingadb) const 
 					"redis_key",
 					redisKeyPair.ObjectKey,
 					"id",
-					icingadb.GetObjectIdentifier(Object),
+					GetObjectIdentifier(item.Object),
 					"runtime_type",
 					"delete"
 				}
@@ -177,19 +182,19 @@ void icingadb::task_queue::PendingConfigItem::Execute(IcingaDB& icingadb) const 
 		);
 	}
 
-	if (DirtyBits & ConfigUpdate) {
+	if (item.DirtyBits & queue::ConfigUpdate) {
 		std::map<RedisConnection::QueryArg, RedisConnection::Query> hMSets;
 		std::vector<Dictionary::Ptr> runtimeUpdates;
-		icingadb.CreateConfigUpdate(Object, icingadb.GetSyncableTypeRedisKeys(Object->GetReflectionType()), hMSets, runtimeUpdates, true);
-		icingadb.ExecuteRedisTransaction(icingadb.m_RconWorker, hMSets, runtimeUpdates);
+		CreateConfigUpdate(item.Object, GetSyncableTypeRedisKeys(item.Object->GetReflectionType()), hMSets, runtimeUpdates, true);
+		ExecuteRedisTransaction(m_RconWorker, hMSets, runtimeUpdates);
 	}
 
-	if (auto checkable = dynamic_pointer_cast<Checkable>(Object); checkable) {
-		if (DirtyBits & FullState) {
-			icingadb.UpdateState(checkable, DirtyBits);
+	if (auto checkable = dynamic_pointer_cast<Checkable>(item.Object); checkable) {
+		if (item.DirtyBits & queue::FullState) {
+			UpdateState(checkable, item.DirtyBits);
 		}
-		if (DirtyBits & NextUpdate) {
-			icingadb.SendNextUpdate(checkable);
+		if (item.DirtyBits & queue::NextUpdate) {
+			SendNextUpdate(checkable);
 		}
 	}
 }
@@ -201,15 +206,15 @@ void icingadb::task_queue::PendingConfigItem::Execute(IcingaDB& icingadb) const 
  * dependency group in Redis. It selects any child checkable from the dependency group to initiate
  * the state update, as all children share the same dependency group state.
  *
- * @param icingadb The IcingaDB instance to use for executing Redis queries.
+ * @param item The queue item to process.
  */
-void icingadb::task_queue::PendingDependencyGroupStateItem::Execute(IcingaDB& icingadb) const
+void IcingaDB::ProcessQueueItem(const icingadb::task_queue::PendingDependencyGroupStateItem& item) const
 {
 	// For dependency group state updates, we don't actually care which child triggered the update,
 	// since all children share the same dependency group state. Thus, we can just pick any child to
 	// start the update from.
-	if (auto child = DepGroup->GetAnyChild(); child) {
-		icingadb.UpdateDependenciesState(child, DepGroup);
+	if (auto child = item.DepGroup->GetAnyChild(); child) {
+		UpdateDependenciesState(child, item.DepGroup);
 	}
 }
 
@@ -219,14 +224,14 @@ void icingadb::task_queue::PendingDependencyGroupStateItem::Execute(IcingaDB& ic
  * This function processes the pending dependency edge item and ensures that the necessary Redis
  * operations are performed to register the child checkable as part of the dependency group.
  *
- * @param icingadb The IcingaDB instance to use for executing Redis queries.
+ * @param item The queue item to process.
  */
-void icingadb::task_queue::PendingDependencyEdgeItem::Execute(IcingaDB& icingadb) const
+void IcingaDB::ProcessQueueItem(const icingadb::task_queue::PendingDependencyEdgeItem& item)
 {
 	std::vector<Dictionary::Ptr> runtimeUpdates;
 	std::map<RedisConnection::QueryArg, RedisConnection::Query> hMSets;
-	icingadb.InsertCheckableDependencies(Child, hMSets, &runtimeUpdates, DepGroup);
-	icingadb.ExecuteRedisTransaction(icingadb.m_RconWorker, hMSets, runtimeUpdates);
+	InsertCheckableDependencies(item.Child, hMSets, &runtimeUpdates, item.DepGroup);
+	ExecuteRedisTransaction(m_RconWorker, hMSets, runtimeUpdates);
 }
 
 /**
@@ -236,15 +241,15 @@ void icingadb::task_queue::PendingDependencyEdgeItem::Execute(IcingaDB& icingadb
  * from Redis. It iterates over the map of Redis keys and deletes the relations associated with
  * the given ID.
  *
- * @param icingadb The IcingaDB instance to use for executing Redis queries.
+ * @param item The queue item to process.
  */
-void icingadb::task_queue::RelationsDeletionItem::Execute(IcingaDB& icingadb) const
+void IcingaDB::ProcessQueueItem(const icingadb::task_queue::RelationsDeletionItem& item)
 {
-	for (const auto& [configKey, checksumKey] : Relations) {
-		if (icingadb.IsStateKey(configKey)) {
-			icingadb.DeleteState(ID, configKey, checksumKey);
+	for (const auto& [configKey, checksumKey] : item.Relations) {
+		if (IsStateKey(configKey)) {
+			DeleteState(item.ID, configKey, checksumKey);
 		} else {
-			icingadb.DeleteRelationship(ID, configKey, checksumKey);
+			DeleteRelationship(item.ID, configKey, checksumKey);
 		}
 	}
 }
@@ -257,22 +262,23 @@ void icingadb::task_queue::RelationsDeletionItem::Execute(IcingaDB& icingadb) co
  */
 void IcingaDB::EnqueueConfigObject(const ConfigObject::Ptr& object, uint32_t bits)
 {
+	namespace queue = icingadb::task_queue;
+
 	if (!GetActive() || !m_RconWorker || !m_RconWorker->IsConnected()) {
 		return; // No need to enqueue anything if we're not connected.
 	}
-	namespace queue = icingadb::task_queue;
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<queue::PendingConfigItem>(object, bits)); !inserted) {
-			m_PendingItems.modify(it, [bits](const std::shared_ptr<queue::PendingQueueItem>& item) {
-				auto configItem = dynamic_cast<queue::PendingConfigItem*>(item.get());
+		if (auto [it, inserted] = m_PendingItems.emplace(queue::PendingConfigItem{object, bits}); !inserted) {
+			m_PendingItems.modify(it, [bits](queue::PendingQueueItem& item) {
+				auto& configItem = std::get<queue::PendingConfigItem>(item.Item);
 				if (bits & queue::ConfigDelete) {
-					configItem->DirtyBits &= ~(queue::ConfigUpdate | queue::FullState);
+					configItem.DirtyBits &= ~(queue::ConfigUpdate | queue::FullState);
 				} else if (bits & queue::ConfigUpdate) {
-					configItem->DirtyBits &= ~queue::ConfigDelete;
+					configItem.DirtyBits &= ~queue::ConfigDelete;
 				}
-				configItem->DirtyBits |= bits & queue::DirtyBitsAll;
+				configItem.DirtyBits |= bits & queue::DirtyBitsAll;
 			});
 		}
 	}
@@ -284,7 +290,7 @@ void IcingaDB::EnqueueDependencyGroupStateUpdate(const DependencyGroup::Ptr& dep
 	if (GetActive() && m_RconWorker && m_RconWorker->IsConnected()) {
 		{
 			std::lock_guard lock(m_PendingItemsMutex);
-			m_PendingItems.insert(std::make_shared<icingadb::task_queue::PendingDependencyGroupStateItem>(depGroup));
+			m_PendingItems.emplace(icingadb::task_queue::PendingDependencyGroupStateItem{depGroup});
 		}
 		m_PendingItemsCV.notify_one();
 	}
@@ -304,7 +310,7 @@ void IcingaDB::EnqueueDependencyChildRegistered(const DependencyGroup::Ptr& depG
 	if (GetActive() && m_RconWorker && m_RconWorker->IsConnected()) {
 		{
 			std::lock_guard lock(m_PendingItemsMutex);
-			m_PendingItems.insert(std::make_shared<icingadb::task_queue::PendingDependencyEdgeItem>(depGroup, child));
+			m_PendingItems.emplace(icingadb::task_queue::PendingDependencyEdgeItem{depGroup, child});
 		}
 		m_PendingItemsCV.notify_one();
 	}
@@ -330,6 +336,8 @@ void IcingaDB::EnqueueDependencyChildRemoved(
 	bool removeGroup
 )
 {
+	namespace queue = icingadb::task_queue;
+
 	if (dependencies.empty() || !GetActive() || !m_RconWorker || !m_RconWorker->IsConnected()) {
 		return; // No need to enqueue anything if we're not connected or there are no dependencies.
 	}
@@ -339,13 +347,12 @@ void IcingaDB::EnqueueDependencyChildRemoved(
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto it(m_PendingItems.find(std::make_pair(child, depGroup))); it != m_PendingItems.end()) {
+		if (m_PendingItems.erase(std::make_pair(depGroup.get(), child.get())) > 0) {
 			cancelledRegistration = true;
-			m_PendingItems.erase(it);
 			if (removeGroup) {
 				// If we're removing the entire group registration, we can also drop any pending dependency group
 				// state update triggered previously as it should no longer have any children left.
-				m_PendingItems.erase(std::make_pair(nullptr, depGroup));
+				m_PendingItems.erase(depGroup.get());
 			}
 		}
 	}
@@ -410,7 +417,7 @@ void IcingaDB::EnqueueDependencyChildRemoved(
 			// Checkable as well. The grandparent Checkable may still have wrong numbers of total children, though it's
 			// not worth traversing the whole tree way up and sending config updates for each one of them, as the next
 			// Redis config dump is going to fix it anyway.
-			EnqueueConfigObject(parent, icingadb::task_queue::ConfigUpdate);
+			EnqueueConfigObject(parent, queue::ConfigUpdate);
 
 			if (!parent->HasAnyDependencies()) {
 				// If the parent Checkable isn't part of any other dependency chain anymore, drop its dependency node entry.
@@ -447,18 +454,20 @@ void IcingaDB::EnqueueDependencyChildRemoved(
  * @param id The ID of the relation to be deleted.
  * @param relations A map of Redis keys from which to delete the relation.
  */
-void IcingaDB::EnqueueRelationsDeletion(const String& id, const icingadb::task_queue::RelationsDeletionItem::RelationsKeySet& relations)
+void IcingaDB::EnqueueRelationsDeletion(const String& id, icingadb::task_queue::RelationsDeletionItem::RelationsKeySet relations)
 {
+	namespace queue = icingadb::task_queue;
+
 	if (!GetActive() || !m_RconWorker || !m_RconWorker->IsConnected()) {
 		return; // No need to enqueue anything if we're not connected.
 	}
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<icingadb::task_queue::RelationsDeletionItem>(id, relations)); !inserted) {
-			m_PendingItems.modify(it, [&relations](std::shared_ptr<icingadb::task_queue::PendingQueueItem>& val) {
-				auto item = dynamic_cast<icingadb::task_queue::RelationsDeletionItem*>(val.get());
-				item->Relations.insert(relations.begin(), relations.end());
+		if (auto [it, inserted] = m_PendingItems.emplace(queue::RelationsDeletionItem{id, relations}); !inserted) {
+			m_PendingItems.modify(it, [&relations](queue::PendingQueueItem& val) {
+				auto& item = std::get<queue::RelationsDeletionItem>(val.Item);
+				item.Relations.merge(std::move(relations));
 			});
 		}
 	}

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -51,26 +51,16 @@ void IcingaDB::PendingItemsThreadProc()
 	// Wait until the initial config dump is done. IcingaDB::OnConnectedHandler will notify us once it's finished.
 	while (GetActive() && !m_ConfigDumpDone) m_PendingItemsCV.wait(lock);
 
-	// Predicate to determine whether the worker thread is allowed to process pending items.
-	auto canContinue = [this] {
-		if (!GetActive()) {
-			return true;
-		}
-		return !m_PendingItems.empty() && m_RconWorker && m_RconWorker->IsConnected() && m_RconWorker->GetPendingQueryCount() < maxPendingQueries;
-	};
-
-	while (true) {
-		// Even if someone notifies us, we still need to verify whether the precondition is actually fulfilled.
-		// However, in case we don't receive any notification, we still want to wake up periodically on our own
-		// to check whether we can proceed (e.g. the Redis connection might have become available again and there
-		// was no activity on the pending items queue to trigger a notification). Thus, we use a timed wait here.
-		while (!canContinue()) m_PendingItemsCV.wait_for(lock, 100ms);
-
-		if (!GetActive()) {
-			break;
-		}
-		if (auto retryAfter = DequeueAndProcessOne(lock); retryAfter > 0ms) {
-			m_PendingItemsCV.wait_for(lock, retryAfter);
+	while (GetActive()) {
+		if (!m_PendingItems.empty() && m_RconWorker && m_RconWorker->IsConnected() && m_RconWorker->GetPendingQueryCount() < maxPendingQueries) {
+			if (auto retryAfter = DequeueAndProcessOne(lock); retryAfter > 0ms) {
+				m_PendingItemsCV.wait_for(lock, retryAfter);
+			}
+		} else {
+			// In case we don't receive any notification, we still want to wake up periodically on our own
+			// to check whether we can proceed (e.g. the Redis connection might have become available again and there
+			// was no activity on the pending items queue to trigger a notification). Thus, we use a timed wait here.
+			m_PendingItemsCV.wait_for(lock, 100ms);
 		}
 	}
 }

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -188,8 +188,7 @@ void IcingaDB::ProcessPendingItem(const PendingConfigItem& item)
 					"runtime_type",
 					"delete"
 				}
-			},
-			RedisConnection::QueryPriority::Config
+			}
 		);
 	}
 

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -7,27 +7,23 @@
 
 using namespace icinga;
 
-PendingQueueItem::PendingQueueItem(PendingItemKey&& id, uint32_t dirtyBits)
-	: DirtyBits{dirtyBits & DirtyBitsAll}, ID{std::move(id)}, EnqueueTime{std::chrono::steady_clock::now()}
+PendingConfigItem::PendingConfigItem(const ConfigObject::Ptr& obj, uint32_t bits)
+	: Object{obj}, DirtyBits{bits & DirtyBitsAll}
 {
 }
 
-PendingConfigItem::PendingConfigItem(const ConfigObject::Ptr& obj, uint32_t bits)
-	: PendingQueueItem{std::make_pair(obj, nullptr), bits}, Object{obj}
-{
-}
 PendingDependencyGroupStateItem::PendingDependencyGroupStateItem(const DependencyGroup::Ptr& depGroup)
-	: PendingQueueItem{std::make_pair(nullptr, depGroup), 0}, DepGroup{depGroup}
+	: DepGroup{depGroup}
 {
 }
 
 PendingDependencyEdgeItem::PendingDependencyEdgeItem(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child)
-	: PendingQueueItem{std::make_pair(child, depGroup), 0}, DepGroup{depGroup}, Child{child}
+	: DepGroup{depGroup}, Child{child}
 {
 }
 
-RelationsDeletionItem::RelationsDeletionItem(const String& id, RelationsKeySet relations)
-	: PendingQueueItem{id, 0}, Relations{std::move(relations)}
+RelationsDeletionItem::RelationsDeletionItem(const String& id, const RelationsKeySet& relations)
+	: ID{id}, Relations{relations}
 {
 }
 
@@ -107,7 +103,7 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 	auto& seqView = m_PendingItems.get<1>();
 	for (auto it(seqView.begin()); it != seqView.end(); ++it) {
 		if (it != seqView.begin()) {
-			if (std::holds_alternative<RelationsDeletionItem>(*it)) {
+			if (dynamic_cast<const RelationsDeletionItem*>(it->get())) {
 				// We don't know whether the previous items are related to this deletion item or not,
 				// thus we can't just process this right now when there are older items in the queue.
 				// Otherwise, we might delete something that is going to be updated/created.
@@ -115,34 +111,30 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 			}
 		}
 
-		auto age = now - std::visit([](const auto& item) { return item.EnqueueTime; }, *it);
-		if (GetActive() && 1000ms > age) {
+		if (auto age = now - (*it)->EnqueueTime; 1000ms > age) {
 			if (it == seqView.begin()) {
 				retryAfter = 1000ms - age;
 			}
 			break;
 		}
 
-		ConfigObject::Ptr cobj;
-		if (auto* citem = std::get_if<PendingConfigItem>(&*it); citem) {
-			cobj = citem->Object;
-		}
-
+		ConfigObject::Ptr cobj = (*it)->GetObjectToLock();
 		ObjectLock olock(cobj, std::defer_lock);
 		if (cobj && !olock.TryLock()) {
 			continue; // Can't lock the object right now, try the next one.
 		}
 
-		PendingItemVariant itemToProcess = *it;
+		auto itemToProcess = *it;
 		seqView.erase(it);
 		madeProgress = true;
 
 		lock.unlock();
 		try {
-			std::visit([this](const auto& item) { ProcessPendingItem(item); }, itemToProcess);
+			itemToProcess->Execute(*this);
 		} catch (const std::exception& ex) {
+			PendingQueueItem& itemRef = *itemToProcess; // For typeid(operand of typeid must not have any side effects).
 			Log(LogCritical, "IcingaDB")
-				<< "Exception while processing pending item of type index '" << itemToProcess.index() << "': "
+				<< "Exception while processing pending item of type '" << typeid(itemRef).name() << "': "
 				<< DiagnosticInformation(ex, GetActive());
 		}
 		lock.lock();
@@ -156,24 +148,27 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 	return retryAfter;
 }
 
-/**
- * Process a single pending object.
- *
- * This function processes a single pending object based on its dirty bits. It checks if the object is a
- * @c ConfigObject and performs the appropriate actions such as sending configuration updates, state updates,
- * or deletions to the Redis connection. The function handles different types of objects, including @c Checkable
- * objects, and ensures that the correct updates are sent based on the dirty bits set for the object.
- *
- * @param item The pending item containing the object and its dirty bits.
- */
-void IcingaDB::ProcessPendingItem(const PendingConfigItem& item)
+ConfigObject::Ptr PendingConfigItem::GetObjectToLock() const
 {
-	if (item.DirtyBits & ConfigDelete) {
-		auto redisKeyPair = GetSyncableTypeRedisKeys(item.Object->GetReflectionType());
-		m_RconWorker->FireAndForgetQueries(
+	return Object;
+}
+
+/**
+ * Execute the pending configuration item.
+ *
+ * This function processes the pending configuration item by performing the necessary Redis operations based
+ * on the dirty bits set for the associated configuration object. It handles configuration deletions, updates,
+ * and state updates for checkable objects.
+ *
+ * @param icingadb The IcingaDB instance to use for executing Redis queries.
+ */
+void PendingConfigItem::Execute(IcingaDB& icingadb) const {
+	if (DirtyBits & ConfigDelete) {
+		auto redisKeyPair = icingadb.GetSyncableTypeRedisKeys(Object->GetReflectionType());
+		icingadb.m_RconWorker->FireAndForgetQueries(
 			{
-				{"HDEL", redisKeyPair.ObjectKey, GetObjectIdentifier(item.Object)},
-				{"HDEL", redisKeyPair.ChecksumKey, GetObjectIdentifier(item.Object)},
+				{"HDEL", redisKeyPair.ObjectKey, icingadb.GetObjectIdentifier(Object)},
+				{"HDEL", redisKeyPair.ChecksumKey, icingadb.GetObjectIdentifier(Object)},
 				{
 					"XADD",
 					"icinga:runtime",
@@ -184,7 +179,7 @@ void IcingaDB::ProcessPendingItem(const PendingConfigItem& item)
 					"redis_key",
 					redisKeyPair.ObjectKey,
 					"id",
-					GetObjectIdentifier(item.Object),
+					icingadb.GetObjectIdentifier(Object),
 					"runtime_type",
 					"delete"
 				}
@@ -192,78 +187,74 @@ void IcingaDB::ProcessPendingItem(const PendingConfigItem& item)
 		);
 	}
 
-	if (item.DirtyBits & ConfigUpdate) {
+	if (DirtyBits & ConfigUpdate) {
 		std::map<RedisConnection::QueryArg, RedisConnection::Query> hMSets;
 		std::vector<Dictionary::Ptr> runtimeUpdates;
-		CreateConfigUpdate(item.Object, GetSyncableTypeRedisKeys(item.Object->GetReflectionType()), hMSets, runtimeUpdates, true);
-		ExecuteRedisTransaction(m_RconWorker, hMSets, runtimeUpdates);
+		icingadb.CreateConfigUpdate(Object, icingadb.GetSyncableTypeRedisKeys(Object->GetReflectionType()), hMSets, runtimeUpdates, true);
+		icingadb.ExecuteRedisTransaction(icingadb.m_RconWorker, hMSets, runtimeUpdates);
 	}
 
-	if (auto checkable = dynamic_pointer_cast<Checkable>(item.Object); checkable) {
-		if (item.DirtyBits & FullState) {
-			UpdateState(checkable, item.DirtyBits);
+	if (auto checkable = dynamic_pointer_cast<Checkable>(Object); checkable) {
+		if (DirtyBits & FullState) {
+			icingadb.UpdateState(checkable, DirtyBits);
 		}
-		if (item.DirtyBits & NextUpdate) {
-			SendNextUpdate(checkable);
+		if (DirtyBits & NextUpdate) {
+			icingadb.SendNextUpdate(checkable);
 		}
 	}
 }
 
 /**
- * Process a single pending dependency group state item.
+ * Execute the pending dependency group state item.
  *
- * This function processes a single pending dependency group state item by updating the dependencies
- * state for the associated dependency group. It selects any child checkable from the dependency group
- * to initiate the state update process.
+ * This function processes the pending dependency group state item by updating the state of the
+ * dependency group in Redis. It selects any child checkable from the dependency group to initiate
+ * the state update, as all children share the same dependency group state.
  *
- * @param item The pending dependency group state item containing the dependency group.
+ * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void IcingaDB::ProcessPendingItem(const PendingDependencyGroupStateItem& item) const
+void PendingDependencyGroupStateItem::Execute(IcingaDB& icingadb) const
 {
 	// For dependency group state updates, we don't actually care which child triggered the update,
 	// since all children share the same dependency group state. Thus, we can just pick any child to
 	// start the update from.
-	if (auto child = item.DepGroup->GetAnyChild(); child) {
-		UpdateDependenciesState(child, item.DepGroup);
+	if (auto child = DepGroup->GetAnyChild(); child) {
+		icingadb.UpdateDependenciesState(child, DepGroup);
 	}
 }
 
 /**
- * Process a single pending dependency edge item.
+ * Execute the pending dependency edge item.
  *
- * This function fully serializes a single pending dependency edge item (child registration)
- * and sends all the resulting Redis queries in a single transaction. The dependencies (edges)
- * to serialize are determined by the dependency group and child checkable the provided item represents.
+ * This function processes the pending dependency edge item and ensures that the necessary Redis
+ * operations are performed to register the child checkable as part of the dependency group.
  *
- * @param item The pending dependency edge item containing the dependency group and child checkable.
+ * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void IcingaDB::ProcessPendingItem(const PendingDependencyEdgeItem& item)
+void PendingDependencyEdgeItem::Execute(IcingaDB& icingadb) const
 {
 	std::vector<Dictionary::Ptr> runtimeUpdates;
 	std::map<RedisConnection::QueryArg, RedisConnection::Query> hMSets;
-	InsertCheckableDependencies(item.Child, hMSets, &runtimeUpdates, item.DepGroup);
-	ExecuteRedisTransaction(m_RconWorker, hMSets, runtimeUpdates);
+	icingadb.InsertCheckableDependencies(Child, hMSets, &runtimeUpdates, DepGroup);
+	icingadb.ExecuteRedisTransaction(icingadb.m_RconWorker, hMSets, runtimeUpdates);
 }
 
 /**
- * Process a single pending deletion item.
+ * Execute the pending relations deletion item.
  *
- * This function processes a single pending deletion item by deleting the specified sub-keys
- * from Redis based on the provided deletion keys map. It ensures that the object's ID is
- * removed from the specified Redis keys and their corresponding checksum keys if indicated.
+ * This function processes the pending relations deletion item by deleting the specified relations
+ * from Redis. It iterates over the map of Redis keys and deletes the relations associated with
+ * the given ID.
  *
- * @param item The pending deletion item containing the ID and deletion keys map.
+ * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void IcingaDB::ProcessPendingItem(const RelationsDeletionItem& item)
+void RelationsDeletionItem::Execute(IcingaDB& icingadb) const
 {
-	ASSERT(std::holds_alternative<std::string>(item.ID)); // Relation deletion items must have real IDs.
-
-	auto id = std::get<std::string>(item.ID);
-	for (auto [configKey, checksumKey] : item.Relations) {
-		if (IsStateKey(configKey)) {
-			DeleteState(id, configKey, checksumKey);
+	for (const auto& [configKey, checksumKey] : Relations) {
+		if (icingadb.IsStateKey(configKey)) {
+			icingadb.DeleteState(ID, configKey, checksumKey);
 		} else {
-			DeleteRelationship(id, configKey, checksumKey);
+			icingadb.DeleteRelationship(ID, configKey, checksumKey);
 		}
 	}
 }
@@ -282,19 +273,15 @@ void IcingaDB::EnqueueConfigObject(const ConfigObject::Ptr& object, uint32_t bit
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto [it, inserted] = m_PendingItems.insert(PendingConfigItem{object, bits}); !inserted) {
-			m_PendingItems.modify(it, [bits](PendingItemVariant& itemToProcess) {
-				std::visit(
-					[&bits](auto& item) {
-						if (bits & ConfigDelete) {
-							item.DirtyBits &= ~(ConfigUpdate | FullState);
-						} else if (bits & ConfigUpdate) {
-							item.DirtyBits &= ~ConfigDelete;
-						}
-						item.DirtyBits |= bits & DirtyBitsAll;
-					},
-					itemToProcess
-				);
+		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<PendingConfigItem>(object, bits)); !inserted) {
+			m_PendingItems.modify(it, [bits](const std::shared_ptr<PendingQueueItem>& item) {
+				auto configItem = dynamic_cast<PendingConfigItem*>(item.get());
+				if (bits & ConfigDelete) {
+					configItem->DirtyBits &= ~(ConfigUpdate | FullState);
+				} else if (bits & ConfigUpdate) {
+					configItem->DirtyBits &= ~ConfigDelete;
+				}
+				configItem->DirtyBits |= bits & DirtyBitsAll;
 			});
 		}
 	}
@@ -306,7 +293,7 @@ void IcingaDB::EnqueueDependencyGroupStateUpdate(const DependencyGroup::Ptr& dep
 	if (GetActive() && m_RconWorker && m_RconWorker->IsConnected()) {
 		{
 			std::lock_guard lock(m_PendingItemsMutex);
-			m_PendingItems.insert(PendingDependencyGroupStateItem{depGroup});
+			m_PendingItems.insert(std::make_shared<PendingDependencyGroupStateItem>(depGroup));
 		}
 		m_PendingItemsCV.notify_one();
 	}
@@ -326,7 +313,7 @@ void IcingaDB::EnqueueDependencyChildRegistered(const DependencyGroup::Ptr& depG
 	if (GetActive() && m_RconWorker && m_RconWorker->IsConnected()) {
 		{
 			std::lock_guard lock(m_PendingItemsMutex);
-			m_PendingItems.insert(PendingDependencyEdgeItem{depGroup, child});
+			m_PendingItems.insert(std::make_shared<PendingDependencyEdgeItem>(depGroup, child));
 		}
 		m_PendingItemsCV.notify_one();
 	}
@@ -469,7 +456,7 @@ void IcingaDB::EnqueueDependencyChildRemoved(
  * @param id The ID of the relation to be deleted.
  * @param relations A map of Redis keys from which to delete the relation.
  */
-void IcingaDB::EnqueueRelationsDeletion(const String& id, const RelationsKeySet& relations)
+void IcingaDB::EnqueueRelationsDeletion(const String& id, const RelationsDeletionItem::RelationsKeySet& relations)
 {
 	if (!GetActive() || !m_RconWorker || !m_RconWorker->IsConnected()) {
 		return; // No need to enqueue anything if we're not connected.
@@ -477,10 +464,10 @@ void IcingaDB::EnqueueRelationsDeletion(const String& id, const RelationsKeySet&
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto [it, inserted] = m_PendingItems.insert(RelationsDeletionItem{id, relations}); !inserted) {
-			m_PendingItems.modify(it, [&relations](PendingItemVariant& val) {
-				auto& item = std::get<RelationsDeletionItem>(val);
-				item.Relations.insert(relations.begin(), relations.end());
+		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<RelationsDeletionItem>(id, relations)); !inserted) {
+			m_PendingItems.modify(it, [&relations](std::shared_ptr<PendingQueueItem>& val) {
+				auto item = dynamic_cast<RelationsDeletionItem*>(val.get());
+				item->Relations.insert(relations.begin(), relations.end());
 			});
 		}
 	}

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -38,23 +38,61 @@ icingadb::task_queue::RelationsDeletionItem::RelationsDeletionItem(const String&
  */
 void IcingaDB::PendingItemsThreadProc()
 {
-	using namespace std::chrono_literals;
 	namespace ch = std::chrono;
+	namespace queue = icingadb::task_queue;
 
 	// Limits the number of pending queries the Rcon can have at any given time to reduce the memory overhead to
 	// the absolute minimum necessary, since the size of the pending queue items is much smaller than the size
 	// of the actual Redis queries. Thus, this will slow down the worker thread a bit from generating too many
 	// Redis queries when the Redis connection is saturated.
 	constexpr std::size_t maxPendingQueries = 128;
+	// The minimum age an item must have before it can be processed.
+	constexpr ch::milliseconds minItemAge{1000};
 
 	std::unique_lock lock(m_PendingItemsMutex);
 	// Wait until the initial config dump is done. IcingaDB::OnConnectedHandler will notify us once it's finished.
 	while (GetActive() && !m_ConfigDumpDone) m_PendingItemsCV.wait(lock);
 
+	auto& seqView = m_PendingItems.get<1>();
 	while (GetActive()) {
 		if (!m_PendingItems.empty() && m_RconWorker && m_RconWorker->IsConnected() && m_RconWorker->GetPendingQueryCount() < maxPendingQueries) {
-			if (auto retryAfter = DequeueAndProcessOne(lock); retryAfter > 0ms) {
-				m_PendingItemsCV.wait_for(lock, retryAfter);
+			auto now = ch::steady_clock::now();
+			auto it = seqView.begin();
+			if (auto age = now - it->EnqueueTime; minItemAge > age) {
+				m_PendingItemsCV.wait_for(lock, minItemAge - age);
+			} else {
+				ConfigObject::Ptr cobj;
+				if (auto confPtr = std::get_if<queue::PendingConfigItem>(&it->Item); confPtr) {
+					cobj = confPtr->Object;
+				} else if (auto edgePtr = std::get_if<queue::PendingDependencyEdgeItem>(&it->Item)) {
+					cobj = edgePtr->Child;
+				}
+
+				ObjectLock olock(cobj, std::defer_lock);
+				// To avoid a deadlock we can't use a regular `Lock` here since another thread might have acquired
+				// the olock already and is waiting to acquire the pending items mutex (which is currently locked here)
+				// to enqueue another update for this config object.
+				if (cobj && !olock.TryLock()) {
+					m_PendingItemsCV.wait_for(lock, 10ms);
+				} else {
+					auto itemToProcess = *it;
+					seqView.erase(it);
+
+					lock.unlock();
+					std::visit([this](auto &item) {
+						try {
+							ProcessQueueItem(item);
+						} catch (const std::exception& ex) {
+							Log(LogCritical, "IcingaDB")
+								<< "Exception while processing pending item of type '" << typeid(decltype(item)).name()
+								<< "': " << DiagnosticInformation(ex, GetActive());
+						}
+					}, itemToProcess.Item);
+					if (cobj) {
+						olock.Unlock();
+					}
+					lock.lock();
+				}
 			}
 		} else {
 			// In case we don't receive any notification, we still want to wake up periodically on our own
@@ -63,86 +101,6 @@ void IcingaDB::PendingItemsThreadProc()
 			m_PendingItemsCV.wait_for(lock, 100ms);
 		}
 	}
-}
-
-/**
- * Dequeue and process a single pending item.
- *
- * This function processes a single pending item from the pending items container. It iterates over
- * the items in insertion order and checks if the first item is old enough to be processed (at least
- * 1000ms old) unless we're being shutting down. If the item can be processed, it attempts to acquire
- * a lock on the associated config object (if applicable) and processes the item accordingly.
- *
- * If the item cannot be processed right now because it's too new, the function returns a duration
- * indicating how long to wait before retrying. Also, if no progress was made during this iteration
- * (i.e., no item was processed), it returns a short delay to avoid busy-looping.
- *
- * @param lock A unique lock on the pending items mutex (must be acquired before calling this function).
- *
- * @return A duration indicating how long to wait before retrying.
- */
-std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<std::mutex>& lock)
-{
-	using namespace std::chrono_literals;
-	namespace ch = std::chrono;
-	namespace queue = icingadb::task_queue;
-
-	bool madeProgress = false; // Did we make any progress in this iteration?
-	ch::duration<double> retryAfter{0}; // If we can't process anything right now, how long to wait before retrying?
-	auto now = ch::steady_clock::now();
-
-	auto& seqView = m_PendingItems.get<1>();
-	for (auto it(seqView.begin()); it != seqView.end(); ++it) {
-		if (it != seqView.begin()) {
-			if (std::holds_alternative<queue::RelationsDeletionItem>(it->Item)) {
-				// We don't know whether the previous items are related to this deletion item or not,
-				// thus we can't just process this right now when there are older items in the queue.
-				// Otherwise, we might delete something that is going to be updated/created.
-				break;
-			}
-		}
-
-		if (auto age = now - it->EnqueueTime; 1000ms > age) {
-			if (it == seqView.begin()) {
-				retryAfter = 1000ms - age;
-			}
-			break;
-		}
-
-		ConfigObject::Ptr cobj;
-		if (auto confPtr = std::get_if<queue::PendingConfigItem>(&it->Item); confPtr) {
-			cobj = confPtr->Object;
-		} else if (auto edgePtr = std::get_if<queue::PendingDependencyEdgeItem>(&it->Item)) {
-			cobj = edgePtr->Child;
-		}
-		ObjectLock olock(cobj, std::defer_lock);
-		if (cobj && !olock.TryLock()) {
-			continue; // Can't lock the object right now, try the next one.
-		}
-
-		auto itemToProcess = *it;
-		seqView.erase(it);
-		madeProgress = true;
-
-		lock.unlock();
-		std::visit([this](auto &item) {
-			try {
-				ProcessQueueItem(item);
-			} catch (const std::exception& ex) {
-				Log(LogCritical, "IcingaDB")
-					<< "Exception while processing pending item of type '" << typeid(decltype(item)).name() << "': "
-					<< DiagnosticInformation(ex, GetActive());
-			}
-		}, itemToProcess.Item);
-		lock.lock();
-		break;
-	}
-
-	if (!madeProgress && retryAfter == 0ms) {
-		// We haven't made any progress, so give it a short delay before retrying.
-		retryAfter = 10ms;
-	}
-	return retryAfter;
 }
 
 /**

--- a/lib/icingadb/icingadb-worker.cpp
+++ b/lib/icingadb/icingadb-worker.cpp
@@ -7,22 +7,22 @@
 
 using namespace icinga;
 
-PendingConfigItem::PendingConfigItem(const ConfigObject::Ptr& obj, uint32_t bits)
+icingadb::task_queue::PendingConfigItem::PendingConfigItem(const ConfigObject::Ptr& obj, uint32_t bits)
 	: Object{obj}, DirtyBits{bits & DirtyBitsAll}
 {
 }
 
-PendingDependencyGroupStateItem::PendingDependencyGroupStateItem(const DependencyGroup::Ptr& depGroup)
+icingadb::task_queue::PendingDependencyGroupStateItem::PendingDependencyGroupStateItem(const DependencyGroup::Ptr& depGroup)
 	: DepGroup{depGroup}
 {
 }
 
-PendingDependencyEdgeItem::PendingDependencyEdgeItem(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child)
+icingadb::task_queue::PendingDependencyEdgeItem::PendingDependencyEdgeItem(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child)
 	: DepGroup{depGroup}, Child{child}
 {
 }
 
-RelationsDeletionItem::RelationsDeletionItem(const String& id, const RelationsKeySet& relations)
+icingadb::task_queue::RelationsDeletionItem::RelationsDeletionItem(const String& id, const RelationsKeySet& relations)
 	: ID{id}, Relations{relations}
 {
 }
@@ -93,7 +93,7 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 	auto& seqView = m_PendingItems.get<1>();
 	for (auto it(seqView.begin()); it != seqView.end(); ++it) {
 		if (it != seqView.begin()) {
-			if (dynamic_cast<const RelationsDeletionItem*>(it->get())) {
+			if (dynamic_cast<const icingadb::task_queue::RelationsDeletionItem*>(it->get())) {
 				// We don't know whether the previous items are related to this deletion item or not,
 				// thus we can't just process this right now when there are older items in the queue.
 				// Otherwise, we might delete something that is going to be updated/created.
@@ -122,7 +122,7 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 		try {
 			itemToProcess->Execute(*this);
 		} catch (const std::exception& ex) {
-			PendingQueueItem& itemRef = *itemToProcess; // For typeid(operand of typeid must not have any side effects).
+			icingadb::task_queue::PendingQueueItem& itemRef = *itemToProcess; // For typeid(operand of typeid must not have any side effects).
 			Log(LogCritical, "IcingaDB")
 				<< "Exception while processing pending item of type '" << typeid(itemRef).name() << "': "
 				<< DiagnosticInformation(ex, GetActive());
@@ -138,7 +138,7 @@ std::chrono::duration<double> IcingaDB::DequeueAndProcessOne(std::unique_lock<st
 	return retryAfter;
 }
 
-ConfigObject::Ptr PendingConfigItem::GetObjectToLock() const
+ConfigObject::Ptr icingadb::task_queue::PendingConfigItem::GetObjectToLock() const
 {
 	return Object;
 }
@@ -152,7 +152,7 @@ ConfigObject::Ptr PendingConfigItem::GetObjectToLock() const
  *
  * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void PendingConfigItem::Execute(IcingaDB& icingadb) const {
+void icingadb::task_queue::PendingConfigItem::Execute(IcingaDB& icingadb) const {
 	if (DirtyBits & ConfigDelete) {
 		auto redisKeyPair = icingadb.GetSyncableTypeRedisKeys(Object->GetReflectionType());
 		icingadb.m_RconWorker->FireAndForgetQueries(
@@ -203,7 +203,7 @@ void PendingConfigItem::Execute(IcingaDB& icingadb) const {
  *
  * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void PendingDependencyGroupStateItem::Execute(IcingaDB& icingadb) const
+void icingadb::task_queue::PendingDependencyGroupStateItem::Execute(IcingaDB& icingadb) const
 {
 	// For dependency group state updates, we don't actually care which child triggered the update,
 	// since all children share the same dependency group state. Thus, we can just pick any child to
@@ -221,7 +221,7 @@ void PendingDependencyGroupStateItem::Execute(IcingaDB& icingadb) const
  *
  * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void PendingDependencyEdgeItem::Execute(IcingaDB& icingadb) const
+void icingadb::task_queue::PendingDependencyEdgeItem::Execute(IcingaDB& icingadb) const
 {
 	std::vector<Dictionary::Ptr> runtimeUpdates;
 	std::map<RedisConnection::QueryArg, RedisConnection::Query> hMSets;
@@ -238,7 +238,7 @@ void PendingDependencyEdgeItem::Execute(IcingaDB& icingadb) const
  *
  * @param icingadb The IcingaDB instance to use for executing Redis queries.
  */
-void RelationsDeletionItem::Execute(IcingaDB& icingadb) const
+void icingadb::task_queue::RelationsDeletionItem::Execute(IcingaDB& icingadb) const
 {
 	for (const auto& [configKey, checksumKey] : Relations) {
 		if (icingadb.IsStateKey(configKey)) {
@@ -260,18 +260,19 @@ void IcingaDB::EnqueueConfigObject(const ConfigObject::Ptr& object, uint32_t bit
 	if (!GetActive() || !m_RconWorker || !m_RconWorker->IsConnected()) {
 		return; // No need to enqueue anything if we're not connected.
 	}
+	namespace queue = icingadb::task_queue;
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<PendingConfigItem>(object, bits)); !inserted) {
-			m_PendingItems.modify(it, [bits](const std::shared_ptr<PendingQueueItem>& item) {
-				auto configItem = dynamic_cast<PendingConfigItem*>(item.get());
-				if (bits & ConfigDelete) {
-					configItem->DirtyBits &= ~(ConfigUpdate | FullState);
-				} else if (bits & ConfigUpdate) {
-					configItem->DirtyBits &= ~ConfigDelete;
+		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<queue::PendingConfigItem>(object, bits)); !inserted) {
+			m_PendingItems.modify(it, [bits](const std::shared_ptr<queue::PendingQueueItem>& item) {
+				auto configItem = dynamic_cast<queue::PendingConfigItem*>(item.get());
+				if (bits & queue::ConfigDelete) {
+					configItem->DirtyBits &= ~(queue::ConfigUpdate | queue::FullState);
+				} else if (bits & queue::ConfigUpdate) {
+					configItem->DirtyBits &= ~queue::ConfigDelete;
 				}
-				configItem->DirtyBits |= bits & DirtyBitsAll;
+				configItem->DirtyBits |= bits & queue::DirtyBitsAll;
 			});
 		}
 	}
@@ -283,7 +284,7 @@ void IcingaDB::EnqueueDependencyGroupStateUpdate(const DependencyGroup::Ptr& dep
 	if (GetActive() && m_RconWorker && m_RconWorker->IsConnected()) {
 		{
 			std::lock_guard lock(m_PendingItemsMutex);
-			m_PendingItems.insert(std::make_shared<PendingDependencyGroupStateItem>(depGroup));
+			m_PendingItems.insert(std::make_shared<icingadb::task_queue::PendingDependencyGroupStateItem>(depGroup));
 		}
 		m_PendingItemsCV.notify_one();
 	}
@@ -303,7 +304,7 @@ void IcingaDB::EnqueueDependencyChildRegistered(const DependencyGroup::Ptr& depG
 	if (GetActive() && m_RconWorker && m_RconWorker->IsConnected()) {
 		{
 			std::lock_guard lock(m_PendingItemsMutex);
-			m_PendingItems.insert(std::make_shared<PendingDependencyEdgeItem>(depGroup, child));
+			m_PendingItems.insert(std::make_shared<icingadb::task_queue::PendingDependencyEdgeItem>(depGroup, child));
 		}
 		m_PendingItemsCV.notify_one();
 	}
@@ -409,7 +410,7 @@ void IcingaDB::EnqueueDependencyChildRemoved(
 			// Checkable as well. The grandparent Checkable may still have wrong numbers of total children, though it's
 			// not worth traversing the whole tree way up and sending config updates for each one of them, as the next
 			// Redis config dump is going to fix it anyway.
-			EnqueueConfigObject(parent, ConfigUpdate);
+			EnqueueConfigObject(parent, icingadb::task_queue::ConfigUpdate);
 
 			if (!parent->HasAnyDependencies()) {
 				// If the parent Checkable isn't part of any other dependency chain anymore, drop its dependency node entry.
@@ -446,7 +447,7 @@ void IcingaDB::EnqueueDependencyChildRemoved(
  * @param id The ID of the relation to be deleted.
  * @param relations A map of Redis keys from which to delete the relation.
  */
-void IcingaDB::EnqueueRelationsDeletion(const String& id, const RelationsDeletionItem::RelationsKeySet& relations)
+void IcingaDB::EnqueueRelationsDeletion(const String& id, const icingadb::task_queue::RelationsDeletionItem::RelationsKeySet& relations)
 {
 	if (!GetActive() || !m_RconWorker || !m_RconWorker->IsConnected()) {
 		return; // No need to enqueue anything if we're not connected.
@@ -454,9 +455,9 @@ void IcingaDB::EnqueueRelationsDeletion(const String& id, const RelationsDeletio
 
 	{
 		std::lock_guard lock(m_PendingItemsMutex);
-		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<RelationsDeletionItem>(id, relations)); !inserted) {
-			m_PendingItems.modify(it, [&relations](std::shared_ptr<PendingQueueItem>& val) {
-				auto item = dynamic_cast<RelationsDeletionItem*>(val.get());
+		if (auto [it, inserted] = m_PendingItems.insert(std::make_shared<icingadb::task_queue::RelationsDeletionItem>(id, relations)); !inserted) {
+			m_PendingItems.modify(it, [&relations](std::shared_ptr<icingadb::task_queue::PendingQueueItem>& val) {
+				auto item = dynamic_cast<icingadb::task_queue::RelationsDeletionItem*>(val.get());
 				item->Relations.insert(relations.begin(), relations.end());
 			});
 		}

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -125,9 +125,6 @@ void IcingaDB::Start(bool runtimeCreated)
 
 	m_WorkQueue.SetName("IcingaDB");
 
-	m_RconWorker->SuppressQueryKind(Prio::CheckResult);
-	m_RconWorker->SuppressQueryKind(Prio::RuntimeStateSync);
-
 	Ptr keepAlive (this);
 
 	m_HistoryThread = std::async(std::launch::async, [this, keepAlive]() { ForwardHistoryEntries(); });

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -23,8 +23,6 @@ using namespace icinga;
 
 #define MAX_EVENTS_DEFAULT 5000
 
-using Prio = RedisConnection::QueryPriority;
-
 String IcingaDB::m_EnvironmentId;
 std::mutex IcingaDB::m_EnvironmentIdInitMutex;
 
@@ -184,7 +182,7 @@ void IcingaDB::PublishStats()
 		}
 	}
 
-	m_Rcon->FireAndForgetQuery(std::move(query), Prio::Heartbeat);
+	m_Rcon->FireAndForgetQuery(std::move(query), {}, true /* high priority */);
 }
 
 void IcingaDB::Stop(bool runtimeRemoved)

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -233,13 +233,6 @@ private:
 		std::mutex m_Mutex;
 	};
 
-	enum StateUpdate
-	{
-		Volatile    = 1ull << 0,
-		RuntimeOnly = 1ull << 1,
-		Full        = Volatile | RuntimeOnly,
-	};
-
 	void OnConnectedHandler();
 
 	void PublishStatsTimerHandler();
@@ -253,8 +246,7 @@ private:
 	void InsertObjectDependencies(const ConfigObject::Ptr& object,
 		std::map<RedisConnection::QueryArg, RedisConnection::Query>& hMSets, std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
 	void UpdateDependenciesState(const Checkable::Ptr& checkable, const DependencyGroup::Ptr& dependencyGroup) const;
-	void UpdateState(const Checkable::Ptr& checkable, StateUpdate mode);
-	void SendConfigUpdate(const ConfigObject::Ptr& object, bool runtimeUpdate);
+	void UpdateState(const Checkable::Ptr& checkable, uint32_t mode);
 	void CreateConfigUpdate(const ConfigObject::Ptr& object, const QueryArgPair& redisKeyPair,
 		std::map<RedisConnection::QueryArg, RedisConnection::Query>& hMSets, std::vector<Dictionary::Ptr>& runtimeUpdates, bool runtimeUpdate);
 	void SendConfigDelete(const ConfigObject::Ptr& object);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -36,6 +36,9 @@ namespace icinga
 #define CONFIG_REDIS_KEY_PREFIX "icinga:"
 #define CHECKSUM_REDIS_KEY_PREFIX CONFIG_REDIS_KEY_PREFIX "checksum:"
 
+namespace icingadb::task_queue
+{
+
 /**
  * Dirty bits for config/state changes.
  *
@@ -89,6 +92,20 @@ struct PendingQueueItem
 	virtual ConfigObject::Ptr GetObjectToLock() const { return nullptr; };
 	virtual void Execute(IcingaDB& icingadb) const = 0;
 };
+
+// A multi-index container for managing pending items with unique IDs and maintaining insertion order.
+// The first index is an ordered unique index based on the pending item key, allowing for efficient
+// lookups and ensuring uniqueness of items. The second index is a sequenced index that maintains the
+// order of insertion, enabling FIFO processing of pending items.
+using PendingItemsSet = boost::multi_index_container<
+	std::shared_ptr<PendingQueueItem>,
+	boost::multi_index::indexed_by<
+		boost::multi_index::ordered_unique<
+			boost::multi_index::const_mem_fun<PendingQueueItem, PendingQueueItem::Key, &PendingQueueItem::GetID>
+		>,
+		boost::multi_index::sequenced<>
+	>
+>;
 
 /**
  * A pending configuration object item.
@@ -176,6 +193,8 @@ struct RelationsDeletionItem : PendingQueueItem
 	Key GetID() const override { return ID; }
 	void Execute(IcingaDB& icingadb) const override;
 };
+
+} // namespace icingadb::task_queue
 
 /**
  * @ingroup icingadb
@@ -426,22 +445,8 @@ private:
 	static String m_EnvironmentId;
 	static std::mutex m_EnvironmentIdInitMutex;
 
-	// A multi-index container for managing pending items with unique IDs and maintaining insertion order.
-	// The first index is an ordered unique index based on the pending item key, allowing for efficient
-	// lookups and ensuring uniqueness of items. The second index is a sequenced index that maintains the
-	// order of insertion, enabling FIFO processing of pending items.
-	using PendingItemsSet = boost::multi_index_container<
-		std::shared_ptr<PendingQueueItem>,
-		boost::multi_index::indexed_by<
-			boost::multi_index::ordered_unique<
-				boost::multi_index::const_mem_fun<PendingQueueItem, PendingQueueItem::Key, &PendingQueueItem::GetID>
-			>,
-			boost::multi_index::sequenced<>
-		>
-	>;
-
 	std::thread m_PendingItemsThread; // The background worker thread (consumer of m_PendingItems).
-	PendingItemsSet m_PendingItems; // Container for pending items with dirty bits (access protected by m_PendingItemsMutex).
+	icingadb::task_queue::PendingItemsSet m_PendingItems; // Container for pending items with dirty bits (access protected by m_PendingItemsMutex).
 	std::mutex m_PendingItemsMutex; // Mutex to protect access to m_PendingItems.
 	std::condition_variable m_PendingItemsCV; // Condition variable to forcefully wake up the worker thread.
 
@@ -452,12 +457,12 @@ private:
 	void EnqueueDependencyGroupStateUpdate(const DependencyGroup::Ptr& depGroup);
 	void EnqueueDependencyChildRegistered(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child);
 	void EnqueueDependencyChildRemoved(const DependencyGroup::Ptr& depGroup, const std::vector<Dependency::Ptr>& dependencies, bool removeGroup);
-	void EnqueueRelationsDeletion(const String& id, const RelationsDeletionItem::RelationsKeySet& relations);
+	void EnqueueRelationsDeletion(const String& id, const icingadb::task_queue::RelationsDeletionItem::RelationsKeySet& relations);
 
-	friend struct PendingConfigItem;
-	friend struct PendingDependencyGroupStateItem;
-	friend struct PendingDependencyEdgeItem;
-	friend struct RelationsDeletionItem;
+	friend struct icingadb::task_queue::PendingConfigItem;
+	friend struct icingadb::task_queue::PendingDependencyGroupStateItem;
+	friend struct icingadb::task_queue::PendingDependencyEdgeItem;
+	friend struct icingadb::task_queue::RelationsDeletionItem;
 };
 }
 

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -150,6 +150,7 @@ struct PendingDependencyEdgeItem : PendingQueueItem
 	PendingDependencyEdgeItem(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child);
 
 	Key GetID() const override { return std::make_pair(Child.get(), DepGroup.get()); }
+	ConfigObject::Ptr GetObjectToLock() const override { return Child; }
 	void Execute(IcingaDB& icingadb) const override;
 };
 

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -473,7 +473,6 @@ private:
 	std::condition_variable m_PendingItemsCV; // Condition variable to forcefully wake up the worker thread.
 
 	void PendingItemsThreadProc();
-	std::chrono::duration<double> DequeueAndProcessOne(std::unique_lock<std::mutex>& lock);
 
 	void ProcessQueueItem(const icingadb::task_queue::PendingConfigItem& item);
 	void ProcessQueueItem(const icingadb::task_queue::PendingDependencyGroupStateItem& item) const;

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -334,7 +334,7 @@ private:
 	static void CommentRemovedHandler(const Comment::Ptr& comment);
 	static void FlappingChangeHandler(const Checkable::Ptr& checkable, double changeTime);
 	static void NewCheckResultHandler(const Checkable::Ptr& checkable);
-	static void NextCheckUpdatedHandler(const Checkable::Ptr& checkable);
+	static void NextCheckChangedHandler(const Checkable::Ptr& checkable);
 	static void DependencyGroupChildRegisteredHandler(const Checkable::Ptr& child, const DependencyGroup::Ptr& dependencyGroup);
 	static void DependencyGroupChildRemovedHandler(const DependencyGroup::Ptr& dependencyGroup, const std::vector<Dependency::Ptr>& dependencies, bool removeGroup);
 	static void HostProblemChangedHandler(const Service::Ptr& service);

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -298,7 +298,6 @@ private:
 
 	void ForwardHistoryEntries();
 
-	std::vector<String> UpdateObjectAttrs(const ConfigObject::Ptr& object, int fieldType, const String& typeNameOverride);
 	Dictionary::Ptr SerializeState(const Checkable::Ptr& checkable);
 
 	/* Stats */

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -17,7 +17,6 @@
 #include "icinga/downtime.hpp"
 #include "remote/messageorigin.hpp"
 #include <boost/multi_index_container.hpp>
-#include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <atomic>
@@ -61,92 +60,47 @@ enum DirtyBits : uint32_t
 	DirtyBitsAll = ConfigUpdate | ConfigDelete | FullState | NextUpdate
 };
 
-/**
- * A pending queue item.
- *
- * This struct represents a generic pending item in the queue that is associated with a unique identifier
- * and dirty bits indicating the type of updates required in Redis. The @c EnqueueTime field records the
- * time when the item was added to the queue, which can be useful for tracking how long an item waits before
- * being processed. This base struct is extended by more specific pending item types that operate on different
- * kinds of objects, such as configuration objects or dependency groups.
- *
- * @ingroup icingadb
- */
-struct PendingQueueItem
-{
-	/**
-	 * A variant type representing the identifier of a pending item.
-	 *
-	 * This variant can hold either a string representing a real Redis hash key or a pair consisting of
-	 * a configuration object pointer and a dependency group pointer. A pending item identified by the
-	 * latter variant type operates primarily on the associated configuration object or dependency group,
-	 * thus the pairs are used for uniqueness in the pending items container.
-	 */
-	using Key = std::variant<std::string /* Redis hash keys */, std::pair<ConfigObject::Ptr, DependencyGroup::Ptr>>;
-
-	virtual ~PendingQueueItem() = default;
-
-	const std::chrono::steady_clock::time_point EnqueueTime{std::chrono::steady_clock::now()};
-
-	virtual Key GetID() const = 0;
-	virtual ConfigObject::Ptr GetObjectToLock() const { return nullptr; };
-	virtual void Execute(IcingaDB& icingadb) const = 0;
-};
-
-// A multi-index container for managing pending items with unique IDs and maintaining insertion order.
-// The first index is an ordered unique index based on the pending item key, allowing for efficient
-// lookups and ensuring uniqueness of items. The second index is a sequenced index that maintains the
-// order of insertion, enabling FIFO processing of pending items.
-using PendingItemsSet = boost::multi_index_container<
-	std::shared_ptr<PendingQueueItem>,
-	boost::multi_index::indexed_by<
-		boost::multi_index::ordered_unique<
-			boost::multi_index::const_mem_fun<PendingQueueItem, PendingQueueItem::Key, &PendingQueueItem::GetID>
-		>,
-		boost::multi_index::sequenced<>
-	>
->;
 
 /**
  * A pending configuration object item.
  *
  * This struct represents a pending item in the queue that is associated with a configuration object.
  * It contains a pointer to the configuration object and the dirty bits indicating the type of updates
- * required for that object in Redis. A pending configuration item operates primarily on config objects,
- * thus the @c ID field in the base struct is only used for uniqueness in the pending items container.
+ * required for that object in Redis.
  *
  * @ingroup icingadb
  */
-struct PendingConfigItem : PendingQueueItem
+struct PendingConfigItem
 {
 	ConfigObject::Ptr Object;
 	uint32_t DirtyBits;
 
 	PendingConfigItem(const ConfigObject::Ptr& obj, uint32_t bits);
 
-	Key GetID() const override { return std::make_pair(Object, nullptr); }
-	ConfigObject::Ptr GetObjectToLock() const override;
-	void Execute(IcingaDB& icingadb) const override;
+	[[nodiscard]] ConfigObject* GetQueueLookupKey() const
+	{
+		return Object.get();
+	}
 };
 
 /**
  * A pending dependency group state item.
  *
  * This struct represents a pending item in the queue that is associated with a dependency group.
- * It contains a pointer to the dependency group for which state updates are required. The dirty bits
- * in the base struct are not used for this item type, as the operation is specific to updating the
- * state of the dependency group itself.
+ * It contains a pointer to the dependency group for which state updates are required.
  *
  * @ingroup icingadb
  */
-struct PendingDependencyGroupStateItem : PendingQueueItem
+struct PendingDependencyGroupStateItem
 {
 	DependencyGroup::Ptr DepGroup;
 
 	explicit PendingDependencyGroupStateItem(const DependencyGroup::Ptr& depGroup);
 
-	Key GetID() const override { return std::make_pair(nullptr, DepGroup.get()); }
-	void Execute(IcingaDB& icingadb) const override;
+	[[nodiscard]] DependencyGroup* GetQueueLookupKey() const
+	{
+		return DepGroup.get();
+	}
 };
 
 /**
@@ -154,21 +108,20 @@ struct PendingDependencyGroupStateItem : PendingQueueItem
  *
  * This struct represents a pending dependency child registration into a dependency group.
  * It contains a pointer to the dependency group and the checkable child being registered.
- * The dirty bits in the base struct are not used for this item type, as the operation is specific
- * to registering the child into the dependency group.
  *
  * @ingroup icingadb
  */
-struct PendingDependencyEdgeItem : PendingQueueItem
+struct PendingDependencyEdgeItem
 {
 	DependencyGroup::Ptr DepGroup;
 	Checkable::Ptr Child;
 
 	PendingDependencyEdgeItem(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child);
 
-	Key GetID() const override { return std::make_pair(Child.get(), DepGroup.get()); }
-	ConfigObject::Ptr GetObjectToLock() const override { return Child; }
-	void Execute(IcingaDB& icingadb) const override;
+	[[nodiscard]] std::pair<DependencyGroup*, Checkable*> GetQueueLookupKey() const
+	{
+		return {DepGroup.get(), Child.get()};
+	}
 };
 
 /**
@@ -181,7 +134,7 @@ struct PendingDependencyEdgeItem : PendingQueueItem
  *
  * @ingroup icingadb
  */
-struct RelationsDeletionItem : PendingQueueItem
+struct RelationsDeletionItem
 {
 	std::string ID;
 	// Set of Redis keys from which to delete a relation, along with their checksums (if any).
@@ -190,9 +143,78 @@ struct RelationsDeletionItem : PendingQueueItem
 
 	RelationsDeletionItem(const String& id, const RelationsKeySet& relations);
 
-	Key GetID() const override { return ID; }
-	void Execute(IcingaDB& icingadb) const override;
+	[[nodiscard]] std::string_view GetQueueLookupKey() const
+	{
+		return ID;
+	}
 };
+
+/**
+ * A pending queue item.
+ *
+ * This struct represents a generic pending item in the queue. The @c EnqueueTime field records the
+ * time when the item was added to the queue, which can be useful for tracking how long an item waits before
+ * being processed. This base struct wraps one of the available more specific pending item types that operate
+ * on different kinds of objects, such as configuration objects or dependency groups.
+ *
+ * @ingroup icingadb
+ */
+struct PendingQueueItem
+{
+	using ItemVariant = std::variant<
+		PendingConfigItem,
+		PendingDependencyGroupStateItem,
+		PendingDependencyEdgeItem,
+		RelationsDeletionItem
+	>;
+
+	ItemVariant Item;
+	std::chrono::steady_clock::time_point EnqueueTime{std::chrono::steady_clock::now()};
+
+	template<typename T,
+		// don't hide the default copy and move constructors
+		typename = std::enable_if_t<!std::is_same_v<std::decay_t<T>, PendingQueueItem>>
+	>
+	explicit PendingQueueItem(T&& item) : Item(std::forward<T>(item)) {}
+};
+
+template<typename T>
+struct KeyExtractor /* not implemented, only the specialization for std::variant is used */;
+
+/**
+ * Helper to use @c PendingQueueItem in @c boost::multi_index_container.
+ *
+ * It implements a key extractor that @c multi_index_container will invoke for each element to create an index.
+ * Every individual type in @c PendingQueueItem::ItemVariant implements a method @c GetQueueLookupKey() that will
+ * be invoked by this key extractor. The return value from the individual type is then returned as part of a second
+ * variant type (its element types are automatically deduced from the individual @c GetQueueLookupKey() methods).
+ * @c multi_index_container will then just use the standard comparison operators on it for building the index.
+ *
+ * @ingroup icingadb
+ */
+template<typename ...Ts>
+struct KeyExtractor<std::variant<Ts...>> {
+	using result_type = std::variant<decltype(std::declval<Ts>().GetQueueLookupKey())...>;
+
+	result_type operator()(const PendingQueueItem& queueItem) const
+	{
+		return std::visit([](const auto& innerItem) -> result_type {
+			return innerItem.GetQueueLookupKey();
+		}, queueItem.Item);
+	};
+};
+
+// A multi-index container for managing pending items with unique IDs and maintaining insertion order.
+// The first index is an ordered unique index based on the pending item key, allowing for efficient
+// lookups and ensuring uniqueness of items. The second index is a sequenced index that maintains the
+// order of insertion, enabling FIFO processing of pending items.
+using PendingItemsSet = boost::multi_index_container<
+	PendingQueueItem,
+	boost::multi_index::indexed_by<
+		boost::multi_index::ordered_unique<KeyExtractor<PendingQueueItem::ItemVariant>>,
+		boost::multi_index::sequenced<>
+	>
+>;
 
 } // namespace icingadb::task_queue
 
@@ -453,16 +475,16 @@ private:
 	void PendingItemsThreadProc();
 	std::chrono::duration<double> DequeueAndProcessOne(std::unique_lock<std::mutex>& lock);
 
+	void ProcessQueueItem(const icingadb::task_queue::PendingConfigItem& item);
+	void ProcessQueueItem(const icingadb::task_queue::PendingDependencyGroupStateItem& item) const;
+	void ProcessQueueItem(const icingadb::task_queue::PendingDependencyEdgeItem& item);
+	void ProcessQueueItem(const icingadb::task_queue::RelationsDeletionItem& item);
+
 	void EnqueueConfigObject(const ConfigObject::Ptr& object, uint32_t bits);
 	void EnqueueDependencyGroupStateUpdate(const DependencyGroup::Ptr& depGroup);
 	void EnqueueDependencyChildRegistered(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child);
 	void EnqueueDependencyChildRemoved(const DependencyGroup::Ptr& depGroup, const std::vector<Dependency::Ptr>& dependencies, bool removeGroup);
-	void EnqueueRelationsDeletion(const String& id, const icingadb::task_queue::RelationsDeletionItem::RelationsKeySet& relations);
-
-	friend struct icingadb::task_queue::PendingConfigItem;
-	friend struct icingadb::task_queue::PendingDependencyGroupStateItem;
-	friend struct icingadb::task_queue::PendingDependencyEdgeItem;
-	friend struct icingadb::task_queue::RelationsDeletionItem;
+	void EnqueueRelationsDeletion(const String& id, icingadb::task_queue::RelationsDeletionItem::RelationsKeySet relations);
 };
 }
 

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -17,6 +17,7 @@
 #include "icinga/downtime.hpp"
 #include "remote/messageorigin.hpp"
 #include <boost/multi_index_container.hpp>
+#include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <atomic>
@@ -58,18 +59,6 @@ enum DirtyBits : uint32_t
 };
 
 /**
- * A variant type representing the identifier of a pending item.
- *
- * This variant can hold either a string representing a real Redis hash key or a pair consisting of
- * a configuration object pointer and a dependency group pointer. A pending item identified by the
- * latter variant type operates primarily on the associated configuration object or dependency group,
- * thus the pairs are used for uniqueness in the pending items container.
- *
- * @ingroup icingadb
- */
-using PendingItemKey = std::variant<std::string /* Redis hash keys */, std::pair<ConfigObject::Ptr, DependencyGroup::Ptr>>;
-
-/**
  * A pending queue item.
  *
  * This struct represents a generic pending item in the queue that is associated with a unique identifier
@@ -82,11 +71,23 @@ using PendingItemKey = std::variant<std::string /* Redis hash keys */, std::pair
  */
 struct PendingQueueItem
 {
-	uint32_t DirtyBits;
-	PendingItemKey ID;
-	const std::chrono::steady_clock::time_point EnqueueTime;
+	/**
+	 * A variant type representing the identifier of a pending item.
+	 *
+	 * This variant can hold either a string representing a real Redis hash key or a pair consisting of
+	 * a configuration object pointer and a dependency group pointer. A pending item identified by the
+	 * latter variant type operates primarily on the associated configuration object or dependency group,
+	 * thus the pairs are used for uniqueness in the pending items container.
+	 */
+	using Key = std::variant<std::string /* Redis hash keys */, std::pair<ConfigObject::Ptr, DependencyGroup::Ptr>>;
 
-	PendingQueueItem(PendingItemKey&& id, uint32_t dirtyBits);
+	virtual ~PendingQueueItem() = default;
+
+	const std::chrono::steady_clock::time_point EnqueueTime{std::chrono::steady_clock::now()};
+
+	virtual Key GetID() const = 0;
+	virtual ConfigObject::Ptr GetObjectToLock() const { return nullptr; };
+	virtual void Execute(IcingaDB& icingadb) const = 0;
 };
 
 /**
@@ -102,8 +103,13 @@ struct PendingQueueItem
 struct PendingConfigItem : PendingQueueItem
 {
 	ConfigObject::Ptr Object;
+	uint32_t DirtyBits;
 
 	PendingConfigItem(const ConfigObject::Ptr& obj, uint32_t bits);
+
+	Key GetID() const override { return std::make_pair(Object, nullptr); }
+	ConfigObject::Ptr GetObjectToLock() const override;
+	void Execute(IcingaDB& icingadb) const override;
 };
 
 /**
@@ -121,6 +127,9 @@ struct PendingDependencyGroupStateItem : PendingQueueItem
 	DependencyGroup::Ptr DepGroup;
 
 	explicit PendingDependencyGroupStateItem(const DependencyGroup::Ptr& depGroup);
+
+	Key GetID() const override { return std::make_pair(nullptr, DepGroup.get()); }
+	void Execute(IcingaDB& icingadb) const override;
 };
 
 /**
@@ -139,10 +148,10 @@ struct PendingDependencyEdgeItem : PendingQueueItem
 	Checkable::Ptr Child;
 
 	PendingDependencyEdgeItem(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child);
-};
 
-// Set of Redis keys from which to delete a relation, along with their checksums (if any).
-using RelationsKeySet = std::set<std::pair<RedisConnection::QueryArg, RedisConnection::QueryArg>>;
+	Key GetID() const override { return std::make_pair(Child.get(), DepGroup.get()); }
+	void Execute(IcingaDB& icingadb) const override;
+};
 
 /**
  * A pending relations deletion item.
@@ -156,9 +165,15 @@ using RelationsKeySet = std::set<std::pair<RedisConnection::QueryArg, RedisConne
  */
 struct RelationsDeletionItem : PendingQueueItem
 {
+	std::string ID;
+	// Set of Redis keys from which to delete a relation, along with their checksums (if any).
+	using RelationsKeySet = std::set<std::pair<RedisConnection::QueryArg, RedisConnection::QueryArg>>;
 	RelationsKeySet Relations;
 
-	RelationsDeletionItem(const String& id, RelationsKeySet relations);
+	RelationsDeletionItem(const String& id, const RelationsKeySet& relations);
+
+	Key GetID() const override { return ID; }
+	void Execute(IcingaDB& icingadb) const override;
 };
 
 /**
@@ -411,33 +426,16 @@ private:
 	static String m_EnvironmentId;
 	static std::mutex m_EnvironmentIdInitMutex;
 
-	// A variant type that can hold any of the pending item types used in the pending items container.
-	using PendingItemVariant = std::variant<
-		PendingConfigItem,
-		PendingDependencyGroupStateItem,
-		PendingDependencyEdgeItem,
-		RelationsDeletionItem
-	>;
-
-	struct PendingItemKeyExtractor
-	{
-		// The type of the key extracted from a pending item required by Boost.MultiIndex.
-		using result_type = const PendingItemKey&;
-
-		result_type operator()(const PendingItemVariant& item) const
-		{
-			return std::visit([](const auto& pendingItem) -> result_type { return pendingItem.ID; }, item);
-		}
-	};
-
 	// A multi-index container for managing pending items with unique IDs and maintaining insertion order.
 	// The first index is an ordered unique index based on the pending item key, allowing for efficient
 	// lookups and ensuring uniqueness of items. The second index is a sequenced index that maintains the
 	// order of insertion, enabling FIFO processing of pending items.
 	using PendingItemsSet = boost::multi_index_container<
-		PendingItemVariant,
+		std::shared_ptr<PendingQueueItem>,
 		boost::multi_index::indexed_by<
-			boost::multi_index::ordered_unique<PendingItemKeyExtractor>, // std::variant has operator< defined.
+			boost::multi_index::ordered_unique<
+				boost::multi_index::const_mem_fun<PendingQueueItem, PendingQueueItem::Key, &PendingQueueItem::GetID>
+			>,
 			boost::multi_index::sequenced<>
 		>
 	>;
@@ -449,16 +447,17 @@ private:
 
 	void PendingItemsThreadProc();
 	std::chrono::duration<double> DequeueAndProcessOne(std::unique_lock<std::mutex>& lock);
-	void ProcessPendingItem(const PendingConfigItem& item);
-	void ProcessPendingItem(const PendingDependencyGroupStateItem& item) const;
-	void ProcessPendingItem(const PendingDependencyEdgeItem& item);
-	void ProcessPendingItem(const RelationsDeletionItem& item);
 
 	void EnqueueConfigObject(const ConfigObject::Ptr& object, uint32_t bits);
 	void EnqueueDependencyGroupStateUpdate(const DependencyGroup::Ptr& depGroup);
 	void EnqueueDependencyChildRegistered(const DependencyGroup::Ptr& depGroup, const Checkable::Ptr& child);
 	void EnqueueDependencyChildRemoved(const DependencyGroup::Ptr& depGroup, const std::vector<Dependency::Ptr>& dependencies, bool removeGroup);
-	void EnqueueRelationsDeletion(const String& id, const RelationsKeySet& relations);
+	void EnqueueRelationsDeletion(const String& id, const RelationsDeletionItem::RelationsKeySet& relations);
+
+	friend struct PendingConfigItem;
+	friend struct PendingDependencyGroupStateItem;
+	friend struct PendingDependencyEdgeItem;
+	friend struct RelationsDeletionItem;
 };
 }
 

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -289,7 +289,7 @@ private:
 	static Dictionary::Ptr GetStats();
 
 	/* utilities */
-	static void DeleteKeys(const RedisConnection::Ptr& conn, const std::vector<RedisConnection::QueryArg>& keys, RedisConnection::QueryPriority priority);
+	static void DeleteKeys(const RedisConnection::Ptr& conn, const std::vector<RedisConnection::QueryArg>& keys);
 	static std::vector<RedisConnection::QueryArg> GetTypeOverwriteKeys(const Type::Ptr& type, bool skipChecksums = false);
 	static void AddDataToHmSets(std::map<RedisConnection::QueryArg, RedisConnection::Query>& hMSets, const RedisConnection::QueryArg& redisKey, const String& id, const Dictionary::Ptr& data);
 	static bool IsStateKey(const RedisConnection::QueryArg& key);

--- a/lib/icingadb/icingadbchecktask.cpp
+++ b/lib/icingadb/icingadbchecktask.cpp
@@ -127,7 +127,8 @@ void IcingadbCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckR
 					"0-0", "0-0", "0-0", "0-0", "0-0", "0-0",
 				}
 			},
-			RedisConnection::QueryPriority::Heartbeat
+			{},
+			true /* high priority */
 		));
 
 		redisTime = std::move(replies.at(0));

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -137,7 +137,7 @@ void RedisConnection::FireAndForgetQuery(Query query, QueryAffects affects, bool
 	auto item (Shared<Query>::Make(std::move(query)));
 
 	asio::post(m_Strand, [this, item, highPriority, affects, ctime = Utility::GetTime()]() {
-		m_Queues.Push(WriteQueueItem{item, nullptr, nullptr, nullptr, nullptr, ctime, affects}, highPriority);
+		m_Queues.Push(WriteQueueItem{item, ctime, affects}, highPriority);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(1);
 	});
@@ -160,7 +160,7 @@ void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, Que
 	auto item (Shared<Queries>::Make(std::move(queries)));
 
 	asio::post(m_Strand, [this, item, affects, ctime = Utility::GetTime()]() {
-		m_Queues.Push(WriteQueueItem{nullptr, item, nullptr, nullptr, nullptr, ctime, affects}, false);
+		m_Queues.Push(WriteQueueItem{item, ctime, affects}, false);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(item->size());
 	});
@@ -185,7 +185,7 @@ RedisConnection::Reply RedisConnection::GetResultOfQuery(RedisConnection::Query 
 	auto item (Shared<std::pair<Query, std::promise<Reply>>>::Make(std::move(query), std::move(promise)));
 
 	asio::post(m_Strand, [this, item, affects, ctime = Utility::GetTime()]() {
-		m_Queues.Push(WriteQueueItem{nullptr, nullptr, item, nullptr, nullptr, ctime, affects}, false);
+		m_Queues.Push(WriteQueueItem{item, ctime, affects}, false);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(1);
 	});
@@ -216,7 +216,7 @@ RedisConnection::Replies RedisConnection::GetResultsOfQueries(Queries queries, Q
 	auto item (Shared<std::pair<Queries, std::promise<Replies>>>::Make(std::move(queries), std::move(promise)));
 
 	asio::post(m_Strand, [this, item, highPriority, affects, ctime = Utility::GetTime()]() {
-		m_Queues.Push(WriteQueueItem{nullptr, nullptr, nullptr, item, nullptr, ctime, affects}, highPriority);
+		m_Queues.Push(WriteQueueItem{item, ctime, affects}, highPriority);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(item->first.size());
 	});
@@ -229,7 +229,7 @@ RedisConnection::Replies RedisConnection::GetResultsOfQueries(Queries queries, Q
 void RedisConnection::EnqueueCallback(const std::function<void(boost::asio::yield_context&)>& callback)
 {
 	asio::post(m_Strand, [this, callback, ctime = Utility::GetTime()]() {
-		m_Queues.Push(WriteQueueItem{nullptr, nullptr, nullptr, nullptr, callback, ctime}, false);
+		m_Queues.Push(WriteQueueItem{callback, ctime, {}}, false);
 		m_QueuedWrites.Set();
 	});
 }
@@ -450,7 +450,15 @@ void RedisConnection::WriteLoop(asio::yield_context& yc)
 		m_QueuedWrites.Wait(yc);
 
 		while (m_Queues.HasWrites()) {
-			WriteItem(yc, m_Queues.PopFront());
+			auto queuedWrite(m_Queues.PopFront());
+			std::visit(
+				[this, &yc, &queuedWrite](const auto& item) {
+					if (WriteItem(item, yc)) {
+						RecordAffected(queuedWrite.Affects, Utility::GetTime());
+					}
+				},
+				queuedWrite.Item
+			);
 		}
 
 		m_QueuedWrites.Clear();
@@ -493,111 +501,138 @@ void RedisConnection::LogStats(asio::yield_context& yc)
 }
 
 /**
- * Send next and schedule receiving the response
+ * Write a single Redis query in a fire-and-forget manner.
  *
- * @param next Redis queries
+ * @param item Redis query
+ *
+ * @return true on success, false on failure.
  */
-void RedisConnection::WriteItem(boost::asio::yield_context& yc, RedisConnection::WriteQueueItem next)
+bool RedisConnection::WriteItem(const FireAndForgetQ& item, boost::asio::yield_context& yc)
 {
-	if (next.FireAndForgetQuery) {
-		auto& item (*next.FireAndForgetQuery);
-		DecreasePendingQueries(1);
+	DecreasePendingQueries(1);
 
-		try {
-			WriteOne(item, yc);
-		} catch (const std::exception& ex) {
-			Log msg (LogCritical, "IcingaDB", "Error during sending query");
-			LogQuery(item, msg);
-			msg << " which has been fired and forgotten: " << ex.what();
+	try {
+		WriteOne(*item, yc);
+	} catch (const std::exception& ex) {
+		Log msg (LogCritical, "IcingaDB", "Error during sending query");
+		LogQuery(*item, msg);
+		msg << " which has been fired and forgotten: " << ex.what();
 
-			return;
-		}
-
-		if (m_Queues.FutureResponseActions.empty() || m_Queues.FutureResponseActions.back().Action != ResponseAction::Ignore) {
-			m_Queues.FutureResponseActions.emplace(FutureResponseAction{1, ResponseAction::Ignore});
-		} else {
-			++m_Queues.FutureResponseActions.back().Amount;
-		}
-
-		m_QueuedReads.Set();
+		return false;
 	}
 
-	if (next.FireAndForgetQueries) {
-		auto& item (*next.FireAndForgetQueries);
-		size_t i = 0;
-
-		DecreasePendingQueries(item.size());
-
-		try {
-			for (auto& query : item) {
-				WriteOne(query, yc);
-				++i;
-			}
-		} catch (const std::exception& ex) {
-			Log msg (LogCritical, "IcingaDB", "Error during sending query");
-			LogQuery(item[i], msg);
-			msg << " which has been fired and forgotten: " << ex.what();
-
-			return;
-		}
-
-		if (m_Queues.FutureResponseActions.empty() || m_Queues.FutureResponseActions.back().Action != ResponseAction::Ignore) {
-			m_Queues.FutureResponseActions.emplace(FutureResponseAction{item.size(), ResponseAction::Ignore});
-		} else {
-			m_Queues.FutureResponseActions.back().Amount += item.size();
-		}
-
-		m_QueuedReads.Set();
+	if (m_Queues.FutureResponseActions.empty() || m_Queues.FutureResponseActions.back().Action != ResponseAction::Ignore) {
+		m_Queues.FutureResponseActions.emplace(FutureResponseAction{1, ResponseAction::Ignore});
+	} else {
+		++m_Queues.FutureResponseActions.back().Amount;
 	}
 
-	if (next.GetResultOfQuery) {
-		auto& item (*next.GetResultOfQuery);
-		DecreasePendingQueries(1);
+	m_QueuedReads.Set();
+	return true;
+}
 
-		try {
-			WriteOne(item.first, yc);
-		} catch (const std::exception&) {
-			item.second.set_exception(std::current_exception());
+/**
+ * Write multiple Redis queries in a fire-and-forget manner.
+ *
+ * @param item Redis queries
+ *
+ * @return true on success, false on failure.
+ */
+bool RedisConnection::WriteItem(const FireAndForgetQs& item, boost::asio::yield_context& yc)
+{
+	size_t i = 0;
 
-			return;
+	DecreasePendingQueries(item->size());
+
+	try {
+		for (auto& query : *item) {
+			WriteOne(query, yc);
+			++i;
 		}
+	} catch (const std::exception& ex) {
+		Log msg (LogCritical, "IcingaDB", "Error during sending query");
+		LogQuery((*item)[i], msg);
+		msg << " which has been fired and forgotten: " << ex.what();
 
-		m_Queues.ReplyPromises.emplace(std::move(item.second));
-
-		if (m_Queues.FutureResponseActions.empty() || m_Queues.FutureResponseActions.back().Action != ResponseAction::Deliver) {
-			m_Queues.FutureResponseActions.emplace(FutureResponseAction{1, ResponseAction::Deliver});
-		} else {
-			++m_Queues.FutureResponseActions.back().Amount;
-		}
-
-		m_QueuedReads.Set();
+		return false;
 	}
 
-	if (next.GetResultsOfQueries) {
-		auto& item (*next.GetResultsOfQueries);
-		DecreasePendingQueries(item.first.size());
+	if (m_Queues.FutureResponseActions.empty() || m_Queues.FutureResponseActions.back().Action != ResponseAction::Ignore) {
+		m_Queues.FutureResponseActions.emplace(FutureResponseAction{item->size(), ResponseAction::Ignore});
+	} else {
+		m_Queues.FutureResponseActions.back().Amount += item->size();
+	}
 
-		try {
-			for (auto& query : item.first) {
-				WriteOne(query, yc);
-			}
-		} catch (const std::exception&) {
-			item.second.set_exception(std::current_exception());
+	m_QueuedReads.Set();
+	return true;
+}
 
-			return;
+/**
+ * Write a single Redis query and enqueue a response promise to be fulfilled once the response has been received.
+ *
+ * @param item Redis query and promise for the response
+ */
+bool RedisConnection::WriteItem(const QueryWithPromise& item, boost::asio::yield_context& yc)
+{
+	DecreasePendingQueries(1);
+
+	try {
+		WriteOne(item->first, yc);
+	} catch (const std::exception&) {
+		item->second.set_exception(std::current_exception());
+
+		return false;
+	}
+
+	m_Queues.ReplyPromises.push(std::move(item->second));
+
+	if (m_Queues.FutureResponseActions.empty() || m_Queues.FutureResponseActions.back().Action != ResponseAction::Deliver) {
+		m_Queues.FutureResponseActions.emplace(FutureResponseAction{1, ResponseAction::Deliver});
+	} else {
+		++m_Queues.FutureResponseActions.back().Amount;
+	}
+
+	m_QueuedReads.Set();
+	return true;
+}
+
+/**
+ * Write multiple Redis queries and enqueue a response promise to be fulfilled once all responses have been received.
+ *
+ * @param item Redis queries and promise for the responses.
+ *
+ * @return true on success, false on failure.
+ */
+bool RedisConnection::WriteItem(const QueriesWithPromise& item, boost::asio::yield_context& yc)
+{
+	DecreasePendingQueries(item->first.size());
+
+	try {
+		for (auto& query : item->first) {
+			WriteOne(query, yc);
 		}
+	} catch (const std::exception&) {
+		item->second.set_exception(std::current_exception());
 
-		m_Queues.RepliesPromises.emplace(std::move(item.second));
-		m_Queues.FutureResponseActions.emplace(FutureResponseAction{item.first.size(), ResponseAction::DeliverBulk});
-
-		m_QueuedReads.Set();
+		return false;
 	}
 
-	if (next.Callback) {
-		next.Callback(yc);
-	}
+	m_Queues.RepliesPromises.emplace(std::move(item->second));
+	m_Queues.FutureResponseActions.emplace(FutureResponseAction{item->first.size(), ResponseAction::DeliverBulk});
 
-	RecordAffected(next.Affects, Utility::GetTime());
+	m_QueuedReads.Set();
+	return true;
+}
+
+/**
+ * Invokes the provided callback immediately.
+ *
+ * @param item Callback to execute
+ */
+bool RedisConnection::WriteItem(const QueryCallback& item, boost::asio::yield_context& yc)
+{
+	item(yc);
+	return true;
 }
 
 /**

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -258,7 +258,7 @@ double RedisConnection::GetOldestPendingQueryTs()
 		double oldest = 0;
 
 		for (auto& queue : m_Queues.Writes) {
-			if (m_SuppressedQueryKinds.find(queue.first) == m_SuppressedQueryKinds.end() && !queue.second.empty()) {
+			if (!queue.second.empty()) {
 				auto ctime (queue.second.front().CTime);
 
 				if (ctime < oldest || oldest == 0) {
@@ -272,29 +272,6 @@ double RedisConnection::GetOldestPendingQueryTs()
 
 	future.wait();
 	return future.get();
-}
-
-/**
- * Mark kind as kind of queries not to actually send yet
- *
- * @param kind Query kind
- */
-void RedisConnection::SuppressQueryKind(RedisConnection::QueryPriority kind)
-{
-	asio::post(m_Strand, [this, kind]() { m_SuppressedQueryKinds.emplace(kind); });
-}
-
-/**
- * Unmark kind as kind of queries not to actually send yet
- *
- * @param kind Query kind
- */
-void RedisConnection::UnsuppressQueryKind(RedisConnection::QueryPriority kind)
-{
-	asio::post(m_Strand, [this, kind]() {
-		m_SuppressedQueryKinds.erase(kind);
-		m_QueuedWrites.Set();
-	});
 }
 
 /**
@@ -474,7 +451,7 @@ void RedisConnection::WriteLoop(asio::yield_context& yc)
 
 	WriteFirstOfHighestPrio:
 		for (auto& queue : m_Queues.Writes) {
-			if (m_SuppressedQueryKinds.find(queue.first) != m_SuppressedQueryKinds.end() || queue.second.empty()) {
+			if (queue.second.empty()) {
 				continue;
 			}
 

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -112,12 +112,22 @@ void LogQuery(RedisConnection::Query& query, Log& msg)
 }
 
 /**
- * Queue a Redis query for sending
+ * Queue a Redis query for sending without waiting for the response in a fire-and-forget manner.
  *
- * @param query Redis query
- * @param priority The query's priority
+ * If the highPriority flag is set to true, the query is treated with high priority and placed at the front of
+ * the write queue, ensuring it is sent before other queued queries. This is useful for time-sensitive operations
+ * that require to be executed promptly, which is the case for IcingaDB heartbeat queries. If there are already
+ * queries with high priority in the queue, the new query is inserted after all existing high priority queries but
+ * before any normal priority queries to maintain the order of high priority items.
+ *
+ * @note The highPriority flag should be used sparingly and only for critical queries, as it can affect the overall
+ * performance and responsiveness of the Redis connection by potentially delaying other queued queries.
+ *
+ * @param query The Redis query to be sent.
+ * @param affects Does the query affect config, state or history data.
+ * @param highPriority Whether the query should be treated with high priority.
  */
-void RedisConnection::FireAndForgetQuery(RedisConnection::Query query, RedisConnection::QueryPriority priority, QueryAffects affects)
+void RedisConnection::FireAndForgetQuery(Query query, QueryAffects affects, bool highPriority)
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
 		Log msg (LogDebug, "IcingaDB", "Firing and forgetting query:");
@@ -125,10 +135,9 @@ void RedisConnection::FireAndForgetQuery(RedisConnection::Query query, RedisConn
 	}
 
 	auto item (Shared<Query>::Make(std::move(query)));
-	auto ctime (Utility::GetTime());
 
-	asio::post(m_Strand, [this, item, priority, ctime, affects]() {
-		m_Queues.Writes[priority].emplace(WriteQueueItem{item, nullptr, nullptr, nullptr, nullptr, ctime, affects});
+	asio::post(m_Strand, [this, item, highPriority, affects, ctime = Utility::GetTime()]() {
+		m_Queues.Push(WriteQueueItem{item, nullptr, nullptr, nullptr, nullptr, ctime, affects}, highPriority);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(1);
 	});
@@ -138,9 +147,8 @@ void RedisConnection::FireAndForgetQuery(RedisConnection::Query query, RedisConn
  * Queue Redis queries for sending
  *
  * @param queries Redis queries
- * @param priority The queries' priority
  */
-void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, RedisConnection::QueryPriority priority, QueryAffects affects)
+void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, QueryAffects affects)
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
 		for (auto& query : queries) {
@@ -150,10 +158,9 @@ void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, Red
 	}
 
 	auto item (Shared<Queries>::Make(std::move(queries)));
-	auto ctime (Utility::GetTime());
 
-	asio::post(m_Strand, [this, item, priority, ctime, affects]() {
-		m_Queues.Writes[priority].emplace(WriteQueueItem{nullptr, item, nullptr, nullptr, nullptr, ctime, affects});
+	asio::post(m_Strand, [this, item, affects, ctime = Utility::GetTime()]() {
+		m_Queues.Push(WriteQueueItem{nullptr, item, nullptr, nullptr, nullptr, ctime, affects}, false);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(item->size());
 	});
@@ -163,11 +170,10 @@ void RedisConnection::FireAndForgetQueries(RedisConnection::Queries queries, Red
  * Queue a Redis query for sending, wait for the response and return (or throw) it
  *
  * @param query Redis query
- * @param priority The query's priority
  *
  * @return The response
  */
-RedisConnection::Reply RedisConnection::GetResultOfQuery(RedisConnection::Query query, RedisConnection::QueryPriority priority, QueryAffects affects)
+RedisConnection::Reply RedisConnection::GetResultOfQuery(RedisConnection::Query query, QueryAffects affects)
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
 		Log msg (LogDebug, "IcingaDB", "Executing query:");
@@ -177,10 +183,9 @@ RedisConnection::Reply RedisConnection::GetResultOfQuery(RedisConnection::Query 
 	std::promise<Reply> promise;
 	auto future (promise.get_future());
 	auto item (Shared<std::pair<Query, std::promise<Reply>>>::Make(std::move(query), std::move(promise)));
-	auto ctime (Utility::GetTime());
 
-	asio::post(m_Strand, [this, item, priority, ctime, affects]() {
-		m_Queues.Writes[priority].emplace(WriteQueueItem{nullptr, nullptr, item, nullptr, nullptr, ctime, affects});
+	asio::post(m_Strand, [this, item, affects, ctime = Utility::GetTime()]() {
+		m_Queues.Push(WriteQueueItem{nullptr, nullptr, item, nullptr, nullptr, ctime, affects}, false);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(1);
 	});
@@ -194,11 +199,10 @@ RedisConnection::Reply RedisConnection::GetResultOfQuery(RedisConnection::Query 
  * Queue Redis queries for sending, wait for the responses and return (or throw) them
  *
  * @param queries Redis queries
- * @param priority The queries' priority
  *
  * @return The responses
  */
-RedisConnection::Replies RedisConnection::GetResultsOfQueries(RedisConnection::Queries queries, RedisConnection::QueryPriority priority, QueryAffects affects)
+RedisConnection::Replies RedisConnection::GetResultsOfQueries(Queries queries, QueryAffects affects, bool highPriority)
 {
 	if (LogDebug >= Logger::GetMinLogSeverity()) {
 		for (auto& query : queries) {
@@ -210,10 +214,9 @@ RedisConnection::Replies RedisConnection::GetResultsOfQueries(RedisConnection::Q
 	std::promise<Replies> promise;
 	auto future (promise.get_future());
 	auto item (Shared<std::pair<Queries, std::promise<Replies>>>::Make(std::move(queries), std::move(promise)));
-	auto ctime (Utility::GetTime());
 
-	asio::post(m_Strand, [this, item, priority, ctime, affects]() {
-		m_Queues.Writes[priority].emplace(WriteQueueItem{nullptr, nullptr, nullptr, item, nullptr, ctime, affects});
+	asio::post(m_Strand, [this, item, highPriority, affects, ctime = Utility::GetTime()]() {
+		m_Queues.Push(WriteQueueItem{nullptr, nullptr, nullptr, item, nullptr, ctime, affects}, highPriority);
 		m_QueuedWrites.Set();
 		IncreasePendingQueries(item->first.size());
 	});
@@ -223,12 +226,10 @@ RedisConnection::Replies RedisConnection::GetResultsOfQueries(RedisConnection::Q
 	return future.get();
 }
 
-void RedisConnection::EnqueueCallback(const std::function<void(boost::asio::yield_context&)>& callback, RedisConnection::QueryPriority priority)
+void RedisConnection::EnqueueCallback(const std::function<void(boost::asio::yield_context&)>& callback)
 {
-	auto ctime (Utility::GetTime());
-
-	asio::post(m_Strand, [this, callback, priority, ctime]() {
-		m_Queues.Writes[priority].emplace(WriteQueueItem{nullptr, nullptr, nullptr, nullptr, callback, ctime, QueryAffects{}});
+	asio::post(m_Strand, [this, callback, ctime = Utility::GetTime()]() {
+		m_Queues.Push(WriteQueueItem{nullptr, nullptr, nullptr, nullptr, callback, ctime}, false);
 		m_QueuedWrites.Set();
 	});
 }
@@ -241,7 +242,7 @@ void RedisConnection::EnqueueCallback(const std::function<void(boost::asio::yiel
  */
 void RedisConnection::Sync()
 {
-	GetResultOfQuery({"PING"}, RedisConnection::QueryPriority::SyncConnection);
+	GetResultOfQuery({"PING"});
 }
 
 /**
@@ -249,21 +250,20 @@ void RedisConnection::Sync()
  *
  * @return *nix timestamp or 0
  */
-double RedisConnection::GetOldestPendingQueryTs()
+double RedisConnection::GetOldestPendingQueryTs() const
 {
 	auto promise (Shared<std::promise<double>>::Make());
 	auto future (promise->get_future());
 
 	asio::post(m_Strand, [this, promise]() {
 		double oldest = 0;
-
-		for (auto& queue : m_Queues.Writes) {
-			if (!queue.second.empty()) {
-				auto ctime (queue.second.front().CTime);
-
-				if (ctime < oldest || oldest == 0) {
-					oldest = ctime;
-				}
+		if (!m_Queues.HighWriteQ.empty()) {
+			oldest = m_Queues.HighWriteQ.front().CTime;
+		}
+		if (!m_Queues.NormalWriteQ.empty()) {
+			auto normalOldest = m_Queues.NormalWriteQ.front().CTime;
+			if (oldest == 0 || normalOldest < oldest) {
+				oldest = normalOldest;
 			}
 		}
 
@@ -449,18 +449,8 @@ void RedisConnection::WriteLoop(asio::yield_context& yc)
 	for (;;) {
 		m_QueuedWrites.Wait(yc);
 
-	WriteFirstOfHighestPrio:
-		for (auto& queue : m_Queues.Writes) {
-			if (queue.second.empty()) {
-				continue;
-			}
-
-			auto next (std::move(queue.second.front()));
-			queue.second.pop();
-
-			WriteItem(yc, std::move(next));
-
-			goto WriteFirstOfHighestPrio;
+		while (m_Queues.HasWrites()) {
+			WriteItem(yc, m_Queues.PopFront());
 		}
 
 		m_QueuedWrites.Clear();

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -38,6 +38,7 @@
 #include <map>
 #include <memory>
 #include <queue>
+#include <deque>
 #include <stdexcept>
 #include <string_view>
 #include <utility>
@@ -141,22 +142,6 @@ struct RedisConnInfo final : SharedObject
 		typedef Value Reply;
 		typedef std::vector<Reply> Replies;
 
-		/**
-		 * Redis query priorities, highest first.
-		 *
-		 * @ingroup icingadb
-		 */
-		enum class QueryPriority : unsigned char
-		{
-			Heartbeat,
-			RuntimeStateStream, // runtime state updates, doesn't affect initially synced states
-			Config, // includes initially synced states
-			RuntimeStateSync, // updates initially synced states at runtime, in parallel to config dump, therefore must be < Config
-			History,
-			CheckResult,
-			SyncConnection = 255
-		};
-
 		struct QueryAffects
 		{
 			size_t Config;
@@ -177,15 +162,15 @@ struct RedisConnInfo final : SharedObject
 			return m_Connected.load();
 		}
 
-		void FireAndForgetQuery(Query query, QueryPriority priority, QueryAffects affects = {});
-		void FireAndForgetQueries(Queries queries, QueryPriority priority, QueryAffects affects = {});
+		void FireAndForgetQuery(Query query, QueryAffects affects = {}, bool highPriority = false);
+		void FireAndForgetQueries(Queries queries, QueryAffects affects = {});
 
-		Reply GetResultOfQuery(Query query, QueryPriority priority, QueryAffects affects = {});
-		Replies GetResultsOfQueries(Queries queries, QueryPriority priority, QueryAffects affects = {});
+		Reply GetResultOfQuery(Query query, QueryAffects affects = {});
+		Replies GetResultsOfQueries(Queries queries, QueryAffects affects = {}, bool highPriority = false);
 
-		void EnqueueCallback(const std::function<void(boost::asio::yield_context&)>& callback, QueryPriority priority);
+		void EnqueueCallback(const std::function<void(boost::asio::yield_context&)>& callback);
 		void Sync();
-		double GetOldestPendingQueryTs();
+		double GetOldestPendingQueryTs() const;
 
 		void SetConnectedCallback(std::function<void(boost::asio::yield_context& yc)> callback);
 
@@ -248,7 +233,7 @@ struct RedisConnInfo final : SharedObject
 			Shared<std::pair<Queries, std::promise<Replies>>>::Ptr GetResultsOfQueries;
 			std::function<void(boost::asio::yield_context&)> Callback;
 
-			double CTime;
+			double CTime; // When was this item queued?
 			QueryAffects Affects;
 		};
 
@@ -306,14 +291,40 @@ struct RedisConnInfo final : SharedObject
 		Atomic<bool> m_Connecting, m_Connected, m_Started;
 
 		struct {
-			// Items to be send to Redis
-			std::map<QueryPriority, std::queue<WriteQueueItem>> Writes;
+			std::queue<WriteQueueItem> HighWriteQ; // High priority writes to be sent to Redis.
+			std::queue<WriteQueueItem> NormalWriteQ; // Normal priority writes to be sent to Redis.
 			// Requestors, each waiting for a single response
 			std::queue<std::promise<Reply>> ReplyPromises;
 			// Requestors, each waiting for multiple responses at once
 			std::queue<std::promise<Replies>> RepliesPromises;
 			// Metadata about all of the above
 			std::queue<FutureResponseAction> FutureResponseActions;
+
+			WriteQueueItem PopFront()
+			{
+				if (!HighWriteQ.empty()) {
+					WriteQueueItem item(std::move(HighWriteQ.front()));
+					HighWriteQ.pop();
+					return item;
+				}
+				WriteQueueItem item(std::move(NormalWriteQ.front()));
+				NormalWriteQ.pop();
+				return item;
+			}
+
+			void Push(WriteQueueItem&& item, bool highPriority)
+			{
+				if (highPriority) {
+					HighWriteQ.push(std::move(item));
+				} else {
+					NormalWriteQ.push(std::move(item));
+				}
+			}
+
+			bool HasWrites() const
+			{
+				return !HighWriteQ.empty() || !NormalWriteQ.empty();
+			}
 		} m_Queues;
 
 		// Indicate that there's something to send/receive

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -38,7 +38,6 @@
 #include <map>
 #include <memory>
 #include <queue>
-#include <set>
 #include <stdexcept>
 #include <string_view>
 #include <utility>
@@ -188,9 +187,6 @@ struct RedisConnInfo final : SharedObject
 		void Sync();
 		double GetOldestPendingQueryTs();
 
-		void SuppressQueryKind(QueryPriority kind);
-		void UnsuppressQueryKind(QueryPriority kind);
-
 		void SetConnectedCallback(std::function<void(boost::asio::yield_context& yc)> callback);
 
 		int GetQueryCount(RingBuffer::SizeType span);
@@ -319,9 +315,6 @@ struct RedisConnInfo final : SharedObject
 			// Metadata about all of the above
 			std::queue<FutureResponseAction> FutureResponseActions;
 		} m_Queues;
-
-		// Kinds of queries not to actually send yet
-		std::set<QueryPriority> m_SuppressedQueryKinds;
 
 		// Indicate that there's something to send/receive
 		AsioEvent m_QueuedWrites;

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -44,6 +44,7 @@
 #include <utility>
 #include <variant>
 #include <vector>
+#include <variant>
 
 namespace icinga
 {
@@ -220,19 +221,20 @@ struct RedisConnInfo final : SharedObject
 			ResponseAction Action;
 		};
 
+		using FireAndForgetQ = Shared<Query>::Ptr; // A single query that does not expect a result.
+		using FireAndForgetQs = Shared<Queries>::Ptr; // Multiple queries that do not expect results.
+		using QueryWithPromise = Shared<std::pair<Query, std::promise<Reply>>>::Ptr; // A single query expecting a result.
+		using QueriesWithPromise = Shared<std::pair<Queries, std::promise<Replies>>>::Ptr; // Multiple queries expecting results.
+		using QueryCallback = std::function<void(boost::asio::yield_context&)>; // A callback to be executed.
+
 		/**
-		 * Something to be send to Redis.
+		 * An item in the write queue to be sent to Redis.
 		 *
 		 * @ingroup icingadb
 		 */
 		struct WriteQueueItem
 		{
-			Shared<Query>::Ptr FireAndForgetQuery;
-			Shared<Queries>::Ptr FireAndForgetQueries;
-			Shared<std::pair<Query, std::promise<Reply>>>::Ptr GetResultOfQuery;
-			Shared<std::pair<Queries, std::promise<Replies>>>::Ptr GetResultsOfQueries;
-			std::function<void(boost::asio::yield_context&)> Callback;
-
+			std::variant<FireAndForgetQ, FireAndForgetQs, QueryWithPromise, QueriesWithPromise, QueryCallback> Item;
 			double CTime; // When was this item queued?
 			QueryAffects Affects;
 		};
@@ -262,7 +264,11 @@ struct RedisConnInfo final : SharedObject
 		void ReadLoop(boost::asio::yield_context& yc);
 		void WriteLoop(boost::asio::yield_context& yc);
 		void LogStats(boost::asio::yield_context& yc);
-		void WriteItem(boost::asio::yield_context& yc, WriteQueueItem item);
+		bool WriteItem(const FireAndForgetQ& item, boost::asio::yield_context& yc);
+		bool WriteItem(const FireAndForgetQs& item, boost::asio::yield_context& yc);
+		bool WriteItem(const QueryWithPromise& item, boost::asio::yield_context& yc);
+		bool WriteItem(const QueriesWithPromise& item, boost::asio::yield_context& yc);
+		bool WriteItem(const QueryCallback& item, boost::asio::yield_context& yc);
 		Reply ReadOne(boost::asio::yield_context& yc);
 		void WriteOne(Query& query, boost::asio::yield_context& yc);
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -73,8 +73,9 @@ enum class ApiCapabilities : uint_fast64_t
 	ExecuteArbitraryCommand = 1u << 0u,
 	IfwApiCheckCommand = 1u << 1u,
 	HostChildrenInheritObjectAuthority = 1u << 2u,
+	GranularNextCheckInvocation = 1u << 3u,
 
-	MyCapabilities = ExecuteArbitraryCommand | IfwApiCheckCommand | HostChildrenInheritObjectAuthority
+	MyCapabilities = ExecuteArbitraryCommand | IfwApiCheckCommand | HostChildrenInheritObjectAuthority | GranularNextCheckInvocation
 };
 
 /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,6 +133,15 @@ set(base_test_SOURCES
   $<TARGET_OBJECTS:methods>
 )
 
+if (ICINGA2_WITH_CHECKER)
+  list(APPEND base_test_SOURCES
+    checker.cpp
+    checker-fixture.cpp
+    checker-fixture.hpp
+    $<TARGET_OBJECTS:checker>
+  )
+endif()
+
 if(ICINGA2_WITH_NOTIFICATION)
   list(APPEND base_test_SOURCES
     notification-notificationcomponent.cpp

--- a/test/base-testloggerfixture.hpp
+++ b/test/base-testloggerfixture.hpp
@@ -66,6 +66,27 @@ public:
 		m_LogEntries.clear();
 	}
 
+	/**
+	 * Counts the number of log entries that match the given regex pattern.
+	 *
+	 * This only counts existing log entries, it does not wait for new ones to arrive.
+	 *
+	 * @param pattern The regex pattern the log message needs to match
+	 *
+	 * @return The number of log entries that match the given pattern
+	 */
+	std::size_t CountExpectedLogPattern(const std::string& pattern)
+	{
+		std::lock_guard lock(m_Mutex);
+		std::size_t count = 0;
+		for (const auto& logEntry : m_LogEntries) {
+			if (boost::regex_match(logEntry.Message.GetData(), boost::regex(pattern))) {
+				++count;
+			}
+		}
+		return count;
+	}
+
 private:
 	void ProcessLogEntry(const LogEntry& entry) override
 	{
@@ -107,6 +128,11 @@ struct TestLoggerFixture
 	}
 
 	~TestLoggerFixture()
+	{
+		DeactivateLogger();
+	}
+
+	void DeactivateLogger() const
 	{
 		testLogger->SetActive(false);
 		testLogger->Deactivate(true);

--- a/test/checker-fixture.cpp
+++ b/test/checker-fixture.cpp
@@ -1,0 +1,209 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "base/utility.hpp"
+#include "config/configcompiler.hpp"
+#include "remote/apilistener.hpp"
+#include "test/checker-fixture.hpp"
+#include "test/icingaapplication-fixture.hpp"
+
+using namespace icinga;
+
+CheckerFixture::CheckerFixture()
+{
+	checker = new CheckerComponent;
+	checker->SetResultTimerInterval(.4); // Speed up result timer for tests
+	checker->SetName("randomizer", true);
+	checker->Register();
+	checker->OnConfigLoaded();
+	checker->PreActivate();
+	checker->Activate();
+
+	// Manually building and registering the command won't work here as we need a real callable
+	// function that produces cr and calls ProcessCheckResult on the checkable. So we use a small
+	// config snippet that imports the random and sleep check commands registered by the "methods-itl.cpp"
+	// file in the methods lib.
+	ConfigItem::RunWithActivationContext(
+		new Function{
+			"checker-fixture",
+			[] {
+				std::unique_ptr<Expression> expression = ConfigCompiler::CompileText(
+					"<checker-fixture>",
+					R"CONFIG(
+object CheckCommand "random" {
+	import "random-check-command"
+}
+
+object CheckCommand "sleep" {
+    import "sleep-check-command"
+}
+)CONFIG"
+				);
+				BOOST_REQUIRE(expression);
+				ScriptFrame frame(true);
+				BOOST_CHECK_NO_THROW(expression->Evaluate(frame));
+			}
+		}
+	);
+
+	Checkable::OnNewCheckResult.connect(
+		[this](const Checkable::Ptr&, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
+			++resultCount;
+			lastResult.store(cr);
+		}
+	);
+	// Track the next check times of the checkables, so we can verify that they are set to the expected
+	// value. The map is populated with the expected checkable names by the RegisterChecable() function.
+	// So, we can safely modify the map from within this signal handler without further locking, since there
+	// won't be any concurrent access to the same keys.
+	Checkable::OnNextCheckChanged.connect([this](const Checkable::Ptr& checkable, const Value&) {
+		if (auto it{nextCheckTimes.find(checkable->GetName())}; it != nextCheckTimes.end()) {
+			it->second = checkable->GetNextCheck();
+		}
+	});
+}
+
+CheckerFixture::~CheckerFixture()
+{
+	checker->Deactivate();
+}
+
+void CheckerFixture::RegisterCheckablesRandom(int count, bool disableChecks, bool unreachable)
+{
+	for (int i = 1; i <= count; ++i) {
+		(void)RegisterCheckable("host-" + std::to_string(i), "random", "", "", disableChecks, unreachable);
+	}
+}
+
+void CheckerFixture::RegisterCheckablesSleep(int count, double sleepTime, bool disableChecks, bool unreachable)
+{
+	for (int i = 1; i <= count; ++i) {
+		auto h = RegisterCheckable("host-" + std::to_string(i), "sleep", "", "", disableChecks, unreachable);
+		h->SetVars(new Dictionary{{"sleep_time", sleepTime}});
+	}
+}
+
+void CheckerFixture::RegisterRemoteChecks(int count, bool isConnected, bool isSyncingReplayLogs)
+{
+	RegisterEndpoint("remote-checker", isConnected, isSyncingReplayLogs);
+	for (int i = 1; i <= count; ++i) {
+		auto h = RegisterCheckable("host-"+std::to_string(i), "random", "", "remote-checker");
+		Checkable::OnRescheduleCheck(h, Utility::GetTime()); // Force initial scheduling
+	}
+}
+
+Host::Ptr CheckerFixture::RegisterCheckable(
+	std::string name,
+	std::string cmd,
+	std::string period,
+	std::string endpoint,
+	bool disableChecks,
+	bool unreachable
+)
+{
+	Host::Ptr host = new Host;
+	host->SetName(std::move(name), true);
+	host->SetCheckCommandRaw(std::move(cmd), true);
+	host->SetCheckInterval(checkInterval, true);
+	host->SetRetryInterval(retryInterval, true);
+	host->SetHAMode(HARunEverywhere, true); // Disable HA for tests
+	host->SetEnableActiveChecks(!disableChecks, true);
+	host->SetCheckPeriodRaw(std::move(period), true);
+	host->SetZoneName(endpoint, true);
+	host->SetCommandEndpointRaw(std::move(endpoint), true);
+	host->SetCheckTimeout(0, true);
+	host->Register();
+	host->OnAllConfigLoaded();
+
+	nextCheckTimes[host->GetName()] = 0.0; // Initialize next check time tracking
+
+	if (unreachable) {
+		Host::Ptr parent = new Host;
+		parent->SetName(Utility::NewUniqueID(), true);
+		parent->SetStateRaw(ServiceCritical, true);
+		parent->SetStateType(StateTypeHard, true);
+		parent->SetLastCheckResult(new CheckResult, true);
+		parent->SetEnableActiveChecks(false, true);
+		parent->Register();
+
+		parent->PreActivate();
+		parent->Activate();
+
+		Dependency::Ptr dep = new Dependency;
+		dep->SetName(Utility::NewUniqueID(), true);
+		dep->SetStateFilter(StateFilterUp, true);
+		dep->SetDisableChecks(true, true);
+		dep->SetParent(parent);
+		dep->SetChild(host);
+		dep->Register();
+
+		dep->OnAllConfigLoaded();
+
+		host->AddDependency(dep);
+	}
+
+	host->PreActivate();
+	host->Activate();
+	return host;
+}
+
+void CheckerFixture::SleepFor(std::chrono::milliseconds milliseconds, bool deactivateLogger) const
+{
+	std::this_thread::sleep_for(milliseconds);
+
+	Checkable::OnNextCheckChanged.disconnect_all_slots();
+	Checkable::OnNewCheckResult.disconnect_all_slots();
+	if (deactivateLogger) {
+		DeactivateLogger();
+	}
+}
+
+Endpoint::Ptr CheckerFixture::RegisterEndpoint(std::string name, bool isConnected, bool isSyncingReplayLogs)
+{
+	auto makeEndpoint = [](const std::string& name, bool syncing) {
+		Endpoint::Ptr remote = new Endpoint;
+		remote->SetName(name, true);
+		if (syncing) {
+			remote->SetSyncing(true);
+		}
+		remote->Register();
+		remote->PreActivate();
+		return remote;
+	};
+
+	Endpoint::Ptr remote = makeEndpoint(name, isSyncingReplayLogs);
+	Endpoint::Ptr local = makeEndpoint("local-tester", false);
+
+	Zone::Ptr zone = new Zone;
+	zone->SetName(remote->GetName(), true);
+	zone->SetEndpointsRaw(new Array{{remote->GetName(), local->GetName()}}, true);
+	zone->Register();
+	zone->OnAllConfigLoaded();
+	zone->PreActivate();
+	zone->Activate();
+
+	ApiListener::Ptr listener = new ApiListener;
+	listener->SetIdentity(local->GetName(), true);
+	listener->SetName(local->GetName(), true);
+	listener->Register();
+	try {
+		listener->OnAllConfigLoaded(); // Initialize the m_LocalEndpoint of the listener!
+
+		// May throw due to various reasons, but we only care that the m_Instance singleton
+		// is set which it will be if no other ApiListener is registered yet.
+		listener->OnConfigLoaded();
+	} catch (const std::exception& ex) {
+		BOOST_TEST_MESSAGE("Exception during ApiListener::OnConfigLoaded: " << DiagnosticInformation(ex));
+	}
+
+	if (isConnected) {
+		JsonRpcConnection::Ptr client = new JsonRpcConnection(
+			new StoppableWaitGroup,
+			"anonymous",
+			false,
+			nullptr,
+			RoleClient
+		);
+		remote->AddClient(client);
+	}
+	return remote;
+}

--- a/test/checker-fixture.hpp
+++ b/test/checker-fixture.hpp
@@ -1,0 +1,122 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#pragma once
+
+#include "base/atomic.hpp"
+#include "checker/checkercomponent.hpp"
+#include "icinga/checkcommand.hpp"
+#include "remote/endpoint.hpp"
+#include "test/base-testloggerfixture.hpp"
+
+namespace icinga {
+
+/**
+ * Test fixture for tests involving the @c CheckerComponent.
+ *
+ * This fixture sets up a CheckerComponent instance and provides utility functions to register
+ * checkable objects. It is derived from @c TestLoggerFixture to capture log output during tests,
+ * so tests can verify that expected log messages are produced. The fixture also connects to the
+ * @c Checkable::OnNewCheckResult signal to count the number of check results produced during tests.
+ */
+struct CheckerFixture : TestLoggerFixture
+{
+	CheckerFixture();
+
+	~CheckerFixture();
+
+	/**
+	 * Registers a fully configured set of checkable hosts that execute the "random" check command.
+	 *
+	 * Each host is configured with a random check command, check interval, and retry interval.
+	 * If @c unreachable is true, each host is made unreachable by adding a dependency on a parent
+	 * host that is in a critical state. This prevents the checker from executing checks for the
+	 * child hosts. The check and retry intervals are kept low to allow for quick test execution,
+	 * but they can be adjusted via the @c interval and @c retry parameters.
+	 *
+	 * @param count Number of checkable hosts to register.
+	 * @param disableChecks If true, disables active checks for each host.
+	 * @param unreachable If true, makes each host unreachable via a dependency.
+	 */
+	void RegisterCheckablesRandom(int count, bool disableChecks = false, bool unreachable = false);
+
+	/**
+	 * Registers a fully configured set of checkable hosts that execute the "sleep" command.
+	 *
+	 * Each host is configured with a sleep check command that sleeps for the specified duration.
+	 * The check and retry intervals can be adjusted via the @c checkInterval and @c retryInterval
+	 * member variables of the fixture. If @c unreachable is true, each host is made unreachable by
+	 * adding a dependency on a parent host that is in a critical state. This prevents the checker
+	 * from executing checks for the child hosts.
+	 *
+	 * @param count Number of checkable hosts to register.
+	 * @param sleepTime Duration (in seconds) that the sleep command should sleep. Defaults to 1.0 second.
+	 * @param disableChecks If true, disables active checks for each host.
+	 * @param unreachable If true, makes each host unreachable via a dependency.
+	 */
+	void RegisterCheckablesSleep(int count, double sleepTime = 1.0, bool disableChecks = false, bool unreachable = false);
+
+	/**
+	 * Registers a remote endpoint and a set of checkable hosts assigned to that endpoint.
+	 *
+	 * The remote endpoint can be configured to appear connected or disconnected, and can also
+	 * be set to be syncing replay as needed for tests involving remote checks.
+	 *
+	 * @param count Number of checkable hosts to register.
+	 * @param isConnected If true, the remote endpoint is marked as connected.
+	 * @param isSyncingReplayLogs If true, the remote endpoint is marked as syncing replay logs.
+	 */
+	void RegisterRemoteChecks(int count, bool isConnected = false, bool isSyncingReplayLogs = false);
+
+	Host::Ptr RegisterCheckable(
+		std::string name,
+		std::string cmd,
+		std::string period = "",
+		std::string endpoint = "",
+		bool disableChecks = false,
+		bool unreachable = false
+	);
+
+	/**
+	 * Sleeps for the specified number of milliseconds, then immediately disconnects all signal handlers
+	 * connected to @c Checkable::OnNextCheckChanged and @c Checkable::OnNewCheckResult.
+	 *
+	 * This is useful in tests to allow some time for checks to be executed and results to be processed,
+	 * while ensuring that no further signal handlers are called after the sleep period. This helps to avoid
+	 * unexpected side effects in tests, since the checker continues to run till the fixture is destroyed.
+	 *
+	 * @param milliseconds Number of milliseconds to sleep.
+	 * @param deactivateLogger If true, deactivates the test logger after sleeping to prevent further log capture.
+	 */
+	void SleepFor(std::chrono::milliseconds milliseconds, bool deactivateLogger = false) const;
+
+	/**
+	 * Registers a remote endpoint with the specified name and connection/syncing state and returns it.
+	 *
+	 * @param name Name of the endpoint to register.
+	 * @param isConnected If true, the endpoint is marked as connected.
+	 * @param isSyncingReplayLogs If true, the endpoint is marked as syncing replay logs.
+	 *
+	 * @return The registered endpoint instance.
+	 */
+	static Endpoint::Ptr RegisterEndpoint(std::string name, bool isConnected = false, bool isSyncingReplayLogs = false);
+
+	/**
+	 * resultCount tracks the number of check results produced by the checker.
+	 *
+	 * This is used in tests to verify that checks are actually being executed and results processed.
+	 * It is incremented from within the OnNewCheckResult signal handler, thus must be atomic.
+	 */
+	std::atomic_int resultCount{0};
+	AtomicOrLocked<CheckResult::Ptr> lastResult; // Stores the last check result received, for inspection in tests.
+	/**
+	 * nextCheckTimes tracks the next scheduled check time for each registered checkable host.
+	 * This might not be used in all tests, but is available for tests that need to verify the exact
+	 * next check timestamp set by the checker.
+	 */
+	std::map<std::string /* host */, double /* next_check */> nextCheckTimes;
+	double checkInterval{.1}; // Interval in seconds between regular checks for each checkable.
+	double retryInterval{.1}; // Interval in seconds between retry checks for each checkable.
+	CheckerComponent::Ptr checker;
+};
+
+} // namespace icinga

--- a/test/checker.cpp
+++ b/test/checker.cpp
@@ -1,0 +1,416 @@
+/* Icinga 2 | (c) 2025 Icinga GmbH | GPLv2+ */
+
+#include "test/checker-fixture.hpp"
+#include "base/scriptglobal.hpp"
+#include "icinga/host.hpp"
+#include "icinga/dependency.hpp"
+#include "icinga/legacytimeperiod.hpp"
+#include "test/utils.hpp"
+#include <boost/test/unit_test.hpp>
+
+using namespace icinga;
+
+BOOST_FIXTURE_TEST_SUITE(checker, CheckerFixture, *boost::unit_test::label("checker"))
+
+BOOST_AUTO_TEST_CASE(single_check)
+{
+	// For a single checkable, there shouldn't be any concurrent checks that trigger this event,
+	// so we can safely use boost assertion macros within the event handler.
+	Checkable::OnNextCheckChanged.connect([this](const Checkable::Ptr& checkable, const Value&) {
+		BOOST_CHECK_EQUAL(checkable->GetName(), "host-1");
+		BOOST_CHECK_LE(checkable->GetNextCheck(), checkable->GetLastCheck() + checkInterval + .5);
+	});
+
+	RegisterCheckablesRandom(1);
+	SleepFor(200ms, true);
+
+	BOOST_CHECK_EQUAL(2, testLogger->CountExpectedLogPattern("Executing check for 'host-1'"));
+	BOOST_CHECK_EQUAL(2, testLogger->CountExpectedLogPattern("Check finished for object 'host-1'"));
+	BOOST_CHECK_EQUAL(2, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(multi_checks)
+{
+	Checkable::OnNextCheckChanged.connect([this](const Checkable::Ptr& checkable, const Value&) {
+		BOOST_CHECK_LE(checkable->GetNextCheck(), checkable->GetLastCheck() + checkInterval + .5);
+	});
+
+	RegisterCheckablesRandom(8);
+	SleepFor(300ms, true);
+
+	CHECK_LOG_MESSAGE("Check finished for object .*", 0s);
+	CHECK_LOG_MESSAGE("Executing check for .*", 0s);
+
+	auto executedC = testLogger->CountExpectedLogPattern("Executing check for .*");
+	auto finishedC = testLogger->CountExpectedLogPattern("Check finished for object .*");
+	BOOST_CHECK_EQUAL(executedC, finishedC);
+	// With 8 checkables and a check interval of 0.1s, we expect that each checkable is checked at least
+	// twice, but some of them possibly up to 3 times, depending on the timing and OS scheduling behavior.
+	BOOST_CHECK_MESSAGE(22 <= resultCount && resultCount <= 25, "got=" << resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(disabled_checks)
+{
+	RegisterCheckablesRandom(4, true);
+	SleepFor(200ms, true);
+
+	auto failedC = testLogger->CountExpectedLogPattern("Skipping check for host .*: active host checks are disabled");
+	BOOST_CHECK_MESSAGE(6 <= failedC && failedC <= 9, "got=" << failedC);
+
+	auto rescheduleC = testLogger->CountExpectedLogPattern("Checks for checkable .* are disabled. Rescheduling check.");
+	BOOST_CHECK_MESSAGE(6 <= rescheduleC && rescheduleC <= 9, "got=" << rescheduleC);
+	BOOST_CHECK_EQUAL(failedC, rescheduleC);
+
+	CHECK_NO_LOG_MESSAGE("Check finished for object .*", 0s);
+	CHECK_NO_LOG_MESSAGE("Executing check for .*", 0s);
+	BOOST_CHECK_EQUAL(0, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(globally_disabled_checks)
+{
+	IcingaApplication::GetInstance()->SetEnableHostChecks(false); // Disable active host checks globally
+
+	RegisterCheckablesRandom(4);
+	SleepFor(200ms, true);
+
+	auto failedC = testLogger->CountExpectedLogPattern("Skipping check for host .*: active host checks are disabled");
+	BOOST_CHECK_MESSAGE(6 <= failedC && failedC <= 9, "got=" << failedC);
+
+	auto rescheduleC = testLogger->CountExpectedLogPattern("Checks for checkable .* are disabled. Rescheduling check.");
+	BOOST_CHECK_MESSAGE(6 <= rescheduleC && rescheduleC <= 9, "got=" << rescheduleC);
+	BOOST_CHECK_EQUAL(failedC, rescheduleC);
+
+	CHECK_NO_LOG_MESSAGE("Check finished for object .*", 0s);
+	CHECK_NO_LOG_MESSAGE("Executing check for .*", 0s);
+	BOOST_CHECK_EQUAL(0, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(unreachable_checkables)
+{
+	// Create a dependency that makes the host unreachable (i.e. no checks should be executed).
+	// This must be done before activating the actual child checkable, otherwise the checker will
+	// immediately schedule a check before the dependency is in place.
+	RegisterCheckablesRandom(4, false, true);
+	SleepFor(200ms, true);
+
+	auto failedC = testLogger->CountExpectedLogPattern("Skipping check for object .*: Dependency failed.");
+	BOOST_CHECK_MESSAGE(6 <= failedC && failedC <= 9, "got=" << failedC);
+
+	auto rescheduleC = testLogger->CountExpectedLogPattern("Checks for checkable .* are disabled. Rescheduling check.");
+	BOOST_CHECK_MESSAGE(6 <= rescheduleC && rescheduleC <= 9, "got=" << rescheduleC);
+	BOOST_CHECK_EQUAL(failedC, rescheduleC);
+
+	CHECK_NO_LOG_MESSAGE("Check finished for object .*", 0s);
+	CHECK_NO_LOG_MESSAGE("Executing check for .*", 0s);
+	BOOST_CHECK_EQUAL(0, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(child_rescheduled_on_parent_recovery)
+{
+	checkInterval = 80; // 1m20s
+
+	auto child = RegisterCheckable("child", "random", "", "", false, true);
+	child->SetMaxCheckAttempts(1);
+	ReceiveCheckResults(child, 1, ServiceCritical, nullptr);
+	BOOST_CHECK_EQUAL(1, resultCount);
+
+	auto parents = child->GetParents();
+	BOOST_REQUIRE_EQUAL(parents.size(), 1);
+
+	CheckableScheduleInfo csi;
+	Checkable::OnRescheduleCheck.connect([&csi](const Checkable::Ptr& checkable, double nextCheck) {
+		csi.Object = checkable;
+		csi.NextCheck = nextCheck;
+	});
+
+	Checkable::Ptr parent = *parents.begin();
+	// When the parent checkable changes its state, then the child checkable should be rescheduled immediately
+	// using the special signal `Checkable::OnRescheduleCheck` signal without changing its actual `next_check`
+	// ts. In that case, the resulting check result should have a different `schedule_start` timestamp than
+	// `child->GetLastCheck()`.
+	ReceiveCheckResults(parent, 1, ServiceOK, nullptr);
+	BOOST_CHECK_EQUAL(2, resultCount); // 1 cr for the child and 1 cr for parent.
+
+	SleepFor(100ms, true);
+	Checkable::OnRescheduleCheck.disconnect_all_slots();
+
+	// Since the used nextcheck ts is randomly chosen one, we can't wait till that time passes.
+	// However, since that timestamp must still be < now + 60, so we can assert it that it's within that range.
+	BOOST_CHECK_EQUAL(csi.Object, child);
+	BOOST_CHECK_NE(csi.NextCheck, 0.0);
+	BOOST_CHECK_LE(csi.NextCheck, Utility::GetTime() + 60);
+
+	// 2 crs from the above ones and maybe the Utility::Random()%60 caused another check
+	// to be executed within the above 100ms sleep, but it shouldn't be more than 3.
+	BOOST_CHECK_LE(resultCount, 3);
+
+	auto cr = lastResult.load();
+	BOOST_REQUIRE(cr);
+	if (resultCount == 2) {
+		BOOST_CHECK_EQUAL(cr, parent->GetLastCheckResult());
+		BOOST_CHECK_NE(cr, child->GetLastCheckResult());
+	} else {
+		BOOST_CHECK_NE(cr, parent->GetLastCheckResult());
+		BOOST_CHECK_EQUAL(cr, child->GetLastCheckResult());
+		BOOST_CHECK_NE(cr->GetScheduleStart(), child->GetLastCheck());
+	}
+}
+
+BOOST_AUTO_TEST_CASE(parent_rescheduled_on_child_state_change)
+{
+	checkInterval = 80; // 1m20s
+
+	auto child = RegisterCheckable("child", "random", "", "", false, true);
+	child->SetMaxCheckAttempts(1);
+
+	auto parents = child->GetParents();
+	BOOST_REQUIRE_EQUAL(parents.size(), 1);
+	Checkable::Ptr parent = *parents.begin();
+	parent->SetMaxCheckAttempts(1);
+	parent->SetEnableActiveChecks(true);
+
+	ReceiveCheckResults(parent, 1, ServiceCritical, nullptr);
+	BOOST_CHECK_EQUAL(1, resultCount);
+
+	CheckableScheduleInfo csi;
+	Checkable::OnRescheduleCheck.connect([&csi](const Checkable::Ptr& checkable, double nextCheck) {
+		csi.Object = checkable;
+		csi.NextCheck = nextCheck;
+	});
+
+	ReceiveCheckResults(child, 1, ServiceWarning, nullptr);
+	BOOST_CHECK_EQUAL(2, resultCount);
+
+	SleepFor(100ms, true);
+	Checkable::OnRescheduleCheck.disconnect_all_slots();
+
+	BOOST_CHECK_EQUAL(parent, csi.Object);
+	BOOST_CHECK_NE(csi.NextCheck, 0.0);
+	BOOST_CHECK_LE(csi.NextCheck, Utility::GetTime()); // Must be < now.
+
+	auto cr = lastResult.load();
+	BOOST_REQUIRE(cr);
+	BOOST_CHECK_NE(cr, parent->GetLastCheckResult());
+	BOOST_CHECK_EQUAL(cr, child->GetLastCheckResult());
+	BOOST_CHECK_EQUAL(2, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(never_in_check_period)
+{
+	TimePeriod::Ptr period = new TimePeriod;
+	period->SetName("never");
+	period->SetUpdate(new Function("LegacyTimePeriod", LegacyTimePeriod::ScriptFunc, {"tp", "begin", "end"}), true);
+	period->Register();
+	period->PreActivate();
+	period->Activate();
+
+	// Register some checkables that are only checked during the "never" time period, which is never.
+	(void)RegisterCheckable("host-1", "random", "never");
+	(void)RegisterCheckable("host-2", "random", "never");
+	(void)RegisterCheckable("host-3", "sleep", "never");
+	(void)RegisterCheckable("host-4", "sleep", "never");
+
+	SleepFor(200ms, true);
+
+	BOOST_CHECK_EQUAL(4, nextCheckTimes.size());
+	for (auto& [host, nextCheck] : nextCheckTimes) {
+		BOOST_TEST_MESSAGE("Host " << std::quoted(host) << " -> next_check: " << std::fixed << std::setprecision(0)
+			<< nextCheck << " expected: " << Convert::ToDouble(period->GetValidEnd()));
+		// The checker should ignore the regular check interval and instead set the next check time based on the tp.
+		BOOST_CHECK_EQUAL(nextCheck, Convert::ToDouble(period->GetValidEnd()));
+	}
+
+	// We expect that no checks are executed, and instead the checker reschedules the checks for the
+	// next valid end time of the "never" time period, which is always 24h from now. So, we should see
+	// 4 log messages about skipping the checks due to the time period, and nothing else.
+	BOOST_CHECK_EQUAL(4, testLogger->CountExpectedLogPattern("Skipping check for object .*, as not in check period 'never', until .*"));
+
+	CHECK_NO_LOG_MESSAGE("Checks for checkable .* are disabled. Rescheduling check.", 0s);
+	CHECK_NO_LOG_MESSAGE("Check finished for object .*", 0s);
+	CHECK_NO_LOG_MESSAGE("Executing check for .*", 0s);
+	BOOST_CHECK_EQUAL(0, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(in_check_period)
+{
+	TimePeriod::Ptr period = new TimePeriod;
+	period->SetName("24x7");
+	period->SetRanges(
+		new Dictionary{
+			{"monday", "00:00-24:00"},
+			{"tuesday", "00:00-24:00"},
+			{"wednesday", "00:00-24:00"},
+			{"thursday", "00:00-24:00"},
+			{"friday", "00:00-24:00"},
+			{"saturday", "00:00-24:00"},
+			{"sunday", "00:00-24:00"}
+		},
+		true
+	);
+	period->SetUpdate(new Function("LegacyTimePeriod", LegacyTimePeriod::ScriptFunc, {"tp", "begin", "end"}), true);
+	period->Register();
+	period->PreActivate();
+	period->Activate();
+
+	// Register some checkables that are only checked during the "24x7" time period, which is always.
+	(void)RegisterCheckable("host-1", "random", "24x7");
+	(void)RegisterCheckable("host-2", "random", "24x7");
+	(void)RegisterCheckable("host-3", "sleep", "24x7");
+	(void)RegisterCheckable("host-4", "sleep", "24x7");
+
+	SleepFor(300ms, true);
+
+	// We expect that checks are executed normally, and the checker sets the next check time based
+	// on the regular check interval. So, we should see multiple checks executed for each checkable.
+	CHECK_LOG_MESSAGE("Executing check for .*", 0s);
+	CHECK_LOG_MESSAGE("Check finished for object .*", 0s);
+
+	CHECK_NO_LOG_MESSAGE("Skipping check for object .*: Dependency failed.", 0s);
+	CHECK_NO_LOG_MESSAGE("Check for checkable checkable .* are disabled. Rescheduling check.", 0s);
+
+	BOOST_CHECK_MESSAGE(5 <= resultCount && resultCount <= 8, "got=" << resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(max_concurrent_checks)
+{
+	// Limit the number of concurrent checks to 4.
+	ScriptGlobal::Set("MaxConcurrentChecks", 4);
+
+	// Register 16 checkables that each sleep for 10 seconds when executing their check.
+	// With a max concurrent check limit of 4, we should see that only 4 checks are executed
+	// at the same time, and the remaining 12 checks are queued until one of the running checks
+	// finishes (which will not happen within the short sleep time of this test).
+	RegisterCheckablesSleep(16, 10);
+	std::this_thread::sleep_for(300ms);
+
+	auto objects(ConfigType::GetObjectsByType<Host>());
+	BOOST_CHECK_EQUAL(16, objects.size());
+
+	for (auto& h : objects) {
+		// Force a reschedule of the checks to see whether the checker does absolutely nothing
+		// when the max concurrent check limit is reached. Normally, this would force the checker
+		// to immediately pick up the checkable and execute its check, but since all 4 slots are
+		// already taken, the checker should just update its queue idx and do nothing else.
+		Checkable::OnRescheduleCheck(h, Utility::GetTime());
+	}
+	std::this_thread::sleep_for(300ms);
+
+	// We expect that only 4 checks are started initially, and the other 12 checks should have
+	// never been run, since the sleep time for each check (10 seconds) is much longer than the
+	// total sleep time of this test (600ms).
+	CHECK_LOG_MESSAGE("Pending checkables: 4; Idle checkables: 12; Checks/s: .*", 0s);
+	BOOST_CHECK_EQUAL(4, testLogger->CountExpectedLogPattern("Scheduling info for checkable .*: Object .*"));
+	BOOST_CHECK_EQUAL(4, testLogger->CountExpectedLogPattern("Executing check for .*"));
+	BOOST_CHECK_EQUAL(4, Checkable::GetPendingChecks());
+
+	CHECK_NO_LOG_MESSAGE("Check finished for object .*", 0s); // none finished yet
+	BOOST_CHECK_EQUAL(0, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(skipped_remote_checks)
+{
+	// The check execution for remote checks is skipped if the remote endpoint is not connected,
+	// not syncing, and we are within the cold startup window (5min after application start).
+	Application::GetInstance()->SetStartTime(Utility::GetTime());
+
+	// Set the check and retry intervals to 60 seconds, since it's sufficient to
+	// just verify that the checks are skipped only once, and not repeatedly.
+	checkInterval = 60;
+	retryInterval = 60;
+
+	RegisterRemoteChecks(8);
+	SleepFor(200ms, true);
+
+	BOOST_CHECK_EQUAL(8, nextCheckTimes.size());
+	for (auto& [host, nextCheck] : nextCheckTimes) {
+		BOOST_TEST_MESSAGE("Host " << std::quoted(host) << " -> next_check: " << std::fixed << std::setprecision(0)
+			<< nextCheck << " roughly expected: " << Utility::GetTime() + checkInterval);
+		// Our algorithm for computing the next check time is not too precise, but it should roughly be within 5s of
+		// the expected next check time based on the check interval. See Checkable::UpdateNextCheck() for details.
+		BOOST_CHECK_GE(nextCheck, Utility::GetTime() + checkInterval-5);
+		BOOST_CHECK_LE(nextCheck, Utility::GetTime() + checkInterval); // but not more than the interval
+	}
+
+	BOOST_CHECK_EQUAL(nullptr, lastResult.load()); // No check results should be received
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Executing check for .*"));
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Check finished for object .*"));
+
+	CHECK_NO_LOG_MESSAGE("Skipping check for object .*: Dependency failed.", 0s);
+	CHECK_NO_LOG_MESSAGE("Checks for checkable .* are disabled. Rescheduling check.", 0s);
+
+	BOOST_CHECK_EQUAL(0, resultCount);
+}
+
+BOOST_AUTO_TEST_CASE(remote_checks_outside_cold_startup)
+{
+	Application::GetInstance()->SetStartTime(Utility::GetTime()-500); // Simulate being outside cold startup window
+
+	checkInterval = 60;
+	retryInterval = 60;
+
+	RegisterRemoteChecks(8);
+	SleepFor(200ms, true);
+
+	BOOST_CHECK_EQUAL(8, nextCheckTimes.size());
+	for (auto& [host, nextCheck] : nextCheckTimes) {
+		BOOST_TEST_MESSAGE("Host " << std::quoted(host) << " -> next_check: " << std::fixed << std::setprecision(0)
+			<< nextCheck << " roughly expected: " << Utility::GetTime() + checkInterval);
+		// Our algorithm for computing the next check time is not too precise, but it should roughly be within 5s of
+		// the expected next check time based on the check interval. See Checkable::UpdateNextCheck() for details.
+		BOOST_CHECK_GE(nextCheck, Utility::GetTime() + checkInterval-5);
+		BOOST_CHECK_LE(nextCheck, Utility::GetTime() + checkInterval); // but not more than the interval
+	}
+
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Executing check for .*"));
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Check finished for object .*"));
+	BOOST_CHECK_EQUAL(8, resultCount);
+
+	CHECK_NO_LOG_MESSAGE("Skipping check for object .*: Dependency failed.", 0s);
+	CHECK_NO_LOG_MESSAGE("Checks for checkable .* are disabled. Rescheduling check.", 0s);
+
+	BOOST_REQUIRE(lastResult.load()); // We should now have a cr!
+
+	auto cr = lastResult.load();
+	BOOST_CHECK_EQUAL(ServiceUnknown, cr->GetState());
+	String expectedOutput = "Remote Icinga instance 'remote-checker' is not connected to '" + Endpoint::GetLocalEndpoint()->GetName() + "'";
+	BOOST_CHECK_EQUAL(expectedOutput, cr->GetOutput());
+}
+
+BOOST_AUTO_TEST_CASE(remote_checks_with_connected_endpoint)
+{
+	// Register a remote endpoint that is connected, so remote checks can be executed or actually simulate
+	// sending the check command to the remote endpoint. In this case, we shouldn't also receive any cr,
+	// but checker should reschedule the check at "now + check_timeout (which is 0) + 30s".
+	RegisterRemoteChecks(8, true);
+	SleepFor(200ms, true);
+
+	BOOST_CHECK_EQUAL(8, nextCheckTimes.size());
+	for (auto& [host, nextCheck] : nextCheckTimes) {
+		// In this case, there shouldn't be any OnNextCheckChanged events triggered,
+		// thus nextCheck should still be 0.0 as initialized by RegisterCheckable().
+		BOOST_CHECK_EQUAL(0.0, nextCheck);
+	}
+
+	auto hosts(ConfigType::GetObjectsByType<Host>());
+	BOOST_CHECK_EQUAL(8, hosts.size());
+
+	for (auto& h : hosts) {
+		// Verify the next_check time is set to roughly now + 30s, since RegisterCheckable()
+		// initializes the check_timeout to 0.
+		BOOST_TEST_MESSAGE("Host " << std::quoted(h->GetName().GetData()) << " -> next_check: " << std::fixed
+			<< std::setprecision(0) << h->GetNextCheck() << " roughly expected: " << Utility::GetTime() + 30);
+		BOOST_CHECK_GE(h->GetNextCheck(), Utility::GetTime() + 25);
+		BOOST_CHECK_LE(h->GetNextCheck(), Utility::GetTime() + 30);
+	}
+
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Sending message 'event::ExecuteCommand' to 'remote-checker'"));
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Executing check for .*"));
+	BOOST_CHECK_EQUAL(8, testLogger->CountExpectedLogPattern("Check finished for object .*"));
+
+	CHECK_NO_LOG_MESSAGE("Skipping check for object .*: Dependency failed.", 0s);
+	CHECK_NO_LOG_MESSAGE("Checks for checkable .* are disabled. Rescheduling check.", 0s);
+
+	BOOST_CHECK_EQUAL(0, resultCount); // No check results should be received yet
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/icingaapplication-fixture.cpp
+++ b/test/icingaapplication-fixture.cpp
@@ -9,6 +9,12 @@ static bool IcingaInitialized = false;
 
 IcingaApplicationFixture::IcingaApplicationFixture()
 {
+	// This limits the number of threads in the thread pool, but does not limit the number of concurrent checks.
+	// By default, we'll have only 2 threads in the pool, which is too low for some heavy checker tests. So, we
+	// set the concurrency to the number of hardware threads available on the system and the global thread pool
+	// size will be the double of that (see threadpool.cpp).
+	Configuration::Concurrency = std::thread::hardware_concurrency();
+
 	if (!IcingaInitialized)
 		InitIcingaApplication();
 }


### PR DESCRIPTION
So, after the long discussions in #10082 that didn't lead to a final conclusion, here's a minimal implementation without too many refactorings and changes to existing logic. This PR changes the checker queueing behaviour a bit to never reschedule checkables with ongoing checks. Thus, we avoid piling up checkables with running checks in the queue that will never be executed anyway. Though, since this change affects a critical part of Icinga 2, we should be very careful with this not to introduce any regressions or performance degradations. Thus far, I've let it run some checks with 500ms intervals and I didn't notice any issues (see the attached graph), though the graph shows at "10:35" a small hiccup caused by some API requests triggered by me. Another, behaviour change is that previously the checker didn't trigger the now dropped `Checkable::OnNextCheckUpdated` signal when active checks were disabled. However, since the Icinga DB `SendNextUpdate` function already has a logic to send a `ZREM` Redis command when active checks are disabled, the checker now also triggers the  `Checkable::OnNextCheckChanged` signal unconditionally.

<img width="1000" height="500" alt="Plot Icinga 2" src="https://github.com/user-attachments/assets/f85ad339-e3c4-464b-a597-b98fa8bd8bbf" />

Now, to the individual changes, each commit is self explaining what it does and why it's needed and contains some more details about the reasoning behind it. So, please have a look at the individual commits.

## Tests

Just like before a simple `/v1/actions/reschedule-check` request triggers **two** `icinga:nextupdate:host` events.
```bash
docker exec -i redis redis-cli -p 6380 -n 12 monitor
OK
----
1758547635.252940 [12 172.18.0.1:57800] "HSET" "icinga:host:state" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "{\"affects_children\":false,\"check_attempt\":1,\"check_source\":\"mbp-yhabteab.fritz.box\",\"check_timeout\":60000,\"environment_id\":\"30e34a7a6c432baf29e051ed428aee3825f25e67\",\"execution_time\":0,\"hard_state\":0,\"host_id\":\"4c80e4ad47034480b3c3bb28885970b6bb50983e\",\"id\":\"4c80e4ad47034480b3c3bb28885970b6bb50983e\",\"in_downtime\":false,\"is_acknowledged\":false,\"is_active\":true,\"is_flapping\":false,\"is_handled\":false,\"is_problem\":true,\"is_reachable\":true,\"is_sticky_acknowledgement\":false,\"last_state_change\":1758545183248,\"last_update\":1758545183248,\"latency\":0,\"next_check\":1758547635218,\"next_update\":1758547695218,\"normalized_performance_data\":\"wrong=85;0;0;0 ok=1;0;0;0 max=215.600000;0;0;0\",\"output\":\" /dev/dm-13: 1.0MiB/s read1, 4.3KiB/s write1, 1.0MiB/s total, 215.6MiB/s max\",\"performance_data\":\"wrong=85;0;0;0; ok=1;0;0;0; max=215.6;0;0;0;\",\"previous_hard_state\":99,\"previous_soft_state\":0,\"scheduling_source\":\"mbp-yhabteab.fritz.box\",\"severity\":2080,\"soft_state\":1,\"state_type\":\"soft\"}"
1758547635.252982 [12 172.18.0.1:57800] "HSET" "icinga:checksum:host:state" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "{\"checksum\":\"b4f84390d527074ed45087fc3ca7bf581dda9522\"}"
1758547635.253002 [12 172.18.0.1:57800] "ZADD" "icinga:nextupdate:host" "1758547695.218023" "4c80e4ad47034480b3c3bb28885970b6bb50983e"
1758547635.255312 [12 172.18.0.1:57800] "HSET" "icinga:host:state" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "{\"affects_children\":false,\"check_attempt\":1,\"check_commandline\":\"'dummy'\",\"check_source\":\"mbp-yhabteab.fritz.box\",\"check_timeout\":60000,\"environment_id\":\"30e34a7a6c432baf29e051ed428aee3825f25e67\",\"execution_time\":0,\"hard_state\":0,\"host_id\":\"4c80e4ad47034480b3c3bb28885970b6bb50983e\",\"id\":\"4c80e4ad47034480b3c3bb28885970b6bb50983e\",\"in_downtime\":false,\"is_acknowledged\":false,\"is_active\":true,\"is_flapping\":false,\"is_handled\":false,\"is_problem\":false,\"is_reachable\":true,\"is_sticky_acknowledgement\":false,\"last_state_change\":1758547635219,\"last_update\":1758547635219,\"latency\":1,\"next_check\":1758547930999,\"next_update\":1758548231003,\"output\":\"Check was successful.\",\"previous_hard_state\":0,\"previous_soft_state\":1,\"scheduling_source\":\"mbp-yhabteab.fritz.box\",\"severity\":0,\"soft_state\":0,\"state_type\":\"hard\"}"
1758547635.255358 [12 172.18.0.1:57800] "HSET" "icinga:checksum:host:state" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "{\"checksum\":\"23738343385294cead94b823a79916c6620dd3b4\"}"
1758547635.255374 [12 172.18.0.1:57800] "ZADD" "icinga:nextupdate:host" "1758548231.003308" "4c80e4ad47034480b3c3bb28885970b6bb50983e"
1758547635.255827 [12 172.18.0.1:57800] "XADD" "icinga:runtime:state" "MAXLEN" "~" "1000000" "*" "runtime_type" "upsert" "redis_key" "icinga:host:state" "checksum" "23738343385294cead94b823a79916c6620dd3b4" "affects_children" "0" "check_attempt" "1" "check_commandline" "'dummy'" "check_source" "mbp-yhabteab.fritz.box" "check_timeout" "60000" "environment_id" "30e34a7a6c432baf29e051ed428aee3825f25e67" "execution_time" "0" "hard_state" "0" "host_id" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "id" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "in_downtime" "0" "is_acknowledged" "0" "is_active" "1" "is_flapping" "0" "is_handled" "0" "is_problem" "0" "is_reachable" "1" "is_sticky_acknowledgement" "0" "last_state_change" "1758547635219" "last_update" "1758547635219" "latency" "1" "next_check" "1758547930999" "next_update" "1758548231003" "output" "Check was successful." "previous_hard_state" "0" "previous_soft_state" "1" "scheduling_source" "mbp-yhabteab.fritz.box" "severity" "0" "soft_state" "0" "state_type" "hard"
```

... while a `/v1/actions/process-check-result` only triggers a single `icinga:nextupdate:event`.
```bash
1758547833.559175 [12 172.18.0.1:57800] "HSET" "icinga:host:state" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "{\"affects_children\":false,\"check_attempt\":1,\"check_source\":\"mbp-yhabteab.fritz.box\",\"check_timeout\":60000,\"environment_id\":\"30e34a7a6c432baf29e051ed428aee3825f25e67\",\"execution_time\":0,\"hard_state\":0,\"host_id\":\"4c80e4ad47034480b3c3bb28885970b6bb50983e\",\"id\":\"4c80e4ad47034480b3c3bb28885970b6bb50983e\",\"in_downtime\":false,\"is_acknowledged\":false,\"is_active\":true,\"is_flapping\":false,\"is_handled\":false,\"is_problem\":true,\"is_reachable\":true,\"is_sticky_acknowledgement\":false,\"last_state_change\":1758547833522,\"last_update\":1758547833522,\"latency\":0,\"next_check\":1758548133522,\"next_update\":1758548193522,\"normalized_performance_data\":\"wrong=85;0;0;0 ok=1;0;0;0 max=215.600000;0;0;0\",\"output\":\" /dev/dm-13: 1.0MiB/s read1, 4.3KiB/s write1, 1.0MiB/s total, 215.6MiB/s max\",\"performance_data\":\"wrong=85;0;0;0; ok=1;0;0;0; max=215.6;0;0;0;\",\"previous_hard_state\":0,\"previous_soft_state\":0,\"scheduling_source\":\"mbp-yhabteab.fritz.box\",\"severity\":2080,\"soft_state\":1,\"state_type\":\"soft\"}"
1758547833.559289 [12 172.18.0.1:57800] "HSET" "icinga:checksum:host:state" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "{\"checksum\":\"0ed63c1311be890a7ad5ffae340a3489db7d57ca\"}"
1758547833.559305 [12 172.18.0.1:57800] "ZADD" "icinga:nextupdate:host" "1758548193.522986" "4c80e4ad47034480b3c3bb28885970b6bb50983e"
1758547833.559430 [12 172.18.0.1:57800] "XADD" "icinga:runtime:state" "MAXLEN" "~" "1000000" "*" "runtime_type" "upsert" "redis_key" "icinga:host:state" "checksum" "0ed63c1311be890a7ad5ffae340a3489db7d57ca" "affects_children" "0" "check_attempt" "1" "check_source" "mbp-yhabteab.fritz.box" "check_timeout" "60000" "environment_id" "30e34a7a6c432baf29e051ed428aee3825f25e67" "execution_time" "0" "hard_state" "0" "host_id" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "id" "4c80e4ad47034480b3c3bb28885970b6bb50983e" "in_downtime" "0" "is_acknowledged" "0" "is_active" "1" "is_flapping" "0" "is_handled" "0" "is_problem" "1" "is_reachable" "1" "is_sticky_acknowledgement" "0" "last_state_change" "1758547833522" "last_update" "1758547833522" "latency" "0" "next_check" "1758548133522" "next_update" "1758548193522" "normalized_performance_data" "wrong=85;0;0;0 ok=1;0;0;0 max=215.600000;0;0;0" "output" " /dev/dm-13: 1.0MiB/s read1, 4.3KiB/s write1, 1.0MiB/s total, 215.6MiB/s max" "performance_data" "wrong=85;0;0;0; ok=1;0;0;0; max=215.6;0;0;0;" "previous_hard_state" "0" "previous_soft_state" "0" "scheduling_source" "mbp-yhabteab.fritz.box" "severity" "2080" "soft_state" "1" "state_type" "soft"
```