### PR TITLE
SELinux: allow `logrotate` to execute `icinga2` binary

### DIFF
--- a/tools/selinux/icinga2.te
+++ b/tools/selinux/icinga2.te
@@ -242,7 +242,18 @@ optional_policy(`
     ')
 ')
 
+########################################
+#
+# Logrotate
+#
 
+# Allow logrotate to execute the Icinga 2 binary for sending USR1 signal to reopen log files.
+optional_policy(`
+    require {
+        type logrotate_t;
+    }
+	can_exec(logrotate_t, icinga2_exec_t)
+')
 
 ########################################
 #


### PR DESCRIPTION
With the last security releases #10530 changed the logrotate config to use the `icinga2 internal signal` command to send the `USR1` signal to the umbrella process, resulting _rightfully_ in SELinux denials since this a confined executable. This PR allows the `logrotate_t` domain to be able to execute that bianry file. This might cause other SELinux deinials if the `icinga2 internal` command opens/reads some other Icinga 2 config files, but I'll test it tomorrow and share the results here.

```bash
time->Mon Nov  3 13:00:02 2025
type=PROCTITLE msg=audit(1762174802.598:899): proctitle=7368002D63000A09092F7573722F7362696E2F6963696E67613220696E7465726E616C207369676E616C202D2D7369672053494755535231202D2D70696420222428636174202F72756E2F6963696E6761322F6963696E6761322E70696420323E202F6465762F6E756C6C292220323E202F6465762F6E756C6C207C7C207472
type=SYSCALL msg=audit(1762174802.598:899): arch=c000003e syscall=21 success=no exit=-13 a0=56005035ab30 a1=4 a2=7ffc8efd9a40 a3=0 items=0 ppid=45588 pid=45591 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="sh" exe="/usr/bin/bash" subj=system_u:system_r:logrotate_t:s0 key=(null)
type=AVC msg=audit(1762174802.598:899): avc:  denied  { read } for  pid=45591 comm="sh" name="icinga2" dev="sda4" ino=8532185 scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:object_r:icinga2_exec_t:s0 tclass=file permissive=0
----
time->Mon Nov  3 14:00:00 2025
type=PROCTITLE msg=audit(1762178400.435:911): proctitle=7368002D63000A09092F7573722F7362696E2F6963696E67613220696E7465726E616C207369676E616C202D2D7369672053494755535231202D2D70696420222428636174202F72756E2F6963696E6761322F6963696E6761322E70696420323E202F6465762F6E756C6C292220323E202F6465762F6E756C6C207C7C207472
type=SYSCALL msg=audit(1762178400.435:911): arch=c000003e syscall=59 success=no exit=-13 a0=55e77ff91b30 a1=55e77ff914b0 a2=55e77ff8f690 a3=1b6 items=0 ppid=46418 pid=46421 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="sh" exe="/usr/bin/bash" subj=system_u:system_r:logrotate_t:s0 key=(null)
type=AVC msg=audit(1762178400.435:911): avc:  denied  { open } for  pid=46421 comm="sh" path="/usr/sbin/icinga2" dev="sda4" ino=8532185 scontext=system_u:system_r:logrotate_t:s0 tcontext=system_u:object_r:icinga2_exec_t:s0 tclass=file permissive=0
```

fixes #10616