### PR TITLE
Fix remaining issues with parallel unit-tests and enable in CI

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -37,6 +37,7 @@ case "$DISTRO" in
     )
 
     ln -vs /usr/bin/cmake3 /usr/local/bin/cmake
+    ln -vs /usr/bin/ctest3 /usr/local/bin/ctest
     ln -vs /usr/bin/ninja-build /usr/local/bin/ninja
     CMAKE_OPTS+=(-DBOOST_{INCLUDEDIR=/boost_1_69_0,LIBRARYDIR=/boost_1_69_0/stage/lib})
     export LD_LIBRARY_PATH=/boost_1_69_0/stage/lib
@@ -117,6 +118,6 @@ cmake \
 
 ninja -v
 
-ninja test
+ctest -j$(nproc) --output-on-failure
 ninja install
 icinga2 daemon -C

--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -38,6 +38,7 @@ case "$DISTRO" in
     )
 
     ln -vs /usr/bin/cmake3 /usr/local/bin/cmake
+    ln -vs /usr/bin/ctest3 /usr/local/bin/ctest
     ln -vs /usr/bin/ninja-build /usr/local/bin/ninja
     CMAKE_OPTS+=(-DBOOST_{INCLUDEDIR=/boost_1_69_0,LIBRARYDIR=/boost_1_69_0/stage/lib})
     export LD_LIBRARY_PATH=/boost_1_69_0/stage/lib
@@ -154,6 +155,6 @@ cd /icinga2/build
 
 ninja -v
 
-ninja test
+ctest -j$(nproc) --output-on-failure
 ninja install
 icinga2 daemon -C

--- a/Containerfile
+++ b/Containerfile
@@ -128,7 +128,7 @@ RUN --mount=type=bind,source=.,target=/icinga2,readonly \
         -DICINGA2_WITH_LIVESTATUS=OFF && \
     make -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") && \
     if [ "${ICINGA2_BUILD_TESTING}" = ON ]; then \
-        ctest -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") --output-on-failure; \
+        ctest -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") --verbose; \
     fi && \
     make install DESTDIR=/icinga2-install
 

--- a/Containerfile
+++ b/Containerfile
@@ -127,7 +127,9 @@ RUN --mount=type=bind,source=.,target=/icinga2,readonly \
         -DICINGA2_WITH_COMPAT=OFF \
         -DICINGA2_WITH_LIVESTATUS=OFF && \
     make -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") && \
-    if [ "${ICINGA2_BUILD_TESTING}" = ON ]; then CTEST_OUTPUT_ON_FAILURE=1 make test; fi && \
+    if [ "${ICINGA2_BUILD_TESTING}" = ON ]; then \
+        ctest -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") --output-on-failure; \
+    fi && \
     make install DESTDIR=/icinga2-install
 
 RUN rm -rf /icinga2-install/etc/icinga2/features-enabled/mainlog.conf \

--- a/Containerfile
+++ b/Containerfile
@@ -128,8 +128,11 @@ RUN --mount=type=bind,source=.,target=/icinga2,readonly \
         -DICINGA2_RUNDIR=/run \
         -DICINGA2_WITH_COMPAT=OFF \
         -DICINGA2_WITH_LIVESTATUS=OFF && \
-    make -j$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") && \
-    if [ "${ICINGA2_BUILD_TESTING}" = ON ]; then CTEST_OUTPUT_ON_FAILURE=1 make test; fi && \
+    JOBS=$([ "$MAKE_JOBS" = auto ] && nproc || echo "$MAKE_JOBS") && \
+    make -j"$JOBS" && \
+    if [ "${ICINGA2_BUILD_TESTING}" = ON ]; then \
+        ctest -j"$JOBS" --output-on-failure; \
+    fi && \
     make install DESTDIR=/icinga2-install
 
 RUN rm -rf /icinga2-install/etc/icinga2/features-enabled/mainlog.conf \

