### PR TITLE
Add Fedora 44 to CI workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -37,6 +37,7 @@ jobs:
           - fedora:41
           - fedora:42
           - fedora:43
+          - fedora:44
 
           - opensuse/leap:15.6
           - opensuse/leap:16.0


### PR DESCRIPTION
As per https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/147