### PR TITLE
Bump OpenSSL shipped for Windows to v3.0.20

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -14,7 +14,7 @@ function ThrowOnNativeFailure {
 $VsVersion = 2022
 $MsvcVersion = '14.3'
 $BoostVersion = @(1, 87, 0)
-$OpensslVersion = '3_0_19'
+$OpensslVersion = '3_0_20'
 
 switch ($Env:BITS) {
 	32 { }

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -33,7 +33,7 @@ if (-not (Test-Path env:CMAKE_ARGS)) {
   $env:CMAKE_ARGS = '[]'
 }
 if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
-  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_0_19-Win${env:BITS}"
+  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_0_20-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
   $env:BOOST_ROOT = "c:\local\boost_1_87_0-Win${env:BITS}"


### PR DESCRIPTION
Update the OpenSSL version referenced in the Windows dev setup script and the build configuration script from v3.0.19 to v3.0.20.

Explicitly requested in https://github.com/Icinga/icinga2/pull/10786#pullrequestreview-4097425596.