### PR TITLE
Silence `unnecessary-virtual-specifier` clang warning

### DIFF
--- a/lib/icinga/notificationcommand.hpp
+++ b/lib/icinga/notificationcommand.hpp
@@ -25,7 +25,7 @@ public:
 
 	static thread_local NotificationCommand::Ptr ExecuteOverride;
 
-	virtual Dictionary::Ptr Execute(const intrusive_ptr<Notification>& notification,
+	Dictionary::Ptr Execute(const intrusive_ptr<Notification>& notification,
 		const User::Ptr& user, const CheckResult::Ptr& cr, const NotificationType& type,
 		const String& author, const String& comment,
 		const Dictionary::Ptr& resolvedMacros = nullptr,


### PR DESCRIPTION
Silence this unnoying Clang warning that spams my build progress output. Cherry-picked from https://github.com/Icinga/icinga2/pull/10723 to get this merged ASAP.

```cxx
In file included from /Users/yhabteab/Workspace/icinga2/lib/icinga/apiactions.cpp:12:
/Users/yhabteab/Workspace/icinga2/lib/icinga/notificationcommand.hpp:28:26: warning: virtual method 'Execute' is inside a 'final' class and can never be overridden [-Wunnecessary-virtual-specifier]
   28 |         virtual Dictionary::Ptr Execute(const intrusive_ptr<Notification>& notification,
      |                                 ^
1 warning generated.
```