### PR TITLE
Fix handling the `std::ifstream::failbit` in `OutgoingHttpMessage`

### DIFF
--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -81,9 +81,12 @@ bool ConfigFilesHandler::HandleRequest(
 		response.result(http::status::ok);
 		response.set(http::field::content_type, "application/octet-stream");
 		response.SendFile(path, yc);
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 500, "Could not read file.",
-			DiagnosticInformation(ex));
+	} catch (const std::ios_base::failure& ex) {
+		if (response.HasSerializationStarted()) {
+			throw;
+		}
+
+		HttpUtility::SendJsonError(response, params, 500, "Could not read file.", DiagnosticInformation(ex));
 	}
 
 	return true;

--- a/lib/remote/httpmessage.cpp
+++ b/lib/remote/httpmessage.cpp
@@ -226,7 +226,7 @@ void OutgoingHttpMessage<isRequest, Body, StreamVariant>::SendFile(
 )
 {
 	std::ifstream fp(path.CStr(), std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
-	fp.exceptions(std::ifstream::badbit | std::ifstream::eofbit);
+	fp.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
 
 	std::uint64_t remaining = fp.tellg();
 	fp.seekg(0);

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -86,6 +86,16 @@ void HttpUtility::SendJsonBody(HttpApiResponse& response, const Dictionary::Ptr&
 void HttpUtility::SendJsonError(HttpApiResponse& response,
 	const Dictionary::Ptr& params, int code, const String& info, const String& diagnosticInformation)
 {
+	if (response.HasSerializationStarted()) {
+		std::ostringstream err;
+		err << "Impossible to send error response after streaming has started: error: '" << code << "', status: '"
+			<< info << "'";
+		if (!diagnosticInformation.IsEmpty()) {
+			err << ", diagnostic_information: '" << diagnosticInformation << "'";
+		}
+		BOOST_THROW_EXCEPTION(std::logic_error{err.str()});
+	}
+
 	Dictionary::Ptr result = new Dictionary({ { "error", code } });
 
 	if (!info.IsEmpty()) {

--- a/test/remote-httpmessage.cpp
+++ b/test/remote-httpmessage.cpp
@@ -353,4 +353,19 @@ BOOST_AUTO_TEST_CASE(response_sendfile)
 	BOOST_REQUIRE_EQUAL(ss.str(), parser.get().body());
 }
 
+BOOST_AUTO_TEST_CASE(response_sendfile_invalid_path)
+{
+	auto future = SpawnSynchronizedCoroutine([this](boost::asio::yield_context yc) {
+		HttpApiResponse response(server);
+
+		response.result(http::status::ok);
+		BOOST_REQUIRE_THROW(response.SendFile("", yc), std::ios_base::failure);
+	});
+
+	auto status = future.wait_for(10s);
+	if (status != std::future_status::ready) {
+		BOOST_FAIL("Exception not thrown.");
+	}
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
There is an error in `OutgoingHttpMessage::SendFile()` where when a file is unreadable for whatever reason the error on `.open()` isn't handled correctly and the function then happily sends uninitialized buffer contents. This adds `std::ifstream::failbit` to `std::ifstream::exceptions()` and thus makes `SendFile()` throw in this case.

This additionally required more explicitly handling the exceptions thrown in `ConfigFilesHandler`. It now directly handles the `std::ios_base::failure` exceptions thrown by `std::ifstream`. If an error can still be sent (because the handler has not yet started streaming the file), the code 500 error will be sent. Otherwise it just rethrows the io-stream error. In case an Asio-Exception is thrown in `SendFile()`, this will be propagated upwards like the other Asio errors are in other handlers.

## Testing

Added a test-case that tests with an empty file. Not exactly the same issue as was reported, but should set the same `failbit` state as the unreadable file.