### PR TITLE
Fix API authentication being broken with clients that send an unauthenticated request first

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -310,16 +310,17 @@ bool EnsureAuthenticatedUser(
 		Log(LogWarning, "HttpServerConnection")
 			<< "Unauthorized request: " << request.method_string() << ' ' << request.target();
 
-		response.result(http::status::unauthorized);
-		response.set(http::field::www_authenticate, "Basic realm=\"Icinga 2\"");
-		response.set(http::field::connection, "close");
-
 		if (request[http::field::accept] == "application/json") {
 			HttpUtility::SendJsonError(response, nullptr, 401, "Unauthorized. Please check your user credentials.");
 		} else {
+			response.result(http::status::unauthorized);
 			response.set(http::field::content_type, "text/html");
 			response.body() << "<h1>Unauthorized. Please check your user credentials.</h1>";
 		}
+
+		// Set additional header fields after the response has been initialized in SendJsonError().
+		response.set(http::field::www_authenticate, "Basic realm=\"Icinga 2\"");
+		response.set(http::field::connection, "close");
 
 		response.Flush(yc);
 

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -83,6 +83,18 @@ void HttpUtility::SendJsonBody(HttpApiResponse& response, const Dictionary::Ptr&
 	response.GetJsonEncoder(params && GetLastParameter(params, "pretty")).Encode(val);
 }
 
+/**
+ * Initialize the response object with the given error code and info.
+ *
+ * Note that this fully resets the response object so any additional headers will need to be set
+ * after initializing the response with this function.
+ *
+ * @param response A reference to the HTTP response to initialize
+ * @param params The parameters sent with the request
+ * @param code The error code to initialize the response with
+ * @param info The error message to include in the JSON body
+ * @param diagnosticInformation Additional debug information included when `verbose` is in params
+ */
 void HttpUtility::SendJsonError(HttpApiResponse& response,
 	const Dictionary::Ptr& params, int code, const String& info, const String& diagnosticInformation)
 {

--- a/test/remote-httpserverconnection.cpp
+++ b/test/remote-httpserverconnection.cpp
@@ -295,6 +295,7 @@ BOOST_AUTO_TEST_CASE(authenticate_error_wronguser)
 
 	BOOST_REQUIRE_EQUAL(response.version(), 11);
 	BOOST_REQUIRE_EQUAL(response.result(), http::status::unauthorized);
+	BOOST_REQUIRE(!response[http::field::www_authenticate].empty());
 	Dictionary::Ptr body = JsonDecode(response.body());
 	BOOST_REQUIRE(body);
 	BOOST_REQUIRE_EQUAL(body->Get("error"), 401);


### PR DESCRIPTION
The single commit just moves setting the `www_authenticate` header field to after `SendJsonError()` has initialized the message. The respective unit-test now also checks for the header in the response and I've added some documentation on this potentially unexpected behavior of `SendJsonError()`.

We should maybe consider some minor refactoring of these `SendJson(Error|Body)` functions to make clearer if they (re-initialize) the message or potentially do or don't send on their own.

Fixes #10836.