### PR TITLE
Remove `opensuse/leap:15.6` from github workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,7 +39,6 @@ jobs:
           - fedora:43
           - fedora:44
 
-          - opensuse/leap:15.6
           - opensuse/leap:16.0
 
           # We don't actually support Rocky Linux as such!


### PR DESCRIPTION
## Description

The distribution is end-of-life on 2026-04-30 (i.e. tomorrow at the time of writing this) and the checks on Github are already failing because some missing package repos or something else along that line.