### PR TITLE
Apply RLIMIT adjustments conditionally based on the target command

### DIFF
--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -439,7 +439,7 @@ static int Main()
 		Configuration::Concurrency = std::thread::hardware_concurrency();
 	}
 
-	if (!autocomplete) {
+	if (!autocomplete && command && command->NeedsRLimitAdjustment()) {
 		Application::SetResourceLimits();
 	}
 

--- a/icinga-app/icinga.cpp
+++ b/icinga-app/icinga.cpp
@@ -281,9 +281,6 @@ static int Main()
 #endif /* RLIMIT_STACK */
 	}
 
-	if (!autocomplete)
-		Application::SetResourceLimits();
-
 	LogSeverity logLevel = Logger::GetConsoleLogSeverity();
 	Logger::SetConsoleLogSeverity(LogWarning);
 
@@ -440,6 +437,10 @@ static int Main()
 
 	if (!Configuration::ConcurrencyWasModified) {
 		Configuration::Concurrency = std::thread::hardware_concurrency();
+	}
+
+	if (!autocomplete) {
+		Application::SetResourceLimits();
 	}
 
 	Application::GetTP().Restart();

--- a/lib/cli/clicommand.cpp
+++ b/lib/cli/clicommand.cpp
@@ -96,6 +96,11 @@ bool CLICommand::IsDeprecated() const
 	return false;
 }
 
+bool CLICommand::NeedsRLimitAdjustment() const
+{
+	return false;
+}
+
 std::mutex& CLICommand::GetRegistryMutex()
 {
 	static std::mutex mtx;

--- a/lib/cli/clicommand.hpp
+++ b/lib/cli/clicommand.hpp
@@ -42,6 +42,7 @@ public:
 	virtual int GetMaxArguments() const;
 	virtual bool IsHidden() const;
 	virtual bool IsDeprecated() const;
+	virtual bool NeedsRLimitAdjustment() const;
 	virtual void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const;
 	virtual ImpersonationLevel GetImpersonationLevel() const;

--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -167,6 +167,11 @@ ImpersonationLevel ConsoleCommand::GetImpersonationLevel() const
 	return ImpersonateNone;
 }
 
+bool ConsoleCommand::NeedsRLimitAdjustment() const
+{
+	return true;
+}
+
 void ConsoleCommand::InitParameters(boost::program_options::options_description& visibleDesc,
 	[[maybe_unused]] boost::program_options::options_description& hiddenDesc) const
 {

--- a/lib/cli/consolecommand.hpp
+++ b/lib/cli/consolecommand.hpp
@@ -30,6 +30,7 @@ public:
 	String GetDescription() const override;
 	String GetShortDescription() const override;
 	ImpersonationLevel GetImpersonationLevel() const override;
+	bool NeedsRLimitAdjustment() const override;
 	void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const override;
 	int Run(const boost::program_options::variables_map& vm, const std::vector<std::string>& ap) const override;

--- a/lib/cli/daemoncommand.cpp
+++ b/lib/cli/daemoncommand.cpp
@@ -176,6 +176,11 @@ String DaemonCommand::GetShortDescription() const
 	return "starts Icinga 2";
 }
 
+bool DaemonCommand::NeedsRLimitAdjustment() const
+{
+	return true;
+}
+
 void DaemonCommand::InitParameters(boost::program_options::options_description& visibleDesc,
 	[[maybe_unused]] boost::program_options::options_description& hiddenDesc) const
 {

--- a/lib/cli/daemoncommand.hpp
+++ b/lib/cli/daemoncommand.hpp
@@ -21,6 +21,7 @@ public:
 
 	String GetDescription() const override;
 	String GetShortDescription() const override;
+	bool NeedsRLimitAdjustment() const override;
 	void InitParameters(boost::program_options::options_description& visibleDesc,
 		boost::program_options::options_description& hiddenDesc) const override;
 	std::vector<String> GetArgumentSuggestions(const String& argument, const String& word) const override;


### PR DESCRIPTION
This PR introduces a conditional check to apply RLIMIT adjustments only when the target sub-command really needs them. To accomplish this, we delay the `Application::SetResourceLimits()` call until we have parsed the command-line arguments and determined which sub-command is being invoked. Well, technically, this delay is also required due to other reasons (see 4d30b03c0fa896b17cf2bbfa6685503f5f1df797), so we can make use of this opportunity to optimize the RLIMIT adjustments as well. Though, currently, the RLIMIT adjustments are only applied for the `icinga2 daemon` and `icinga2 console` sub-command, but we can discuss whether we want to apply them for the following sub-commands as well:

- [x] `PKISignCSRCommand`: This command is used to sign certificate signing requests invoked via `icinga2 pki sign-csr` (no RLIMIT change required).
- [x] `FeatureListCommand`: This command is used to list available features invoked via `icinga2 feature list` (same as above, doesn't require any RLIMITs).
- [x] `ObjectListCommand`: This command is used to list configuration objects invoked via `icinga2 object list` (same as above).
- [x] `InternalSignalCommand`: This command is used to send internal signals to the running daemon invoked via `icinga2 signal` (it definitely doesn't need RLIMIT adjustments).
- [ ] `NodeWizardCommand`: This command is used to run the node wizard invoked via `icinga2 node wizard` (might also connect to a remote peer).
- [x] `CARestoreCommand`: This command is used to restore a removed certificate request invoked via `icinga2 ca restore` (no RLIMITs required).
- [x] `FeatureEnableCommand`: This command is used to enable a feature invoked via the `icinga2 feature enable` sub-command (it definitely doesn't need RLIMIT adjustments).
- [x] `FeatureDisableCommand` (same as above but for disabling features).
- [ ] `PKINewCertCommand`: This command is used to generate a new certificate invoked via `icinga2 pki new-cert`.
- [ ] `PKIRequestCommand`: This command requests a new certificate from a remote peer invoked via `icinga2 pki request`.
- [ ] `NodeSetupCommand`: Invoked via the `icinga2 node setup` sub-command, might also conditionally connect to a remote peer.
- [x] `VariableGetCommand`: This command is used to retrieve the value of a variable invoked via the `icinga2 variable get` sub-command (it definitely doesn't need RLIMIT adjustments).
- [x] `VariableListCommand`: Same as above but for listing variables.
- [ ] `PKINewCACommand`: Sets up a new Icinga 2 CA invoked via `icinga2 pki new-ca`.
- [x] `CASignCommand`: Signs a certificate signing request from the `/var/lib/icinga2/certificate-requests` directory invoked via `icinga2 ca sign` (maybe stack related limits, but IMHO it should need any adjustments).
- [x] `CARemoveCommand`: Removes/renames a certificate request from the `/var/lib/icinga2/certificate-requests` directory invoked via `icinga2 ca remove` (NOPE).
- [ ] `CAListCommand`: Lists all certificate requests in the `/var/lib/icinga2/certificate-requests` directory invoked via `icinga2 ca list` (NOPE).
- [ ] `PKISaveCertCommand`: Saves a certificate fetched from a remote peer locally invoked via `icinga2 pki save-cert`.
- [x] `PKITicketCommand`: Generates a PKI ticket locally invoked via `icinga2 pki ticket` (definitely no RLIMIT adjustment is needed for this).
- [x] `ApiSetupCommand`: Performs a similar setup as the `NodeSetupCommand` but never connects to a remote peer invoked via `icinga2 api setup`. IMHO, this doesn't need any RLIMIT adjustments.
- [x] `PKIVerifyCommand`: Verifies a given certificate locally invoked via `icinga2 pki verify` (I don't think we need to adjust any RLMITs for this).

fixes #10617