### PR TITLE
More compiler warnings silenced

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -12,6 +12,15 @@ SCL_ENABLE_GCC=()
 # we're considering moving to C++20 and/or the -ti.hpp files are generated differently.
 WARN_FLAGS="-Wall -Wextra -Wno-template-id-cdtor -Wno-stringop-overflow"
 
+# amazonlinux:2 has a really old GNU bison (3.0.4), which still emits register storage
+# specifiers, that even the only slightly more modern compiler warns that C++17 does not
+# allow (duh).
+case "$DISTRO" in
+  amazonlinux:2)
+    WARN_FLAGS="${WARN_FLAGS} -Wno-register"
+    ;;
+esac
+
 # -Wattributes needs to be disabled to not get warnings in old compilers about not-yet
 # understood attributes, like [[gnu::no_dangling]] on many of the "stable" distros.
 case "$DISTRO" in

--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -12,6 +12,18 @@ SCL_ENABLE_GCC=()
 # we're considering moving to C++20 and/or the -ti.hpp files are generated differently.
 WARN_FLAGS="-Wall -Wextra -Wno-template-id-cdtor -Wno-stringop-overflow"
 
+# -Wattributes needs to be disabled to not get warnings in old compilers about not-yet
+# understood attributes, like [[gnu::no_dangling]] on many of the "stable" distros.
+case "$DISTRO" in
+  amazonlinux:2023 |\
+  debian:1[12] |\
+  *suse*:15.* |\
+  rockylinux:[89] |\
+  ubuntu:22.04)
+    WARN_FLAGS="${WARN_FLAGS} -Wno-attributes"
+    ;;
+esac
+
 case "$DISTRO" in
   alpine:*)
     # Packages inspired by the Alpine package, just

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,10 @@ endif()
 
 find_package(Boost ${BOOST_MIN_VERSION} COMPONENTS coroutine context date_time filesystem iostreams thread program_options regex REQUIRED)
 
+# Suppress only OpenSSL's own deprecation attributes (we must keep supporting
+# OpenSSL 1.0/1.1 API).
+add_compile_definitions(OPENSSL_SUPPRESS_DEPRECATED)
+
 # Boost.Coroutine2 (the successor of Boost.Coroutine)
 # (1) doesn't even exist in old Boost versions and
 # (2) isn't supported by ASIO, yet.

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -1122,7 +1122,8 @@ bool Process::DoEvents()
 	Log(LogNotice, "Process")
 		<< "PID " << m_PID << " (" << PrettyPrintArguments(m_Arguments) << ") terminated with exit code " << exitcode;
 #else /* _WIN32 */
-	int status, exitcode;
+	int status = 0;
+	int exitcode = 0;
 	if (could_not_kill || m_PID == -1) {
 		exitcode = 128;
 	} else if (ProcessWaitPID(m_Process, &status) != m_Process) {

--- a/lib/config/applyrule.hpp
+++ b/lib/config/applyrule.hpp
@@ -81,8 +81,8 @@ public:
 		const Expression::Ptr& filter, const String& package, const String& fkvar, const String& fvvar, const Expression::Ptr& fterm,
 		bool ignoreOnError, const DebugInfo& di, const Dictionary::Ptr& scope);
 	static const std::vector<ApplyRule::Ptr>& GetRules(const Type::Ptr& sourceType, const Type::Ptr& targetType);
-	static const std::set<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const String& host);
-	static const std::set<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service);
+	[[gnu::no_dangling]] static const std::set<ApplyRule::Ptr>& GetTargetedHostRules(const Type::Ptr& sourceType, const String& host);
+	[[gnu::no_dangling]] static const std::set<ApplyRule::Ptr>& GetTargetedServiceRules(const Type::Ptr& sourceType, const String& host, const String& service);
 	static bool GetTargetHosts(Expression* assignFilter, std::vector<const String *>& hosts, const Dictionary::Ptr& constants = nullptr);
 	static bool GetTargetServices(Expression* assignFilter, std::vector<std::pair<const String *, const String *>>& services, const Dictionary::Ptr& constants = nullptr);
 

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -178,7 +178,7 @@ bool HttpUtility::IsValidHeaderValue(std::string_view value)
 		}
 	}
 
-	return std::all_of(value.begin(), value.end(), [](char c) {
-		return c == ' ' || c == '\t' || ('\x21' <= c && c <= '\x7e') || ('\x80' <= c && c <= '\xff');
+	return std::all_of(value.begin(), value.end(), [](unsigned char c) {
+		return c == ' ' || c == '\t' || (c >= 0x21 && c <= 0x7e) || c >= 0x80;
 	});
 }


### PR DESCRIPTION
Silences/Fixes some more of the remaining compiler warnings.

Most of these are false-positives or harmless reminders that something could be wrong (but isn't in our case). I want to get rid of these to reduce noise in compiler output and GH problem-matcher annotations.

For the `-Wtype-limits` commit I previously had versions with `#pragma gcc diagnostics ...` that disabled the warning and preprocessor `#if`/`#else` that differentiated based on sigend or unsigend `char` platforms. But the simplest solution is actually to convert to `unsigned char` unconditionally, which should be safe and allow to reduce the check from `'\x80' <= c && c <= '\xff'` to `c >= 0x80`.