### PR TITLE
ifw-api: omit password from curl command in check result

### DIFF
--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -428,11 +428,9 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	}
 
 	if (!username.IsEmpty() && !password.IsEmpty()) {
-		auto authn (username + ":" + password);
-
-		req->set(field::authorization, "Basic " + Base64::Encode(authn));
+		req->set(field::authorization, "Basic " + Base64::Encode(username + ":" + password));
 		cmdLine->Add("--user");
-		cmdLine->Add(authn);
+		cmdLine->Add(username);
 	}
 
 	auto& io (IoEngine::Get().GetIoContext());


### PR DESCRIPTION
Icinga (DB) Web has a special permission to show the check command line. Well-written plugins receive passwords via env vars which don't appear even there. Now ifw-api also hides the password using curl -u USER, not USER:PASS. The new command is still working, it just prompts for the password.

(Public PR [explicitly requested](https://github.com/Icinga/icinga2/security/advisories/GHSA-mrhh-rpv5-64g8#advisory-comment-218680) by @julianbrost.)