### PR TITLE
Container: ICINGA_LOG_LEVEL Environment Variable

### DIFF
--- a/tools/container/entrypoint.sh
+++ b/tools/container/entrypoint.sh
@@ -110,6 +110,9 @@ if [ ! -e "$ca" ]; then
                 printf "%s" "$value" > "$ca"
                 chmod 0644 "$ca"
                 ;;
+            "log_level")
+                # Ignore. To be used when launching Icinga 2 below.
+                ;;
             *)
                 # We don't know how to handle this environment variable, so log it and move on.
                 icinga2_log "warning" "Ignoring unknown environment variable $k"
@@ -137,6 +140,11 @@ if [ ! -e "$msmtprc_path" ] && [ -n "${MSMTPRC}" ]; then
     chmod 0644 "$msmtprc_path"
 fi
 
-icinga2_log "information" "Starting Icinga 2 daemon."
+icinga2_log "information" "Finished Icinga 2 Docker entrypoint script."
+
+if [ -v "ICINGA_LOG_LEVEL" ] && [ "$(basename "$1")" = "icinga2" ]; then
+    icinga2_log "information" "Launching Icinga 2 in \"$ICINGA_LOG_LEVEL\" log level."
+    exec "$@" "--log-level" "$ICINGA_LOG_LEVEL"
+fi
 
 exec "$@"


### PR DESCRIPTION
Introduce a new `ICINGA_LOG_LEVEL` environment variable to the container entrypoint script. If set, Icinga 2 is executed with the `--log-level` from the variable. For example, when setting `ICINGA_LOG_LEVEL=debug`, Icinga 2 will produce debug logs.

Furthermore, the entrypoint's final log message was slightly altered to not explicitly state that Icinga 2 will be executed. Otherwise, this might be a bit confusing when starting something else than Icinga 2 in the container.

---

Start Icinga 2 with debug logs.

```
$ docker run -it --rm -e ICINGA_LOG_LEVEL=debug icinga/icinga2:pr10666
[2025-12-05 14:13:52 +0000] information/DockerEntrypoint: Icinga 2 Docker entrypoint script started.
[2025-12-05 14:13:52 +0000] information/DockerEntrypoint: No node setup required based on environment variables.
[2025-12-05 14:13:52 +0000] information/DockerEntrypoint: Finished Icinga 2 Docker entrypoint script.
[2025-12-05 14:13:52 +0000] information/DockerEntrypoint: Launching Icinga 2 in "debug" log level.
[2025-12-05 14:13:52 +0000] information/cli: Icinga application loader (version: v2.15.0-201-g3ca8f0756)
[2025-12-05 14:13:52 +0000] notice/cli: Spawning seamless worker process doing the actual work
[2025-12-05 14:13:52 +0000] notice/cli: Spawned worker process (PID 56), waiting for it to load its config
[2025-12-05 14:13:52 +0000] information/cli: Loading configuration file(s).
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /data/etc/icinga2/icinga2.conf
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /data/etc/icinga2/constants.conf
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /data/etc/icinga2/zones.conf
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /usr/share/icinga2/include/itl
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /usr/share/icinga2/include/command-icinga.conf
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /usr/share/icinga2/include/plugins
[2025-12-05 14:13:52 +0000] notice/ConfigCompiler: Compiling config file: /usr/share/icinga2/include/command-plugins.conf
[ . . . ]
```

The debug logging might also be "useful" for other Icinga 2 subcommands.

```
$ docker run -it --rm -e ICINGA_LOG_LEVEL=debug icinga/icinga2:pr10666 icinga2 feature list
[2025-12-05 14:15:44 +0000] information/DockerEntrypoint: Icinga 2 Docker entrypoint script started.
[2025-12-05 14:15:44 +0000] information/DockerEntrypoint: No node setup required based on environment variables.
[2025-12-05 14:15:44 +0000] information/DockerEntrypoint: Finished Icinga 2 Docker entrypoint script.
[2025-12-05 14:15:44 +0000] information/DockerEntrypoint: Launching Icinga 2 in "debug" log level.
debug/cli: Adding feature: api
debug/cli: Adding feature: checker
debug/cli: Adding feature: debuglog
debug/cli: Adding feature: elasticsearch
debug/cli: Adding feature: gelf
debug/cli: Adding feature: graphite
debug/cli: Adding feature: icingadb
debug/cli: Adding feature: ido-mysql
debug/cli: Adding feature: ido-pgsql
debug/cli: Adding feature: influxdb
debug/cli: Adding feature: influxdb2
debug/cli: Adding feature: journald
debug/cli: Adding feature: mainlog
debug/cli: Adding feature: notification
debug/cli: Adding feature: opentsdb
debug/cli: Adding feature: perfdata
debug/cli: Adding feature: syslog
debug/cli: Adding feature: checker
debug/cli: Adding feature: mainlog
debug/cli: Adding feature: notification
Disabled features: api debuglog elasticsearch gelf graphite icingadb ido-mysql ido-pgsql influxdb influxdb2 journald opentsdb perfdata syslog
debug/cli: Adding feature: checker
debug/cli: Adding feature: mainlog
debug/cli: Adding feature: notification
Enabled features: checker mainlog notification
```

However, it has no effect if the main command is not `icinga2`.

```
docker run -it --rm -e ICINGA_LOG_LEVEL=debug icinga/icinga2:pr10666 date
[2025-12-05 14:16:39 +0000] information/DockerEntrypoint: Icinga 2 Docker entrypoint script started.
[2025-12-05 14:16:39 +0000] information/DockerEntrypoint: No node setup required based on environment variables.
[2025-12-05 14:16:39 +0000] information/DockerEntrypoint: Finished Icinga 2 Docker entrypoint script.
Fri Dec  5 14:16:39 UTC 2025
```