### PR TITLE
Fix documentation on global custom variables

### DIFF
--- a/doc/03-monitoring-basics.md
+++ b/doc/03-monitoring-basics.md
@@ -500,7 +500,7 @@ up macros and their respective values:
 2. Service object
 3. Host object
 4. Command object
-5. Global custom variables in the `Vars` constant
+5. IcingaApplication object
 
 This execution order allows you to define default values for custom variables
 in your command objects.

--- a/doc/17-language-reference.md
+++ b/doc/17-language-reference.md
@@ -506,7 +506,6 @@ ZonesDir            |**Read-only.** Contains the path of the zones.d directory. 
 
 Constant            | Description
 --------------------|-------------------
-Vars                |**Read-write.** Contains a dictionary with global custom variables. Not set by default.
 NodeName            |**Read-write.** Contains the cluster node name. Set to the local hostname by default.
 ReloadTimeout       |**Read-write.** Defines the reload timeout for child processes. Defaults to `300s`.
 Environment         |**Read-write.** The name of the Icinga environment. Included in the SNI host name for outbound connections. Not set by default.

--- a/tools/syntax/nano/icinga2.nanorc
+++ b/tools/syntax/nano/icinga2.nanorc
@@ -126,7 +126,6 @@ icolor green		"\s(/=)\s"
 icolor yellow 	"(PrefixDir|SysconfDir|ZonesDir|LocalStateDir|RunDir|PkgDataDir|StatePath|ObjectsPath)"
 icolor yellow 	"(PidPath|NodeName|ApplicationType|EnableNotifications|EnableEventHandlers|EnableFlapping)"
 icolor yellow 	"(EnableHostChecks|EnableServiceChecks|EnablePerfdata|UseVfork|RunAsUser|RunAsGroup|PluginDir)"
-icolor yellow 	"(Vars\s+)"
 
 ## Boolean
 icolor blue 	"(true|false)"

--- a/tools/syntax/vim/syntax/icinga2.vim
+++ b/tools/syntax/vim/syntax/icinga2.vim
@@ -266,7 +266,7 @@ syn keyword	icinga2PathConstant	ObjectsPath PidPath PkgDataDir PrefixDir Program
 syn keyword 	icinga2PathConstant	VarsPath ZonesDir
 
 " Global constants
-syn keyword 	icinga2GlobalConstant	Vars NodeName Environment RunAsUser RunAsGroup MaxConcurrentChecks ApiBindHost ApiBindPort EventEngine AttachDebugger
+syn keyword 	icinga2GlobalConstant	NodeName Environment RunAsUser RunAsGroup MaxConcurrentChecks ApiBindHost ApiBindPort EventEngine AttachDebugger
 
 " Application runtime constants
 syn keyword	icinga2GlobalConstant	PlatformName PlatformVersion PlatformKernel PlatformKernelVersion BuildCompilerName BuildCompilerVersion BuildHostName


### PR DESCRIPTION
Global custom variables were moved from the global `Vars` constant to the `vars` attribute of the `IcingaApplication` object in v2.4 (84536da22161a04f3cb929b4452e808f17354238), however the documentation wasn't updated accordingly.

See #3238 for a bit of context of the change. The change was also mentioned in the v2.4.0 changelog:

https://github.com/Icinga/icinga2/blob/cf699b2cd438020b1c461a3389e2631e11499e3c/CHANGELOG.md#L4432

This commit updates the documentation accordingly. The `vars` attribute of `IcingaApplication` is already documented in `09-object-types.md`, so no addition for this is needed.

There is still a reference in `24-appendix.md` that I left unchanged because it is related to the IDO, which is deprecated and scheduled for removal in v2.18, so I didn't bother checking what the IDO actually does in respect to global custom variables.