### PR TITLE
Bump OpenSSL shipped for Windows to v3.5.6

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -14,7 +14,7 @@ function ThrowOnNativeFailure {
 $VsVersion = 2022
 $MsvcVersion = '14.3'
 $BoostVersion = @(1, 90, 0)
-$OpensslVersion = '3_5_5'
+$OpensslVersion = '3_5_6'
 
 switch ($Env:BITS) {
 	32 { }

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -33,7 +33,7 @@ if (-not (Test-Path env:CMAKE_ARGS)) {
   $env:CMAKE_ARGS = '[]'
 }
 if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
-  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_5_5-Win${env:BITS}"
+  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_5_6-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
   $env:BOOST_ROOT = "c:\local\boost_1_90_0-Win${env:BITS}"


### PR DESCRIPTION
Update the OpenSSL version referenced in the Windows dev setup script and the build configuration script from v3.5.5 to v3.5.6.

refs https://github.com/Icinga/icinga2/issues/10778#issuecomment-4204919485