### PR TITLE
Fix minor issues with `PerfdataWriterConnection`

### DIFF
--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -71,19 +71,19 @@ void PerfdataWriterConnection::Disconnect()
 
 	IoEngine::SpawnCoroutine(m_Strand, [&](boost::asio::yield_context yc) {
 		try {
-			/* Cancel any outstanding operations of the other coroutine.
-			 * Since we're on the same strand we're hopefully guaranteed that all cancellations
-			 * result in exceptions thrown by the yield_context, even if its already queued for
-			 * completion.
-			 */
-			Visit(m_Stream, [](const auto& stream) {
-				if (stream->lowest_layer().is_open()) {
-					stream->lowest_layer().cancel();
-				}
-			});
-			m_ReconnectTimer.cancel();
+			if (m_SendActive) {
+				Visit(m_Stream, [](const auto& stream) {
+					if (stream->lowest_layer().is_open()) {
+						boost::system::error_code ec;
+						stream->lowest_layer().close(ec);
+					}
+				});
+				m_ReconnectTimer.cancel();
+				m_Connected = false;
+			} else {
+				Disconnect(std::move(yc));
+			}
 
-			Disconnect(std::move(yc));
 			promise.set_value();
 		} catch (const std::exception& ex) {
 			promise.set_exception(std::current_exception());

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -63,7 +63,7 @@ bool PerfdataWriterConnection::IsStopped() const
 
 void PerfdataWriterConnection::Disconnect()
 {
-	if (m_Stopped.exchange(true, std::memory_order_relaxed)) {
+	if (m_Stopped.exchange(true)) {
 		return;
 	}
 
@@ -153,7 +153,7 @@ void PerfdataWriterConnection::EnsureConnected(const boost::asio::yield_context&
 
 void PerfdataWriterConnection::Disconnect(boost::asio::yield_context yc)
 {
-	if (!m_Connected.exchange(false, std::memory_order_relaxed)) {
+	if (!m_Connected.exchange(false)) {
 		return;
 	}
 

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -161,8 +161,9 @@ void PerfdataWriterConnection::Disconnect(boost::asio::yield_context yc)
 		m_Stream,
 		[&](Shared<AsioTlsStream>::Ptr& stream) { stream->GracefulDisconnect(m_Strand, yc); },
 		[&](Shared<AsioTcpStream>::Ptr& stream) {
-			stream->lowest_layer().shutdown(boost::asio::socket_base::shutdown_both);
-			stream->lowest_layer().close();
+			boost::system::error_code ec;
+			stream->lowest_layer().shutdown(boost::asio::socket_base::shutdown_both, ec);
+			stream->lowest_layer().close(ec);
 		}
 	);
 

--- a/lib/perfdata/perfdatawriterconnection.hpp
+++ b/lib/perfdata/perfdatawriterconnection.hpp
@@ -95,16 +95,16 @@ public:
 					Log(LogCritical, m_LogFacility)
 						<< "Error while " << (m_Connected ? "sending" : "connecting") << " to '" << m_Host << ":"
 						<< m_Port << "' for '" << m_ParentName << "': " << ex.what();
+				}
 
-					m_Stream = MakeStream();
-					m_Connected = false;
+				m_Stream = MakeStream();
+				m_Connected = false;
 
-					try {
-						BackoffWait(yc);
-					} catch (const std::exception&) {
-						promise.set_exception(std::make_exception_ptr(Stopped{}));
-						return;
-					}
+				try {
+					BackoffWait(yc);
+				} catch (const std::exception&) {
+					promise.set_exception(std::make_exception_ptr(Stopped{}));
+					return;
 				}
 			}
 		});

--- a/lib/perfdata/perfdatawriterconnection.hpp
+++ b/lib/perfdata/perfdatawriterconnection.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/defer.hpp"
 #include "base/io-engine.hpp"
 #include "base/tlsstream.hpp"
 #include <boost/asio/buffer.hpp>
@@ -69,6 +70,9 @@ public:
 		std::promise<RetType> promise;
 
 		IoEngine::SpawnCoroutine(m_Strand, [&](boost::asio::yield_context yc) {
+			m_SendActive = true;
+			Defer resetSendActive{[this] { m_SendActive = false; }};
+
 			while (true) {
 				try {
 					EnsureConnected(yc);
@@ -139,6 +143,8 @@ private:
 
 	std::atomic_bool m_Stopped{false};
 	std::atomic_bool m_Connected{false};
+
+	bool m_SendActive{};
 
 	bool m_VerifyPeerCertificate;
 	Shared<boost::asio::ssl::context>::Ptr m_SslContext;

--- a/test/perfdata-perfdatatargetfixture.hpp
+++ b/test/perfdata-perfdatatargetfixture.hpp
@@ -71,11 +71,20 @@ public:
 		BOOST_REQUIRE(stream->next_layer().IsVerifyOK());
 	}
 
-	void Shutdown()
+	void Shutdown(bool wait = false)
 	{
 		BOOST_REQUIRE(std::holds_alternative<Shared<AsioTlsStream>::Ptr>(m_Stream));
 		auto& stream = std::get<Shared<AsioTlsStream>::Ptr>(m_Stream);
 		try {
+			if (wait) {
+				std::array<std::byte, 128> buf{};
+				boost::asio::mutable_buffer readBuf (buf.data(), buf.size());
+				boost::system::error_code ec;
+
+				do {
+					stream->read_some(readBuf, ec);
+				} while (!ec);
+			}
 			stream->next_layer().shutdown();
 		} catch (const std::exception& ex) {
 			if (const auto* se = dynamic_cast<const boost::system::system_error*>(&ex);

--- a/test/perfdata-perfdatatargetfixture.hpp
+++ b/test/perfdata-perfdatatargetfixture.hpp
@@ -75,23 +75,16 @@ public:
 	{
 		BOOST_REQUIRE(std::holds_alternative<Shared<AsioTlsStream>::Ptr>(m_Stream));
 		auto& stream = std::get<Shared<AsioTlsStream>::Ptr>(m_Stream);
-		try {
-			if (wait) {
-				std::array<std::byte, 128> buf{};
-				boost::asio::mutable_buffer readBuf (buf.data(), buf.size());
-				boost::system::error_code ec;
+		boost::system::error_code ec;
+		if (wait) {
+			std::array<std::byte, 128> buf{};
+			boost::asio::mutable_buffer readBuf (buf.data(), buf.size());
 
-				do {
-					stream->read_some(readBuf, ec);
-				} while (!ec);
-			}
-			stream->next_layer().shutdown();
-		} catch (const std::exception& ex) {
-			if (const auto* se = dynamic_cast<const boost::system::system_error*>(&ex);
-				!se || se->code() != boost::asio::error::eof) {
-				BOOST_FAIL("Exception in shutdown(): " << ex.what());
-			}
+			do {
+				stream->read_some(readBuf, ec);
+			} while (!ec);
 		}
+		stream->next_layer().shutdown(ec);
 
 		ResetStream();
 	}

--- a/test/perfdata-perfdatawriterconnection.cpp
+++ b/test/perfdata-perfdatawriterconnection.cpp
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(stuck_reading_response)
 		requestReadPromise.set_value();
 		// Do not send a response but react to the shutdown to be polite.
 		shutdownPromise.get_future().get();
-		Shutdown();
+		Shutdown(true);
 	}};
 
 	TestThread timeoutThread{[&]() {
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(http_send_retry)
 
 		SendResponse();
 
-		Shutdown();
+		Shutdown(true);
 	}};
 
 	boost::beast::http::request<boost::beast::http::string_body> request{boost::beast::http::verb::post, "foo", 10};


### PR DESCRIPTION
This fixes multiple minor issues with `PerfdataWriterConnection` and its test-cases.

- 1114d0b27c0f5a24e6517c4ddc4d3cca5658edfd, cb92a16c25062b1e5ce2b48835c56b896d6448c4, and 05af40d6a4195c495a6f2a189d31bf9c308c3261: Fix the `stream truncated` errors in some test-cases or test cases getting stuck, mostly during parallel test execution.
- 6bd7384f1a6b8130ba5b1d2e5ab75e2b28117b63: Fixes a potential issue where a TCP `shutdown()` could get the class stuck in a reconnect loop.
- a5717d99e7021b86aae4cf4cca2b531865b4687f: Fixes segmentation faults in `__cxa_end_catch` during test execution when compiled against `libcxxrt` used on FreeBSD, which seems to be having a problem in Boost.Context when suspending a coroutine inside a catch-handler. From my research it seems Linux and other BSDs have moved on from this library in favor of `libc++abi`, but FreeBSD didn't (yet). In any case, it's a simple fix because the code doesn't actually need to be in the catch handler.

## Remaining Issues

This PR contained a fix for issues encountered on the `armhf` and `s390x` architectures with the thread-local storage used in `std::promise` in connection with boost::asio coroutines leading to segfaults. This will be addressed in a separate PR later on.