### PR TITLE
Fix invalid category in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -16,7 +16,6 @@ platforms:
   - windows
   - web
 categories:
-  - monitoring
   - data-collection
   - data-visualization
   - data-analytics


### PR DESCRIPTION
The 'monitoring' category is not part of the official list of software categories: https://yml.publiccode.tools/categories-list.html