### PR TITLE
Windows: set ACLs for %ProgramData%\icinga2\var as well

### DIFF
--- a/icinga-installer/icinga-installer.cpp
+++ b/icinga-installer/icinga-installer.cpp
@@ -270,9 +270,15 @@ static int InstallIcinga(void)
 	// TODO: In Icinga 2.14, rename features-available/mainlog.conf to mainlog.conf.deprecated
 	//       so that it's no longer listed as an available feature.
 
-	ExecuteCommand("icacls", "\"" + dataDir + "\" /grant *S-1-5-20:(oi)(ci)m");
-	ExecuteCommand("icacls", "\"" + dataDir + "\\etc\" /inheritance:r /grant:r *S-1-5-20:(oi)(ci)m *S-1-5-32-544:(oi)(ci)f");
-	ExecuteCommand("icacls", "\"" + dataDir + "\\var\" /inheritance:r /grant:r *S-1-5-20:(oi)(ci)m *S-1-5-32-544:(oi)(ci)f");
+	if (!ExecuteCommand("icacls", "\"" + dataDir + "\" /grant *S-1-5-20:(oi)(ci)m")){
+		throw std::runtime_error("failed to set ACLs for " + dataDir);
+	}
+	if (!ExecuteCommand("icacls", "\"" + dataDir + "\\etc\" /inheritance:r /grant:r *S-1-5-20:(oi)(ci)m *S-1-5-32-544:(oi)(ci)f")) {
+		throw std::runtime_error("failed to set ACLs for " + dataDir + "\\etc");
+	}
+	if (!ExecuteCommand("icacls", "\"" + dataDir + "\\var\" /inheritance:r /grant:r *S-1-5-20:(oi)(ci)m *S-1-5-32-544:(oi)(ci)f")) {
+		throw std::runtime_error("failed to set ACLs for " + dataDir + "\\var");
+	}
 
 	ExecuteIcingaCommand("--scm-install daemon");
 


### PR DESCRIPTION
The contents of `var` are created without special permissions, so they inherit the permissions from `var`, hence changing them on `var` fixes the issue.

I've also added some error handling for `ExecuteCommand("icacls", ...)`, otherwise, there could be a risk that the command fails silently during the upgrade, not even fixing the issue. It's done the same way as all the other error reporting in this file, by throwing a C++ exception. While this works to make the MSI report an error, the error isn't very helpful:

<img width="535" height="427" alt="image" src="https://github.com/user-attachments/assets/b83cca08-08e4-4bc4-bfda-bbc0584cc6f2" />

Fixing this goes beyond the scope of this security fix (in general, that whole file has a wild mix of using return values and exceptions for error reporting, which might be a good idea to clean up as well).

## Tests

### Before

Installing the 2.15.1 release version and running `icinga2 api setup` results in the following unsafe permissions:

<img width="1100" height="695" alt="image" src="https://github.com/user-attachments/assets/3a91dd71-4530-41d0-bda2-2f7fd657444c" />

### After

After installing (direct upgrade isn't possible given that the version numbers of snapshot versions compare less than the last release, hence uninstall and install of the other version) a fixed MSI (built locally from 0189a3b4a3dd7df47637f0a974c291a93c8d2a16), this has fixed the permissions for the still existing files:

<img width="1104" height="702" alt="image" src="https://github.com/user-attachments/assets/f52b599c-66dc-4868-b919-e3e9ff5505b1" />

> [!NOTE]
> Note that this change was already reviewed privately and is part of the just released v2.15.2, v2.14.8, and v2.13.14 releases.

fixes [GHSA-vfjg-6fpv-4mmr](https://github.com/Icinga/icinga2/security/advisories/GHSA-vfjg-6fpv-4mmr)
fixes #10682