### PR TITLE
doc: Explain icingadb built-in check

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -108,6 +108,16 @@ cluster\_lag\_critical | **Optional.** Critical threshold for log lag in seconds
 ### icingadb <a id="itl-icinga-icingadb"></a>
 
 Check command for the built-in `icingadb` check.
+It performs multiple checks, such as verifying that:
+
+- The `IcingaDB` object has an active Redis connection.
+- The Icinga DB daemon is active and has recently sent a heartbeat to Redis.
+- Exactly one Icinga DB daemon is claiming responsibility in HA mode.
+- Icinga 2 does not take too long dumping the configuration to Redis (_full dump_).
+- The Icinga DB daemon does not take too long synchronizing the configuration to the relational database (_full sync_).
+- Icinga 2 does not generate more entires than it can write into the Redis queue (_redis backlog_).
+- Icinga DB does keep up with reading entries from the Redis queue and writing it to the relational database (_database backlog_).
+  This might result in outdated history entries and object attributes, used for filtering by Icinga DB Web.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 


### PR DESCRIPTION
Briefly explain what the built-in icingadb check actually checks and what outputs one can expect. This does not contain every possible check output, but touches the different topics the check verifies.

References Icinga/icingadb#1009.