### PR TITLE
Improve debug message when dependency child/parent don't exist

### DIFF
--- a/lib/icinga/dependency.cpp
+++ b/lib/icinga/dependency.cpp
@@ -223,26 +223,46 @@ void Dependency::InitChildParentReferences()
 	Host::Ptr childHost = Host::GetByName(GetChildHostName());
 
 	if (childHost) {
-		if (GetChildServiceName().IsEmpty())
+		if (GetChildServiceName().IsEmpty()) {
 			m_Child = childHost;
-		else
+		} else {
 			m_Child = childHost->GetServiceByShortName(GetChildServiceName());
+			if (!m_Child) {
+				BOOST_THROW_EXCEPTION(ScriptError(
+					"Dependency '" + GetName() + "' references child service '" + GetChildServiceName() + "' on '" +
+						GetChildHostName() + "' which doesn't exist.",
+					GetDebugInfo()
+				));
+			}
+		}
+	} else {
+		BOOST_THROW_EXCEPTION(ScriptError(
+			"Dependency '" + GetName() + "' references child host '" + GetChildHostName() + "' which doesn't exist.",
+			GetDebugInfo()
+		));
 	}
-
-	if (!m_Child)
-		BOOST_THROW_EXCEPTION(ScriptError("Dependency '" + GetName() + "' references a child host/service which doesn't exist.", GetDebugInfo()));
 
 	Host::Ptr parentHost = Host::GetByName(GetParentHostName());
 
 	if (parentHost) {
-		if (GetParentServiceName().IsEmpty())
+		if (GetParentServiceName().IsEmpty()) {
 			m_Parent = parentHost;
-		else
+		} else {
 			m_Parent = parentHost->GetServiceByShortName(GetParentServiceName());
+			if (!m_Parent) {
+				BOOST_THROW_EXCEPTION(ScriptError(
+					"Dependency '" + GetName() + "' references parent service '" + GetParentServiceName() + "' on '" +
+						GetParentHostName() + "' which doesn't exist.",
+					GetDebugInfo()
+				));
+			}
+		}
+	} else {
+		BOOST_THROW_EXCEPTION(ScriptError(
+			"Dependency '" + GetName() + "' references parent host '" + GetParentHostName() + "' which doesn't exist.",
+			GetDebugInfo()
+		));
 	}
-
-	if (!m_Parent)
-		BOOST_THROW_EXCEPTION(ScriptError("Dependency '" + GetName() + "' references a parent host/service which doesn't exist.", GetDebugInfo()));
 }
 
 void Dependency::OnAllConfigLoaded()


### PR DESCRIPTION
## Description

Debug messages for non-existent references to the parent/child of a dependency in `Dependency::InitChildParentReferences()` currently only print the name of the dependency object and whether the non-existent reference is to a child or parent, but not the name of the non-existent child/parent or if the checkable referenced is a host or service. This makes it hard to debug issues in case the names of hosts/services used in a dependency are generated via DSL.

For an extended description of the use case, also see this [community post](https://community.icinga.com/t/dynamic-service-to-service-dependencies-based-on-parent-service-var/15353).

## Solution

With this PR, now all relevant information is part of the debug information. Now it also explicitly mentions whether the non-existent child/parent was supposed to be a host or service.

Fixes #10736.