### PR TITLE
Windows TL;DR dev env: use Visual Studio 2022, not 2019

### DIFF
--- a/doc/21-development.md
+++ b/doc/21-development.md
@@ -1813,12 +1813,12 @@ cd .\icinga2\
 mkdir build
 cd .\build\
 
-& "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
+& "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" `
   -DICINGA2_UNITY_BUILD=OFF -DBoost_INCLUDE_DIR=C:\local\boost_1_85_0-Win64 `
   -DBISON_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_bison.exe `
   -DFLEX_EXECUTABLE=C:\ProgramData\chocolatey\lib\winflexbison3\tools\win_flex.exe ..
 
-& "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\MSBuild.exe" .\icinga2.sln
+& "C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" .\icinga2.sln
 ```
 
 Building icinga2.sln via Visual Studio itself seems to require a reboot


### PR DESCRIPTION
because this is what `doc/win-dev.ps1` installs since #9747.

Even if VS 2019 was installed previously, it won't find the nowadays used Boost for MSVC 14.3.

As a dev, I have to setup an Icinga Windows dev env from time to time. This shall just work.