### PR TITLE
Fix host name verification for `PerfdataWriterConnection`

### DIFF
--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -99,7 +99,7 @@ AsioTlsOrTcpStream PerfdataWriterConnection::MakeStream() const
 {
 	AsioTlsOrTcpStream ret;
 	if (m_SslContext) {
-		ret = Shared<AsioTlsStream>::Make(IoEngine::Get().GetIoContext(), *m_SslContext);
+		ret = Shared<AsioTlsStream>::Make(IoEngine::Get().GetIoContext(), *m_SslContext, m_Host);
 	} else {
 		ret = Shared<AsioTcpStream>::Make(IoEngine::Get().GetIoContext());
 	}

--- a/test/perfdata-perfdatatargetfixture.hpp
+++ b/test/perfdata-perfdatatargetfixture.hpp
@@ -39,16 +39,24 @@ public:
 	explicit PerfdataWriterTargetFixture(AsioTlsOrTcpStream stream)
 		: m_Stream(std::move(stream)),
 		  m_Acceptor(
-			  IoEngine::Get().GetIoContext(),
-			  boost::asio::ip::tcp::endpoint{boost::asio::ip::address_v4::loopback(), 0}
+			  IoEngine::Get().GetIoContext()
 		  )
 	{
+		boost::asio::ip::tcp::endpoint ep{boost::asio::ip::address_v4::loopback(), 0};
+		m_Acceptor.open(ep.protocol());
+		m_Acceptor.bind(ep);
 	}
 
 	unsigned short GetPort() { return m_Acceptor.local_endpoint().port(); }
 
+	void Listen()
+	{
+		m_Acceptor.listen();
+	}
+
 	void Accept()
 	{
+		Listen();
 		BOOST_REQUIRE_NO_THROW(
 			std::visit([&](auto& stream) { return m_Acceptor.accept(stream->lowest_layer()); }, m_Stream)
 		);

--- a/test/perfdata-perfdatatargetfixture.hpp
+++ b/test/perfdata-perfdatatargetfixture.hpp
@@ -82,7 +82,7 @@ public:
 	void ResetStream()
 	{
 		if (std::holds_alternative<Shared<AsioTlsStream>::Ptr>(m_Stream)) {
-			m_Stream = Shared<AsioTlsStream>::Make(IoEngine::Get().GetIoContext(), *m_SslContext);
+			m_Stream = Shared<AsioTlsStream>::Make(IoEngine::Get().GetIoContext(), *m_SslContext, "localhost");
 		} else {
 			m_Stream = Shared<AsioTcpStream>::Make(IoEngine::Get().GetIoContext());
 		}

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -130,10 +130,9 @@ BOOST_AUTO_TEST_CASE(finish_during_timeout)
  */
 BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 {
-	TestThread mockTargetThread{[&]() { Accept(); }};
-
 	std::promise<void> p;
 	TestThread timeoutThread{[&]() {
+		Accept();
 		auto f = p.get_future();
 		GetConnection().CancelAfterTimeout(f, 50ms);
 		BOOST_REQUIRE(f.wait_for(0ms) == std::future_status::timeout);
@@ -144,7 +143,6 @@ BOOST_AUTO_TEST_CASE(stuck_in_handshake)
 	);
 
 	REQUIRE_JOINS_WITHIN(timeoutThread, 1s);
-	REQUIRE_JOINS_WITHIN(mockTargetThread, 1s);
 }
 
 /* When the disconnect timeout runs out while sending something to a slow or blocking server, we

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -17,7 +17,7 @@ public:
 	{
 		m_PdwSslContext = MakeContext("client");
 
-		m_Conn = new PerfdataWriterConnection{"Test", "test", "127.0.0.1", std::to_string(GetPort()), m_PdwSslContext};
+		m_Conn = new PerfdataWriterConnection{"Test", "test", "localhost", std::to_string(GetPort()), m_PdwSslContext};
 	}
 
 	auto& GetConnection() { return *m_Conn; }

--- a/test/remote-certificate-fixture.cpp
+++ b/test/remote-certificate-fixture.cpp
@@ -95,19 +95,19 @@ void RequiresCertificate::AddCaFixture(const String& caFixtureName)
 	m_CaFixtures.emplace_back(caFixtureName);
 }
 
-void RequiresCertificate::AddCertFixture(const String& cn, const String& caFixture, const String& certFixture)
+void RequiresCertificate::AddCertFixture(const String& name, const String& caFixture, const String& certFixture)
 {
 	auto& mts = boost::unit_test::framework::master_test_suite();
 	boost::unit_test::decorator::base_ptr certLabel{new boost::unit_test::label{"cert"}};
 
 	auto* setup = boost::unit_test::make_test_case(
-		[cn]() {
+		[name]() {
 			CertificateFixture certFixture;
 			auto persistentCertsPath = CertificateFixture::m_PersistentCertsDir / "certs";
-			auto keyFile = persistentCertsPath / (cn.GetData() + ".key");
-			auto csrFile = persistentCertsPath / (cn.GetData() + ".csr");
-			auto crtFile = persistentCertsPath / (cn.GetData() + ".crt");
-			PkiUtility::NewCert(cn, keyFile.string(), csrFile.string(), "");
+			auto keyFile = persistentCertsPath / (name.GetData() + ".key");
+			auto csrFile = persistentCertsPath / (name.GetData() + ".csr");
+			auto crtFile = persistentCertsPath / (name.GetData() + ".crt");
+			PkiUtility::NewCert("localhost", keyFile.string(), csrFile.string(), "");
 			PkiUtility::SignCsr(csrFile.string(), crtFile.string());
 		},
 		certFixture.GetData() + "_setup",

--- a/test/remote-certificate-fixture.hpp
+++ b/test/remote-certificate-fixture.hpp
@@ -95,7 +95,7 @@ private:
 	static inline std::vector<String> m_CaFixtures;
 
 	static void AddCaFixture(const String& caFixtureName);
-	static void AddCertFixture(const String& cn, const String& caFixture, const String& certFixture);
+	static void AddCertFixture(const String& name, const String& caFixture, const String& certFixture);
 };
 
 } // namespace icinga


### PR DESCRIPTION
Fixes the host name verification for `PerfdataWriterConnection` by correctly appending the optional `host` parameter when constructing the `AsioTlsStream`. This was omitted from the original PR #10668 by accident, despite the writers correctly passing the parameter before.

### Testing

Given that the writers worked with this check in place before #10668, and `PerfdataWriterConnection` otherwise was verified in that PR, I'll not retest all TLS-capable backends this time.

Also, since the `PerfdataWriterConnection` unit-tests failed after this change and the fixtures used needed two small adjustments to work again, that verifies both that the check does fail if the host names don't match up and succeeds when they are made to match up again.

~~I've also added an additional test-case that ensures the verification fails when the host name doesn't match.~~ The test case will be moved to a separate PR linking to this one at a later point.

Fixes #10797.