### PR TITLE
TimePeriod: properly validate `ranges` field

### DIFF
--- a/lib/icinga/timeperiod.cpp
+++ b/lib/icinga/timeperiod.cpp
@@ -372,6 +372,8 @@ void TimePeriod::Dump()
 
 void TimePeriod::ValidateRanges(const Lazy<Dictionary::Ptr>& lvalue, const ValidationUtils& utils)
 {
+	ObjectImpl::ValidateRanges(lvalue, utils);
+
 	if (!lvalue())
 		return;
 


### PR DESCRIPTION
Just came across this weird behavior. Even though the class compiler generated a proper validator for the `ranges` field, no one cared to actually call it from within the overridden method, resulting in some weird errors bing displayed instead.

## Before

```bash
[2025-11-14 16:51:28 +0100] critical/config: Error: Operator + cannot be applied to values of type 'String' and 'Array'
[2025-11-14 16:51:28 +0100] critical/config: 1 error
[2025-11-14 16:51:28 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```

## After

```bash
[2025-11-14 16:37:57 +0100] critical/config: Error: Validation failed for object '24x7' of type 'TimePeriod'; Attribute 'ranges' -> 'monday': Invalid type.
Location: in icinga2.conf: 253:5-255:5
icinga2.conf(251):     import "legacy-timeperiod"
icinga2.conf(252):
icinga2.conf(253):     ranges = {
                       ^^^^^^^^^^
icinga2.conf(254):         "monday" = []
                   ^^^^^^^^^^^^^^^^^^^^^
icinga2.conf(255):     }
                   ^^^^^
icinga2.conf(256): }
icinga2.conf(257):
[2025-11-14 16:37:57 +0100] critical/config: 1 error
[2025-11-14 16:37:57 +0100] critical/cli: Config validation failed. Re-run with 'icinga2 daemon -C' after fixing the config.
```