--- a/lib/base/tcpsocket.hpp
+++ b/lib/base/tcpsocket.hpp
@@ -83,6 +83,7 @@ void Connect(Socket& socket, const String& node, const String& service, boost::a
 
 			break;
 		} catch (const std::exception& ex) {
+			Log(LogDebug, "Connect") << "Execption: " << ex.what();
 			auto se (dynamic_cast<const boost::system::system_error*>(&ex));
 
 			if ((se && se->code() == boost::asio::error::operation_aborted) || ++current == result.end()) {

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -49,11 +49,12 @@ void GelfWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perf
 	for (const GelfWriter::Ptr& gelfwriter : ConfigType::GetObjectsByType<GelfWriter>()) {
 		size_t workQueueItems = gelfwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = gelfwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
+		auto connection = gelfwriter->m_LockedConnection.load();
 
 		nodes.emplace_back(gelfwriter->GetName(), new Dictionary({
 			{ "work_queue_items", workQueueItems },
 			{ "work_queue_item_rate", workQueueItemRate },
-			{ "connected", gelfwriter->m_Connection->IsConnected() },
+			{ "connected", connection && connection->IsConnected() },
 			{ "source", gelfwriter->GetSource() }
 		}));
 
@@ -90,7 +91,8 @@ void GelfWriter::Resume()
 	/* Register exception handler for WQ tasks. */
 	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
-	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort(), m_SslContext, !GetInsecureNoverify()};
+	m_LockedConnection.store(new PerfdataWriterConnection{this, GetHost(), GetPort(), m_SslContext, !GetInsecureNoverify()});
+	m_Connection = m_LockedConnection.load();
 
 	/* Register event handlers. */
 	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -34,6 +34,7 @@ protected:
 
 private:
 	PerfdataWriterConnection::Ptr m_Connection;
+	Locked<PerfdataWriterConnection::Ptr> m_LockedConnection;
 	WorkQueue m_WorkQueue{10000000, 1};
 	Shared<boost::asio::ssl::context>::Ptr m_SslContext;
 

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -58,11 +58,12 @@ void GraphiteWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& 
 	for (const GraphiteWriter::Ptr& graphitewriter : ConfigType::GetObjectsByType<GraphiteWriter>()) {
 		size_t workQueueItems = graphitewriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = graphitewriter->m_WorkQueue.GetTaskCount(60) / 60.0;
+		auto connection = graphitewriter->m_LockedConnection.load();
 
 		nodes.emplace_back(graphitewriter->GetName(), new Dictionary({
 			{ "work_queue_items", workQueueItems },
 			{ "work_queue_item_rate", workQueueItemRate },
-			{ "connected", graphitewriter->m_Connection->IsConnected() }
+			{ "connected", connection && connection->IsConnected() }
 		}));
 
 		perfdata->Add(new PerfdataValue("graphitewriter_" + graphitewriter->GetName() + "_work_queue_items", workQueueItems));
@@ -85,7 +86,8 @@ void GraphiteWriter::Resume()
 	/* Register exception handler for WQ tasks. */
 	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
-	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort()};
+	m_LockedConnection.store(new PerfdataWriterConnection{this, GetHost(), GetPort()});
+	m_Connection = m_LockedConnection.load();
 
 	/* Register event handlers. */
 	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -36,6 +36,7 @@ protected:
 
 private:
 	PerfdataWriterConnection::Ptr m_Connection;
+	Locked<PerfdataWriterConnection::Ptr> m_LockedConnection;
 	WorkQueue m_WorkQueue{10000000, 1};
 
 	boost::signals2::connection m_HandleCheckResults;

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -55,11 +55,12 @@ void OpenTsdbWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& 
 	for (const OpenTsdbWriter::Ptr& opentsdbwriter : ConfigType::GetObjectsByType<OpenTsdbWriter>()) {
 		size_t workQueueItems = opentsdbwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = opentsdbwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
+		auto connection = opentsdbwriter->m_LockedConnection.load();
 
 		nodes.emplace_back(
 			opentsdbwriter->GetName(),
 			new Dictionary({
-			{ "connected", opentsdbwriter->m_Connection->IsConnected() },
+			{ "connected", connection && connection->IsConnected() },
 				{"work_queue_items", workQueueItems},
 				{"work_queue_item_rate", workQueueItemRate}
 				}
@@ -90,7 +91,8 @@ void OpenTsdbWriter::Resume()
 
 	ReadConfigTemplate();
 
-	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort()};
+	m_LockedConnection.store(new PerfdataWriterConnection{this, GetHost(), GetPort()});
+	m_Connection = m_LockedConnection.load();
 
 	m_HandleCheckResults = Service::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
 		CheckResultHandler(checkable, cr);

--- a/lib/perfdata/opentsdbwriter.hpp
+++ b/lib/perfdata/opentsdbwriter.hpp
@@ -37,6 +37,7 @@ private:
 	WorkQueue m_WorkQueue{10000000, 1};
 	std::string m_MsgBuf;
 	PerfdataWriterConnection::Ptr m_Connection;
+	Locked<PerfdataWriterConnection::Ptr> m_LockedConnection;
 
 	boost::signals2::connection m_HandleCheckResults;
 

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -69,6 +69,7 @@ void PerfdataWriterConnection::Disconnect()
 	std::promise<void> promise;
 
 	IoEngine::SpawnCoroutine(m_Strand, [&](boost::asio::yield_context yc) {
+		Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Disconnect::1";
 		try {
 			/* Cancel any outstanding operations of the other coroutine.
 			 * Since we're on the same strand we're hopefully guaranteed that all cancellations
@@ -85,9 +86,12 @@ void PerfdataWriterConnection::Disconnect()
 			);
 			m_ReconnectTimer.cancel();
 
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Disconnect::3";
 			Disconnect(std::move(yc));
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Disconnect::4";
 			promise.set_value();
 		} catch (const std::exception& ex) {
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Disconnect::5";
 			promise.set_exception(std::current_exception());
 		}
 	});
@@ -130,12 +134,16 @@ void PerfdataWriterConnection::EnsureConnected(const boost::asio::yield_context&
 
 	std::visit(
 		[&](auto& stream) {
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::EnsureConnected::1";
 			::Connect(stream->lowest_layer(), m_Host, m_Port, yc);
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::EnsureConnected::2";
 
 			if constexpr (std::is_same_v<std::decay_t<decltype(stream)>, Shared<AsioTlsStream>::Ptr>) {
+				Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::EnsureConnected::3";
 				using type = boost::asio::ssl::stream_base::handshake_type;
 
 				stream->next_layer().async_handshake(type::client, yc);
+				Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::EnsureConnected::4";
 
 				if (m_VerifyPeerCertificate) {
 					if (!stream->next_layer().IsVerifyOK()) {

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -173,8 +173,9 @@ void PerfdataWriterConnection::Disconnect(boost::asio::yield_context yc)
 			if constexpr (std::is_same_v<std::decay_t<decltype(stream)>, Shared<AsioTlsStream>::Ptr>) {
 				stream->GracefulDisconnect(m_Strand, yc);
 			} else {
-				stream->lowest_layer().shutdown(boost::asio::socket_base::shutdown_both);
-				stream->lowest_layer().close();
+				boost::system::error_code ec;
+				stream->lowest_layer().shutdown(boost::asio::socket_base::shutdown_both, ec);
+				stream->lowest_layer().close(ec);
 			}
 		},
 		m_Stream

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -76,9 +76,13 @@ void PerfdataWriterConnection::Disconnect()
 			 * completion.
 			 */
 			std::visit(
-				[](const auto& stream) {
+				[&](const auto& stream) {
 					if (stream->lowest_layer().is_open()) {
-						stream->lowest_layer().cancel();
+						if (m_Connected) {
+							stream->lowest_layer().cancel();
+						} else {
+							stream->lowest_layer().close();
+						}
 					}
 				},
 				m_Stream
@@ -160,7 +164,7 @@ void PerfdataWriterConnection::EnsureConnected(const boost::asio::yield_context&
 
 void PerfdataWriterConnection::Disconnect(boost::asio::yield_context yc)
 {
-	if (!m_Connected.exchange(false, std::memory_order_relaxed)) {
+	if (!m_Connected.exchange(false)) {
 		return;
 	}
 

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -66,7 +66,7 @@ void PerfdataWriterConnection::Disconnect()
 		return;
 	}
 
-	std::promise<void> promise;
+	SyncResult<void> ret;
 
 	IoEngine::SpawnCoroutine(m_Strand, [&](boost::asio::yield_context yc) {
 		try {
@@ -90,13 +90,13 @@ void PerfdataWriterConnection::Disconnect()
 			m_ReconnectTimer.cancel();
 
 			Disconnect(std::move(yc));
-			promise.set_value();
+			ret.SetValue();
 		} catch (const std::exception& ex) {
-			promise.set_exception(std::current_exception());
+			ret.SetException(std::current_exception());
 		}
 	});
 
-	promise.get_future().get();
+	ret.Get();
 }
 
 AsioTlsOrTcpStream PerfdataWriterConnection::MakeStream() const

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -62,7 +62,7 @@ bool PerfdataWriterConnection::IsStopped() const
 
 void PerfdataWriterConnection::Disconnect()
 {
-	if (m_Stopped.exchange(true, std::memory_order_relaxed)) {
+	if (m_Stopped.exchange(true)) {
 		return;
 	}
 
@@ -133,6 +133,10 @@ void PerfdataWriterConnection::EnsureConnected(const boost::asio::yield_context&
 			::Connect(stream->lowest_layer(), m_Host, m_Port, yc);
 
 			if constexpr (std::is_same_v<std::decay_t<decltype(stream)>, Shared<AsioTlsStream>::Ptr>) {
+				if (m_Stopped) {
+					BOOST_THROW_EXCEPTION(Stopped{});
+				}
+
 				using type = boost::asio::ssl::stream_base::handshake_type;
 
 				stream->next_layer().async_handshake(type::client, yc);

--- a/lib/perfdata/perfdatawriterconnection.hpp
+++ b/lib/perfdata/perfdatawriterconnection.hpp
@@ -61,20 +61,28 @@ public:
 	template<typename Buffer>
 	auto Send(Buffer&& buf)
 	{
+		Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::1";
 		if (m_Stopped) {
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::1.1";
 			BOOST_THROW_EXCEPTION(Stopped{});
 		}
+		Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::2";
 
 		using RetType = decltype(WriteMessage(std::declval<Buffer>(), std::declval<boost::asio::yield_context>()));
 		std::promise<RetType> promise;
 
 		IoEngine::SpawnCoroutine(m_Strand, [&](boost::asio::yield_context yc) {
+			Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::3";
+
 			while (true) {
 				try {
+					Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::5";
 					EnsureConnected(yc);
+					Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::6";
 
 					if constexpr (std::is_void_v<RetType>) {
 						WriteMessage(std::forward<Buffer>(buf), yc);
+						Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::7";
 						promise.set_value();
 					} else {
 						promise.set_value(WriteMessage(std::forward<Buffer>(buf), yc));
@@ -83,7 +91,9 @@ public:
 					m_RetryTimeout = InitialRetryWait;
 					return;
 				} catch (const std::exception& ex) {
+					Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::8";
 					if (m_Stopped) {
+						Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::8.1";
 						promise.set_exception(std::make_exception_ptr(Stopped{}));
 						return;
 					}
@@ -96,8 +106,11 @@ public:
 					m_Connected = false;
 
 					try {
+						Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::9";
 						BackoffWait(yc);
+						Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::10";
 					} catch (const std::exception&) {
+						Log(LogDebug, m_LogFacility) << "PerfdataWriterConnection::Send::11";
 						promise.set_exception(std::make_exception_ptr(Stopped{}));
 						return;
 					}

--- a/lib/perfdata/perfdatawriterconnection.hpp
+++ b/lib/perfdata/perfdatawriterconnection.hpp
@@ -10,6 +10,7 @@
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
 #include <future>
+#include <utility>
 
 namespace icinga {
 
@@ -20,6 +21,56 @@ class PerfdataWriterConnection final : public Object
 {
 	static constexpr auto InitialRetryWait = 50ms;
 	static constexpr auto FinalRetryWait = 32s;
+
+	template<typename T>
+	class SyncResult
+	{
+		using ValueType = std::variant<std::monostate, std::conditional_t<std::is_void_v<T>, bool, T>, std::exception_ptr>;
+
+	public:
+		template<typename U, typename V = T, typename = std::enable_if_t<!std::is_void_v<V>>>
+		void SetValue(U&& v)
+		{
+			std::lock_guard lock(m_Mutex);
+			m_Value = std::forward<U>(v);
+			m_Cv.notify_one();
+		}
+
+		template<typename V = T, typename = std::enable_if_t<std::is_void_v<V>>>
+		void SetValue()
+		{
+			std::lock_guard lock(m_Mutex);
+			m_Value = true;
+			m_Cv.notify_one();
+		}
+
+		void SetException(std::exception_ptr ep)
+		{
+			std::lock_guard lock(m_Mutex);
+			m_Value = ValueType{ep};
+			m_Cv.notify_one();
+		}
+
+		T Get()
+		{
+			std::unique_lock l(m_Mutex);
+			m_Cv.wait(l, [&] { return !std::holds_alternative<std::monostate>(m_Value); });
+			if (std::holds_alternative<std::exception_ptr>(m_Value)) {
+				std::rethrow_exception(std::get<std::exception_ptr>(m_Value));
+			}
+
+			if constexpr (std::is_void_v<T>) {
+				return;
+			} else {
+				return std::move(std::get<T>(m_Value));
+			}
+		}
+
+	private:
+		std::mutex m_Mutex;
+		std::condition_variable m_Cv;
+		ValueType m_Value;
+	};
 
 public:
 	DECLARE_PTR_TYPEDEFS(PerfdataWriterConnection);
@@ -66,7 +117,7 @@ public:
 		}
 
 		using RetType = decltype(WriteMessage(std::declval<Buffer>(), std::declval<boost::asio::yield_context>()));
-		std::promise<RetType> promise;
+		SyncResult<RetType> ret;
 
 		IoEngine::SpawnCoroutine(m_Strand, [&](boost::asio::yield_context yc) {
 			while (true) {
@@ -75,16 +126,16 @@ public:
 
 					if constexpr (std::is_void_v<RetType>) {
 						WriteMessage(std::forward<Buffer>(buf), yc);
-						promise.set_value();
+						ret.SetValue();
 					} else {
-						promise.set_value(WriteMessage(std::forward<Buffer>(buf), yc));
+						ret.SetValue(WriteMessage(std::forward<Buffer>(buf), yc));
 					}
 
 					m_RetryTimeout = InitialRetryWait;
 					return;
 				} catch (const std::exception& ex) {
 					if (m_Stopped) {
-						promise.set_exception(std::make_exception_ptr(Stopped{}));
+						ret.SetException(std::make_exception_ptr(Stopped{}));
 						return;
 					}
 
@@ -98,14 +149,14 @@ public:
 					try {
 						BackoffWait(yc);
 					} catch (const std::exception&) {
-						promise.set_exception(std::make_exception_ptr(Stopped{}));
+						ret.SetException(std::make_exception_ptr(Stopped{}));
 						return;
 					}
 				}
 			}
 		});
 
-		return promise.get_future().get();
+		return ret.Get();
 	}
 
 	void Disconnect();

--- a/test/base-timer.cpp
+++ b/test/base-timer.cpp
@@ -10,7 +10,7 @@
  * Windows needs a special handicap to keep up with the other OSs.
  */
 #ifdef _WIN32
-static constexpr double timeMultiplier = 10;
+static constexpr double timeMultiplier = 5;
 #else //_WIN32
 static constexpr double timeMultiplier = 1;
 #endif //_WIN32
@@ -38,10 +38,10 @@ BOOST_AUTO_TEST_CASE(invoke)
 
 	Timer::Ptr timer = Timer::Create();
 	timer->OnTimerExpired.connect([&counter](const Timer* const&) { counter++; });
-	timer->SetInterval(.1 * timeMultiplier);
+	timer->SetInterval(.2 * timeMultiplier);
 
 	timer->Start();
-	Utility::Sleep(.55 * timeMultiplier);
+	Utility::Sleep(1.1 * timeMultiplier);
 	timer->Stop();
 
 	// At this point, the timer should have fired exactly 5 times (0.5 / 0.1) and the sixth time
@@ -55,12 +55,12 @@ BOOST_AUTO_TEST_CASE(scope)
 
 	Timer::Ptr timer = Timer::Create();
 	timer->OnTimerExpired.connect([&counter](const Timer* const&) { counter++; });
-	timer->SetInterval(.1 * timeMultiplier);
+	timer->SetInterval(.2 * timeMultiplier);
 
 	timer->Start();
-	Utility::Sleep(.55 * timeMultiplier);
+	Utility::Sleep(1.1 * timeMultiplier);
 	timer.reset();
-	Utility::Sleep(.1 * timeMultiplier);
+	Utility::Sleep(.2 * timeMultiplier);
 
 	// At this point, the timer should have fired exactly 5 times (0.5 / 0.1) and the sixth time
 	// should not have fired yet as we destroyed the timer after 0.55 seconds (0.6 would be needed),

--- a/test/perfdata-elasticsearchwriter.cpp
+++ b/test/perfdata-elasticsearchwriter.cpp
@@ -45,13 +45,13 @@ BOOST_AUTO_TEST_CASE(pause_with_pending_work)
 	ResumeWriter();
 
 	// Process check-results until the writer is stuck.
-	BOOST_REQUIRE_MESSAGE(GetWriterStuck(10s), "Failed to get Writer stuck.");
+	BOOST_REQUIRE_MESSAGE(GetWriterStuck(20s), "Failed to get Writer stuck.");
 
 	// Now try to pause.
 	PauseWriter();
 
 	REQUIRE_LOG_MESSAGE("Connection stopped\\.", 10s);
-	REQUIRE_LOG_MESSAGE("'ElasticsearchWriter' paused\\.", 10s);
+	REQUIRE_LOG_MESSAGE("'ElasticsearchWriter' paused\\.", 1s);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/perfdata-gelfwriter.cpp
+++ b/test/perfdata-gelfwriter.cpp
@@ -36,12 +36,12 @@ BOOST_AUTO_TEST_CASE(pause_with_pending_work)
 	ResumeWriter();
 
 	// Process check-results until the writer is stuck.
-	BOOST_REQUIRE_MESSAGE(GetWriterStuck(10s), "Failed to get Writer stuck.");
+	BOOST_REQUIRE_MESSAGE(GetWriterStuck(20s), "Failed to get Writer stuck.");
 
 	// Now stop reading and try to pause OpenTsdbWriter.
 	PauseWriter();
 
-	REQUIRE_LOG_MESSAGE("Connection stopped\\.", 1s);
+	REQUIRE_LOG_MESSAGE("Connection stopped\\.", 10s);
 	REQUIRE_LOG_MESSAGE("'GelfWriter' paused\\.", 1s);
 }
 

--- a/test/perfdata-graphitewriter.cpp
+++ b/test/perfdata-graphitewriter.cpp
@@ -35,13 +35,13 @@ BOOST_AUTO_TEST_CASE(pause_with_pending_work)
 	ResumeWriter();
 
 	// Process check-results until the writer is stuck.
-	BOOST_REQUIRE_MESSAGE(GetWriterStuck(10s), "Failed to get Writer stuck.");
+	BOOST_REQUIRE_MESSAGE(GetWriterStuck(20s), "Failed to get Writer stuck.");
 
 	// Now stop reading and try to pause OpenTsdbWriter.
 	PauseWriter();
 
 	REQUIRE_LOG_MESSAGE("Connection stopped\\.", 10s);
-	REQUIRE_LOG_MESSAGE("'GraphiteWriter' paused\\.", 10s);
+	REQUIRE_LOG_MESSAGE("'GraphiteWriter' paused\\.", 1s);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/perfdata-influxdbwriter.cpp
+++ b/test/perfdata-influxdbwriter.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(pause_with_pending_work)
 	ResumeWriter();
 
 	// Process check-results until the writer is stuck.
-	BOOST_REQUIRE_MESSAGE(GetWriterStuck(10s), "Failed to get Writer stuck.");
+	BOOST_REQUIRE_MESSAGE(GetWriterStuck(20s), "Failed to get Writer stuck.");
 
 	// Now try to pause.
 	PauseWriter();

--- a/test/perfdata-opentsdbwriter.cpp
+++ b/test/perfdata-opentsdbwriter.cpp
@@ -41,13 +41,13 @@ BOOST_AUTO_TEST_CASE(pause_with_pending_work)
 	ResumeWriter();
 
 	// Process check-results until the writer is stuck.
-	BOOST_REQUIRE_MESSAGE(GetWriterStuck(10s), "Failed to get Writer stuck.");
+	BOOST_REQUIRE_MESSAGE(GetWriterStuck(20s), "Failed to get Writer stuck.");
 
 	// Now stop reading and try to pause OpenTsdbWriter.
 	PauseWriter();
 
 	REQUIRE_LOG_MESSAGE("Connection stopped\\.", 10s);
-	REQUIRE_LOG_MESSAGE("'OpenTsdbWriter' paused\\.", 10s);
+	REQUIRE_LOG_MESSAGE("'OpenTsdbWriter' paused\\.", 1s);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/perfdata-perfdatatargetfixture.hpp
+++ b/test/perfdata-perfdatatargetfixture.hpp
@@ -39,16 +39,24 @@ public:
 	explicit PerfdataWriterTargetFixture(AsioTlsOrTcpStream stream)
 		: m_Stream(std::move(stream)),
 		  m_Acceptor(
-			  IoEngine::Get().GetIoContext(),
-			  boost::asio::ip::tcp::endpoint{boost::asio::ip::address_v4::loopback(), 0}
+			  IoEngine::Get().GetIoContext()
 		  )
 	{
+		boost::asio::ip::tcp::endpoint ep{boost::asio::ip::address_v4::loopback(), 0};
+		m_Acceptor.open(ep.protocol());
+		m_Acceptor.bind(ep);
 	}
 
 	unsigned short GetPort() { return m_Acceptor.local_endpoint().port(); }
 
+	void Listen()
+	{
+		m_Acceptor.listen();
+	}
+
 	void Accept()
 	{
+		Listen();
 		BOOST_REQUIRE_NO_THROW(
 			std::visit([&](auto& stream) { return m_Acceptor.accept(stream->lowest_layer()); }, m_Stream)
 		);
@@ -63,11 +71,20 @@ public:
 		BOOST_REQUIRE(stream->next_layer().IsVerifyOK());
 	}
 
-	void Shutdown()
+	void Shutdown(bool wait = false)
 	{
 		BOOST_REQUIRE(std::holds_alternative<Shared<AsioTlsStream>::Ptr>(m_Stream));
 		auto& stream = std::get<Shared<AsioTlsStream>::Ptr>(m_Stream);
 		try {
+			if (wait) {
+				std::array<std::byte, 128> buf{};
+				boost::asio::mutable_buffer readBuf (buf.data(), buf.size());
+				boost::system::error_code ec;
+
+				do {
+					stream->read_some(readBuf, ec);
+				} while (!ec);
+			}
 			stream->next_layer().shutdown();
 		} catch (const std::exception& ex) {
 			if (const auto* se = dynamic_cast<const boost::system::system_error*>(&ex);

--- a/test/perfdata-perfdatatargetfixture.hpp
+++ b/test/perfdata-perfdatatargetfixture.hpp
@@ -71,11 +71,20 @@ public:
 		BOOST_REQUIRE(stream->next_layer().IsVerifyOK());
 	}
 
-	void Shutdown()
+	void Shutdown(bool wait = false)
 	{
 		BOOST_REQUIRE(std::holds_alternative<Shared<AsioTlsStream>::Ptr>(m_Stream));
 		auto& stream = std::get<Shared<AsioTlsStream>::Ptr>(m_Stream);
 		try {
+			if (wait) {
+				std::array<std::byte, 128> buf{};
+				boost::asio::mutable_buffer readBuf (buf.data(), buf.size());
+				boost::system::error_code ec;
+
+				do {
+					stream->read_some(readBuf, ec);
+				} while (!ec);
+			}
 			stream->next_layer().shutdown();
 		} catch (const std::exception& ex) {
 			if (const auto* se = dynamic_cast<const boost::system::system_error*>(&ex);

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -130,10 +130,9 @@ BOOST_AUTO_TEST_CASE(finish_during_timeout)
  */
 BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 {
-	TestThread mockTargetThread{[&]() { Accept(); }};
-
 	std::promise<void> p;
 	TestThread timeoutThread{[&]() {
+		Accept();
 		auto f = p.get_future();
 		GetConnection().CancelAfterTimeout(f, 50ms);
 		BOOST_REQUIRE(f.wait_for(0ms) == std::future_status::timeout);
@@ -144,7 +143,6 @@ BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 	);
 
 	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
 }
 
 /* When the disconnect timeout runs out while sending something to a slow or blocking server, we

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -130,19 +130,29 @@ BOOST_AUTO_TEST_CASE(finish_during_timeout)
  */
 BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 {
+	Logger::SetConsoleLogSeverity(LogDebug);
+	Logger::EnableConsoleLog();
+	Log(LogDebug, "stuck_in_handshake") << "1";
 	std::promise<void> p;
 	TestThread timeoutThread{[&]() {
+		Log(LogDebug, "stuck_in_handshake") << "2";
 		Accept();
+		Log(LogDebug, "stuck_in_handshake") << "3";
 		auto f = p.get_future();
 		GetConnection().CancelAfterTimeout(f, 50ms);
+		Log(LogDebug, "stuck_in_handshake") << "4";
 		BOOST_REQUIRE(f.wait_for(0ms) == std::future_status::timeout);
+		Log(LogDebug, "stuck_in_handshake") << "5";
 	}};
 
+	Log(LogDebug, "stuck_in_handshake") << "6";
 	BOOST_REQUIRE_THROW(
 		GetConnection().Send(boost::asio::const_buffer{"foobar", 7}), PerfdataWriterConnection::Stopped
 	);
+	Log(LogDebug, "stuck_in_handshake") << "7";
 
 	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
+	Log(LogDebug, "stuck_in_handshake") << "8";
 }
 
 /* When the disconnect timeout runs out while sending something to a slow or blocking server, we

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -56,14 +56,14 @@ BOOST_AUTO_TEST_CASE(connection_refused)
 	std::promise<void> p;
 	TestThread timeoutThread{[&]() {
 		auto f = p.get_future();
-		GetConnection().CancelAfterTimeout(f, 50ms);
+		GetConnection().CancelAfterTimeout(f, 250ms);
 	}};
 
 	BOOST_REQUIRE_THROW(
 		GetConnection().Send(boost::asio::const_buffer{"foobar", 7}), PerfdataWriterConnection::Stopped
 	);
 
-	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
+	REQUIRE_JOINS_WITHIN(timeoutThread, 10s);
 }
 
 /* The PerfdataWriterConnection connects automatically when sending the first data.
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(ensure_connected)
 	BOOST_REQUIRE_NO_THROW(GetConnection().Disconnect());
 	disconnectedPromise.set_value();
 
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
+	REQUIRE_JOINS_WITHIN(mockTargetThread, 10s);
 }
 
 /* Verify that data can still be sent while CancelAfterTimeout is waiting and the timeout
@@ -113,15 +113,15 @@ BOOST_AUTO_TEST_CASE(finish_during_timeout)
 
 	TestThread timeoutThread{[&]() {
 		auto f = p.get_future();
-		GetConnection().CancelAfterTimeout(f, 50ms);
+		GetConnection().CancelAfterTimeout(f, 250ms);
 		BOOST_REQUIRE(f.wait_for(0ms) == std::future_status::ready);
 		BOOST_REQUIRE(!GetConnection().IsConnected());
 	}};
 
 	GetConnection().Send(boost::asio::const_buffer{"foobar", 7});
 
-	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
+	REQUIRE_JOINS_WITHIN(timeoutThread, 10s);
+	REQUIRE_JOINS_WITHIN(mockTargetThread, 10s);
 }
 
 /* For the client, even a hanging server will accept the connection immediately, since it's done
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 	TestThread timeoutThread{[&]() {
 		Accept();
 		auto f = p.get_future();
-		GetConnection().CancelAfterTimeout(f, 50ms);
+		GetConnection().CancelAfterTimeout(f, 250ms);
 		BOOST_REQUIRE(f.wait_for(0ms) == std::future_status::timeout);
 	}};
 
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 		GetConnection().Send(boost::asio::const_buffer{"foobar", 7}), PerfdataWriterConnection::Stopped
 	);
 
-	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
+	REQUIRE_JOINS_WITHIN(timeoutThread, 10s);
 }
 
 /* When the disconnect timeout runs out while sending something to a slow or blocking server, we
@@ -185,8 +185,8 @@ BOOST_AUTO_TEST_CASE(stuck_sending)
 	BOOST_REQUIRE_THROW(GetConnection().Send(buf), PerfdataWriterConnection::Stopped);
 	shutdownPromise.set_value();
 
-	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
+	REQUIRE_JOINS_WITHIN(timeoutThread, 10s);
+	REQUIRE_JOINS_WITHIN(mockTargetThread, 10s);
 }
 
 /* This simulates a server that is stuck after receiving a HTTP request and before sending their
@@ -226,8 +226,8 @@ BOOST_AUTO_TEST_CASE(stuck_reading_response)
 	BOOST_REQUIRE_THROW(GetConnection().Send(request), PerfdataWriterConnection::Stopped);
 	shutdownPromise.set_value();
 
-	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
+	REQUIRE_JOINS_WITHIN(timeoutThread, 10s);
+	REQUIRE_JOINS_WITHIN(mockTargetThread, 10s);
 }
 
 /* This test simulates a server that closes the connection and reappears at a later time.
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(reconnect_failed)
 	BOOST_REQUIRE_NO_THROW(GetConnection().Send(boost::asio::const_buffer{randomData.data(), randomData.size()}));
 	BOOST_REQUIRE_NO_THROW(GetConnection().Disconnect());
 
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
+	REQUIRE_JOINS_WITHIN(mockTargetThread, 10s);
 }
 
 /* This tests if retrying an http send will reproducibly lead to the exact same message being
@@ -329,7 +329,7 @@ BOOST_AUTO_TEST_CASE(http_send_retry)
 	BOOST_REQUIRE_NO_THROW(GetConnection().Send(request));
 	BOOST_REQUIRE_NO_THROW(GetConnection().Disconnect());
 
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
+	REQUIRE_JOINS_WITHIN(mockTargetThread, 10s);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(stuck_reading_response)
 		requestReadPromise.set_value();
 		// Do not send a response but react to the shutdown to be polite.
 		shutdownPromise.get_future().get();
-		Shutdown();
+		Shutdown(true);
 	}};
 
 	TestThread timeoutThread{[&]() {
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(http_send_retry)
 
 		SendResponse();
 
-		Shutdown();
+		Shutdown(true);
 	}};
 
 	boost::beast::http::request<boost::beast::http::string_body> request{boost::beast::http::verb::post, "foo", 10};

--- a/test/perfdata-perfdatawriterfixture.hpp
+++ b/test/perfdata-perfdatawriterfixture.hpp
@@ -121,6 +121,7 @@ object Host "h1" {
 
 	void ResumeWriter()
 	{
+		Listen();
 		static_cast<ConfigObject::Ptr>(m_Writer)->OnConfigLoaded();
 		m_Writer->SetActive(true);
 		m_Writer->Activate();


### PR DESCRIPTION
### Description

This PR enables and fixes parallel unit-test execution on the Github Runners.

It has been split off from #10767 because the debugging loop around the ARM64 container image was very time intensive and was holding up the review of the PR. Also, more fixes will be necessary than fit into the scope of that PR.

Fixes #10811. (though most of the actual fixes are in #10849)