### PR TITLE
Forward port Changelog entries from previous releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -21,6 +21,7 @@ assignees: ''
 - [ ] Create release on GitHub
 - [ ] Update public docs
 - [ ] Announce release
+- [ ] Forward-port the `CHANGELOG` changes to `master`
 
 ## Update Bundled Windows Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## 2.15.2 (2026-01-29)
 
-Additionally, it includes two minor bug fixes regarding SELinux policies and the OpenSSL version shipped on Windows.
+This security release fixes a problem in the Icinga 2 Windows MSI that did not
+set proper permissions for `%ProgramData%\icinga2\var`. Additionally, it includes
+two minor bug fixes regarding our SELinux policy and updates the OpenSSL version
+shipped on Windows.
 
+* CVE-2026-24413: Fix permissions of `%ProgramData%\icinga2\var` on Windows.
 * Windows: Update to OpenSSL 3.0.19. #10706
 * SELinux: Fix policy to allow `logrotate` to execute the `icinga2` binary in order to send `SIGUSR1` for log rotation. #10643
 * SELinux: Fix policy to allow `icinga2` to send `SIGTERM` to nagios plugins processes on timeout. #10694

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga2/milestones?state=closed).
 
+## 2.15.1 (2025-10-16)
+
+This version includes bug fixes regarding config deployments and improvements
+to allow for better debugging of problems related to JSON-RPC cluster
+communication.
+
+Note that one fix affects the logrotate configuration. If it was modified
+locally, it might not be updated automatically by the package manager and
+applying the changes manually is necessary. For details, please check the
+[upgrading docs](https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/#upgrading-to-2-15-1).
+
+* Don't send signals as root in safe-reload script and logrotate config. #10590
+* When a reload triggered from Icinga Director (or the /v1/config API) fails,
+  the corresponding state is cleared, allowing to deploy a new config without
+  having to restart Icinga 2 manually first. #10584
+* Add JSON-RPC utilization metrics and troubleshooting docs. #10586
+* When sending cluster messages to other zones, prefer endpoints in the order
+  as specified in the zone configuration. #10587
+* Track the number of JSON-RPC messages received for each message type per
+  endpoint. #10585
+* Add support for building with Boost v1.89 and use it on Windows. #10578
+* Windows: Update to OpenSSL 3.0.18. #10591
+
 ## 2.15.0 (2025-06-18)
 
 This Icinga 2 release is focused on adding Icinga 2 dependencies support to Icinga DB, but also includes a number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,49 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## 2.15.1 (2025-10-16)
 
-This version includes bug fixes regarding config deployments and improvements
-to allow for better debugging of problems related to JSON-RPC cluster
-communication.
+This release fixes multiple security issues. Two of them allow authenticated
+API users to learn restricted information or crash Icinga 2. A third issue
+affects the scripts provided with Icinga 2 and allows a limited privilege
+escalation where the Icinga 2 daemon user can trick root into sending signals to
+arbitrary processes.
+
+In addition, this version also includes bug fixes regarding config deployments
+and improvements to allow for better debugging of problems related to JSON-RPC
+cluster communication.
 
 Note that one fix affects the logrotate configuration. If it was modified
 locally, it might not be updated automatically by the package manager and
 applying the changes manually is necessary. For details, please check the
 [upgrading docs](https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/#upgrading-to-2-15-1).
 
-* Don't send signals as root in safe-reload script and logrotate config. #10590
+### Security
+
+* CVE-2025-61907: Prevent API users from accessing variables and objects they
+  don't have access to within filter expressions. This allowed authenticated
+  API users to learn information they aren't allowed to access directly.
+* CVE-2025-61908: Add a missing null pointer check while evaluating
+  expressions. This allowed authenticated API users to crash the Icinga 2
+  daemon by supplying a crafted filter expression.
+* CVE-2025-61909: Don't send signals as root in safe-reload script and
+  logrotate config. This allowed a limited privilege escalation from the Icinga
+  2 service user to root. The scope is limited to sending SIGHUP or SIGUSR1 to
+  an arbitrary process. #10590
+* Windows: Update to OpenSSL 3.0.18. #10591
+
+### Bugfixes
+
 * When a reload triggered from Icinga Director (or the /v1/config API) fails,
   the corresponding state is cleared, allowing to deploy a new config without
   having to restart Icinga 2 manually first. #10584
+
+### Enhancements
+
 * Add JSON-RPC utilization metrics and troubleshooting docs. #10586
 * When sending cluster messages to other zones, prefer endpoints in the order
   as specified in the zone configuration. #10587
 * Track the number of JSON-RPC messages received for each message type per
   endpoint. #10585
 * Add support for building with Boost v1.89 and use it on Windows. #10578
-* Windows: Update to OpenSSL 3.0.18. #10591
 
 ## 2.15.0 (2025-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga2/milestones?state=closed).
 
+## 2.15.2 (2026-01-29)
+
+Additionally, it includes two minor bug fixes regarding SELinux policies and the OpenSSL version shipped on Windows.
+
+* Windows: Update to OpenSSL 3.0.19. #10706
+* SELinux: Fix policy to allow `logrotate` to execute the `icinga2` binary in order to send `SIGUSR1` for log rotation. #10643
+* SELinux: Fix policy to allow `icinga2` to send `SIGTERM` to nagios plugins processes on timeout. #10694
+* doc: Update Windows development docs to use Visual Studio 2022 instead of 2019. #10695
+
 ## 2.15.1 (2025-10-16)
 
 This release fixes multiple security issues. Two of them allow authenticated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,21 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
+## 2.12.12 (2025-05-27)
+
+This security release fixes a critical issue in the certificate renewal logic in Icinga 2, which
+might incorrectly renew an invalid certificate. However, only nodes with access to the Icinga CA
+private key running with OpenSSL older than version 1.1.0 (released in 2016) are vulnerable. So this
+typically affects Icinga 2 masters running on operating systems like RHEL 7 and Amazon Linux 2.
+
+* CVE-2025-48057: Prevent invalid certificates from being renewed with OpenSSL older than v1.1.0.
+* Fix use-after-free in VerifyCertificate(): Additionally, a use-after-free was found in the same
+  function which is fixed as well, but in case it is triggered, typically only a wrong error code
+  may be shown in a log message.
+* Windows: Update OpenSSL shipped on Windows to v3.0.16. #10455
+* Windows: Fix unknown ctest(1) `--log_level` argument. #10453
+* Don't require to build .msi as admin. #10454
+
 ## 2.12.11 (2024-11-12)
 
 This security release fixes a TLS certificate validation bypass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,9 +581,12 @@ Add `linux_netdev` check command. #9045
 
 ## 2.13.14 (2026-01-29)
 
-This release updates the bundled OpenSSL library and includes changes to allow
-building with newer toolchains.
+This security release fixes a problem in the Icinga 2 Windows MSI that did not
+set proper permissions for `%ProgramData%\icinga2\var`. Additionally, it
+updates the bundled OpenSSL library and includes changes to allow building with
+newer toolchains.
 
+* CVE-2026-24413: Fix permissions of `%ProgramData%\icinga2\var` on Windows.
 * Windows: Update to OpenSSL 3.0.19. #10704
 * Allow building with CMake 4. #10625
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,17 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
+## 2.12.9 (2022-06-30)
+
+This release includes some fixes and a performance improvement
+resulting in faster config validation and reload times.
+
+### Bugfixes
+
+* Fix a race-condition involving object attribute updates that could result in a crash. #9394
+* Speed up config validation by avoiding redundant serialization of objects. #9401
+* Windows: Update bundled version OpenSSL. #9414
+
 ## 2.12.8 (2022-04-28)
 
 In the previous version 2.12.7, one bugfix was applied incorrectly. This is fixed by this release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,19 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
+# 2.12.6 (2021-08-19)
+
+The main focus of these versions is a security vulnerability in the TLS certificate verification of our metrics writers ElasticsearchWriter, GelfWriter and InfluxdbWriter.
+
+### Security
+
+* Add TLS server certificate validation to ElasticsearchWriter, GelfWriter and InfluxdbWriter
+
+Depending on your setup, manual intervention beyond installing the new versions
+may be required, so please read the more detailed information in the
+[release blog post](https://icinga.com/blog/2021/08/19/icinga-2-13-1-security-release//)
+carefully
+
 ## 2.12.5 (2021-07-15)
 
 Version 2.12.5 fixes two security vulnerabilities that may lead to privilege

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,20 @@ Thanks to all contributors:
 * Reduce task function allocation overhead by using a per-thread created lambda in `WorkQueue`. #9575
 * Remove redundant trailing empty lines and add missing newlines in some files. #7799
 
+## 2.14.7 (2025-10-16)
+
+This version includes a fix for sending signals and updates dependencies used
+in Windows builds.
+
+Note that one fix affects the logrotate configuration. If it was modified
+locally, it might not be updated automatically by the package manager and
+applying the changes manually is necessary. For details, please check the
+[upgrading docs](https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/#upgrading-to-2-15-1).
+
+* Don't send signals as root in safe-reload script and logrotate config. #10597
+* Windows: Update to OpenSSL 3.0.18. #10595
+* Windows: upgrade build toolchain to Visual Studio 2022. #10594
+
 ## 2.14.6 (2025-05-27)
 
 This security release fixes a critical issue in the certificate renewal logic in Icinga 2, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,14 @@ Add `linux_netdev` check command. #9045
 * Several code quality improvements. #8815 #9106 #9250
   #9508 #9517 #9537 #9594 #9605 #9606 #9641 #9658 #9702 #9717 #9738
 
+## 2.13.14 (2026-01-29)
+
+This release updates the bundled OpenSSL library and includes changes to allow
+building with newer toolchains.
+
+* Windows: Update to OpenSSL 3.0.19. #10704
+* Allow building with CMake 4. #10625
+
 ## 2.13.13 (2025-10-16)
 
 This release fixes multiple security issues. Two of them allow authenticated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,15 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
+## 2.12.11 (2024-11-12)
+
+This security release fixes a TLS certificate validation bypass.
+Given the severity of that issue, users are advised to upgrade all nodes immediately.
+
+* Security: fix TLS certificate validation bypass. CVE-2024-49369
+* Security: update OpenSSL shipped on Windows to v3.0.15.
+* Windows: sign MSI packages with a certificate the OS trusts by default.
+
 ## 2.12.10 (2023-02-16)
 
 This security release updates Boost and OpenSSL libraries bundled on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1099,7 +1099,7 @@ and repairs broken SELinux policies.
 
 ### Bugfixes
 
-* SELinux: repair broken policies. #9689
+* SELinux: fix user and domain creation by explicitly setting the role. #9689
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,15 @@ Thanks to all contributors:
 * Reduce task function allocation overhead by using a per-thread created lambda in `WorkQueue`. #9575
 * Remove redundant trailing empty lines and add missing newlines in some files. #7799
 
+## 2.14.8 (2026-01-29)
+
+This release updates the bundled OpenSSL library and includes changes to allow
+building with newer toolchains.
+
+* Windows: Update to OpenSSL 3.0.19. #10705
+* Bump Boost shipped for Windows to v1.87. #10651
+* Allow building with CMake 4. #10624
+
 ## 2.14.7 (2025-10-16)
 
 This version includes a fix for sending signals and updates dependencies used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,9 +221,12 @@ Thanks to all contributors:
 
 ## 2.14.8 (2026-01-29)
 
-This release updates the bundled OpenSSL library and includes changes to allow
-building with newer toolchains.
+This security release fixes a problem in the Icinga 2 Windows MSI that did not
+set proper permissions for `%ProgramData%\icinga2\var`. Additionally, it
+updates the bundled OpenSSL library and includes changes to allow building with
+newer toolchains.
 
+* CVE-2026-24413: Fix permissions of `%ProgramData%\icinga2\var` on Windows.
 * Windows: Update to OpenSSL 3.0.19. #10705
 * Bump Boost shipped for Windows to v1.87. #10651
 * Allow building with CMake 4. #10624

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,15 +581,29 @@ Add `linux_netdev` check command. #9045
 
 ## 2.13.13 (2025-10-16)
 
-This version includes a fix for sending signals and updates dependencies used
-in Windows builds.
+This release fixes multiple security issues. Two of them allow authenticated
+API users to learn restricted information or crash Icinga 2. A third issue
+affects the scripts provided with Icinga 2 and allows a limited privilege
+escalation where the Icinga 2 daemon user can trick root into sending signals to
+arbitrary processes.
 
 Note that one fix affects the logrotate configuration. If it was modified
 locally, it might not be updated automatically by the package manager and
 applying the changes manually is necessary. For details, please check the
 [upgrading docs](https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/#upgrading-to-2-15-1).
 
-* Don't send signals as root in safe-reload script and logrotate config. #10601
+* CVE-2025-61907: Prevent API users from accessing variables and objects they
+  don't have access to within filter expressions. This allowed authenticated
+  API users to learn information they aren't allowed to access directly. In this
+  version this also applies to the TicketSalt variable which was previously
+  accessible through the /v1/variables API in this version.
+* CVE-2025-61908: Add a missing null pointer check while evaluating
+  expressions. This allowed authenticated API users to crash the Icinga 2
+  daemon by supplying a crafted filter expression.
+* CVE-2025-61909: Don't send signals as root in safe-reload script and
+  logrotate config. This allowed a limited privilege escalation from the Icinga
+  2 service user to root. The scope is limited to sending SIGHUP or SIGUSR1 to
+  an arbitrary process. #10601
 * Windows: Update to OpenSSL 3.0.18. #10602
 * Windows: upgrade build toolchain to Visual Studio 2022. #10598
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -579,6 +579,20 @@ Add `linux_netdev` check command. #9045
 * Several code quality improvements. #8815 #9106 #9250
   #9508 #9517 #9537 #9594 #9605 #9606 #9641 #9658 #9702 #9717 #9738
 
+## 2.13.13 (2025-10-16)
+
+This version includes a fix for sending signals and updates dependencies used
+in Windows builds.
+
+Note that one fix affects the logrotate configuration. If it was modified
+locally, it might not be updated automatically by the package manager and
+applying the changes manually is necessary. For details, please check the
+[upgrading docs](https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/#upgrading-to-2-15-1).
+
+* Don't send signals as root in safe-reload script and logrotate config. #10601
+* Windows: Update to OpenSSL 3.0.18. #10602
+* Windows: upgrade build toolchain to Visual Studio 2022. #10598
+
 ## 2.13.12 (2025-05-27)
 
 This security release fixes a critical issue in the certificate renewal logic in Icinga 2, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,7 +1052,76 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
-# 2.12.6 (2021-08-19)
+## 2.12.7 (2022-04-14)
+
+This version includes bugfixes for many features of Icinga 2, including fixes for multiple crashes.
+
+### API
+
+* The /v1/config/stages endpoint now immediately rejects parallel config updates
+  instead of accepting and then later failing to verify and activate them. #9326
+
+### Certificates
+
+* The lifetime of newly issued node certificates is reduced from 15 years to 397 days. #9338
+* Compare cluster certificate tickets in constant time. #9334
+
+### Notifications
+
+* Fix a crash that could happen while sending notifications shortly after Icinga 2 started. #9125
+
+### Checks and Commands
+
+* Fix a deadlock when processing check results for checkables with dependencies. #9229
+* Fix a message routing loop that can happen for event commands that are executed within a zone
+  using `command_endpoint` that resulted in excessive execution of the command. #9261
+
+### Downtimes
+
+* Fix scheduling of downtimes for all services on child hosts. #9184
+* Creating fixed downtimes starting immediately now send a corresponding notification. #9185
+* Fix some issues involving daylight saving time changes that could result in an hour missing
+  from scheduled downtimes. This fix applies to time periods as well. #9246
+* Fix a bug where downtimes on the day after a daylight saving time change could be off by an hour. #9253
+
+### Configuration
+
+* Fix the evaluation order of default templates when used in combination with apply rules.
+  Now default templates are imported first as stated in the documentation and
+  as it already happens for objects defined without using apply. #9294
+
+### IDO
+
+* Fix an issue where contacts were not written correctly to the notification history
+  if multiple IDO instances are active on the same node. #9243
+* Explicitly set the encoding for MySQL connections as a workaround for changed defaults
+  in Debian bullseye. #9313
+* Ship a MySQL schema upgrade that fixes inconsistent version information in the
+  full schema file and upgrade files which could have resulted in inaccurate reports
+  of an outdated schema version. #9140
+
+### Performance Data Writers
+
+* Fix a race condition in the InfluxDB Writers that could result in a crash. #9247
+* All writers no longer send metrics multiple times after HA failovers. #9329
+
+### Build
+
+* Fix the order of linker flags to fix builds on some ARM platforms. #9167
+* Fix an issue when building within an unrelated Git repository,
+  version information from that repository could incorrectly be used for Icinga 2. #9156
+* Windows: Update bundled Boost version to 1.78.0 and OpenSSL to 1.1.1n #9320 #9327
+
+### Internals
+
+* Fix some race conditions due to missing synchronization.
+  These race conditions should not have caused any practical problems
+  besides incorrect numbers in debug log message. #9305
+* Move the startup.log and status files created when validating incoming cluster config updates
+  to /var/lib/icinga2/api and always keep the last failed startup.log to ease debugging. #9336
+* Remove outdated and incorrect of the severity attributes #9244
+
+## 2.12.6 (2021-08-19)
 
 The main focus of these versions is a security vulnerability in the TLS certificate verification of our metrics writers ElasticsearchWriter, GelfWriter and InfluxdbWriter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,23 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
+## 2.12.10 (2023-02-16)
+
+This security release updates Boost and OpenSSL libraries bundled on Windows
+and repairs broken SELinux policies.
+
+### Security
+
+* Windows: update bundled OpenSSL to v1.1.1t. #9686
+
+### Bugfixes
+
+* SELinux: repair broken policies. #9689
+
+### Enhancements
+
+* Windows: update bundled Boost to v1.81. #9686
+
 ## 2.12.9 (2022-06-30)
 
 This release includes some fixes and a performance improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1052,6 +1052,19 @@ Thanks to all contributors:
 * Metrics
   * OpenTSDB-Writer: Remove incorrect space causing missing tag error #8245
 
+## 2.12.8 (2022-04-28)
+
+In the previous version 2.12.7, one bugfix was applied incorrectly. This is fixed by this release.
+
+### Downtimes
+
+* Scheduling downtimes for all children and all services no longer fails due to an object name conflict.
+  Only version 2.11.7 was affected by this issue. #9349
+
+### Windows
+
+* Update the bundled version of Boost to 1.79.0. #9359
+
 ## 2.12.7 (2022-04-14)
 
 This version includes bugfixes for many features of Icinga 2, including fixes for multiple crashes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,15 +233,27 @@ newer toolchains.
 
 ## 2.14.7 (2025-10-16)
 
-This version includes a fix for sending signals and updates dependencies used
-in Windows builds.
+This release fixes multiple security issues. Two of them allow authenticated
+API users to learn restricted information or crash Icinga 2. A third issue
+affects the scripts provided with Icinga 2 and allows a limited privilege
+escalation where the Icinga 2 daemon user can trick root into sending signals to
+arbitrary processes.
 
 Note that one fix affects the logrotate configuration. If it was modified
 locally, it might not be updated automatically by the package manager and
 applying the changes manually is necessary. For details, please check the
 [upgrading docs](https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/#upgrading-to-2-15-1).
 
-* Don't send signals as root in safe-reload script and logrotate config. #10597
+* CVE-2025-61907: Prevent API users from accessing variables and objects they
+  don't have access to within filter expressions. This allowed authenticated
+  API users to learn information they aren't allowed to access directly.
+* CVE-2025-61908: Add a missing null pointer check while evaluating
+  expressions. This allowed authenticated API users to crash the Icinga 2
+  daemon by supplying a crafted filter expression.
+* CVE-2025-61909: Don't send signals as root in safe-reload script and
+  logrotate config. This allowed a limited privilege escalation from the Icinga
+  2 service user to root. The scope is limited to sending SIGHUP or SIGUSR1 to
+  an arbitrary process. #10597
 * Windows: Update to OpenSSL 3.0.18. #10595
 * Windows: upgrade build toolchain to Visual Studio 2022. #10594
 

--- a/ICINGA2_VERSION
+++ b/ICINGA2_VERSION
@@ -1,2 +1,2 @@
-Version: 2.15.0
+Version: 2.15.1
 Revision: 1

--- a/ICINGA2_VERSION
+++ b/ICINGA2_VERSION
@@ -1,2 +1,2 @@
-Version: 2.15.1
+Version: 2.15.0
 Revision: 1


### PR DESCRIPTION
Forward ported all missing changelog entries of: `v2.15.1`, `v2.15.2`, `v2.14.7`, `v2.14.8`, `v2.13.13`, `v2.13.14`, `v2.12.6`, `v2.12.7`, `v2.12.8`, `v2.12.9`, `v2.12.10`, `v2.12.11`, `v2.12.12`.