### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 # CMake 3.17 is required, CMake policy compatibility was verified up to 3.17.
 cmake_minimum_required(VERSION 3.17...3.17)
-set(BOOST_MIN_VERSION "1.66.0")
+set(BOOST_MIN_VERSION "1.69.0")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Commit 76fa0d9 removed the Boost system library, which means the headers only variant is used. This was added in Boost 1.69.0, so BOOST_MIN_VERSION should be changes.