### PR TITLE
Release issue template: docker-icinga2 is only required for pre-2.16

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,7 +17,7 @@ assignees: ''
 - [ ] Create and push a signed tag for the version
 - [ ] Build and release DEB and RPM packages
 - [ ] Build and release Windows packages
-- [ ] Merge dependency updates in https://github.com/Icinga/docker-icinga2/pulls
+- [ ] Only for releases of versions older than v2.16: Merge dependency updates in https://github.com/Icinga/docker-icinga2/pulls
 - [ ] Create release on GitHub
 - [ ] Update public docs
 - [ ] Announce release


### PR DESCRIPTION
Starting with v2.16, container images are built from within this repo without using the docker-icinga2 repo. Thus, updates there are only relevant if an older version is released.