### PR TITLE
Enable the pthread_np.h header on OpenBSD and DragonFly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ Bernd Arnold <wopfel@gmail.com>
 Bernd Erk <bernd.erk@icinga.com>
 Berthold Cogel <cogel@uni-koeln.de>
 Blerim Sheqa <blerim.sheqa@icinga.com>
+Brad Smith <brad@comstyle.com>
 Brendan Jurd <direvus@gmail.com>
 Brian De Wolf <git@bldewolf.com>
 Brian Dockter <specus@gmail.com>

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -34,9 +34,9 @@
 #include <utf8.h>
 #include <vector>
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #	include <pthread_np.h>
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __OpenBSD__ || DragonFly */
 
 #ifdef HAVE_CXXABI_H
 #	include <cxxabi.h>


### PR DESCRIPTION
Necessary for pthread_set_name_np().