### PR TITLE
docs: Fix rendering issue on icinga.com

### DIFF
--- a/doc/15-troubleshooting.md
+++ b/doc/15-troubleshooting.md
@@ -2086,6 +2086,7 @@ requiring them to be processed in the same order that they were sent. This is cu
 messages from the same connection sequentially.
 
 To work around this limit, the following approaches are possible:
+
 1. Try to redistribute load between connections, for example if the overloaded connection is between the master and
    a satellite zone, try splitting this zone into two, distributing the load across two connections.
 2. Reduce the load on that connection. Typically, the most frequent message type will be check results, so reducing


### PR DESCRIPTION
The listings on [icinga.com](https://icinga.com/docs/icinga-2/latest/doc/15-troubleshooting/#cluster-troubleshooting-overloaded-json-rpc-connections) seem to be broken just due to the missing empty line added by this PR.

<img width="701" height="200" alt="Bildschirmfoto 2026-01-16 um 10 16 52" src="https://github.com/user-attachments/assets/caf0b5e4-ab9a-4583-b304-33af477b0109" />

