### PR TITLE
Fix compiler crash on SLES 15.7 arm64 runner

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -123,8 +123,8 @@ void CpuBoundWork::Done()
 			}
 
 			// Again, a delayed wake-up is fine, hence unlocked.
-			for (auto& [strand, cv] : subscribers) {
-				boost::asio::post(strand, [cv = std::move(cv)] { cv->NotifyOne(); });
+			for (auto& subscriber : subscribers) {
+				boost::asio::post(subscriber.first, [cv = std::move(subscriber.second)] { cv->NotifyOne(); });
 			}
 		}
 	}


### PR DESCRIPTION
The `std::move` init-capture initialization with a structured-bindgs created variable caused the GCC 7.5.0 compiler on SLES 15.7 arm64 runner to segfault, and replacing the structured-binding with a traditional unpacked `pair` fixed it. No idea why, but it's likely some compiler bug that's already fixed in newer version but after a quick search in the GCC bug tracker, I didn't find any issues related to this, so I've no references.