### PR TITLE
fix: console handler race condition during icinga2 restart

### DIFF
--- a/lib/remote/consolehandler.cpp
+++ b/lib/remote/consolehandler.cpp
@@ -6,6 +6,7 @@
 #include "remote/httputility.hpp"
 #include "remote/filterutility.hpp"
 #include "config/configcompiler.hpp"
+#include "base/application.hpp"
 #include "base/configwriter.hpp"
 #include "base/scriptglobal.hpp"
 #include "base/logger.hpp"
@@ -104,8 +105,7 @@ bool ConsoleHandler::HandleRequest(
 	bool sandboxed = HttpUtility::GetLastParameter(params, "sandboxed");
 
 	ConfigObjectsSharedLock lock (std::try_to_lock);
-
-	if (!lock) {
+	if (!lock || Application::IsRestarting() || Application::IsShuttingDown()) {
 		HttpUtility::SendJsonError(response, params, 503, "Icinga is reloading.");
 		return true;
 	}


### PR DESCRIPTION
After the director does a deploy the global variable `Application::m_RequestRestart` is set and only read every 2.5 seconds from the application thread. A very unlucky user can step into that gap and cause a race-condition with `Internal.run_with_activation_context` from the director live-creation, leaving icinga2 in an inconsistent state, before the `ConfigObjectsSharedLock` takes over the control-flow.

fixes: #10524