### PR TITLE
Bump Boost shipped for Windows to v1.90

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -13,7 +13,7 @@ function ThrowOnNativeFailure {
 
 $VsVersion = 2022
 $MsvcVersion = '14.3'
-$BoostVersion = @(1, 89, 0)
+$BoostVersion = @(1, 90, 0)
 $OpensslVersion = '3_0_18'
 
 switch ($Env:BITS) {

--- a/tools/win32/configure-dev.ps1
+++ b/tools/win32/configure-dev.ps1
@@ -34,10 +34,10 @@ if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
   $env:OPENSSL_ROOT_DIR = 'c:\local\OpenSSL-Win64'
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = 'c:\local\boost_1_89_0'
+  $env:BOOST_ROOT = 'c:\local\boost_1_90_0'
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_89_0\lib64-msvc-14.3'
+  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_90_0\lib64-msvc-14.3'
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -36,10 +36,10 @@ if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
   $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_0_18-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = "c:\local\boost_1_89_0-Win${env:BITS}"
+  $env:BOOST_ROOT = "c:\local\boost_1_90_0-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_89_0-Win${env:BITS}\lib${env:BITS}-msvc-14.3"
+  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_90_0-Win${env:BITS}\lib${env:BITS}-msvc-14.3"
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'


### PR DESCRIPTION
Tested with `nix-build i2boost190.nix`. I use NixOS btw.

<details>
  <summary>`cat i2boost190.nix`</summary>

```nix
with import <nixpkgs> {}; (icinga2.override {
boost186 = boost189.overrideAttrs (old: {
  src = fetchurl {
      urls = [
        "mirror://sourceforge/boost/boost_1_90_0.tar.bz2"
        "https://boostorg.jfrog.io/artifactory/main/release/1.90.0/source/boost_1_90_0.tar.bz2"
      ];
      sha256 = "49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305";
    };
  });
}).overrideAttrs (old: {
cmakeFlags = old.cmakeFlags ++ ["-DICINGA2_UNITY_BUILD=OFF"];
})
```
</details>

ldd(1) proves the correct Boost version.

<details>
  <summary>`ldd $(nix-build i2boost190.nix)/lib/icinga2/sbin/icinga2`</summary>

```
	linux-vdso.so.1 (0x00007f9d84486000)
	libdl.so.2 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libdl.so.2 (0x00007f9d8447b000)
	libboost_coroutine.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_coroutine.so.1.90.0 (0x00007f9d84474000)
	libboost_context.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_context.so.1.90.0 (0x00007f9d8446f000)
	libboost_filesystem.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_filesystem.so.1.90.0 (0x00007f9d82fd5000)
	libboost_iostreams.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_iostreams.so.1.90.0 (0x00007f9d84454000)
	libboost_thread.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_thread.so.1.90.0 (0x00007f9d82fb5000)
	libboost_program_options.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_program_options.so.1.90.0 (0x00007f9d82f49000)
	libboost_regex.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_regex.so.1.90.0 (0x00007f9d82eef000)
	libssl.so.3 => /nix/store/61i74yjkj9p1qphfl7018ja4sdwkipx0-openssl-3.6.0/lib/libssl.so.3 (0x00007f9d82dd8000)
	libcrypto.so.3 => /nix/store/61i74yjkj9p1qphfl7018ja4sdwkipx0-openssl-3.6.0/lib/libcrypto.so.3 (0x00007f9d82600000)
	libsystemd.so.0 => /nix/store/zf8qy81dsw1vqwgh9p9n2h40s1k0g2l1-systemd-258.2/lib/libsystemd.so.0 (0x00007f9d82403000)
	libedit.so.0 => /nix/store/nl7g7gvx5ikrayb0ck53xfwdpj4462vv-libedit-20251016-3.1/lib/libedit.so.0 (0x00007f9d82d9a000)
	libncursesw.so.6 => /nix/store/yijhn548p2589pkybgvbhll09bqsxy0q-ncurses-6.5/lib/libncursesw.so.6 (0x00007f9d82d1e000)
	libboost_random.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_random.so.1.90.0 (0x00007f9d84449000)
	libboost_date_time.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_date_time.so.1.90.0 (0x00007f9d82d19000)
	libboost_atomic.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_atomic.so.1.90.0 (0x00007f9d82d0f000)
	libboost_chrono.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_chrono.so.1.90.0 (0x00007f9d82d05000)
	libboost_container.so.1.90.0 => /nix/store/sy8w4xksq9gzh7998ls4skd15wfb6kxk-boost-1.89.0/lib/libboost_container.so.1.90.0 (0x00007f9d82ced000)
	libstdc++.so.6 => /nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib/libstdc++.so.6 (0x00007f9d82000000)
	libm.so.6 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libm.so.6 (0x00007f9d8231b000)
	libgcc_s.so.1 => /nix/store/xm08aqdd7pxcdhm0ak6aqb1v7hw5q6ri-gcc-14.3.0-lib/lib/libgcc_s.so.1 (0x00007f9d82cbf000)
	libpthread.so.0 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libpthread.so.0 (0x00007f9d82cba000)
	libc.so.6 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/libc.so.6 (0x00007f9d81c00000)
	librt.so.1 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/librt.so.1 (0x00007f9d82cb5000)
	libicudata.so.76 => /nix/store/4424mzk2pyia5v1j33zjgrjaivrdy03y-icu4c-76.1/lib/libicudata.so.76 (0x00007f9d7fc00000)
	libicui18n.so.76 => /nix/store/4424mzk2pyia5v1j33zjgrjaivrdy03y-icu4c-76.1/lib/libicui18n.so.76 (0x00007f9d7f800000)
	libicuuc.so.76 => /nix/store/4424mzk2pyia5v1j33zjgrjaivrdy03y-icu4c-76.1/lib/libicuuc.so.76 (0x00007f9d7f400000)
	libz.so.1 => /nix/store/l7xwm1f6f3zj2x8jwdbi8gdyfbx07sh7-zlib-1.3.1/lib/libz.so.1 (0x00007f9d82c95000)
	libbz2.so.1 => /nix/store/xgavznqg1ay2hycpp7yy9ia1n751jcla-bzip2-1.0.8/lib/libbz2.so.1 (0x00007f9d82c7f000)
	liblzma.so.5 => /nix/store/q5vlz5jl6p7mv220s2vf6z5pqi1n935z-xz-5.8.1/lib/liblzma.so.5 (0x00007f9d822e9000)
	libzstd.so.1 => /nix/store/s7vmxmhkq439cjb7ag9w198p6dk7kl0w-zstd-1.5.7/lib/libzstd.so.1 (0x00007f9d81f27000)
	libcap.so.2 => /nix/store/3xqyk85v0b36n9fv1b76jjzwrjc1lami-libcap-2.77-lib/lib/libcap.so.2 (0x00007f9d822dc000)
	/nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/xx7cm72qy2c0643cm1ipngd87aqwkcdp-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007f9d84488000)
```
</details>