### PR TITLE
Fix potential nullptr-dereference in perfdata writer stats functions

### DIFF
--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -49,11 +49,12 @@ void GelfWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& perf
 	for (const GelfWriter::Ptr& gelfwriter : ConfigType::GetObjectsByType<GelfWriter>()) {
 		size_t workQueueItems = gelfwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = gelfwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
+		auto connection = gelfwriter->m_LockedConnection.load();
 
 		nodes.emplace_back(gelfwriter->GetName(), new Dictionary({
 			{ "work_queue_items", workQueueItems },
 			{ "work_queue_item_rate", workQueueItemRate },
-			{ "connected", gelfwriter->m_Connection->IsConnected() },
+			{ "connected", connection && connection->IsConnected() },
 			{ "source", gelfwriter->GetSource() }
 		}));
 
@@ -91,6 +92,7 @@ void GelfWriter::Resume()
 	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort(), m_SslContext, !GetInsecureNoverify()};
+	m_LockedConnection.store(m_Connection);
 
 	/* Register event handlers. */
 	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -34,6 +34,7 @@ protected:
 
 private:
 	PerfdataWriterConnection::Ptr m_Connection;
+	Locked<PerfdataWriterConnection::Ptr> m_LockedConnection;
 	WorkQueue m_WorkQueue{10000000, 1};
 	Shared<boost::asio::ssl::context>::Ptr m_SslContext;
 

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -58,11 +58,12 @@ void GraphiteWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& 
 	for (const GraphiteWriter::Ptr& graphitewriter : ConfigType::GetObjectsByType<GraphiteWriter>()) {
 		size_t workQueueItems = graphitewriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = graphitewriter->m_WorkQueue.GetTaskCount(60) / 60.0;
+		auto connection = graphitewriter->m_LockedConnection.load();
 
 		nodes.emplace_back(graphitewriter->GetName(), new Dictionary({
 			{ "work_queue_items", workQueueItems },
 			{ "work_queue_item_rate", workQueueItemRate },
-			{ "connected", graphitewriter->m_Connection->IsConnected() }
+			{ "connected", connection && connection->IsConnected() }
 		}));
 
 		perfdata->Add(new PerfdataValue("graphitewriter_" + graphitewriter->GetName() + "_work_queue_items", workQueueItems));
@@ -86,6 +87,7 @@ void GraphiteWriter::Resume()
 	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort()};
+	m_LockedConnection.store(m_Connection);
 
 	/* Register event handlers. */
 	m_HandleCheckResults = Checkable::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable,

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -36,6 +36,7 @@ protected:
 
 private:
 	PerfdataWriterConnection::Ptr m_Connection;
+	Locked<PerfdataWriterConnection::Ptr> m_LockedConnection;
 	WorkQueue m_WorkQueue{10000000, 1};
 
 	boost::signals2::connection m_HandleCheckResults;

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -55,11 +55,12 @@ void OpenTsdbWriter::StatsFunc(const Dictionary::Ptr& status, const Array::Ptr& 
 	for (const OpenTsdbWriter::Ptr& opentsdbwriter : ConfigType::GetObjectsByType<OpenTsdbWriter>()) {
 		size_t workQueueItems = opentsdbwriter->m_WorkQueue.GetLength();
 		double workQueueItemRate = opentsdbwriter->m_WorkQueue.GetTaskCount(60) / 60.0;
+		auto connection = opentsdbwriter->m_LockedConnection.load();
 
 		nodes.emplace_back(
 			opentsdbwriter->GetName(),
 			new Dictionary({
-			{ "connected", opentsdbwriter->m_Connection->IsConnected() },
+			{ "connected", connection && connection->IsConnected() },
 				{"work_queue_items", workQueueItems},
 				{"work_queue_item_rate", workQueueItemRate}
 				}
@@ -91,6 +92,7 @@ void OpenTsdbWriter::Resume()
 	ReadConfigTemplate();
 
 	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort()};
+	m_LockedConnection.store(m_Connection);
 
 	m_HandleCheckResults = Service::OnNewCheckResult.connect([this](const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&) {
 		CheckResultHandler(checkable, cr);

--- a/lib/perfdata/opentsdbwriter.hpp
+++ b/lib/perfdata/opentsdbwriter.hpp
@@ -37,6 +37,7 @@ private:
 	WorkQueue m_WorkQueue{10000000, 1};
 	std::string m_MsgBuf;
 	PerfdataWriterConnection::Ptr m_Connection;
+	Locked<PerfdataWriterConnection::Ptr> m_LockedConnection;
 
 	boost::signals2::connection m_HandleCheckResults;
 


### PR DESCRIPTION
This fixes a crash in `GelfWriter`, `GraphiteWriter` and `OpenTsdbWriter` that occurs when the writer's stats functions are called, for example by the `icinga` check plugin, before the writer has been initialized.

Fixes #10842.