### PR TITLE
GHA: Cleanup backbot action

### DIFF
--- a/.github/workflows/backbot.yml
+++ b/.github/workflows/backbot.yml
@@ -49,7 +49,6 @@ jobs:
           github_token: ${{ steps.backbot-token.outputs.token }}
           copy_labels_pattern: '^(?!cla\/signed$).*' # copy all labels other than the cla/signed label
           label_pattern: 'backport-to-(support\/\d+\.\d+)' # regex to match labels like backport-to-support/2.14
-          conflict_resolution: 'draft_commit_conflicts' # create a draft PR if there are conflicts
           merge_commits: skip # skip merge commits found in the original PR history
           pull_description: |-
             Backport of #${pull_number} to `${target_branch}`, triggered by a label.


### PR DESCRIPTION
This PR cleans up the Backbot workflow a bit by dropping some superfluous or non-functional parts of the used action configuration. This has been on my TODO list for quite some time, but I never got around to it. So here we go finally.

The underlying action ([`korthout/backport-action`](https://github.com/korthout/backport-action)) can be configured which labels to copy from the original PR to the backport PR. In the previous configuration, there was a setting to exclude the `cla/signed` label from being copied, but it was misconfigured and thus ineffective. This has been fixed now.

Furthermore, there was a setting to copy reviewers from the original PR to the backport PR, but this setting was ineffective as well, and reviewers were never copied. I've removed this setting now to avoid confusion. Lastly, there was a setting to let the action create a draft PR in case of cherry-pick conflicts. However, that option must be nested under the `experimental` configuration block to be effective, which was not the case before. I've removed this setting completely now, since I didn't want to enable any experimental features for such trivial task.