### PR TITLE
Add a wrapper around `std::visit` that accepts multiple overloads

### DIFF
--- a/lib/base/CMakeLists.txt
+++ b/lib/base/CMakeLists.txt
@@ -90,6 +90,7 @@ set(base_SOURCES
   unixsocket.cpp unixsocket.hpp
   utility.cpp utility.hpp
   value.cpp value.hpp value-operators.cpp
+  visit.hpp
   wait-group.cpp wait-group.hpp
   win32.hpp
   workqueue.cpp workqueue.hpp

--- a/lib/base/visit.hpp
+++ b/lib/base/visit.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <variant>
+
+namespace icinga {
+
+namespace detail{
+
+template<class... Ts>
+struct Overloaded : Ts... { using Ts::operator()...; };
+
+template<class... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
+} // namespace detail
+
+/**
+ * A more convenient wrapper around std::visit.
+ *
+ * Instead of allowing to dispatch a single functor on an arbitrary number of variant objects,
+ * this allows to dispatch any number of overloads on a single variant object, which more closely
+ * fits the way this project uses @c std::variant.
+ *
+ * @param variant The variant to dispatch on
+ * @param overloads A set of overloads to handle each member of the variant
+ *
+ * @return The value std::visit() returns.
+ */
+template<typename Variant, typename... Overloads>
+auto Visit(Variant&& variant, Overloads&&... overloads)
+{
+	return std::visit(detail::Overloaded{std::forward<Overloads>(overloads)...}, std::forward<Variant>(variant));
+}
+
+} // namespace icinga

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -3,6 +3,7 @@
 
 #include "perfdata/perfdatawriterconnection.hpp"
 #include "base/tcpsocket.hpp"
+#include "base/visit.hpp"
 #include <boost/asio/use_future.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
@@ -75,14 +76,11 @@ void PerfdataWriterConnection::Disconnect()
 			 * result in exceptions thrown by the yield_context, even if its already queued for
 			 * completion.
 			 */
-			std::visit(
-				[](const auto& stream) {
-					if (stream->lowest_layer().is_open()) {
-						stream->lowest_layer().cancel();
-					}
-				},
-				m_Stream
-			);
+			Visit(m_Stream, [](const auto& stream) {
+				if (stream->lowest_layer().is_open()) {
+					stream->lowest_layer().cancel();
+				}
+			});
 			m_ReconnectTimer.cancel();
 
 			Disconnect(std::move(yc));
@@ -128,27 +126,26 @@ void PerfdataWriterConnection::EnsureConnected(const boost::asio::yield_context&
 		return;
 	}
 
-	std::visit(
-		[&](auto& stream) {
+	Visit(
+		m_Stream,
+		[&](const Shared<AsioTcpStream>::Ptr& stream) { ::Connect(stream->lowest_layer(), m_Host, m_Port, yc); },
+		[&](const Shared<AsioTlsStream>::Ptr& stream) {
 			::Connect(stream->lowest_layer(), m_Host, m_Port, yc);
 
-			if constexpr (std::is_same_v<std::decay_t<decltype(stream)>, Shared<AsioTlsStream>::Ptr>) {
-				using type = boost::asio::ssl::stream_base::handshake_type;
+			using type = boost::asio::ssl::stream_base::handshake_type;
 
-				stream->next_layer().async_handshake(type::client, yc);
+			stream->next_layer().async_handshake(type::client, yc);
 
-				if (m_VerifyPeerCertificate) {
-					if (!stream->next_layer().IsVerifyOK()) {
-						BOOST_THROW_EXCEPTION(
-							std::runtime_error{
-								"TLS certificate validation failed: " + stream->next_layer().GetVerifyError()
-							}
-						);
-					}
+			if (m_VerifyPeerCertificate) {
+				if (!stream->next_layer().IsVerifyOK()) {
+					BOOST_THROW_EXCEPTION(
+						std::runtime_error{
+							"TLS certificate validation failed: " + stream->next_layer().GetVerifyError()
+						}
+					);
 				}
 			}
-		},
-		m_Stream
+		}
 	);
 
 	m_Connected = true;
@@ -160,16 +157,13 @@ void PerfdataWriterConnection::Disconnect(boost::asio::yield_context yc)
 		return;
 	}
 
-	std::visit(
-		[&](auto& stream) {
-			if constexpr (std::is_same_v<std::decay_t<decltype(stream)>, Shared<AsioTlsStream>::Ptr>) {
-				stream->GracefulDisconnect(m_Strand, yc);
-			} else {
-				stream->lowest_layer().shutdown(boost::asio::socket_base::shutdown_both);
-				stream->lowest_layer().close();
-			}
-		},
-		m_Stream
+	Visit(
+		m_Stream,
+		[&](Shared<AsioTlsStream>::Ptr& stream) { stream->GracefulDisconnect(m_Strand, yc); },
+		[&](Shared<AsioTcpStream>::Ptr& stream) {
+			stream->lowest_layer().shutdown(boost::asio::socket_base::shutdown_both);
+			stream->lowest_layer().close();
+		}
 	);
 
 	m_Stream = MakeStream();
@@ -177,29 +171,23 @@ void PerfdataWriterConnection::Disconnect(boost::asio::yield_context yc)
 
 void PerfdataWriterConnection::WriteMessage(boost::asio::const_buffer buf, const boost::asio::yield_context& yc)
 {
-	std::visit(
-		[&](auto& stream) {
-			boost::asio::async_write(*stream, buf, yc);
-			stream->async_flush(yc);
-		},
-		m_Stream
-	);
+	Visit(m_Stream, [&](auto& stream) {
+		boost::asio::async_write(*stream, buf, yc);
+		stream->async_flush(yc);
+	});
 }
 
 HttpResponse PerfdataWriterConnection::WriteMessage(const HttpRequest& request, const boost::asio::yield_context& yc)
 {
 	boost::beast::http::response<boost::beast::http::string_body> response;
-	std::visit(
-		[&](auto& stream) {
-			boost::beast::http::request_serializer<boost::beast::http::string_body> sr{request};
-			boost::beast::http::async_write(*stream, sr, yc);
-			stream->async_flush(yc);
+	Visit(m_Stream, [&](auto& stream) {
+		boost::beast::http::request_serializer<boost::beast::http::string_body> sr{request};
+		boost::beast::http::async_write(*stream, sr, yc);
+		stream->async_flush(yc);
 
-			boost::beast::flat_buffer buf;
-			boost::beast::http::async_read(*stream, buf, response, yc);
-		},
-		m_Stream
-	);
+		boost::beast::flat_buffer buf;
+		boost::beast::http::async_read(*stream, buf, response, yc);
+	});
 
 	if (!response.keep_alive()) {
 		Disconnect(yc);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(base_test_SOURCES
   base-tlsutility.cpp base-tlsutility.hpp
   base-utility.cpp
   base-value.cpp
+  base-visit.cpp
   config-apply.cpp
   config-ops.cpp
   icinga-checkresult.cpp

--- a/test/base-visit.cpp
+++ b/test/base-visit.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <BoostTestTargetConfig.h>
+#include "base/visit.hpp"
+
+using namespace icinga;
+
+BOOST_AUTO_TEST_SUITE(base_visit)
+
+// This test-case tests if Visit correctly dispatches on types that all provide the same interface.
+BOOST_AUTO_TEST_CASE(same)
+{
+	using AllSameVariant = std::variant<std::string, std::vector<int>>;
+
+	AllSameVariant testVar = std::string{"test"};
+	BOOST_REQUIRE_EQUAL(Visit(testVar, [](auto& var) { return std::size(var); }), 4);
+
+	testVar = std::vector{0, 1, 2, 3, 4};
+	BOOST_REQUIRE_EQUAL(Visit(testVar, [](auto& var) { return std::size(var); }), 5);
+}
+
+// This test-case verifies that Visit dispatches different methods to the correct types.
+// Note how when the `u` is removed from the `1234u` testVar assignment, the test will fail,
+// because it defaults to the signed `int` variant member.
+BOOST_AUTO_TEST_CASE(different)
+{
+	using NumbersVariant = std::variant<unsigned int, int, double>;
+
+	auto testVisit = [](auto& var) {
+		return Visit(
+			var,
+			[](unsigned int val) {
+				BOOST_REQUIRE_EQUAL(val, 1234);
+				return 1;
+			},
+			[](int val) {
+				BOOST_REQUIRE_EQUAL(val, -15);
+				return 2;
+			},
+			[](double val) {
+				BOOST_REQUIRE_EQUAL(val, 74.1234);
+				return 3;
+			}
+		);
+	};
+
+	NumbersVariant testVar = 1234u;
+	BOOST_REQUIRE_EQUAL(testVisit(testVar), 1);
+
+	testVar = -15;
+	BOOST_REQUIRE_EQUAL(testVisit(testVar), 2);
+
+	testVar = 74.1234;
+	BOOST_REQUIRE_EQUAL(testVisit(testVar), 3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a wrapper around `std::visit` that accepts only a single variant, but multiple overload alternatives that cover all the types in the variant. As an added benefit, having the function object as the last parameter will lead to nicer formatting from `clang-format`, in case only one generic overload is provided, with only a single level of indentation.

In addition, to showcase the function, this PR refactors `PerfdataWriterConnection` to use it to dispatch on its `m_Stream` variant.

### Testing

I've added two test-cases that showcase operation of `Visit` both with a single `auto&` typed lambda and multiple for explicit type pattern matching.

Strictly speaking, these tests aren't really necessary, since the compiler ensures that:
+ there is an overload in the set for each variant member type
+ that there are no ambiguous overloads (for example, `double` in the variant, overloads for `int` and `float`)
+ the return-types match

Since the function is not picked by dark template-meta-programming magic that might force conversions or pick the wrong overload by chance, but with standard overload resolution, that should always be fine. Or at least I can't come up with a situation where this wouldn't lead to a compiler error but something unexpected off the top of my head.