### PR TITLE
Add Ubuntu 26.04 to CI workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,6 +55,7 @@ jobs:
           - ubuntu:24.04
           - ubuntu:25.04
           - ubuntu:25.10
+          - ubuntu:26.04
 
         platform:
           - linux/amd64


### PR DESCRIPTION
As per https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/146