### PR TITLE
[Backport support/2.15] Fix openSUSE 15.6 GitHub actions

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -55,7 +55,7 @@ case "$DISTRO" in
     ;;
 
   *suse*)
-    zypper in -y bison ccache cmake flex gcc-c++ ninja rpm-config-SUSE \
+    zypper in -y --allow-downgrade bison ccache cmake flex gcc-c++ ninja rpm-config-SUSE \
       {lib{edit,mariadb,openssl},ncurses,postgresql,systemd}-devel \
       libboost_{context,coroutine,filesystem,iostreams,program_options,regex,system,test,thread}-devel
     ;;


### PR DESCRIPTION
Manual backport of #10832 to `support/2.15`, because there was a small merge conflict due to the addition of the protobuf build dependency in 2.16.