### PR TITLE
Auto backport PRs based on labels

### DIFF
--- a/.github/workflows/authors-file.yml
+++ b/.github/workflows/authors-file.yml
@@ -21,7 +21,7 @@ jobs:
           git add AUTHORS
           git log --format='format:%aN <%aE>' "$(
             git merge-base HEAD^1 HEAD^2
-          )..HEAD^2" | sed '/^dependabot\[bot] /d' >> AUTHORS
+          )..HEAD^2" | sed '/^(dependabot|github-actions)\[bot] /d' >> AUTHORS
           sort -uo AUTHORS AUTHORS
           git diff AUTHORS >> AUTHORS.diff
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,31 @@
+name: Backport Merged Pull Requests
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # so it can comment
+      pull-requests: write # so it can create pull requests
+
+    # Only run if the pull request was merged and not by a bot
+    if: ${{ github.event.pull_request.merged == true && github.actor != 'github-actions[bot]' }}
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create Backport Pull Request
+        uses: korthout/backport-action@v3
+        with:
+          cherry_picking: auto
+          copy_labels_pattern: '^(?!cla-signed$).*' # copy all labels other than the cla-signed label
+          label_pattern: 'backport-to-(support\/\d+\.\d+)' # regex to match labels like backport-to-support/2.14
+          conflict_resolution: 'draft_commit_conflicts' # create a draft PR if there are conflicts


### PR DESCRIPTION
This workflow automatically backports merged pull requests to specified branches based on labels. Until now, this was done manually and was kinda annoying. With this workflow, we can simply add a label like `backport-to-support/2.14` to a pull request, and when it gets merged into the main branch, a backport pull request will be automatically created targeting the `support/2.14` branch. This workflow uses the [`korthout/backport-action`](https://github.com/korthout/backport-action) GitHub Action to handle the backporting process. The result will roughly look this:

- https://github.com/yhabteab/icinga2/pull/2
- https://github.com/yhabteab/icinga2/pull/3