### PR TITLE
Fast-track fix for cert chain processing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -197,6 +197,7 @@ Mathieu Lutfy <mathieu@bidon.ca>
 Matthaus Owens <matthaus@puppetlabs.com>
 Matthias Baur <m.baur@syseleven.de>
 Matthias Döhler <matthias.doehler@netways.de>
+Matthias Hensler <matthias@wspse.de>
 Matthias Schales <black-dragon131@web.de>
 Mattia Codato <mattia.codato@wuerth-phoenix.com>
 Maurice Meyer <morre@mor.re>

--- a/AUTHORS
+++ b/AUTHORS
@@ -162,6 +162,7 @@ Lee Clemens <sftw@leeclemens.net>
 Lee Garrett <lgarrett@rocketjump.eu>
 Lennart Betz <lennart.betz@icinga.com>
 Leon Stringer <leon@priorsvle.com>
+lersveen <7195448+lersveen@users.noreply.github.com>
 lihan <tclh123@gmail.com>
 log1-c <24474580+log1-c@users.noreply.github.com>
 Lord Hepipud <contact@lordhepipud.de>

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -70,6 +70,11 @@ std::shared_ptr<X509> UnbufferedAsioTlsStream::GetPeerCertificate()
 	return std::shared_ptr<X509>(SSL_get_peer_certificate(native_handle()), X509_free);
 }
 
+STACK_OF(X509) *UnbufferedAsioTlsStream::GetPeerCertificateChain()
+{
+	return SSL_get_peer_cert_chain(native_handle());
+}
+
 void UnbufferedAsioTlsStream::BeforeHandshake(handshake_type type)
 {
 	namespace ssl = boost::asio::ssl;

--- a/lib/base/tlsstream.hpp
+++ b/lib/base/tlsstream.hpp
@@ -79,6 +79,7 @@ public:
 	bool IsVerifyOK();
 	String GetVerifyError();
 	std::shared_ptr<X509> GetPeerCertificate();
+	STACK_OF(X509) *GetPeerCertificateChain();
 
 	template<class... Args>
 	inline

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -1059,10 +1059,10 @@ String BinaryToHex(const unsigned char* data, size_t length) {
 
 bool VerifyCertificate(const std::shared_ptr<X509> &caCertificate, const std::shared_ptr<X509> &certificate, const String& crlFile, STACK_OF(X509) *chain)
 {
-	return VerifyCertificate(caCertificate.get(), certificate.get(), crlFile);
+	return VerifyCertificate(caCertificate.get(), certificate.get(), crlFile, chain);
 }
 
-bool VerifyCertificate(X509* caCertificate, X509* certificate, const String& crlFile)
+bool VerifyCertificate(X509* caCertificate, X509* certificate, const String& crlFile, STACK_OF(X509) *chain)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 	/*
@@ -1094,7 +1094,7 @@ bool VerifyCertificate(X509* caCertificate, X509* certificate, const String& crl
 	}
 
 	std::unique_ptr<X509_STORE_CTX, decltype(&X509_STORE_CTX_free)> csc{X509_STORE_CTX_new(), &X509_STORE_CTX_free};
-	X509_STORE_CTX_init(csc.get(), store.get(), certificate, nullptr);
+	X509_STORE_CTX_init(csc.get(), store.get(), certificate, chain);
 
 	int rc = X509_verify_cert(csc.get());
 

--- a/lib/base/tlsutility.cpp
+++ b/lib/base/tlsutility.cpp
@@ -1057,7 +1057,7 @@ String BinaryToHex(const unsigned char* data, size_t length) {
 	return output;
 }
 
-bool VerifyCertificate(const std::shared_ptr<X509> &caCertificate, const std::shared_ptr<X509> &certificate, const String& crlFile)
+bool VerifyCertificate(const std::shared_ptr<X509> &caCertificate, const std::shared_ptr<X509> &certificate, const String& crlFile, STACK_OF(X509) *chain)
 {
 	return VerifyCertificate(caCertificate.get(), certificate.get(), crlFile);
 }

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -96,7 +96,7 @@ String SHA256(const String& s);
 String RandomString(int length);
 String BinaryToHex(const unsigned char* data, size_t length);
 
-bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::shared_ptr<X509>& certificate, const String& crlFile);
+bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::shared_ptr<X509>& certificate, const String& crlFile, STACK_OF(X509) *chain = nullptr);
 bool VerifyCertificate(X509* caCertificate, X509* certificate, const String& crlFile);
 bool IsCa(const std::shared_ptr<X509>& cacert);
 int GetCertificateVersion(const std::shared_ptr<X509>& cert);

--- a/lib/base/tlsutility.hpp
+++ b/lib/base/tlsutility.hpp
@@ -97,7 +97,7 @@ String RandomString(int length);
 String BinaryToHex(const unsigned char* data, size_t length);
 
 bool VerifyCertificate(const std::shared_ptr<X509>& caCertificate, const std::shared_ptr<X509>& certificate, const String& crlFile, STACK_OF(X509) *chain = nullptr);
-bool VerifyCertificate(X509* caCertificate, X509* certificate, const String& crlFile);
+bool VerifyCertificate(X509* caCertificate, X509* certificate, const String& crlFile, STACK_OF(X509) *chain = nullptr);
 bool IsCa(const std::shared_ptr<X509>& cacert);
 int GetCertificateVersion(const std::shared_ptr<X509>& cert);
 String GetSignatureAlgorithm(const std::shared_ptr<X509>& cert);

--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -38,9 +38,8 @@ Value RequestCertificateHandler(const MessageOrigin::Ptr& origin, const Dictiona
 
 	/* Use the presented client certificate if not provided. */
 	if (certText.IsEmpty()) {
-		auto stream (origin->FromClient->GetStream());
-		cert = stream->next_layer().GetPeerCertificate();
-		chain = stream->next_layer().GetPeerCertificateChain();
+		cert = tlsConn.GetPeerCertificate(); 
+		chain = tlsConn.GetPeerCertificateChain();
 	} else {
 		cert = StringToCertificate(certText);
 		chain = nullptr;


### PR DESCRIPTION
(New PR after #10733 was [accidentally closed](https://github.com/Icinga/icinga2/pull/10733#issuecomment-4023330739))

As [suggested](https://github.com/Icinga/icinga2/pull/9795#issuecomment-3718234143) by @Al2Klimov, this PR fast-tracks the initial implementation from https://github.com/Icinga/icinga2/pull/9795.

Original description by @sircubbi:

> Similar to https://github.com/Icinga/icinga2/pull/8859 this patch works around https://github.com/Icinga/icinga2/issues/7719 by allowing the intermediate certificate presented by the icinga2-agent.
> 
> To make this work the icinga2-master only holds to root-ca in its local ca.crt, while the icinga2-agent has the intermediate-cert in its local ca.crt (or the intermediate together with the root in the ca.crt / or the intermediate in the cert.pem - doesn't matter).
> 

closes https://github.com/Icinga/icinga2/pull/9026
closes https://github.com/Icinga/icinga2/pull/9795