### PR TITLE
workflows: Fix backbot action

### DIFF
--- a/.github/workflows/backbot.yml
+++ b/.github/workflows/backbot.yml
@@ -1,6 +1,6 @@
 name: Backbot
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.backbot-token.outputs.token }} # To make authenticated git operations.
+          sha: ${{ github.event.pull_request.head.sha }} # Checkout the latest commit of the merged PR.
 
       - name: Run Backbot
         uses: korthout/backport-action@d07416681cab29bf2661702f925f020aaa962997 # v3.4.1


### PR DESCRIPTION
This PR contains the following two commits:

1. The condition was wrong because `github.event_name` will never be `labeled` since this field always refers to the actual type of the event, which in this case will always be `pull_request`. We need to determine which type of activity has triggered the workflow via the `github.event.action` context instead.
2. Changes the event type to [`pull_request_target`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target) because using the `pull_request` event I wasn't able to trigger the workflow by adding a label to an already merged PR [^1]. The `labeled` action is listed for the pull_request event as well, but I wasn't able to get it working that way. Using `pull_request_target` on the other hand, I was able to easily trigger the workflow by adding the label to an already merged PR[^2]. So, I've switched to `pull_request_target` event similar to what nixpkgs does in their backport workflow[^3].

[^1]: https://github.com/Icinga/icinga2/pull/10534
[^2]: https://github.com/yhabteab/icinga2/pull/54 (scroll to the bottom)
[^3]: https://github.com/NixOS/nixpkgs/blob/master/.github/workflows/backport.yml