### PR TITLE
third-party/execvpe: Fix icinga2_execvpe definition

### DIFF
--- a/third-party/execvpe/execvpe.c
+++ b/third-party/execvpe/execvpe.c
@@ -49,10 +49,7 @@ scripts_argv (const char *file, char *const argv[], int argc, char **new_argv)
 /* Execute FILE, searching in the `PATH' environment variable if it contains
    no slashes, with arguments ARGV and environment from ENVP.  */
 int
-icinga2_execvpe (file, argv, envp)
-     const char *file;
-     char *const argv[];
-     char *const envp[];
+icinga2_execvpe (const char *file, char *const argv[], char *const envp[])
 {
   if (*file == '\0')
     {


### PR DESCRIPTION
Replace the old K&R C function definition of the icinga2_execvpe function with a regular function definition. The issue with K&R is that they do lack a prototype definition, resulting in warnings now.

    third-party/execvpe/execvpe.c:52:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]
       52 | icinga2_execvpe (file, argv, envp)
          | ^
    1 warning generated.

See further: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2432.pdf