### PR TITLE
Revert "ITL: ssl_cert: vars.ssl_cert_cn: default to "$ssl_cert_altnam……es$""

### DIFF
--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -599,7 +599,6 @@ object CheckCommand "ssl_cert" {
 
 	vars.ssl_cert_address = "$check_address$"
 	vars.ssl_cert_port = 443
-	vars.ssl_cert_cn = "$ssl_cert_altnames$"
 }
 
 object CheckCommand "varnish" {


### PR DESCRIPTION
This was added in https://github.com/Icinga/icinga2/pull/9758 for backwards compatibility. However, it doesn't work as expected because `ssl_cert_altnames` is a boolean option and `ssl_cert_cn` expects a pattern. This results in `--match true` or `--match false` being passed to `check_cert`, which causes false negatives.