### PR TITLE
Timeout: lift `VERIFY` -> `ASSERT` to prevent crashes in release builds

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -30,7 +30,7 @@ using namespace icinga;
 CpuBoundWork::CpuBoundWork(boost::asio::yield_context yc, boost::asio::io_context::strand& strand)
 	: m_Done(false)
 {
-	VERIFY(strand.running_in_this_thread());
+	VERIFY(IoEngine::IsStrandRunningOnThisThread(strand));
 
 	auto& ie (IoEngine::Get());
 	Shared<AsioConditionVariable>::Ptr cv;

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -237,7 +237,7 @@ public:
 	Timeout(boost::asio::io_context::strand& strand, const Timer::duration_type& timeoutFromNow, OnTimeout onTimeout)
 		: m_Timer(strand.context(), timeoutFromNow), m_Cancelled(Shared<Atomic<bool>>::Make(false))
 	{
-		VERIFY(strand.running_in_this_thread());
+		ASSERT(strand.running_in_this_thread());
 
 		m_Timer.async_wait(boost::asio::bind_executor(
 			strand, [cancelled = m_Cancelled, onTimeout = std::move(onTimeout)](boost::system::error_code ec) {

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -96,6 +96,27 @@ public:
 
 	static IoEngine& Get();
 
+	/**
+	 * Checks whether the given strand is currently running in the calling thread.
+	 *
+	 * This is a simple wrapper around @c running_in_this_thread() with a little but significant difference:
+	 * It is marked as @c noinline to prevent the compiler from ever inlining the call to this function and
+	 * thus potentially optimizing away the thread-local storage access that is required for this function
+	 * to work correctly. This is especially important for the case where the caller is a coroutine that have
+	 * some suspension points between the calls to this function, and cause the compiler to assume that the
+	 * thread-local access performed by @c running_in_this_thread() is invariant across these suspensions and
+	 * thus optimize it by caching the result in a register or on the stack, which would lead to incorrect
+	 * results after resuming the coroutine on a different thread. For more details, see [^1][^2][^3].
+	 *
+	 * [^1]: https://github.com/chriskohlhoff/asio/issues/1366
+	 * [^2]: https://bugs.llvm.org/show_bug.cgi?id=19177
+	 * [^3]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26461
+	 */
+	BOOST_NOINLINE static bool IsStrandRunningOnThisThread(const boost::asio::io_context::strand& strand)
+	{
+		return strand.running_in_this_thread();
+	}
+
 	boost::asio::io_context& GetIoContext();
 
 	static inline size_t GetCoroutineStackSize() {
@@ -237,7 +258,7 @@ public:
 	Timeout(boost::asio::io_context::strand& strand, const Timer::duration_type& timeoutFromNow, OnTimeout onTimeout)
 		: m_Timer(strand.context(), timeoutFromNow), m_Cancelled(Shared<Atomic<bool>>::Make(false))
 	{
-		ASSERT(strand.running_in_this_thread());
+		ASSERT(IoEngine::IsStrandRunningOnThisThread(strand));
 
 		m_Timer.async_wait(boost::asio::bind_executor(
 			strand, [cancelled = m_Cancelled, onTimeout = std::move(onTimeout)](boost::system::error_code ec) {

--- a/lib/otel/otel.cpp
+++ b/lib/otel/otel.cpp
@@ -353,7 +353,7 @@ void OTel::ExportLoop(boost::asio::yield_context& yc)
 				// indicate a broken connection and force a reconnect in those cases. For the `end_of_stream` case,
 				// we downgrade the log severity to debug level since this is a normal occurrence when using an OTEL
 				// collector compatible backend that don't honor keep-alive connections (e.g., OpenSearch Data Prepper).
-				if (m_Stopped || (ser && ser->code() == http::error::end_of_stream)) {
+				if (m_Stopped || (ser && (ser->code() == http::error::end_of_stream || ser->code() == boost::asio::error::broken_pipe))) {
 					severity = LogDebug;
 				}
 				Log{severity, "OTelExporter", DiagnosticInformation(ex, false)};


### PR DESCRIPTION
`strand.running_in_this_thread()` relies on thread-local storage internally, and may return false positives if the coroutine is resumed on a different thread than it was suspended in. In debug builds, this is not a problem, since there's no TLS optimization done by the compiler, but in release builds, the compiler might cache the address of the thread-local variable read before the coroutine suspension, and thus potentially reuse the same address in a different thread after resumption, which would cause `running_in_this_thread()` to return false or even crash (but we didn't see any crashes related to this). So, perform the assertion only in debug builds to prevent potential wrong usages of the `Timeout` class. For more details, see [^1][^2][^3].

To verify the bug, you can apply the following patch to the `OTel` class:

```diff
diff --git a/lib/otel/otel.cpp b/lib/otel/otel.cpp
index 42be64f3a..1ed39d589 100644
--- a/lib/otel/otel.cpp
+++ b/lib/otel/otel.cpp
@@ -282,6 +282,7 @@ void OTel::Connect(boost::asio::yield_context& yc)
 				boost::system::error_code ec;
 				m_RetryExportAndConnTimer.expires_after(Backoff(attempt));
 				m_RetryExportAndConnTimer.async_wait(yc[ec]);
+				VERIFY(m_Strand.running_in_this_thread());
 			}
 		}
 	}
@@ -314,6 +315,7 @@ void OTel::ExportLoop(boost::asio::yield_context& yc)
 		// avoid waiting indefinitely in that case.
 		while (!m_Request && !m_Stopped) {
 			m_ExportAsioCV.Wait(yc);
+			VERIFY(m_Strand.running_in_this_thread());
 		}

 		if (m_Stopped) {
```

<details><summary>Crush Dumps</summary>

```bash
[2026-04-13 09:31:27 +0200] information/OTelExporter: Connecting to OpenTelemetry backend on host 'localhost:8428'.
[2026-04-13 09:31:27 +0200] critical/OTelExporter: Cannot connect to OpenTelemetry backend 'localhost:8428' (attempt #1): Connection refused [system:61 at /opt/homebrew/include/boost/asio/detail/reactive_socket_connect_op.hpp:97:37 in function 'do_complete']
/Users/yhabteab/Workspace/icinga2/lib/base/io-engine.hpp:240: assertion failed: strand.running_in_this_thread()
Caught SIGABRT.
Current time: 2026-04-13 09:31:27 +0200

[2026-04-13 09:31:27 +0200] critical/Application: Icinga 2 has terminated unexpectedly. Additional information can be found in '/Users/yhabteab/Workspace/icinga2/prefix/var/log/icinga2/crash/report.1776065487.747801'
[2026-04-13 09:31:27 +0200] notice/cli: Seamless worker (PID 14160) stopped, stopping as well
```

```bash
Stacktrace:
 0# icinga::Application::SigAbrtHandler(int) in /Users/yhabteab/Workspace/icinga2/prefix/lib/icinga2/sbin/icinga2
 1# _sigtramp in /usr/lib/system/libsystem_platform.dylib
 2# pthread_kill in /usr/lib/system/libsystem_pthread.dylib
 3# abort in /usr/lib/system/libsystem_c.dylib
 4# icinga::IoEngine::Get() in /Users/yhabteab/Workspace/icinga2/prefix/lib/icinga2/sbin/icinga2
 5# icinga::OTel::Connect(boost::asio::basic_yield_context<boost::asio::executor>&) in /Users/yhabteab/Workspace/icinga2/prefix/lib/icinga2/sbin/icinga2
 6# icinga::OTel::ExportLoop(boost::asio::basic_yield_context<boost::asio::executor>&) in /Users/yhabteab/Workspace/icinga2/prefix/lib/icinga2/sbin/icinga2
 7# void boost::context::detail::fiber_entry<boost::context::detail::fiber_record<boost::context::fiber, boost::context::basic_fixedsize_stack<boost::context::stack_traits>, boost::asio::detail::spawned_fiber_thread::entry_point<boost::asio::detail::spawn_entry_point<boost::asio::io_context::strand, void icinga::IoEngine::SpawnCoroutine<boost::asio::io_context::strand, icinga::OTel::Start()::$_0>(boost::asio::io_context::strand&, icinga::OTel::Start()::$_0)::'lambda'(boost::asio::basic_yield_context<boost::asio::executor>), boost::asio::detail::detached_handler>>>>(boost::context::detail::transfer_t) in /Users/yhabteab/Workspace/icinga2/prefix/lib/icinga2/sbin/icinga2
```

</details> 

[^1]: https://github.com/chriskohlhoff/asio/issues/1366
[^2]: https://bugs.llvm.org/show_bug.cgi?id=19177
[^3]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26461

fixes #10783