### PR TITLE
Track deleted runtime objects to avoid erroneous recreation

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -155,8 +155,9 @@ Dictionary::Iterator Dictionary::End()
  * Removes the item specified by the iterator from the dictionary.
  *
  * @param it The iterator.
+ * @return an iterator to the element after the removed element.
  */
-void Dictionary::Remove(Dictionary::Iterator it)
+Dictionary::Iterator Dictionary::Remove(Dictionary::Iterator it)
 {
 	ASSERT(OwnsLock());
 	std::unique_lock<std::shared_timed_mutex> lock (m_DataMutex);
@@ -164,7 +165,7 @@ void Dictionary::Remove(Dictionary::Iterator it)
 	if (m_Frozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Dictionary must not be modified."));
 
-	m_Data.erase(it);
+	return m_Data.erase(it);
 }
 
 /**

--- a/lib/base/dictionary.hpp
+++ b/lib/base/dictionary.hpp
@@ -56,7 +56,7 @@ public:
 
 	void Remove(const String& key);
 
-	void Remove(Iterator it);
+	Iterator Remove(Iterator it);
 
 	void Clear();
 

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -274,6 +274,19 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 
 	ConfigObject::Ptr object = ctype->GetObject(objName);
 
+	// Check if the deletion is for an older object version
+	double objVersion = params->Get("version");
+	if (object && objVersion < object->GetVersion()) {
+		Log(LogNotice, "ApiListener")
+			<< "Discarding 'config delete object' message"
+			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
+			<< " for object '" << object->GetName()
+			<< "': Object version " << std::fixed << object->GetVersion()
+			<< " is more recent than the deleted version " << std::fixed << objVersion << ".";
+
+		return Empty;
+	}
+
 	if (!object) {
 		Log(LogNotice, "ApiListener")
 			<< "Could not delete non-existent object '" << objName << "' with type '" << params->Get("type") << "'.";

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -287,8 +287,8 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 	// Check if the deletion is for an older object version
 	double objVersion = params->Get("version");
 	if (object && objVersion < object->GetVersion()) {
-		Log(LogNotice, "ApiListener")
-			<< "Discarding 'config delete object' message"
+		Log(LogInformation, "ApiListener")
+			<< "Ignoring 'config delete object' message"
 			<< " from '" << identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName() << "')"
 			<< " for object '" << object->GetName()
 			<< "': Object version " << std::fixed << object->GetVersion()
@@ -553,6 +553,38 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 
 	Log(LogInformation, "ApiListener")
 		<< "Finished syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
+}
+
+/**
+ * Prunes the list of deleted runtime objects.
+ *
+ * This takes into account the longest log duration of all the endpoints in the cluster and
+ * then deletes the entries for objects that are older than that.
+ *
+ * The reasoning is that once a deletion is older than log duration of an endpoint it is
+ * unlikely that we could still get any delayed updates to the object versions that were deleted.
+ * At that point, either all endpoints are up-to-date, or the problematic messages have been
+ * dropped from the replay log anyway.
+ */
+void ApiListener::PruneDeletedRuntimeObjects()
+{
+	auto deletedRuntimeObjects = GetDeletedRuntimeObjects();
+
+	double maxLogDuration = 0;
+	for (const auto &endpoint : ConfigType::GetObjectsByType<Endpoint>()) {
+		maxLogDuration = std::max(maxLogDuration, endpoint->GetLogDuration());
+	}
+	double cutoff = Utility::GetTime() - maxLogDuration;
+
+	ObjectLock lock(deletedRuntimeObjects);
+
+	for (auto it = deletedRuntimeObjects->Begin(); it != deletedRuntimeObjects->End();) {
+		if (it->second < cutoff) {
+			it = deletedRuntimeObjects->Remove(it);
+		} else {
+			it++;
+		};
+	}
 }
 
 static String MakeDeletionTimestampKey(const String& typeName, const String& objName)

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -98,6 +98,16 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 	/* update the object */
 	double objVersion = params->Get("version");
 
+	auto deletedVersion = listener->GetRuntimeObjectDeletionTs(objType, objName);
+	if (deletedVersion >= objVersion) {
+		Log(LogInformation, "ApiListener")
+			<< "Ignoring config update for deleted object '" << objName << "' of type '" << objType << "' from '"
+			<< identity << "' (endpoint: '" << endpoint->GetName() << "', zone: '" << endpointZone->GetName()
+			<< "'): Object version " << std::fixed << objVersion << " is less recent than the deleted version "
+			<< std::fixed << deletedVersion << ".";
+		return Empty;
+	}
+
 	Type::Ptr ptype = Type::GetByName(objType);
 	auto *ctype = dynamic_cast<ConfigType *>(ptype.get());
 
@@ -287,6 +297,11 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 		return Empty;
 	}
 
