### PR TITLE
ITL: Network Protocol for all Manubulon SNMP Checks

### DIFF
--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -2205,10 +2205,7 @@ nscp_modules                | **Optional.** An array of NSClient++ modules to lo
 ## Plugin Check Commands for Manubulon SNMP <a id="snmp-manubulon-plugin-check-commands"></a>
 
 The `SNMP Manubulon Plugin Check Commands` provide configuration for plugin check
-commands provided by the [SNMP Manubulon project](http://nagios.manubulon.com/index_snmp.html).
-
-**Note:** Some plugin parameters are only available in Debian packages or in a
-[forked repository](https://github.com/dnsmichi/manubulon-snmp) with patches applied.
+commands provided by the [SNMP Manubulon project](https://github.com/SteScho/manubulon-snmp).
 
 The SNMP manubulon plugin check commands assume that the global constant named `ManubulonPluginDir`
 is set to the path where the Manubublon SNMP plugins are installed.
@@ -2248,168 +2245,180 @@ You can enable these plugin check commands by adding the following the include d
 
 ### snmp-env <a id="plugin-check-command-snmp-env"></a>
 
-Check command object for the [check_snmp_env.pl](http://nagios.manubulon.com/snmp_env.html) plugin.
+Check command object for the `check_snmp_env.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
 
-Name                    | Description
-------------------------|--------------
-snmp_address            | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-snmp_nocrypt            | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
-snmp_community          | **Optional.** The SNMP community. Defaults to "public".
-snmp_port               | **Optional.** The SNMP port connection.
-snmp_v2                 | **Optional.** SNMP version to 2c. Defaults to false.
-snmp_v3                 | **Optional.** SNMP version to 3. Defaults to false.
-snmp_login              | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
-snmp_password           | **Required.** SNMP version 3 password. No value defined as default.
-snmp_v3_use_privpass    | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
-snmp_v3_use_authprotocol| **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
-snmp_authprotocol       | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
-snmp_privpass           | **Required.** SNMP version 3 priv password. No value defined as default.
-snmp_env_type           | **Optional.** Environment Type [cisco|nokia|bc|iron|foundry|linux]. Defaults to "cisco".
-snmp_env_fan            | **Optional.** Minimum fan rpm value (only needed for 'iron' & 'linux')
-snmp_env_celsius        | **Optional.** Maximum temp in degrees celsius (only needed for 'iron' & 'linux')
-snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
-snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
+Name                      | Description
+--------------------------|--------------
+snmp_address              | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers unreleased version).
+snmp_network_protocol     | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
+snmp_nocrypt              | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
+snmp_community            | **Optional.** The SNMP community. Defaults to "public".
+snmp_port                 | **Optional.** The SNMP port connection.
+snmp_v2                   | **Optional.** SNMP version to 2c. Defaults to false.
+snmp_v3                   | **Optional.** SNMP version to 3. Defaults to false.
+snmp_login                | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
+snmp_password             | **Required.** SNMP version 3 password. No value defined as default.
+snmp_v3_use_privpass      | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
+snmp_v3_use_authprotocol  | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
+snmp_authprotocol         | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
+snmp_privpass             | **Required.** SNMP version 3 priv password. No value defined as default.
+snmp_env_type             | **Optional.** Environment Type [cisco|nokia|bc|iron|foundry|linux]. Defaults to "cisco".
+snmp_env_fan              | **Optional.** Minimum fan rpm value (only needed for 'iron' & 'linux')
+snmp_env_celsius          | **Optional.** Maximum temp in degrees celsius (only needed for 'iron' & 'linux')
+snmp_perf                 | **Optional.** Enable perfdata values. Defaults to true.
+snmp_timeout              | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 
 ### snmp-load <a id="plugin-check-command-snmp-load"></a>
 
-Check command object for the [check_snmp_load.pl](http://nagios.manubulon.com/snmp_load.html) plugin.
+Check command object for the `check_snmp_load.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
 
-Name                    | Description
-------------------------|--------------
-snmp_address            | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-snmp_nocrypt            | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
-snmp_community          | **Optional.** The SNMP community. Defaults to "public".
-snmp_port               | **Optional.** The SNMP port connection.
-snmp_v2                 | **Optional.** SNMP version to 2c. Defaults to false.
-snmp_v3                 | **Optional.** SNMP version to 3. Defaults to false.
-snmp_login              | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
-snmp_password           | **Required.** SNMP version 3 password. No value defined as default.
-snmp_v3_use_privpass    | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
-snmp_v3_use_authprotocol| **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
-snmp_authprotocol       | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
-snmp_privpass           | **Required.** SNMP version 3 priv password. No value defined as default.
-snmp_warn               | **Optional.** The warning threshold. Change the `snmp_load_type` var to "netsl" for using 3 values.
-snmp_crit               | **Optional.** The critical threshold. Change the `snmp_load_type` var to "netsl" for using 3 values.
-snmp_load_type          | **Optional.** Load type. Defaults to "stand". Check all available types in the [snmp load](http://nagios.manubulon.com/snmp_load.html) documentation.
-snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
-snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
+Name                      | Description
+--------------------------|--------------
+snmp_address              | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers version 2.0.0).
+snmp_network_protocol     | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
+snmp_nocrypt              | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
+snmp_community            | **Optional.** The SNMP community. Defaults to "public".
+snmp_port                 | **Optional.** The SNMP port connection.
+snmp_v2                   | **Optional.** SNMP version to 2c. Defaults to false.
+snmp_v3                   | **Optional.** SNMP version to 3. Defaults to false.
+snmp_login                | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
+snmp_password             | **Required.** SNMP version 3 password. No value defined as default.
+snmp_v3_use_privpass      | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
+snmp_v3_use_authprotocol  | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
+snmp_authprotocol         | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
+snmp_privpass             | **Required.** SNMP version 3 priv password. No value defined as default.
+snmp_warn                 | **Optional.** The warning threshold. Change the `snmp_load_type` var to "netsl" for using 3 values. Defaults to 85.
+snmp_crit                 | **Optional.** The critical threshold. Change the `snmp_load_type` var to "netsl" for using 3 values. Defaults to 95.
+snmp_load_type            | **Optional.** Load type. Defaults to "stand". Check all available types in the [snmp load](http://nagios.manubulon.com/snmp_load.html) documentation.
+snmp_perf                 | **Optional.** Enable perfdata values. Defaults to true.
+snmp_timeout              | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 
 ### snmp-memory <a id="plugin-check-command-snmp-memory"></a>
 
-Check command object for the [check_snmp_mem.pl](http://nagios.manubulon.com/snmp_mem.html) plugin.
+Check command object for the `check_snmp_mem.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
-Name                    | Description
-------------------------|--------------
-snmp_address            | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-snmp_nocrypt            | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
-snmp_community          | **Optional.** The SNMP community. Defaults to "public".
-snmp_port               | **Optional.** The SNMP port connection.
-snmp_v2                 | **Optional.** SNMP version to 2c. Defaults to false.
-snmp_v3                 | **Optional.** SNMP version to 3. Defaults to false.
-snmp_login              | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
-snmp_password           | **Required.** SNMP version 3 password. No value defined as default.
-snmp_v3_use_privpass    | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
-snmp_v3_use_authprotocol| **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
-snmp_authprotocol       | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
-snmp_privpass           | **Required.** SNMP version 3 priv password. No value defined as default.
-snmp_warn               | **Optional.** The warning threshold.
-snmp_crit               | **Optional.** The critical threshold.
-snmp_is_cisco		| **Optional.** Change OIDs for Cisco switches. Defaults to false.
-snmp_is_hp              | **Optional.** Change OIDs for HP/Procurve switches. Defaults to false.
-snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
-snmp_memcached          | **Optional.** Include cached memory in used memory, Defaults to false.
-snmp_membuffer          | **Optional.** Exclude buffered memory in used memory, Defaults to false.
-snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
+Name                      | Description
+--------------------------|--------------
+snmp_address              | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers version 2.0.0).
+snmp_network_protocol     | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
+snmp_nocrypt              | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
+snmp_community            | **Optional.** The SNMP community. Defaults to "public".
+snmp_port                 | **Optional.** The SNMP port connection.
+snmp_v2                   | **Optional.** SNMP version to 2c. Defaults to false.
+snmp_v3                   | **Optional.** SNMP version to 3. Defaults to false.
+snmp_login                | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
+snmp_password             | **Required.** SNMP version 3 password. No value defined as default.
+snmp_v3_use_privpass      | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
+snmp_v3_use_authprotocol  | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
+snmp_authprotocol         | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
+snmp_privpass             | **Required.** SNMP version 3 priv password. No value defined as default.
+snmp_warn                 | **Optional.** The warning threshold. Defaults to 94,50.
+snmp_crit                 | **Optional.** The critical threshold.Defaults to 98,80.
+snmp_is_cisco             | **Optional.** Change OIDs for Cisco switches. Defaults to false.
+snmp_is_hp                | **Optional.** Change OIDs for HP/Procurve switches. Defaults to false.
+snmp_perf                 | **Optional.** Enable perfdata values. Defaults to true.
+snmp_memcached            | **Optional.** Include cached memory in used memory, Defaults to false.
+snmp_membuffer            | **Optional.** Exclude buffered memory in used memory, Defaults to false.
+snmp_timeout              | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
 
 ### snmp-storage <a id="plugin-check-command-snmp-storage"></a>
 
-Check command object for the [check_snmp_storage.pl](http://nagios.manubulon.com/snmp_storage.html) plugin.
+Check command object for the `check_snmp_storage.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
-Name                    | Description
-------------------------|--------------
-snmp_address            | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-snmp_nocrypt            | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
-snmp_community          | **Optional.** The SNMP community. Defaults to "public".
-snmp_port               | **Optional.** The SNMP port connection.
-snmp_v2                 | **Optional.** SNMP version to 2c. Defaults to false.
-snmp_v3                 | **Optional.** SNMP version to 3. Defaults to false.
-snmp_login              | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
-snmp_password           | **Required.** SNMP version 3 password. No value defined as default.
-snmp_v3_use_privpass    | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
-snmp_v3_use_authprotocol| **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
-snmp_authprotocol       | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
-snmp_privpass           | **Required.** SNMP version 3 priv password. No value defined as default.
-snmp_warn               | **Optional.** The warning threshold.
-snmp_crit               | **Optional.** The critical threshold.
-snmp_storage_name       | **Optional.** Storage name. Default to regex "^/$$". More options available in the [snmp storage](http://nagios.manubulon.com/snmp_storage.html) documentation.
-snmp_storage_type       | **Optional.** Filter by storage type. Valid options are Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk. No value defined as default.
-snmp_perf               | **Optional.** Enable perfdata values. Defaults to true.
-snmp_exclude            | **Optional.** Select all storages except the one(s) selected by -m. No action on storage type selection.
-snmp_timeout            | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
-snmp_storage_olength	| **Optional.** Max-size of the SNMP message, useful in case of Too Long responses.
+Name                      | Description
+--------------------------|--------------
+snmp_address              | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers version 2.0.0).
+snmp_network_protocol     | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
+snmp_nocrypt              | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
+snmp_community            | **Optional.** The SNMP community. Defaults to "public".
+snmp_port                 | **Optional.** The SNMP port connection.
+snmp_v2                   | **Optional.** SNMP version to 2c. Defaults to false.
+snmp_v3                   | **Optional.** SNMP version to 3. Defaults to false.
+snmp_login                | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
+snmp_password             | **Required.** SNMP version 3 password. No value defined as default.
+snmp_v3_use_privpass      | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
+snmp_v3_use_authprotocol  | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
+snmp_authprotocol         | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
+snmp_privpass             | **Required.** SNMP version 3 priv password. No value defined as default.
+snmp_warn                 | **Optional.** The warning threshold. Defaults to 80.
+snmp_crit                 | **Optional.** The critical threshold. Defaults to 90.
+snmp_storage_name         | **Optional.** Storage name. Default to regex "^/$$". More options available in the [snmp storage](http://nagios.manubulon.com/snmp_storage.html) documentation.
+snmp_storage_type         | **Optional.** Filter by storage type. Valid options are Other, Ram, VirtualMemory, FixedDisk, RemovableDisk, FloppyDisk, CompactDisk, RamDisk, FlashMemory, or NetworkDisk. No value defined as default.
+snmp_perf                 | **Optional.** Enable perfdata values. Defaults to true.
+snmp_exclude              | **Optional.** Select all storages except the one(s) selected by -m. No action on storage type selection.
+snmp_timeout              | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
+snmp_storage_olength	    | **Optional.** Max-size of the SNMP message, useful in case of Too Long responses.
 
 ### snmp-interface <a id="plugin-check-command-snmp-interface"></a>
 
-Check command object for the [check_snmp_int.pl](http://nagios.manubulon.com/snmp_int.html) plugin.
+Check command object for the `check_snmp_int.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
-Name                        | Description
-----------------------------|--------------
-snmp_address                | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
-snmp_nocrypt                | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
-snmp_community              | **Optional.** The SNMP community. Defaults to "public".
-snmp_port                   | **Optional.** The SNMP port connection.
-snmp_v2                     | **Optional.** SNMP version to 2c. Defaults to false.
-snmp_v3                     | **Optional.** SNMP version to 3. Defaults to false.
-snmp_login                  | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
-snmp_password               | **Required.** SNMP version 3 password. No value defined as default.
-snmp_v3_use_privpass        | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
-snmp_v3_use_authprotocol    | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
-snmp_authprotocol           | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
-snmp_privpass               | **Required.** SNMP version 3 priv password. No value defined as default.
-snmp_warn                   | **Optional.** The warning threshold.
-snmp_crit                   | **Optional.** The critical threshold.
-snmp_interface              | **Optional.** Network interface name. Default to regex "eth0".
-snmp_interface_inverse      | **Optional.** Inverse Interface check, down is ok. Defaults to false as it is missing.
-snmp_interface_perf         | **Optional.** Check the input/output bandwidth of the interface. Defaults to true.
-snmp_interface_label        | **Optional.** Add label before speed in output: in=, out=, errors-out=, etc.
-snmp_interface_bits_bytes   | **Optional.** Output performance data in bits/s or Bytes/s. **Depends** on snmp_interface_kbits set to true. Defaults to true.
-snmp_interface_percent      | **Optional.** Output performance data in % of max speed. Defaults to false.
-snmp_interface_kbits        | **Optional.** Make the warning and critical levels in KBits/s. Defaults to true.
-snmp_interface_megabytes    | **Optional.** Make the warning and critical levels in Mbps or MBps. **Depends** on snmp_interface_kbits set to true. Defaults to true.
-snmp_interface_64bit        | **Optional.** Use 64 bits counters instead of the standard counters when checking bandwidth & performance data for interface >= 1Gbps. Defaults to false.
-snmp_interface_errors       | **Optional.** Add error & discard to Perfparse output. Defaults to true.
-snmp_interface_extended_checks | **Optional.** Also check the error and discard input/output. When enabled format of `snmp_warn` and `snmp_crit` changes to <In bytes>,<Out bytes>,<In error>,<Out error>,<In disc>,<Out disc>. More options available in the [snmp interface](http://nagios.manubulon.com/snmp_int.html) documentation. Defaults to false.
-snmp_interface_noregexp     | **Optional.** Do not use regexp to match interface name in description OID. Defaults to false.
-snmp_interface_delta        | **Optional.** Delta time of perfcheck. Defaults to "300" (5 min).
+Name                            | Description
+--------------------------------|--------------
+snmp_address                    | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set       | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers unreleased version).
+snmp_network_protocol           | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
+snmp_nocrypt                    | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
+snmp_community                  | **Optional.** The SNMP community. Defaults to "public".
+snmp_port                       | **Optional.** The SNMP port connection.
+snmp_v2                         | **Optional.** SNMP version to 2c. Defaults to false.
+snmp_v3                         | **Optional.** SNMP version to 3. Defaults to false.
+snmp_login                      | **Optional.** SNMP version 3 username. Defaults to "snmpuser".
+snmp_password                   | **Required.** SNMP version 3 password. No value defined as default.
+snmp_v3_use_privpass            | **Optional.** Define to use SNMP version 3 priv password. Defaults to false.
+snmp_v3_use_authprotocol        | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
+snmp_authprotocol               | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
+snmp_privpass                   | **Required.** SNMP version 3 priv password. No value defined as default.
+snmp_warn                       | **Optional.** The warning threshold. Defaults to 300,400.
+snmp_crit                       | **Optional.** The critical threshold. Defaults to 0,600.
+snmp_interface                  | **Optional.** Network interface name. Default to regex "eth0".
+snmp_interface_inverse          | **Optional.** Inverse Interface check, down is ok. Defaults to false as it is missing.
+snmp_interface_perf             | **Optional.** Check the input/output bandwidth of the interface. Defaults to true.
+snmp_interface_label            | **Optional.** Add label before speed in output: in=, out=, errors-out=, etc.
+snmp_interface_bits_bytes       | **Optional.** Output performance data in bits/s or Bytes/s. **Depends** on snmp_interface_kbits set to true. Defaults to true.
+snmp_interface_percent          | **Optional.** Output performance data in % of max speed. Defaults to false.
+snmp_interface_kbits            | **Optional.** Make the warning and critical levels in KBits/s. Defaults to true.
+snmp_interface_megabytes        | **Optional.** Make the warning and critical levels in Mbps or MBps. **Depends** on snmp_interface_kbits set to true. Defaults to true.
+snmp_interface_64bit            | **Optional.** Use 64 bits counters instead of the standard counters when checking bandwidth & performance data for interface >= 1Gbps. Defaults to false.
+snmp_interface_errors           | **Optional.** Add error & discard to Perfparse output. Defaults to true.
+snmp_interface_extended_checks  | **Optional.** Also check the error and discard input/output. When enabled format of `snmp_warn` and `snmp_crit` changes to <In bytes>,<Out bytes>,<In error>,<Out error>,<In disc>,<Out disc>. More options available in the [snmp interface](http://nagios.manubulon.com/snmp_int.html) documentation. Defaults to false.
+snmp_interface_noregexp         | **Optional.** Do not use regexp to match interface name in description OID. Defaults to false.
+snmp_interface_delta            | **Optional.** Delta time of perfcheck. Defaults to "300" (5 min).
 snmp_interface_warncrit_percent | **Optional.** Make the warning and critical levels in % of reported interface speed. If set, **snmp_interface_megabytes** needs to be set to false. Defaults to false.
-snmp_interface_ifname       | **Optional.** Switch from IF-MIB::ifDescr to IF-MIB::ifName when looking up the interface's name.
-snmp_interface_ifalias      | **Optional.** Switch from IF-MIB::ifDescr to IF-MIB::ifAlias when looking up the interface's name.
-snmp_interface_weathermap   | **Optional.** Output data for ["weathermap" lines](http://docs.nagvis.org/1.9/en_US/lines_weathermap_style.html) in NagVis. **Depends** on `snmp_interface_perf` set to true. Defaults to `false`. **Note**: Available in `check_snmp_int.pl v2.1.0`.
-snmp_perf                   | **Optional.** Enable perfdata values. Defaults to true.
-snmp_timeout                | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
-snmp_interface_admin        | **Optional.** Use administrative status instead of operational. Defaults to false.
+snmp_interface_ifname           | **Optional.** Switch from IF-MIB::ifDescr to IF-MIB::ifName when looking up the interface's name.
+snmp_interface_ifalias          | **Optional.** Switch from IF-MIB::ifDescr to IF-MIB::ifAlias when looking up the interface's name.
+snmp_interface_weathermap       | **Optional.** Output data for ["weathermap" lines](http://docs.nagvis.org/1.9/en_US/lines_weathermap_style.html) in NagVis. **Depends** on `snmp_interface_perf` set to true. Defaults to `false`. **Note**: Available in `check_snmp_int.pl v2.1.0`.
+snmp_perf                       | **Optional.** Enable perfdata values. Defaults to true.
+snmp_timeout                    | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
+snmp_interface_admin            | **Optional.** Use administrative status instead of operational. Defaults to false.
 
 ### snmp-process <a id="plugin-check-command-snmp-process"></a>
 
-Check command object for the [check_snmp_process.pl](http://nagios.manubulon.com/snmp_process.html) plugin.
+Check command object for the `check_snmp_process.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
 Name                       | Description
 ---------------------------|--------------
 snmp_address               | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set  | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers version 2.0.0).
+snmp_network_protocol      | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
 snmp_nocrypt               | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
 snmp_community             | **Optional.** The SNMP community. Defaults to "public".
 snmp_port                  | **Optional.** The SNMP port connection.
@@ -2421,8 +2430,8 @@ snmp_v3_use_privpass       | **Optional.** Define to use SNMP version 3 priv pas
 snmp_v3_use_authprotocol   | **Optional.** Define to use SNMP version 3 authentication protocol. Defaults to false.
 snmp_authprotocol          | **Optional.** SNMP version 3 authentication protocol. Defaults to "md5,des".
 snmp_privpass              | **Required.** SNMP version 3 priv password. No value defined as default..
-snmp_warn                  | **Optional.** The warning threshold.
-snmp_crit                  | **Optional.** The critical threshold.
+snmp_warn                  | **Optional.** The warning threshold. Defaults to 0.
+snmp_crit                  | **Optional.** The critical threshold. Defaults to 0.
 snmp_process_name          | **Optional.** Name of the process (regexp). No trailing slash!. Defaults to ".*".
 snmp_perf                  | **Optional.** Enable perfdata values. Defaults to true.
 snmp_timeout               | **Optional.** The command timeout in seconds. Defaults to 5 seconds.
@@ -2435,13 +2444,15 @@ snmp_process_cpu_threshold | **Optional.** Defines the warning and critical thre
 
 ### snmp-service <a id="plugin-check-command-snmp-service"></a>
 
-Check command object for the [check_snmp_win.pl](http://nagios.manubulon.com/snmp_windows.html) plugin.
+Check command object for the `check_snmp_win.pl` plugin.
 
 Custom variables passed as [command parameters](03-monitoring-basics.md#command-passing-parameters):
 
 Name                       | Description
 ---------------------------|--------------
 snmp_address               | **Optional.** The host's address. Defaults to "$address$" if the host's `address` attribute is set, "$address6$" otherwise.
+snmp_network_protocol_set  | **Optional.** Explicitly set a network protocol, see "$snmp_network_protocol$" (Requiers unreleased version).
+snmp_network_protocol      | **Optional.** Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to `snmp_address` protocol with UDP, requires "$snmp_network_protocol_set$".
 snmp_nocrypt               | **Optional.** Define SNMP encryption. If set to `false`, `snmp_v3` needs to be enabled. Defaults to `true` (no encryption).
 snmp_community             | **Optional.** The SNMP community. Defaults to "public".
 snmp_port                  | **Optional.** The SNMP port connection.

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -1,10 +1,6 @@
 // SPDX-FileCopyrightText: 2012 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/**
- * main snmp-manubulon template
- */
-
 template CheckCommand "snmp-manubulon-command" {
 	import "ipv4-or-ipv6"
 
@@ -12,6 +8,11 @@ template CheckCommand "snmp-manubulon-command" {
 		"-H" = {
 			value = "$snmp_address$"
 			description = "Name or IP address of host to check"
+		}
+		"--protocol" = {
+			set_if = "$snmp_network_protocol_set$"
+			value = "$snmp_network_protocol$"
+			description = "Network protocol to be used. One of 'udp/ipv4', 'udp/ipv6', 'tcp/ipv4', 'tcp/ipv6'. Defaults to snmp_address protocol with UDP."
 		}
 		"-C" = {
 			set_if = "$snmp_nocrypt$"
@@ -59,6 +60,9 @@ template CheckCommand "snmp-manubulon-command" {
 	}
 
 	vars.snmp_address = "$check_address$"
+	vars.snmp_network_protocol = {{
+		(macro("$address$") && !macro("$check_ipv6$") || macro("$check_ipv4$")) ? "udp/ipv4" : "udp/ipv6"
+	}}
 	vars.snmp_nocrypt = true
 	vars.snmp_community = "public"
 	vars.snmp_v2 = false
@@ -69,12 +73,6 @@ template CheckCommand "snmp-manubulon-command" {
 	vars.snmp_authprotocol = "md5,des"
 	vars.snmp_timeout = "5"
 }
-
-
-/**
- * snmp env
- *   Url reference: http://nagios.manubulon.com/snmp_env.html
- */
 
 object CheckCommand "snmp-env" {
 	import "snmp-manubulon-command"
@@ -104,12 +102,6 @@ object CheckCommand "snmp-env" {
 	vars.snmp_perf = true
 }
 
-
-/**
- * snmp load
- *   Url reference: http://nagios.manubulon.com/snmp_load.html
- */
-
 object CheckCommand "snmp-load" {
 	import "snmp-manubulon-command"
 
@@ -131,14 +123,6 @@ object CheckCommand "snmp-load" {
 	vars.snmp_crit = 95
 	vars.snmp_perf = true
 }
-
-
-/**
- * Memory and swap usage on Linux given by Net-snmp
- *   Memory usage on cisco routers or Pix
- *   For other systems use check_snmp_storage.pl
- *   Url reference: http://nagios.manubulon.com/snmp_mem.html
- */
 
 object CheckCommand "snmp-memory" {
 	import "snmp-manubulon-command"
@@ -176,11 +160,6 @@ object CheckCommand "snmp-memory" {
 	vars.snmp_membuffer = false
 }
 
-
-/**
- * snmp storage - Disk/Memory
- *   Url reference: http://nagios.manubulon.com/snmp_storage.html
- */
 object CheckCommand "snmp-storage" {
 	import "snmp-manubulon-command"
 
@@ -215,12 +194,6 @@ object CheckCommand "snmp-storage" {
 	vars.snmp_perf = true
 	vars.snmp_exclude = false
 }
-
-
-/**
- * snmp network interfaces
- *   Url reference: http://nagios.manubulon.com/snmp_int.html
- */
 
 object CheckCommand "snmp-interface" {
 	import "snmp-manubulon-command"
@@ -323,12 +296,6 @@ object CheckCommand "snmp-interface" {
 	vars.snmp_perf = true
 }
 
-
-/**
- * snmp process
- *   Url reference: http://nagios.manubulon.com/snmp_process.html
- */
-
 object CheckCommand "snmp-process" {
 	import "snmp-manubulon-command"
 
@@ -374,11 +341,6 @@ object CheckCommand "snmp-process" {
 	vars.snmp_process_cpu_usage = false
 	vars.snmp_process_cpu_threshold = "0,0"
 }
-
-/**
- * snmp service
- *   Url reference: http://nagios.manubulon.com/snmp_windows.html
- */
 
 object CheckCommand "snmp-service" {
 	import "snmp-manubulon-command"


### PR DESCRIPTION
Add a new `snmp_network_protocol` custom var to all Manubulon SNMP checks to configure the underlying network protocols. By default, the `snmp-manubulon-command` template, used by all Manubulon SNMP checks, sets the protocol to udp and the version of the IP matching the `snmp_address`.

In the meantime, the upstream moved to GitHub. This was also reflected in the docs and outdated comments, pointing to outdated versions of the checks, were removed.

---

I have tested these changes with the following four hosts.

```
template Host "snmp-test" {
  import "generic-host"
  vars.snmp_test = true
}

object Host "snmp-test-v4only" {
  import "snmp-test"
  address = "127.0.0.1"
}

object Host "snmp-test-v6only" {
  import "snmp-test"
  address6 = "::1"
}

object Host "snmp-test-ds-v4" {
  import "snmp-test"
  address = "127.0.0.1"
  address6 = "::1"
  vars.check_ipv4 = true
}

object Host "snmp-test-ds-v6" {
  import "snmp-test"
  address = "127.0.0.1"
  address6 = "::1"
  vars.check_ipv6 = true
}

apply Service "snmp-interface" {
  import "generic-service"

  check_command = "snmp-interface"

  assign where host.vars.snmp_test
}
```

The `--protocol` flag of the executed command contained either `udp/ipv4` or `udp/ipv6`, matching the expectation reflected in the host name.

---

Fixes #10790.