### PR TITLE
icingadb: use object identifiers for state history event IDs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -175,6 +175,7 @@ Maciej Dems <maciej.dems@p.lodz.pl>
 Magnus Bäck <magnus@noun.se>
 Maik Stuebner <maik@stuebner.info>
 Malte Rabenseifner <mail@malte-rabenseifner.de>
+Manas Singh <00manassingh00@gmail.com>
 Manuel Reiter <reiter@csc.uni-frankfurt.de>
 Marc Rupprecht <marc.rupprecht@netways.de>
 Marcus van Dam <marcus@marcusvandam.nl>

--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -197,7 +197,6 @@ with `root` permissions unless noted otherwise.
 ```bash
 apt install icinga2
 ```
-
 <!-- {% endif %} -->
 
 <!-- {% if rhel %} -->

--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -197,6 +197,13 @@ with `root` permissions unless noted otherwise.
 ```bash
 apt install icinga2
 ```
+
+!!! info
+
+    On Debian 11 and Ubuntu 22.04, the official Icinga 2 packages currently do **not**
+    provide the `otlpmetrics` feature (`OTLPMetricsWriter`). These package builds disable
+    OpenTelemetry support because the default Protobuf compiler version in those distributions
+    is too old for the required OpenTelemetry code generation.
 <!-- {% endif %} -->
 
 <!-- {% if rhel %} -->

--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -198,12 +198,6 @@ with `root` permissions unless noted otherwise.
 apt install icinga2
 ```
 
-!!! info
-
-    On Debian 11 and Ubuntu 22.04, the official Icinga 2 packages currently do **not**
-    provide the `otlpmetrics` feature (`OTLPMetricsWriter`). These package builds disable
-    OpenTelemetry support because the default Protobuf compiler version in those distributions
-    is too old for the required OpenTelemetry code generation.
 <!-- {% endif %} -->
 
 <!-- {% if rhel %} -->

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1878,6 +1878,12 @@ or any other OTLP-compatible backend that accepts OTLP data over HTTP. This conf
 [otlpmetrics feature](14-features.md#otlpmetrics-writer). You can find more information about OpenTelemetry and OTLP
 on the [OpenTelemetry website](https://opentelemetry.io/).
 
+!!! info
+
+    The official package builds for Debian 11 and Ubuntu 22.04 do not include this object type.
+    These builds disable OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`) because the
+    default Protobuf compiler version is too old for the required code generation.
+
 A basic copy and pastable example configuration is shown below:
 
 ```

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1880,7 +1880,7 @@ on the [OpenTelemetry website](https://opentelemetry.io/).
 
 !!! info
 
-    The official package builds for Debian 11 and Ubuntu 22.04 do not include this object type.
+    The official package builds for Debian 11, Ubuntu 22.04 and Amazon Linux 2 do not include this object type.
     These builds disable OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`) because the
     default Protobuf compiler version is too old for the required code generation.
 

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -678,10 +678,6 @@ icinga2 feature enable otlpmetrics
     icinga2 feature list | grep otlpmetrics
     ```
 
-    If you need `OTLPMetricsWriter` on these platforms, use one of the following:
-    1. Build Icinga 2 from source with a newer Protobuf toolchain and `ICINGA2_WITH_OPENTELEMETRY=ON`.
-    2. Use a newer distribution release where package dependencies satisfy the OpenTelemetry build requirements.
-
 By default, the OTLPMetrics Writer expects the OpenTelemetry Collector or any other OTLP HTTP receiver to listen at
 `127.0.0.1` on port `4318` but most of the third-party backends use their own ports, so you may need to adjust the
 configuration accordingly. Additionally, the `metrics_endpoint` can vary based on the backend you are using.

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -663,6 +663,25 @@ In order to enable this feature, you can use the following command:
 icinga2 feature enable otlpmetrics
 ```
 
+!!! info
+
+    **Package availability note (Debian 11 / Ubuntu 22.04):**
+    The official Icinga 2 packages for Debian 11 and Ubuntu 22.04 are built with
+    `-DICINGA2_WITH_OPENTELEMETRY=OFF`, because the default Protobuf compiler in these
+    distributions is too old for the OpenTelemetry code generation used by Icinga 2.
+    As a result, the `otlpmetrics` feature (and `OTLPMetricsWriter` type) is not available
+    in those package builds.
+
+    You can verify this on a node with:
+
+    ```bash
+    icinga2 feature list | grep otlpmetrics
+    ```
+
+    If you need `OTLPMetricsWriter` on these platforms, use one of the following:
+    1. Build Icinga 2 from source with a newer Protobuf toolchain and `ICINGA2_WITH_OPENTELEMETRY=ON`.
+    2. Use a newer distribution release where package dependencies satisfy the OpenTelemetry build requirements.
+
 By default, the OTLPMetrics Writer expects the OpenTelemetry Collector or any other OTLP HTTP receiver to listen at
 `127.0.0.1` on port `4318` but most of the third-party backends use their own ports, so you may need to adjust the
 configuration accordingly. Additionally, the `metrics_endpoint` can vary based on the backend you are using.

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -665,8 +665,8 @@ icinga2 feature enable otlpmetrics
 
 !!! info
 
