### PR TITLE
Fix openSUSE 15.6 GitHub actions

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -61,7 +61,7 @@ case "$DISTRO" in
     ;;
 
   *suse*)
-    zypper in -y bison ccache cmake flex gcc-c++ ninja rpm-config-SUSE \
+    zypper in -y --allow-downgrade bison ccache cmake flex gcc-c++ ninja rpm-config-SUSE \
       {lib{edit,mariadb,openssl},ncurses,postgresql,systemd,protobuf}-devel \
       libboost_{context,coroutine,filesystem,iostreams,program_options,regex,system,test,thread}-devel
     ;;


### PR DESCRIPTION
The runner image ships libncurses6-6.1-150000.5.33.1, but the only ncurses-devel available in the configured repos is 6.1-150000.5.30.1, which requires an exact-version match on libncurses6.

closes #10831