### PR TITLE
publiccode.yml: update to GPL 3 (or later)

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -60,7 +60,7 @@ description:
       - https://icinga.com/wp-content/uploads/2025/07/demo_screenshot-scaled.png
       - https://icinga.com/wp-content/uploads/2025/05/icinga-for-kubernetes-screenshot.png
 legal:
-  license: GPL-2.0-or-later
+  license: GPL-3.0-or-later
 maintenance:
   type: internal
   contacts:


### PR DESCRIPTION
The overall license changes to GPL 3 (or later) with the 2.16.0 release. This file on the default branch was intentionally kept on the older license information to reflect the license information of released versions. Now it's time to update it here as well for the upcoming 2.16.0 release.

resolves #10724 