### PR TITLE
Replace `CpuBoundWork`

### DIFF
--- a/doc/19-technical-concepts.md
+++ b/doc/19-technical-concepts.md
@@ -1148,21 +1148,6 @@ hidden in Boost ASIO, Beast, Coroutine and Context libraries.
 
 #### Data Exchange: Coroutines and I/O Engine <a id="technical-concepts-tls-network-io-connection-data-exchange-coroutines"></a>
 
-Light-weight and fast operations such as connection handling or TLS handshakes
-are performed in the default `IoBoundWorkSlot` pool inside the I/O engine.
-
-The I/O engine has another pool available: `CpuBoundWork`.
-
-This is used for processing CPU intensive tasks, such as handling a HTTP request.
-Depending on the available CPU cores, this is limited to `std::thread::hardware_concurrency() * 3u / 2u`.
-
-```
-1 core * 3 / 2 = 1
-2 cores * 3 / 2 = 3
-8 cores * 3 / 2 = 12
-16 cores * 3 / 2 = 24
-```
-
 The I/O engine itself is used with all network I/O in Icinga, not only the cluster
 and the REST API. Features such as Graphite, InfluxDB, etc. also consume its functionality.
 

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -5,6 +5,7 @@
 
 #include "base/atomic.hpp"
 #include "base/debug.hpp"
+#include "base/defer.hpp"
 #include "base/exception.hpp"
 #include "base/lazy-init.hpp"
 #include "base/logger.hpp"
@@ -96,6 +97,9 @@ public:
 		Get().m_AlreadyExpiredTimer.async_wait(yc);
 	}
 
+	using SlowSlot = std::unique_ptr<Defer>;
+	SlowSlot TryAcquireSlowSlot();
+
 private:
 	IoEngine();
 
@@ -107,6 +111,8 @@ private:
 	boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_KeepAlive;
 	std::vector<std::thread> m_Threads;
 	boost::asio::deadline_timer m_AlreadyExpiredTimer;
+	std::mutex m_SlowSlotsMutex;
+	int m_SlowSlotsAvailable;
 };
 
 class TerminateIoThread : public std::exception

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -30,55 +30,12 @@ namespace icinga
 {
 
 /**
- * Scope lock for CPU-bound work done in an I/O thread
- *
- * @ingroup base
- */
-class CpuBoundWork
-{
-public:
-	CpuBoundWork(boost::asio::yield_context yc);
-	CpuBoundWork(const CpuBoundWork&) = delete;
-	CpuBoundWork(CpuBoundWork&&) = delete;
-	CpuBoundWork& operator=(const CpuBoundWork&) = delete;
-	CpuBoundWork& operator=(CpuBoundWork&&) = delete;
-	~CpuBoundWork();
-
-	void Done();
-
-private:
-	bool m_Done;
-};
-
-/**
- * Scope break for CPU-bound work done in an I/O thread
- *
- * @ingroup base
- */
-class IoBoundWorkSlot
-{
-public:
-	IoBoundWorkSlot(boost::asio::yield_context yc);
-	IoBoundWorkSlot(const IoBoundWorkSlot&) = delete;
-	IoBoundWorkSlot(IoBoundWorkSlot&&) = delete;
-	IoBoundWorkSlot& operator=(const IoBoundWorkSlot&) = delete;
-	IoBoundWorkSlot& operator=(IoBoundWorkSlot&&) = delete;
-	~IoBoundWorkSlot();
-
-private:
-	boost::asio::yield_context yc;
-};
-
-/**
  * Async I/O engine
  *
  * @ingroup base
  */
 class IoEngine
 {
-	friend CpuBoundWork;
-	friend IoBoundWorkSlot;
-
 public:
 	IoEngine(const IoEngine&) = delete;
 	IoEngine(IoEngine&&) = delete;
@@ -150,7 +107,6 @@ private:
 	boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_KeepAlive;
 	std::vector<std::thread> m_Threads;
 	boost::asio::deadline_timer m_AlreadyExpiredTimer;
-	std::atomic_int_fast32_t m_CpuBoundSemaphore;
 };
 
 class TerminateIoThread : public std::exception

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -100,8 +100,6 @@ bool EventsHandler::HandleRequest(
 
 	EventsSubscriber subscriber (std::move(eventTypes), HttpUtility::GetLastParameter(params, "filter"), l_ApiQuery);
 
-	IoBoundWorkSlot dontLockTheIoThread (yc);
-
 	response.result(http::status::ok);
 	response.set(http::field::content_type, "application/json");
 	response.StartStreaming(true);

--- a/lib/remote/httpmessage.hpp
+++ b/lib/remote/httpmessage.hpp
@@ -5,6 +5,7 @@
 #include "base/dictionary.hpp"
 #include "base/json.hpp"
 #include "base/tlsstream.hpp"
+#include "remote/apilistener.hpp"
 #include "remote/apiuser.hpp"
 #include "remote/httpserverconnection.hpp"
 #include "remote/url.hpp"
@@ -269,6 +270,8 @@ public:
 
 	JsonEncoder GetJsonEncoder(bool pretty = false);
 
+	bool TryAcquireSlowSlot();
+
 private:
 	using Serializer = boost::beast::http::response_serializer<HttpResponse::body_type>;
 	Serializer m_Serializer{*this};
@@ -276,6 +279,7 @@ private:
 
 	HttpServerConnection::Ptr m_Server;
 	Shared<AsioTlsStream>::Ptr m_Stream;
+	IoEngine::SlowSlot m_SlowSlot;
 };
 
 } // namespace icinga


### PR DESCRIPTION
The idea of `CpuBoundWork` was to prevent too many coroutines from performing long-running actions at the same time so that some worker threads are always available for other tasks. However, in practice, once all slots provided by `CpuBoundWork` were used, this would also block the handling of JSON-RPC messages, effectively bringing down the whole cluster communication.

The core idea of the replacement in this PR is still similar, the main differences are:

- It is no longer used during JSON-RPC message handling. The corresponding handlers are rather quick, so they don't block the threads for long. Additionally, JSON-RPC message handling is essential for an Icinga 2 cluster to work, so making them wait for something makes little sense.
- There's no more operation to wait a slot. Instead, HTTP requests are now rejected with a 503 Service Unavailable error if there's no slot available. This means that if there is too much load on an Icinga 2 instance from HTTP requests, this shows in error messages instead of more and more waiting requests accumulating and increased response times.

This does not limit the total number of running HTTP requests. In particular, those streaming the response (for example using chunked encoding) are no longer counted once they enter the streaming phase. There is a very specific reason for this: otherwise, a slow or malicious client would block the slot for the whole time it's reading the response, which could take a while. If that happens on multiple connections, the whole pool could be blocked by clients reading responses very slowly. **In particular, this fixes a denial of service problem introduced by #10516 (not yet released), hence the *blocker* label.**

## Tests

Send enough slow requests at once. Slow requests can be forced for example by executing `sleep()` as a console command inside the running dameon:

```sh
cd "$(mktemp -d)" # create a directory for the outputs

for i in {1..17}; do
  curl -Ssku root:icinga https://localhost:5665/v1/console/execute-script --json '{"command":"sleep(3)"}' &> $i &
done

# wait for all the commands to complete

# extra loop + echo for pretty output as files are not ending in a newline
for f in *; do cat "$f"; echo; done
```

Example output:

```
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"error":503,"status":"Too many requests already in progress, please try again later."}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
{"results":[{"code":200,"result":null,"status":"Executed successfully."}]}
```

16 is the number of available slots on my machine. However, you might also see more requests failing if other clients send requests at the same time.