### PR TITLE
ITL: Update check_disk definition

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -420,29 +420,28 @@ disk\_wfree      	| **Optional.** The free space warning threshold. Defaults to 
 disk\_cfree      	| **Optional.** The free space critical threshold. Defaults to "10%". If the percent sign is omitted, units from `disk_units` are used.
 disk\_inode\_wfree 	| **Optional.** The free inode warning threshold.
 disk\_inode\_cfree 	| **Optional.** The free inode critical threshold.
-disk\_partition		| **Optional.** The partition. **Deprecated in 2.3.**
-disk\_partition\_excluded  | **Optional.** The excluded partition. **Deprecated in 2.3.**
 disk\_partitions 	| **Optional.** The partition(s). Multiple partitions must be defined as array.
 disk\_partitions\_excluded | **Optional.** The excluded partition(s). Multiple partitions must be defined as array.
 disk\_exact\_match      | **Optional.** For paths or partitions specified with -p, only check for exact paths. May be true or false.
 disk\_errors\_only      | **Optional.** Display only devices/mountpoints with errors. May be true or false.
 disk\_ignore\_reserved  | **Optional.** If set, account root-reserved blocks are not accounted for freespace in perfdata. May be true or false.
+disk\_inode\_perfdata   | **Optional.** Display inode usage in perfdata. (Monitoring Plugins only)
 disk\_group             | **Optional.** Group paths. Thresholds apply to (free-)space of all partitions together.
-disk\_kilobytes         | **Optional.** Same as --units kB. May be true or false.
 disk\_local             | **Optional.** Only check local filesystems. May be true or false.
 disk\_stat\_remote\_fs  | **Optional.** Only check local filesystems against thresholds. Yet call stat on remote filesystems to test if they are accessible (e.g. to detect Stale NFS Handles). May be true or false.
 disk\_mountpoint          | **Optional.** Display the mountpoint instead of the partition. May be true or false.
-disk\_megabytes           | **Optional.** Same as --units MB. May be true or false.
 disk\_all                 | **Optional.** Explicitly select all paths. This is equivalent to -R '.\*'. May be true or false.
 disk\_eregi\_path         | **Optional.** Case insensitive regular expression for path/partition. Multiple regular expression strings must be defined as array.
 disk\_ereg\_path          | **Optional.** Regular expression for path or partition. Multiple regular expression strings must be defined as array.
 disk\_ignore\_eregi\_path | **Optional.** Regular expression to ignore selected path/partition (case insensitive). Multiple regular expression strings must be defined as array.
 disk\_ignore\_ereg\_path  | **Optional.** Regular expression to ignore selected path or partition. Multiple regular expression strings must be defined as array.
+disk\_ignore\_missing\    | **Optional.** Return OK if no filesystem matches, filesystem does not exist or is inaccessible. (Monitoring Plugins only)
 disk\_timeout             | **Optional.** Seconds before connection times out (default: 10).
 disk\_units               | **Optional.** Choose bytes, kB, MB, GB, TB.
+disk\_kilobytes         | **Optional.** Same as --units kB. May be true or false.
+disk\_megabytes           | **Optional.** Same as --units MB. May be true or false.
 disk\_exclude\_type       | **Optional.** Ignore all filesystems of indicated type. Multiple regular expression strings must be defined as array. Defaults to "none", "tmpfs", "sysfs", "proc", "configfs", "devtmpfs", "devfs", "mtmfs", "tracefs", "cgroup", "fuse.\*" (only Monitoring Plugins support this so far), "fuse.gvfsd-fuse", "fuse.gvfs-fuse-daemon", "fuse.sshfs", "fdescfs", "overlay", "nsfs", "squashfs".
 disk\_include\_type       | **Optional.** Check only filesystems of indicated type. Multiple regular expression strings must be defined as array.
