### PR TITLE
Lower log level in HttpServerConnection

### DIFF
--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -502,7 +502,7 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 				request.User(ApiUser::GetByAuthHeader(std::string(request[http::field::authorization])));
 			}
 
-			Log logMsg (LogInformation, "HttpServerConnection");
+			Log logMsg (LogNotice, "HttpServerConnection");
 
 			logMsg << "Request " << request.method_string() << ' ' << request.target()
 				<< " (from " << m_PeerAddress


### PR DESCRIPTION
Change the log level from LogInformation to LogNotice to reduce log noise in large environments. With many checks running, info-level messages can generate excessive log volume, making it harder to identify relevant events and understand what is happening.