+	/* We need to store the deletion timestamp even if no object exists, to protect against
+	 * endpoints that try to sync back objects that would have been deleted by this message.
+	 */
+	listener->UpdateRuntimeObjectDeletionTs(objType, objName, objVersion);
+
 	if (!object) {
 		Log(LogNotice, "ApiListener")
 			<< "Could not delete non-existent object '" << objName << "' with type '" << params->Get("type") << "'.";
@@ -450,6 +465,24 @@ void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const Mess
 	if (object->GetPackage() != "_api")
 		return;
 
+	auto typeName = object->GetReflectionType()->GetName();
+	auto objName = object->GetName();
+
+	/* Update the deletion timestamp only if the deletion didn't originate from another
+	 * endpoint, because when this deletion was triggered via a JSON-RPC message, the
+	 * stored timestamp is the one that was set in `ApiListener::ConfigDeleteObjectAPIHandler`
+	 * and  already reflects the time the original deletion was triggered.
+	 * Also set if no timestamp was stored yet, as a safeguard. There shouldn't be any
+	 * situation where this happens, but that relies on the correct execution order of
+	 * many other functions, like cascading deletes always propagating in the correct
+	 * order through JSON-RPC, so the children are always deleted first.
+	 */
+	double deletionTime = GetRuntimeObjectDeletionTs(typeName, objName);
+	if (!origin || origin->IsLocal() || deletionTime == 0) {
+		deletionTime = Utility::GetTime();
+		UpdateRuntimeObjectDeletionTs(typeName, objName, deletionTime);
+	}
+
 	/* only send objects to zones which have access to the object */
 	if (client) {
 		Zone::Ptr target_zone = client->GetEndpoint()->GetZone();
@@ -473,7 +506,7 @@ void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const Mess
 
 	params->Set("name", object->GetName());
 	params->Set("type", object->GetReflectionType()->GetName());
-	params->Set("version", object->GetVersion());
+	params->Set("version", deletionTime);
 
 
 #ifdef I2_DEBUG
@@ -520,4 +553,48 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 
 	Log(LogInformation, "ApiListener")
 		<< "Finished syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
+}
+
+static String MakeDeletionTimestampKey(const String& typeName, const String& objName)
+{
+	return typeName + ":" + objName;
+}
+
+/**
+ * Get the timestamp at which the object has been most recently deleted.
+ *
+ * @param typeName The name of the tyope of the object
+ * @param objName The name of the object
+ * @return the timestamp of the object, or 0 if there was no entry.
+ */
+double ApiListener::GetRuntimeObjectDeletionTs(const String& typeName, const String& objName)
+{
+	auto dict = GetDeletedRuntimeObjects();
+	auto ts = dict->Get(MakeDeletionTimestampKey(typeName, objName));
+	if (ts.IsNumber()) {
+		return ts.Get<double>();
+	}
+	return 0;
+}
+
+/**
+ * Updates the deletion timestamp for the object.
+ *
+ * The timestamp will not be changed in case a newer timestamp has already been stored
+ * for the object.
+ *
+ * @param typeName The name of the tyope of the object
+ * @param objName The name of the object
+ * @param ts the timestamp
+ */
+bool ApiListener::UpdateRuntimeObjectDeletionTs(const String& typeName, const String& objName, double ts)
+{
+	auto dict = GetDeletedRuntimeObjects();
+	ObjectLock lock(dict);
+	auto current = GetRuntimeObjectDeletionTs(typeName, objName);
+	if (current > ts) {
+		return false;
+	}
+	dict->Set(MakeDeletionTimestampKey(typeName, objName), ts);
+	return true;
 }

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -297,6 +297,12 @@ void ApiListener::Start(bool runtimeCreated)
 	m_Timer->Start();
 	m_Timer->Reschedule(0);
 
+	m_DeletedRuntimeObjectsTimer = Timer::Create();
+	m_DeletedRuntimeObjectsTimer->OnTimerExpired.connect([this](const Timer* const&) { PruneDeletedRuntimeObjects(); });
+	m_DeletedRuntimeObjectsTimer->SetInterval(15 * 60);
+	m_DeletedRuntimeObjectsTimer->Start();
+	m_DeletedRuntimeObjectsTimer->Reschedule(0);
+
 	m_ReconnectTimer = Timer::Create();
 	m_ReconnectTimer->OnTimerExpired.connect([this](const Timer * const&) { ApiReconnectTimerHandler(); });
 	m_ReconnectTimer->SetInterval(10);
@@ -379,6 +385,7 @@ void ApiListener::Stop(bool runtimeDeleted)
 	m_CleanupCertificateRequestsTimer->Stop(true);
 	m_AuthorityTimer->Stop(true);
 	m_ReconnectTimer->Stop(true);
+	m_DeletedRuntimeObjectsTimer->Stop(true);
 	m_Timer->Stop(true);
 	m_RenewOwnCertTimer->Stop(true);
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -183,6 +183,7 @@ private:
 	std::set<HttpServerConnection::Ptr> m_HttpClients;
 
 	Timer::Ptr m_Timer;
+	Timer::Ptr m_DeletedRuntimeObjectsTimer;
 	Timer::Ptr m_ReconnectTimer;
 	Timer::Ptr m_AuthorityTimer;
 	Timer::Ptr m_CleanupCertificateRequestsTimer;
@@ -204,6 +205,7 @@ private:
 	void CleanupCertificateRequestsTimerHandler();
 	void CheckApiPackageIntegrity();
 
+	void PruneDeletedRuntimeObjects();
 	double GetRuntimeObjectDeletionTs(const String& typeName, const String& objName);
 	bool UpdateRuntimeObjectDeletionTs(const String& typeName, const String& objName, double ts);
 

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -204,6 +204,9 @@ private:
 	void CleanupCertificateRequestsTimerHandler();
 	void CheckApiPackageIntegrity();
 
+	double GetRuntimeObjectDeletionTs(const String& typeName, const String& objName);
+	bool UpdateRuntimeObjectDeletionTs(const String& typeName, const String& objName, double ts);
+
 	bool AddListener(const String& node, const String& service);
 	void StopListener();
 	void AddConnection(const Endpoint::Ptr& endpoint);

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -67,6 +67,10 @@ class ApiListener : ConfigObject
 	[config, no_user_modify] bool enforce_filter_expression_permission {
 		default {{{ return false; }}}
 	};
+
+	[state, no_user_modify] Dictionary::Ptr deleted_runtime_objects {
+		default {{{ return new Dictionary(); }}}
+	};
 };
 
 }


### PR DESCRIPTION
## Description

This fixes deleted objects being recreated and the cluster state becoming inconsistent after deleting objects via the API on one endpoint, while the second endpoint was offline or not reachable.

This is done by keeping track of deleted objects in a map of the deleted objects name to the object's "version". If the object would be recreated with a version that is older or equal to the version it has been deleted with, the object creation is being skipped. This is done in the expectation that at the same time the deletion event is being replayed to the other endpoint that is trying to sync the object creation.

## Testing

For now I have built an integration test in my own dev-docker environment based on the steps described in #10022. Additionally the test also verifies that afterwards creating a new object with the same name works fine. I've not yet tested various split-brain scenarios @julianbrost and I discussed offline.

Fixes #10022.