-disk\_inode\_perfdata     | **Optional.** Display inode usage in perfdata
 disk\_np\_inode\_perfdata | **Optional.** Enable performance data for inode-based statistics (Requires: nagios-plugins >= 2.3.0)
 disk\_extra\_opts         | **Optional.** Read extra plugin options from an ini file.
 

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -1637,9 +1637,6 @@ object CheckCommand "disk" {
 	command = [ PluginDir + "/check_disk" ]
 
 	arguments = {
-		/*
-		"-C" (disk_clear) is missing on purpose, since there is no useful use case possible the way check_disk is mapped here
-		*/
 		"--extra-opts" = {
 			value = "$disk_extra_opts$"
 			description = "Read extra plugin options from an ini file."
@@ -1666,21 +1663,13 @@ object CheckCommand "disk" {
 			description = "Exit with CRITICAL status if less than PERCENT of inode space is free"
 			order = -3
 		}
-		"-P" = {
-			description = "Display inode usage in perfdata"
-			set_if = "$disk_inode_perfdata$"
-		}
-		"--inode-perfdata" = {
-			description = "Enable performance data for inode-based statistics (nagios-plugins)"
-			set_if = "$disk_np_inode_perfdata$"
-		}
 		"-p" = {
 			value = "$disk_partitions$"
 			description = "Path or partition (may be repeated)"
 			repeat_key = true
 			order = 1
 		}
-		"-p_old" = {
+		"-p_old" = { /* Deprecated in 2.3. */
 			key = "-p"
 			value = "$disk_partition$"
 			order = 1
@@ -1689,10 +1678,13 @@ object CheckCommand "disk" {
 			value = "$disk_partitions_excluded$"
 			description = "Ignore device (only works if -p unspecified)"
 		}
-		"-x_old" = {
+		"-x_old" = { /* Deprecated in 2.3. */
 			key = "-x"
 			value = "$disk_partition_excluded$"
 		}
+		/*
+		"-C" (disk_clear) is missing on purpose, since there is no useful use case possible the way check_disk is mapped here
+		*/
 		"-E" = {
 			set_if = "$disk_exact_match$"
 			description = "For paths or partitions specified with -p, only check for exact paths"
@@ -1705,13 +1697,13 @@ object CheckCommand "disk" {
 			set_if = "$disk_ignore_reserved$"
 			description = "Don't account root-reserved blocks into freespace in perfdata"
 		}
+		"-P" = { /* Monitoring Plugins only */
+			description = "Display inode usage in perfdata (Monitoring Plugins)"
+			set_if = "$disk_inode_perfdata$"
+		}
 		"-g" = {
 			value = "$disk_group$"
 			description = "Group paths. Thresholds apply to (free-)space of all partitions together"
-		}
-		"-k" = {
-			set_if = "$disk_kilobytes$"
-			description = "Same as --units kB"
 		}
 		"-l" = {
 			set_if = "$disk_local$"
@@ -1724,10 +1716,6 @@ object CheckCommand "disk" {
 		"-M" = {
 			set_if = "$disk_mountpoint$"
 			description = "Display the mountpoint instead of the partition"
-		}
-		"-m" = {
-			set_if = "$disk_megabytes$"
-			description = "Same as --units MB"
 		}
 		"-A" = {
 			set_if = "$disk_all$"
@@ -1756,6 +1744,11 @@ object CheckCommand "disk" {
 			repeat_key = true
 			order = 2
 		}
+		"-n" = { /* Monitoring Plugins only */
+			value = "$disk_ignore_missing$"
+			description = "Return OK if no filesystem matches, filesystem does not exist or is inaccessible (Monitoring Plugins)"
+			order = -1
+		}
 		"-t" = {
 			value = "$disk_timeout$"
 			description = "Seconds before connection times out (default: 10)"
@@ -1763,6 +1756,14 @@ object CheckCommand "disk" {
 		"-u" = {
 			value = "$disk_units$"
 			description = "Choose bytes, kB, MB, GB, TB"
+		}
+		"-k" = {
+			set_if = "$disk_kilobytes$"
+			description = "Same as --units kB"
+		}
+		"-m" = {
+			set_if = "$disk_megabytes$"
+			description = "Same as --units MB"
 		}
 		"-X" = {
 			value = "$disk_exclude_type$"
@@ -1773,6 +1774,10 @@ object CheckCommand "disk" {
 			value = "$disk_include_type$"
 			description = "Check only filesystems of indicated type (may be repeated)"
 			repeat_key = true
+		}
+		"--inode-perfdata" = { /* Nagios Plugins only */
+			description = "Enable performance data for inode-based statistics (Nagios Plugins)"
+			set_if = "$disk_np_inode_perfdata$"
 		}
 	}
 


### PR DESCRIPTION
Update the check_disk ITL CheckCommand based on the Monitoring Plugins.

- Add the missing "-n"/"--ignore-missing" option as the new "disk_ignore_missing" custom var.
- Sort arguments according to the man page to ease spotting diffs.
- Sort Markdown table identical to CheckCommand arguments.
- Remove deprecated "disk_partition{,_excluded}" from Markdown table.