### PR TITLE
parser: fix ambiguous grammar rules

### DIFF
--- a/lib/config/config_parser.yy
+++ b/lib/config/config_parser.yy
@@ -314,7 +314,7 @@ lterm_items_inner: lterm %dprec 2
 		$$ = new std::vector<std::pair<std::unique_ptr<Expression>, EItemInfo> >();
 		$$->emplace_back(std::unique_ptr<Expression>($1), EItemInfo{true, @1});
 	}
-	| rterm_no_side_effect
+	| rterm_no_side_effect %dprec 3
 	{
 		$$ = new std::vector<std::pair<std::unique_ptr<Expression>, EItemInfo> >();
 		$$->emplace_back(std::unique_ptr<Expression>($1), EItemInfo{false, @1});
@@ -330,7 +330,7 @@ lterm_items_inner: lterm %dprec 2
 			$$->emplace_back(std::unique_ptr<Expression>($3), EItemInfo{true, @3});
 		}
 	}
-	| lterm_items_inner sep rterm_no_side_effect %dprec 1
+	| lterm_items_inner sep rterm_no_side_effect %dprec 2
 	{
 		if ($1)
 			$$ = $1;

--- a/test/config-ops.cpp
+++ b/test/config-ops.cpp
@@ -241,6 +241,18 @@ BOOST_AUTO_TEST_CASE(advanced)
 	expr = ConfigCompiler::CompileText("<test>", "{{ 3 }}");
 	func = expr->Evaluate(frame).GetValue();
 	BOOST_CHECK(func->Invoke() == 3);
+
+	expr = ConfigCompiler::CompileText("<test>", "var something; var different; () => { {{ {{{foo}}} }} }()");
+	auto assertExpectedErr = [](const std::exception& e) {
+		String message = e.what();
+		bool isExpectedError = message.Contains("Value computed is not used.");
+		BOOST_REQUIRE_MESSAGE(isExpectedError, "Unexpected error message: " << message);
+		return isExpectedError;
+	};
+	BOOST_CHECK_EXCEPTION(expr->Evaluate(frame), ScriptError, assertExpectedErr);
+
+	expr = ConfigCompiler::CompileText("<test>", "() => { {{ {{{foo}}} }} }()");
+	BOOST_CHECK_EXCEPTION(expr->Evaluate(frame), ScriptError, assertExpectedErr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR fixes a DSL config parsing ambiguity discovered by @julianbrost  by using this expression `() => { {{ {{{foo}}} }} }()`. First, I thought that only the last two rules were conflicting each other due to the same assigned dynamic precedence. However, after adding this expression as a test case, I found that the entire `lterm_items_inner` rule was conflicting due to the inconsistent precedence assignments in its alternate rules. I've now changed the precedence assignments so that it always prefers the rule that reduces on/shifts `rterm_no_side_effect` first, so that when you have pure expressions like the trigger of this bug, it reports an error about unused value instead of a parsing error. The precedence only needs to be consistent with the rules on the same level, i.e. a rule that can directly be reduced to `lterm_items_inner` without a recursion doesn't need to have a smaller or higher precedence than a rule that has left recursion, because they will never conflict.

<details><summary>Expand Me</summary>

```bash
Ambiguity detected.
Option 1,
  lterm_items_inner -> <Rule 6, tokens 1 .. 10>
    lterm -> <Rule 70, tokens 1 .. 10>
      rterm_side_effect -> <Rule 88, tokens 1 .. 10>
        rterm -> <Rule 146, tokens 1 .. 8>
          rterm_no_side_effect -> <Rule 143, tokens 1 .. 8>
            rterm_no_side_effect_no_dict -> <Rule 114, tokens 1 .. 8>
              '(' <tokens 1 .. 1>
              identifier_items <empty>
              ')' <tokens 2 .. 2>
              use_specifier <empty>
              "=> (T_FOLLOWS)" <tokens 3 .. 3>
              @15 -> <Rule 113, empty>
              rterm_scope -> <Rule 84, tokens 4 .. 8>
                '{' <tokens 4 .. 4>
                @13 -> <Rule 83, empty>
                statements -> <Rule 2, tokens 5 .. 7>
                  optional_newlines -> <Rule 169, empty>
                  lterm_items -> <Rule 4, tokens 5 .. 7>
                    lterm_items_inner -> <Rule 7, tokens 5 .. 7>
                      rterm_no_side_effect -> <Rule 143, tokens 5 .. 7>
                        rterm_no_side_effect_no_dict -> <Rule 142, tokens 5 .. 7>
                          "{{ (T_NULLARY_LAMBDA_BEGIN)" <tokens 5 .. 5>
                          @18 -> <Rule 141, empty>
                          statements -> <Rule 2, tokens 6 .. 6>
                            optional_newlines -> <Rule 169, empty>
                            lterm_items -> <Rule 4, tokens 6 .. 6>
                              lterm_items_inner -> <Rule 7, tokens 6 .. 6>
                                rterm_no_side_effect -> <Rule 143, tokens 6 .. 6>
                                  rterm_no_side_effect_no_dict -> <Rule 92, tokens 6 .. 6>
                                    T_STRING <tokens 6 .. 6>
                          "}} (T_NULLARY_LAMBDA_END)" <tokens 7 .. 7>
                '}' <tokens 8 .. 8>
        '(' <tokens 9 .. 9>
        rterm_items -> <Rule 71, empty>
        ')' <tokens 10 .. 10>

Option 2,
  lterm_items_inner -> <Rule 7, tokens 1 .. 10>
    rterm_no_side_effect -> <Rule 143, tokens 1 .. 10>
      rterm_no_side_effect_no_dict -> <Rule 115, tokens 1 .. 10>
        '(' <tokens 1 .. 1>
        identifier_items <empty>
        ')' <tokens 2 .. 2>
        use_specifier <empty>
        "=> (T_FOLLOWS)" <tokens 3 .. 3>
        rterm -> <Rule 145, tokens 4 .. 10>
          rterm_side_effect -> <Rule 88, tokens 4 .. 10>
            rterm -> <Rule 146, tokens 4 .. 8>
              rterm_no_side_effect -> <Rule 144, tokens 4 .. 8>
                rterm_dict -> <Rule 80, tokens 4 .. 8>
                  '{' <tokens 4 .. 4>
                  @11 -> <Rule 79, empty>
                  statements -> <Rule 2, tokens 5 .. 7>
                    optional_newlines -> <Rule 169, empty>
                    lterm_items -> <Rule 4, tokens 5 .. 7>
                      lterm_items_inner -> <Rule 7, tokens 5 .. 7>
                        rterm_no_side_effect -> <Rule 143, tokens 5 .. 7>
                          rterm_no_side_effect_no_dict -> <Rule 142, tokens 5 .. 7>
                            "{{ (T_NULLARY_LAMBDA_BEGIN)" <tokens 5 .. 5>
                            @18 -> <Rule 141, empty>
                            statements -> <Rule 2, tokens 6 .. 6>
                              optional_newlines -> <Rule 169, empty>
                              lterm_items -> <Rule 4, tokens 6 .. 6>
                                lterm_items_inner -> <Rule 7, tokens 6 .. 6>
                                  rterm_no_side_effect -> <Rule 143, tokens 6 .. 6>
                                    rterm_no_side_effect_no_dict -> <Rule 92, tokens 6 .. 6>
                                      T_STRING <tokens 6 .. 6>
                            "}} (T_NULLARY_LAMBDA_END)" <tokens 7 .. 7>
                  '}' <tokens 8 .. 8>
            '(' <tokens 9 .. 9>
            rterm_items -> <Rule 71, empty>
            ')' <tokens 10 .. 10>

[2025-09-26 12:05:53 +0200] critical/config: Error: syntax is ambiguous
Location: in icinga2.conf: 1:0-1:26
icinga2.conf(1): () => { {{ {{{foo}}} }} }()
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
icinga2.conf(2):
[2025-09-26 12:05:53 +0200] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

</details> 