### PR TITLE
Freeze perfdata arrays and remove locks in code using them

### DIFF
--- a/lib/icinga/checkresult.cpp
+++ b/lib/icinga/checkresult.cpp
@@ -33,3 +33,11 @@ double CheckResult::CalculateLatency() const
 
 	return latency;
 }
+
+void CheckResult::SetPerformanceData(const Array::Ptr& value, bool suppress_events, const Value& cookie)
+{
+	if (value) {
+		value->Freeze();
+	}
+	ObjectImpl<CheckResult>::SetPerformanceData(value, suppress_events, cookie);
+}

--- a/lib/icinga/checkresult.hpp
+++ b/lib/icinga/checkresult.hpp
@@ -22,6 +22,7 @@ public:
 
 	double CalculateExecutionTime() const;
 	double CalculateLatency() const;
+	void SetPerformanceData(const Array::Ptr& value, bool suppress_events = false, const Value& cookie = Empty) override;
 };
 
 }

--- a/lib/icinga/checkresult.ti
+++ b/lib/icinga/checkresult.ti
@@ -60,7 +60,7 @@ class CheckResult
 	[state, enum] ServiceState "state";
 	[state, enum] ServiceState previous_hard_state;
 	[state] String output;
-	[state] Array::Ptr performance_data;
+	[state, set_virtual] Array::Ptr performance_data;
 
 	[state] bool active {
 		default {{{ return true; }}}

--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -185,8 +185,6 @@ String PluginUtility::FormatPerfdata(const Array::Ptr& perfdata, bool normalize)
 
 	std::ostringstream result;
 
-	ObjectLock olock(perfdata);
-
 	bool first = true;
 	for (const Value& pdv : perfdata) {
 		if (!first)

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -202,7 +202,6 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
 	if (perfdata) {
-		ObjectLock olock(perfdata);
 		for (const Value& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -196,7 +196,6 @@ void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const Check
 			Array::Ptr perfdata = cr->GetPerformanceData();
 
 			if (perfdata) {
-				ObjectLock olock(perfdata);
 				for (const Value& val : perfdata) {
 					PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -224,7 +224,6 @@ void GraphiteWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
-	ObjectLock olock(perfdata);
 	for (const Value& val : perfdata) {
 		PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -213,7 +213,6 @@ void InfluxdbCommonWriter::CheckResultHandler(const Checkable::Ptr& checkable, c
 		double ts = cr->GetExecutionEnd();
 
 		if (Array::Ptr perfdata = cr->GetPerformanceData()) {
-			ObjectLock olock(perfdata);
 			for (const Value& val : perfdata) {
 				PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -308,7 +308,6 @@ void OpenTsdbWriter::AddPerfdata(const Checkable::Ptr& checkable, const String& 
 
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
-	ObjectLock olock(perfdata);
 	for (const Value& val : perfdata) {
 		PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/otlpmetricswriter.cpp
+++ b/lib/perfdata/otlpmetricswriter.cpp
@@ -181,7 +181,6 @@ void OTLPMetricsWriter::CheckResultHandler(const Checkable::Ptr& checkable, cons
 		auto endTime = cr->GetExecutionEnd();
 
 		Array::Ptr perfdata = cr->GetPerformanceData();
-		ObjectLock olock(perfdata);
 		for (const Value& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 			if (val.IsObjectType<PerfdataValue>()) {

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -38,6 +38,7 @@ BOOST_AUTO_TEST_CASE(quotes)
 BOOST_AUTO_TEST_CASE(multiple)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=123456 testB=123456");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd);
@@ -47,12 +48,14 @@ BOOST_AUTO_TEST_CASE(multiple)
 BOOST_AUTO_TEST_CASE(multiline)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata(" 'testA'=123456  'testB'=123456");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd);
 	BOOST_CHECK_EQUAL(str, "testA=123456 testB=123456");
 
 	pd = PluginUtility::SplitPerfdata(" 'testA'=123456  \n'testB'=123456");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	str = PluginUtility::FormatPerfdata(pd);
@@ -62,6 +65,7 @@ BOOST_AUTO_TEST_CASE(multiline)
 BOOST_AUTO_TEST_CASE(normalize)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=2m;3;4;1;5 testB=2foobar");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd, true);
@@ -333,6 +337,7 @@ BOOST_AUTO_TEST_CASE(ignore_warn_crit_ranges)
 BOOST_AUTO_TEST_CASE(empty_warn_crit_min_max)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=5;;7;1;9 testB=5;7;;1;9 testC=5;;;1;9 testD=2m;;;1 testE=5;;7;;");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 5);
 
 	String str = PluginUtility::FormatPerfdata(pd, true);

--- a/test/perfdata-perfdatawriterfixture.hpp
+++ b/test/perfdata-perfdatawriterfixture.hpp
@@ -96,7 +96,7 @@ object Host "h1" {
 		std::size_t unchangedCount = 0;
 		while(true){
 			ReceiveCheckResults(10, ServiceCritical, [&](const CheckResult::Ptr& cr) {
-				cr->GetPerformanceData()->Add(new PerfdataValue{GetRandomString("", 4096), 1});
+				cr->SetPerformanceData(new Array{new PerfdataValue{GetRandomString("", 4096), 1}});
 			});
 
 			if (std::chrono::steady_clock::now() - start >= timeout) {


### PR DESCRIPTION
Since perfdata is set once when a check result is created and never changed again, locking this `Array` is unnecessary. This avoids components unnecessarily waiting on each other when processing perfdata by freezing it in `CheckResult::SetPerformanceData()`.

This fixes the locking cascade observed sometimes when the perfdata writer work queue blocks, where it extends to a lock on the entire check result eventually, affecting even more components. This may even escalate to a full deadlock if a `PerfdataWriterConnection` locking the array shares a strand implmentation slot with a `JsonRpcConnection` (or possibly even `HttpServerConnection`) blocked by either the `ObjectLock` of the perfdata array directly or another lock downstream of that (more detail [here](https://github.com/Icinga/icinga2/issues/10825#issuecomment-4552342717)).

Also note that this *will* currently affect `OTLPMetricsWriter`, so it might be a good idea to backport #10857 to 2.16 regardless of whether we reapply the `PerfdataWriterConnection`.

## Testing

Now that we know what the issue is, it is very easy to reproduce. Add the following definition to the root `CMakeLists.txt` and start a setup with at least one master and one satellite that both produce check-results.
```
add_definitions(-DBOOST_ASIO_STRAND_IMPLEMENTATIONS=32)
```
This sets the number of strand implementation objects to a lower one (down from 192), making "collisions" (quoted, because it's intended behavior) significantly more likely. Then restart the satellite a couple times, each time waiting a couple of seconds to see if the perfdata writer's queue starts climbing.

Without this branch it takes about ~5 restarts until I can reproduce the deadlock. With this branch, no amount of restarts will get the perfdata writers stuck.

## Future considerations: `boost::asio::io_context::strand`

To avoid situations like this in the future, we should consider migrating all strand uses to the more modern executor-templated strand `boost::asio::strand<boost::asio::io_context>`, which doesn't have this limitation. It could still deadlock if the number of IO-threads is exhausted, but that would be significantly more difficult than accidentally hitting this issue again. I'll create an issue and link to this PR from there.

Fixes #10848, fixes #10825.