### PR TITLE
Redis exceptions: add proper what() messages

### DIFF
--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -324,7 +324,7 @@ public:
 class RedisProtocolError : public std::runtime_error
 {
 protected:
-	inline explicit RedisProtocolError(std::string_view msg) : runtime_error("Redis protocol error: " + std::string(msg))
+	explicit RedisProtocolError(std::string_view msg) : runtime_error("Redis protocol error: " + std::string(msg))
 	{
 	}
 };
@@ -337,7 +337,7 @@ protected:
 class BadRedisType : public RedisProtocolError
 {
 public:
-	inline explicit BadRedisType(char type) : RedisProtocolError("bad type: " + std::string(&type, 1))
+	explicit BadRedisType(char type) : RedisProtocolError("bad type: " + std::string(&type, 1))
 	{
 	}
 };
@@ -350,7 +350,7 @@ public:
 class BadRedisInt : public RedisProtocolError
 {
 public:
-	inline explicit BadRedisInt(std::string_view intStr) : RedisProtocolError("bad int: " + std::string(intStr))
+	explicit BadRedisInt(std::string_view intStr) : RedisProtocolError("bad int: " + std::string(intStr))
 	{
 	}
 };


### PR DESCRIPTION
RedisDisconnected::what() and RedisProtocolError::what() always returned an empty string. Similarly, BadRedisType::what() and BadRedisInt::what() only return the value that couldn't be parsed without any information about the exception type. If only what() is used when printing the exception, as it's typical, this results in unhelpful log messages like the following when simply stopping the Redis server:

    [2026-02-23 14:33:33 +0100] critical/IcingaDB: Error during receiving the response to a query which has been fired and forgotten: Connection reset by peer [system:104 at /usr/include/boost/asio/detail/reactive_socket_recv_op.hpp:134 in function 'do_complete']
    [2026-02-23 14:33:33 +0100] critical/IcingaDB: Error during receiving the response to a query which has been fired and forgotten:
    [2026-02-23 14:33:33 +0100] critical/IcingaDB: Error during receiving the response to a query which has been fired and forgotten:
    [2026-02-23 14:33:33 +0100] critical/IcingaDB: Cannot connect to redis-1:6379: Connection refused [system:111 at /usr/include/boost/asio/detail/reactive_socket_connect_op.hpp:98 in function 'do_complete']

This commit changes these messages so that something like "Redis disconnected", "Redis protocol error: bad int: foo", or "Redis protocol error: bad type: ?" is returned. In doing so, it also removes a member of type std::vector<char> in BadRedisInt as this is unsafe to use in exceptions (it violates the requirement that copy constructor and assignment must be nothrow, see https://en.cppreference.com/w/cpp/error/exception.html#Standard_exception_requirements).

With this commit, the log messages are now a bit more helpful:

    [2026-02-23 15:08:23 +0100] critical/IcingaDB: Error during receiving the response to a query which has been fired and forgotten: Connection reset by peer [system:104 at /usr/include/boost/asio/detail/reactive_socket_recv_op.hpp:134 in function 'do_complete']
    [2026-02-23 15:08:23 +0100] critical/IcingaDB: Error during receiving the response to a query which has been fired and forgotten: Redis disconnected
    [2026-02-23 15:08:23 +0100] critical/IcingaDB: Error during receiving the response to a query which has been fired and forgotten: Redis disconnected
    [2026-02-23 15:08:23 +0100] critical/IcingaDB: Cannot connect to redis-1:6379: Connection refused [system:111 at /usr/include/boost/asio/detail/reactive_socket_connect_op.hpp:98 in function 'do_complete']

Additionally, some minor cleanup around the exceptions is done: use `BOOST_THROW_EXCEPTION()` and remove redundant `inline` specifiers.