### PR TITLE
Fix misleading TLS handshake error logging

### DIFF
--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -743,7 +743,8 @@ void ApiListener::NewClientHandlerInternal(
 		}
 
 		Log(LogCritical, "ApiListener")
-			<< "Client TLS handshake failed (" << conninfo << "): " << ec.message();
+			<< (role == RoleClient ? "Client" : "Server")
+			<< " TLS handshake failed (" << conninfo << "): " << ec.message();
 		return;
 	}
 


### PR DESCRIPTION
The log message on TLS handshake errors always stated that a client handshake failed, even if if the connection was acting as the server. The commit changes it so that the actual role is taken into account.

Previously, it logged something like this (you can see that it was a server-side handshake in that it logs `from $address` instead of `to $address`):

```
[2026-04-16 17:51:53 +0200] critical/ApiListener: Client TLS handshake failed (from [::ffff:172.18.0.1]:35478): Operation canceled
```

Now it correctly like this:

```
[2026-04-16 17:54:52 +0200] critical/ApiListener: Server TLS handshake failed (from [::ffff:172.18.0.1]:51038): Operation canceled
```

(Log message can be triggered by `nc localhost 5665` and waiting.)