### PR TITLE
docs: clarify OTLPMetricsWriter unavailability on Debian 11 and Ubunt…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -175,6 +175,7 @@ Maciej Dems <maciej.dems@p.lodz.pl>
 Magnus Bäck <magnus@noun.se>
 Maik Stuebner <maik@stuebner.info>
 Malte Rabenseifner <mail@malte-rabenseifner.de>
+Manas Singh <00manassingh00@gmail.com>
 Manuel Reiter <reiter@csc.uni-frankfurt.de>
 Marc Rupprecht <marc.rupprecht@netways.de>
 Marcus van Dam <marcus@marcusvandam.nl>

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1878,6 +1878,12 @@ or any other OTLP-compatible backend that accepts OTLP data over HTTP. This conf
 [otlpmetrics feature](14-features.md#otlpmetrics-writer). You can find more information about OpenTelemetry and OTLP
 on the [OpenTelemetry website](https://opentelemetry.io/).
 
+!!! info
+
+    The official package builds for Debian 11, Ubuntu 22.04 and Amazon Linux 2 do not include this object type.
+    These builds disable OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`) because the
+    default Protobuf compiler version is too old for the required code generation.
+
 A basic copy and pastable example configuration is shown below:
 
 ```

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -663,6 +663,21 @@ In order to enable this feature, you can use the following command:
 icinga2 feature enable otlpmetrics
 ```
 
+!!! info
+
+    **Package availability note (Debian 11 / Ubuntu 22.04 / Amazon Linux 2):**
+    The official Icinga 2 packages for Debian 11, Ubuntu 22.04 and Amazon Linux 2 are built with
+    `-DICINGA2_WITH_OPENTELEMETRY=OFF`, because the default Protobuf compiler in these
+    distributions is too old for the OpenTelemetry code generation used by Icinga 2.
+    As a result, the `otlpmetrics` feature (and `OTLPMetricsWriter` type) is not available
+    in those package builds.
+
+    You can verify this on a node with:
+
+    ```bash
+    icinga2 feature list | grep otlpmetrics
+    ```
+
 By default, the OTLPMetrics Writer expects the OpenTelemetry Collector or any other OTLP HTTP receiver to listen at
 `127.0.0.1` on port `4318` but most of the third-party backends use their own ports, so you may need to adjust the
 configuration accordingly. Additionally, the `metrics_endpoint` can vary based on the backend you are using.

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -16,6 +16,12 @@ ElasticsearchWriter is deprecated in v2.16 and will be removed in v2.18. In case
 we suggest migrating to the new OTLPMetricsWriter as a replacement. The index data structure in Elasticsearch will be
 different though, so any third-party tools working with that data will need to be adapted as well.
 
+!!! info
+
+    The official Icinga 2 packages for Debian 11, Ubuntu 22.04 and Amazon Linux 2 are currently built without
+    OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`), so `OTLPMetricsWriter` is not
+    available there unless you build Icinga 2 with a newer Protobuf toolchain.
+
 ### Deprecation of user-defined DSL Namespaces
 
 If you were previously using constructs like `namespace my_utils { ... }` in your config, we suggest


### PR DESCRIPTION
- Add prominent note in OTLP feature docs with root cause:
- package builds disable OpenTelemetry (ICINGA2_WITH_OPENTELEMETRY=OFF) due to older default Protobuf toolchain.
- Add the same caveat to the OTLPMetricsWriter object type reference.
- Add install-time note in Debian/Ubuntu installation section.
- Add upgrade-path caveat in ElasticsearchWriter -> OTLPMetricsWriter migration section.
- Include verification command and practical alternatives (build with newer Protobuf toolchain or use newer distro release).

Fixes #10823.