### PR TITLE
Don't run tests when building container image without testing

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -127,7 +127,7 @@ RUN --mount=type=bind,source=.,target=/icinga2,readonly \
         -DICINGA2_WITH_COMPAT=OFF \
         -DICINGA2_WITH_LIVESTATUS=OFF && \
     make -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") && \
-    CTEST_OUTPUT_ON_FAILURE=1 make test && \
+    if [ "${ICINGA2_BUILD_TESTING}" = ON ]; then CTEST_OUTPUT_ON_FAILURE=1 make test; fi && \
     make install DESTDIR=/icinga2-install
 
 RUN rm -rf /icinga2-install/etc/icinga2/features-enabled/mainlog.conf \


### PR DESCRIPTION
## Description

When disabling testing via setting the `ICINGA2_BUILD_TESTING` container build argument to `OFF`, testing is excluded from the build, but farther down `make test` is executed unconditionally, leading the container build to fail.

It is often useful for development to disable testing when building the container image because it allows for more rapid edit-compile-run loop involving running a container. Testing works well enough with a local build, so it doesn't need to happen on every `docker compose build` (in my use-case).

## Solution

This adds a check on `ICINGA2_BUILD_TESTING` and only runs `make test` if it is set to `ON`. Pretty straight forward and probably omitted by mistake in the first place (because why else add the build arg).