### PR TITLE
doc/win-dev.ps1: request reboot after Chocolatey install

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -10,6 +10,8 @@ function ThrowOnNativeFailure {
 	}
 }
 
+$InstalledChocolatey = $false
+
 
 $VsVersion = 2022
 $MsvcVersion = '14.3'
@@ -68,6 +70,12 @@ try {
 
 	Set-ItemProperty -Path $RegEnv -Name Path -Value ((Get-ItemProperty -Path $RegEnv -Name Path).Path + $ChocoPath)
 	$Env:Path += $ChocoPath
+	$InstalledChocolatey = $true
+}
+
+# Fresh Chocolatey installs may require a reboot before .NET tooling becomes usable.
+if ($InstalledChocolatey -and -not $Env:GITHUB_ACTIONS) {
+	throw 'Chocolatey was installed. Reboot Windows and run doc/win-dev.ps1 again.'
 }
 
 # GitHub Actions uses an image that comes with most dependencies preinstalled. Don't install them twice.


### PR DESCRIPTION
When Chocolatey is installed in the same run, later .NET related installs can fail until reboot.
This change stops early with a clear reboot message and asks to rerun \\doc/win-dev.ps1\\.
closes #10475