### PR TITLE
`Downtime::AddDowntime()`: remove unused parameter `const MessageOrigin::Ptr& origin`

### DIFF
--- a/lib/icinga/downtime.cpp
+++ b/lib/icinga/downtime.cpp
@@ -253,7 +253,7 @@ Downtime::Ptr Downtime::AddDowntime(const Checkable::Ptr& checkable, const Strin
 	const String& comment, double startTime, double endTime, bool fixed,
 	const Downtime::Ptr& parentDowntime, double duration,
 	const String& scheduledDowntime, const String& scheduledBy, const String& parent,
-	const String& id, const MessageOrigin::Ptr& origin)
+	const String& id)
 {
 	String fullName;
 	String triggeredBy;

--- a/lib/icinga/downtime.hpp
+++ b/lib/icinga/downtime.hpp
@@ -56,8 +56,7 @@ public:
 	static Ptr AddDowntime(const intrusive_ptr<Checkable>& checkable, const String& author,
 		const String& comment, double startTime, double endTime, bool fixed,
 		const Ptr& parentDowntime, double duration, const String& scheduledDowntime = String(),
-		const String& scheduledBy = String(), const String& parent = String(), const String& id = String(),
-		const MessageOrigin::Ptr& origin = nullptr);
+		const String& scheduledBy = String(), const String& parent = String(), const String& id = String());
 
 	static void RemoveDowntime(const String& id, bool includeChildren, DowntimeRemovalReason removalReason,
 		const String& removedBy = "");


### PR DESCRIPTION
Requested by https://github.com/Icinga/icinga2/pull/9728#issuecomment-3783580377 which is a slightly other construction area.

Oversight form #9729.