### PR TITLE
Don't unnecessarily install git in build stage

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,7 +20,6 @@ RUN apt-get update && \
         cmake \
         flex \
         g++ \
-        git \
         libboost1.83-dev \
         libboost-context1.83-dev \
         libboost-coroutine1.83-dev \


### PR DESCRIPTION
Previously the plugins were installed via `git clone ...` but now we are using the `ADD` instruction to download a specific commit of each plugin directly from GitHub. Thus, we no longer need to install git in the base build image, which reduces the image size a bit.