### PR TITLE
GHA: Add openSUSE 16

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,6 +41,7 @@ jobs:
 
           - opensuse/leap:15.5
           - opensuse/leap:15.6
+          - opensuse/leap:16.0
 
           # We don't actually support Rocky Linux as such!
           # We just use that RHEL clone to test the original.


### PR DESCRIPTION
Adds the newly released [openSUSE Leap 16](https://get.opensuse.org/leap/16.0/).