### PR TITLE
Fix building with Visual Studio 2026 (while keeping support for VS 2022)

### DIFF
--- a/agent/windows-setup-agent/Icinga2SetupAgent.csproj
+++ b/agent/windows-setup-agent/Icinga2SetupAgent.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Icinga</RootNamespace>
     <AssemblyName>Icinga2SetupAgent</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>

--- a/tools/win32/configure-dev.ps1
+++ b/tools/win32/configure-dev.ps1
@@ -1,6 +1,8 @@
 Set-PsDebug -Trace 1
 
-# Specify default targets for VS 2022 for developers.
+. "$PSScriptRoot\find-vs.ps1"
+
+# Specify default targets for developers.
 
 if (-not (Test-Path env:ICINGA2_BUILDPATH)) {
   $env:ICINGA2_BUILDPATH = '.\debug'
@@ -22,7 +24,7 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
   $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
 }
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
-  $env:CMAKE_GENERATOR = 'Visual Studio 17 2022'
+  $env:CMAKE_GENERATOR = Get-VSCMakeGenerator
 }
 if (-not (Test-Path env:CMAKE_GENERATOR_PLATFORM)) {
   $env:CMAKE_GENERATOR_PLATFORM = 'x64'

--- a/tools/win32/configure-dev.ps1
+++ b/tools/win32/configure-dev.ps1
@@ -26,6 +26,9 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
   $env:CMAKE_GENERATOR = Get-VSCMakeGenerator
 }
+if (-not (Test-Path env:CMAKE_GENERATOR_TOOLSET)) {
+  $env:CMAKE_GENERATOR_TOOLSET = 'v143'
+}
 if (-not (Test-Path env:CMAKE_GENERATOR_PLATFORM)) {
   $env:CMAKE_GENERATOR_PLATFORM = 'x64'
 }