-    **Package availability note (Debian 11 / Ubuntu 22.04):**
-    The official Icinga 2 packages for Debian 11 and Ubuntu 22.04 are built with
+    **Package availability note (Debian 11 / Ubuntu 22.04 / Amazon Linux 2):**
+    The official Icinga 2 packages for Debian 11, Ubuntu 22.04 and Amazon Linux 2 are built with
     `-DICINGA2_WITH_OPENTELEMETRY=OFF`, because the default Protobuf compiler in these
     distributions is too old for the OpenTelemetry code generation used by Icinga 2.
     As a result, the `otlpmetrics` feature (and `OTLPMetricsWriter` type) is not available

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -16,6 +16,12 @@ ElasticsearchWriter is deprecated in v2.16 and will be removed in v2.18. In case
 we suggest migrating to the new OTLPMetricsWriter as a replacement. The index data structure in Elasticsearch will be
 different though, so any third-party tools working with that data will need to be adapted as well.
 
+!!! info
+
+    The official Icinga 2 packages for Debian 11 and Ubuntu 22.04 are currently built without
+    OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`), so `OTLPMetricsWriter` is not
+    available there unless you build Icinga 2 with a newer Protobuf toolchain.
+
 ### Deprecation of user-defined DSL Namespaces
 
 If you were previously using constructs like `namespace my_utils { ... }` in your config, we suggest

--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -18,7 +18,7 @@ different though, so any third-party tools working with that data will need to b
 
 !!! info
 
-    The official Icinga 2 packages for Debian 11 and Ubuntu 22.04 are currently built without
+    The official Icinga 2 packages for Debian 11, Ubuntu 22.04 and Amazon Linux 2 are currently built without
     OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`), so `OTLPMetricsWriter` is not
     available there unless you build Icinga 2 with a newer Protobuf toolchain.
 

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -1905,7 +1905,7 @@ void IcingaDB::SendStateChange(const ConfigObject::Ptr& object, const CheckResul
 	auto eventTime (cr->GetExecutionEnd());
 	auto eventTs (TimestampToMilliseconds(eventTime));
 
-	Array::Ptr rawId = new Array({m_EnvironmentId, object->GetName()});
+	Array::Ptr rawId = new Array({m_EnvironmentId, GetObjectIdentifier(object)});
 	rawId->Add(eventTs);
 
 	RedisConnection::Query xAdd ({

--- a/lib/icingadb/icingadb-utility.cpp
+++ b/lib/icingadb/icingadb-utility.cpp
@@ -92,7 +92,7 @@ String IcingaDB::GetObjectIdentifier(const ConfigObject::Ptr& object)
  */
 String IcingaDB::CalcEventID(const char* eventType, const ConfigObject::Ptr& object, double eventTime, NotificationType nt)
 {
-	Array::Ptr rawId = new Array({object->GetName()});
+	Array::Ptr rawId = new Array({GetObjectIdentifier(object)});
 	rawId->Insert(0, m_EnvironmentId);
 	rawId->Insert(1, eventType);
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ if(ICINGA2_WITH_PGSQL)
 endif()
 
 if(ICINGA2_WITH_ICINGADB)
+  list(APPEND types_test_SOURCES icingadb-eventid.cpp)
   list(APPEND types_test_SOURCES $<TARGET_OBJECTS:icingadb>)
 endif()
 

--- a/test/icingadb-eventid.cpp
+++ b/test/icingadb-eventid.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2012 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "icingadb/icingadb.hpp"
+#include "icinga/host.hpp"
+#include <BoostTestTargetConfig.h>
+
+using namespace icinga;
+
+BOOST_AUTO_TEST_CASE(calc_event_id_uses_object_identifier)
+{
+	Host::Ptr host = new Host();
+	host->SetName("master01");
+
+	host->SetIcingadbIdentifier("id-a");
+	auto first = IcingaDB::CalcEventID("state_change", host, 1710000000.123);
+
+	host->SetIcingadbIdentifier("id-b");
+	auto second = IcingaDB::CalcEventID("state_change", host, 1710000000.123);
+
+	BOOST_CHECK_NE(first, second);
+}


### PR DESCRIPTION
State history IDs in the Icinga DB publisher were derived from object names, which can collide in HA setups where similarly named checks exist on different masters. This could cause service history entries to appear mixed between hosts/endpoints.

This change makes state history identity use the stable Icinga DB object identifier instead of raw object name:

CalcEventID(...) now hashes GetObjectIdentifier(object) (not object->GetName()).
SendStateChange(...) now builds history id from {environment_id, object_identifier, event_ts}.