### PR TITLE
IsValidHeaderValue: use front()/back() instead of iterators

### DIFF
--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -138,7 +138,7 @@ bool HttpUtility::IsValidHeaderValue(std::string_view value)
 
 	if (!value.empty()) {
 		// Must not start or end with space or tab.
-		for (char c : {*value.begin(), *value.rbegin()}) {
+		for (char c : {value.front(), value.back()}) {
 			if (c == ' ' || c == '\t') {
 				return false;
 			}


### PR DESCRIPTION
Don't ask me why I wasn't thinking of the very basic front() and back() methods when writing this code. Does exactly the same here, but is much more straight-forward than the extra iterator detour.

(This PR is pretty much the result of the random "what was I thinking while implementing #10563" thought while solving yesterday's advent of code puzzle.)