### PR TITLE
Windows: bump OpenSSL to `3.0.19` (backport to 2.15)

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -14,7 +14,7 @@ function ThrowOnNativeFailure {
 $VsVersion = 2022
 $MsvcVersion = '14.3'
 $BoostVersion = @(1, 89, 0)
-$OpensslVersion = '3_0_18'
+$OpensslVersion = '3_0_19'
 
 switch ($Env:BITS) {
 	32 { }

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -33,7 +33,7 @@ if (-not (Test-Path env:CMAKE_ARGS)) {
   $env:CMAKE_ARGS = '[]'
 }
 if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
-  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_0_18-Win${env:BITS}"
+  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_0_19-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
   $env:BOOST_ROOT = "c:\local\boost_1_89_0-Win${env:BITS}"


### PR DESCRIPTION
Backport #10701 to support/2.15 branch.