@@ -59,7 +62,8 @@ if (Test-Path CMakeCache.txt) {
 
 & cmake.exe "$sourcePath" `
   -DCMAKE_BUILD_TYPE="$env:CMAKE_BUILD_TYPE" `
-  -G "$env:CMAKE_GENERATOR" -A "$env:CMAKE_GENERATOR_PLATFORM" -DCPACK_GENERATOR=WIX `
+  -G "$env:CMAKE_GENERATOR" -A "$env:CMAKE_GENERATOR_PLATFORM" `
+  -T "$env:CMAKE_GENERATOR_TOOLSET" -DCPACK_GENERATOR=WIX `
   -DCMAKE_INSTALL_PREFIX="$env:ICINGA2_INSTALLPATH" `
   -DOPENSSL_ROOT_DIR="$env:OPENSSL_ROOT_DIR" `
   -DBOOST_LIBRARYDIR="$env:BOOST_LIBRARYDIR" `

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -1,5 +1,7 @@
 Set-PsDebug -Trace 1
 
+. "$PSScriptRoot\find-vs.ps1"
+
 if (-not (Test-Path env:ICINGA2_BUILDPATH)) {
   $env:ICINGA2_BUILDPATH = '.\build'
 }
@@ -17,7 +19,7 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
   $env:PATH = $env:CMAKE_PATH + ';' + $env:PATH
 }
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
-  $env:CMAKE_GENERATOR = 'Visual Studio 17 2022'
+  $env:CMAKE_GENERATOR = Get-VSCMakeGenerator
 }
 if (-not (Test-Path env:BITS)) {
   $env:BITS = 64

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -21,6 +21,9 @@ if (-not ($env:PATH -contains $env:CMAKE_PATH)) {
 if (-not (Test-Path env:CMAKE_GENERATOR)) {
   $env:CMAKE_GENERATOR = Get-VSCMakeGenerator
 }
+if (-not (Test-Path env:CMAKE_GENERATOR_TOOLSET)) {
+  $env:CMAKE_GENERATOR_TOOLSET = 'v143'
+}
 if (-not (Test-Path env:BITS)) {
   $env:BITS = 64
 }
@@ -63,7 +66,8 @@ if (Test-Path CMakeCache.txt) {
 
 & cmake.exe "$sourcePath" `
   -DCMAKE_BUILD_TYPE="$env:CMAKE_BUILD_TYPE" `
-  -G "$env:CMAKE_GENERATOR" -A "$env:CMAKE_GENERATOR_PLATFORM" -DCPACK_GENERATOR=WIX `
+  -G "$env:CMAKE_GENERATOR" -A "$env:CMAKE_GENERATOR_PLATFORM" `
+  -T "$env:CMAKE_GENERATOR_TOOLSET" -DCPACK_GENERATOR=WIX `
   -DOPENSSL_ROOT_DIR="$env:OPENSSL_ROOT_DIR" `
   -DBOOST_LIBRARYDIR="$env:BOOST_LIBRARYDIR" `
   -DBOOST_INCLUDEDIR="$env:BOOST_ROOT" `

--- a/tools/win32/find-vs.ps1
+++ b/tools/win32/find-vs.ps1
@@ -1,0 +1,50 @@
+# Query a single `vswhere` property for the selected VS install. The auto-detection can be
+# overriden by setting the VS_INSTALL_PATH environment variable.
+# By default, the latest install that has the C++ (x86/x64) toolset will be selected.
+# If `vswhere` itself cannot be found or if it did not successfully return the requested
+# property an error will be thrown.
+function Get-VSProperty($property) {
+  $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+  if (-not (Test-Path $vswhere)) {
+    throw "Could not find vswhere.exe at: ${vswhere}"
+  }
+
+  if (Test-Path env:VS_INSTALL_PATH) {
+    $selector = @('-path', $env:VS_INSTALL_PATH)
+  } else {
+    $selector = @('-latest', '-products', '*',
+                  '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
+  }
+
+  $value = & $vswhere @selector -property $property
+  if ($LastExitCode -ne 0 -or [string]::IsNullOrEmpty($value)) {
+    throw "vswhere could not determine '${property}' for the selected Visual Studio installation"
+  }
+
+  return $value
+}
+
+# Root directory of the VS installation for locating the vcvars*.bat file.
+function Get-VSInstallPath {
+  return Get-VSProperty 'installationPath'
+}
+
+# CMake can auto-detect the latest installed VS version, but that doesn't have to align with the
+# version we have selected above, for example when using the VS_INSTALL_PATH override.
+# Therefore it is generated from the same `vswhere` result that is used to detect the VS path.
+# An error is thrown if the VS version we have selected is not supported by CMake.
+function Get-VSCMakeGenerator {
+  $major = (Get-VSProperty 'installationVersion').Split('.')[0]
+
+  # Get the supported VS versions from CMake and check match it against the one we have.
+  $generator = & cmake.exe --help |
+    Select-String -Pattern "(Visual Studio $major\b[^=]*)=" |
+    ForEach-Object { $_.Matches.Groups[1].Value.Trim() } |
+    Select-Object -First 1
+
+  if (-not $generator) {
+    throw "Installed CMake has no 'Visual Studio $major' generator (CMake too old for this VS?); set CMAKE_GENERATOR to override"
+  }
+
+  return $generator
+}

--- a/tools/win32/load-vsenv.ps1
+++ b/tools/win32/load-vsenv.ps1
@@ -3,6 +3,8 @@
 
 Set-PsDebug -Trace 1
 
+. "$PSScriptRoot\find-vs.ps1"
+
 $SOURCE = Get-Location
 
 if (Test-Path env:ICINGA2_BUILDPATH) {
@@ -15,35 +17,15 @@ if (-not (Test-Path $BUILD)) {
   mkdir $BUILD | Out-Null
 }
 
-if (Test-Path env:VS_INSTALL_PATH) {
-  $VSBASE = $env:VS_INSTALL_PATH
-} else {
-  $VSBASE = "C:\Program Files\Microsoft Visual Studio\2022"
-}
-
 if (Test-Path env:BITS) {
   $bits = $env:BITS
 } else {
   $bits = 64
 }
 
-# Execute vcvars in cmd and store env
-$vcvars_locations = @(
-  "${VSBASE}\BuildTools\VC\Auxiliary\Build\vcvars${bits}.bat"
-  "${VSBASE}\Community\VC\Auxiliary\Build\vcvars${bits}.bat"
-  "${VSBASE}\Enterprise\VC\Auxiliary\Build\vcvars${bits}.bat"
-)
-
-$vcvars = $null
-foreach ($file in $vcvars_locations) {
-  if (Test-Path $file) {
-    $vcvars = $file
-    break
-  }
-}
-
-if ($vcvars -eq $null) {
-  throw "Could not get Build environment script at locations: ${vcvars_locations}"
+$vcvars = "$(Get-VSInstallPath)\VC\Auxiliary\Build\vcvars${bits}.bat"
+if (-not (Test-Path $vcvars)) {
+  throw "Could not get Build environment script at location: ${vcvars}"
 }
 
 cmd.exe /c "call `"${vcvars}`" && set > `"${BUILD}\vcvars.txt`""


### PR DESCRIPTION
Due to [changes to the Github Windows Runner images](https://redirect.github.com/actions/runner-images/issues/14017) that went live today (2026-06-15), we suddenly need to build and run our Windows checks with VS 2026. This PR changes our Windows build/configure scripts to detect the Visual studio paths the canonical way via the `vswhere` command instead of hard-coding versions.

## Description

This contains four individual fixes:

### Getting the path for the Visual Studio install using `vswhere`

This is straight forward: `vswhere` has a `installationPath` property that does exactly this. The override variable `VS_INSTALL_PATH` is kept and optionally fed to `vswhere` via the `-path` flag, ensuring that the other properties (like the next one) also take it into account.

### Determining the matching CMake generator from the detected installation

CMake supports each Visual Studio version via its own generator, for example previously this was `Visual Studio 17 2022`. The major version can easily be retrieved via the `installationVersion` property from `vswhere`, but there is no good way to get that year number. But since these always match up and there is only a single generator for each major version, I added a function that checks if CMake has a generator for this major version with a regex pattern and then select that one.

I've tried to do this in a future-proof way so no additional manual edits need to be made as long as the installed CMake version supports the generator.

Since this functionality is needed by both this fix and the previous one, I've put all `vswhere`-related code into the new file `find-vs.ps1`. The other scripts can then source this file and call the functions in it without code duplication.

### Explicitly setting the toolset version when configuring CMake

Visual Studio 2022 defaults to toolset 14.3, while Visual Studio 2026 defaults to 14.5. Since our Gitlab Pipelines are (for now) still on Visual Studio 2022 it is better to stick to 14.3 for now. Luckily VS 2026 (or rather the Github images) still has this toolset installed, so all it takes is explicitly configuring it in CMake with the `CMAKE_GENERATOR_TOOLSET` variable (which can still be used to override the default). This should be a noop on VS 2022 and should produce the same output on VS 2026.

At some point in the future maybe this can be abstracted out so it can easily be defined in a single place.

### Bump the .NET version in the project file

This is somewhat unrelated, but it causes an error because VS 2026 doesn't support the .NET version we set in the installer project file anymore. And since there is no `auto` setting or simply leaving out the node from the XML, updating it to 4.8 seems to be the best option. Common "wisdom" seems to be that this version should be (and remain) supported on all newer VS versions.

## Testing

This seems to pass both the Github CI as well as work with the Pipelines on Gitlab.

fixes #10885