### PR TITLE
Fix high response latency with multiple API-requests targeting non-existent hosts or services

### DIFF
--- a/lib/base/exception.cpp
+++ b/lib/base/exception.cpp
@@ -280,7 +280,7 @@ String icinga::DiagnosticInformation(const std::exception& ex, bool verbose, boo
 	return result.str();
 }
 
-String icinga::DiagnosticInformation(const boost::exception_ptr& eptr, bool verbose)
+String icinga::DiagnosticInformation(const std::exception_ptr& eptr, bool verbose)
 {
 	boost::stacktrace::stacktrace *pt = GetLastExceptionStack();
 	boost::stacktrace::stacktrace stack;
@@ -295,7 +295,7 @@ String icinga::DiagnosticInformation(const boost::exception_ptr& eptr, bool verb
 		context = *pc;
 
 	try {
-		boost::rethrow_exception(eptr);
+		std::rethrow_exception(eptr);
 	} catch (const std::exception& ex) {
 		return DiagnosticInformation(ex, verbose, pt ? &stack : nullptr, pc ? &context : nullptr);
 	} catch (...) {

--- a/lib/base/exception.cpp
+++ b/lib/base/exception.cpp
@@ -298,9 +298,9 @@ String icinga::DiagnosticInformation(const boost::exception_ptr& eptr, bool verb
 		boost::rethrow_exception(eptr);
 	} catch (const std::exception& ex) {
 		return DiagnosticInformation(ex, verbose, pt ? &stack : nullptr, pc ? &context : nullptr);
+	} catch (...) {
+		return boost::current_exception_diagnostic_information();
 	}
-
-	return boost::diagnostic_information(eptr);
 }
 
 ScriptError::ScriptError(String message)

--- a/lib/base/exception.hpp
+++ b/lib/base/exception.hpp
@@ -14,7 +14,6 @@
 #include <boost/exception/errinfo_errno.hpp>
 #include <boost/exception/errinfo_file_name.hpp>
 #include <boost/exception/diagnostic_information.hpp>
-#include <boost/exception_ptr.hpp>
 #include <boost/stacktrace.hpp>
 
 #ifdef _WIN32
@@ -115,7 +114,7 @@ std::string to_string(const ContextTraceErrorInfo& e);
  */
 String DiagnosticInformation(const std::exception& ex, bool verbose = true,
 	boost::stacktrace::stacktrace *stack = nullptr, ContextTrace *context = nullptr);
-String DiagnosticInformation(const boost::exception_ptr& eptr, bool verbose = true);
+String DiagnosticInformation(const std::exception_ptr& eptr, bool verbose = true);
 
 class posix_error : virtual public std::exception, virtual public boost::exception {
 public:

--- a/lib/base/workqueue.cpp
+++ b/lib/base/workqueue.cpp
@@ -163,7 +163,7 @@ bool WorkQueue::HasExceptions() const
  * Returns all exceptions which have occurred for tasks in this work queue. When a
  * custom exception callback is set this method will always return an empty list.
  */
-std::vector<boost::exception_ptr> WorkQueue::GetExceptions() const
+std::vector<std::exception_ptr> WorkQueue::GetExceptions() const
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);
 
@@ -172,7 +172,7 @@ std::vector<boost::exception_ptr> WorkQueue::GetExceptions() const
 
 void WorkQueue::ReportExceptions(const String& facility, bool verbose) const
 {
-	std::vector<boost::exception_ptr> exceptions = GetExceptions();
+	std::vector<std::exception_ptr> exceptions = GetExceptions();
 
 	for (const auto& eptr : exceptions) {
 		Log(LogCritical, facility)
@@ -236,7 +236,7 @@ void WorkQueue::RunTaskFunction(const TaskFunction& func)
 	try {
 		func();
 	} catch (const std::exception&) {
-		boost::exception_ptr eptr = boost::current_exception();
+		std::exception_ptr eptr = std::current_exception();
 
 		{
 			std::unique_lock<std::mutex> mutex(m_Mutex);

--- a/lib/base/workqueue.hpp
+++ b/lib/base/workqueue.hpp
@@ -9,7 +9,6 @@
 #include "base/ringbuffer.hpp"
 #include "base/logger.hpp"
 #include <boost/thread/thread.hpp>
-#include <boost/exception_ptr.hpp>
 #include <condition_variable>
 #include <mutex>
 #include <queue>
@@ -52,7 +51,7 @@ bool operator<(const Task& a, const Task& b);
 class WorkQueue
 {
 public:
-	typedef std::function<void (boost::exception_ptr)> ExceptionCallback;
+	using ExceptionCallback = std::function<void(std::exception_ptr)>;
 
 	WorkQueue(size_t maxItems = 0, int threadCount = 1, LogSeverity statsLogLevel = LogInformation);
 	~WorkQueue();
@@ -113,7 +112,7 @@ public:
 	void SetExceptionCallback(const ExceptionCallback& callback);
 
 	bool HasExceptions() const;
-	std::vector<boost::exception_ptr> GetExceptions() const;
+	std::vector<std::exception_ptr> GetExceptions() const;
 	void ReportExceptions(const String& facility, bool verbose = false) const;
 
 protected:
@@ -137,7 +136,7 @@ private:
 	std::priority_queue<Task, std::deque<Task> > m_Tasks;
 	int m_NextTaskID{0};
 	ExceptionCallback m_ExceptionCallback;
-	std::vector<boost::exception_ptr> m_Exceptions;
+	std::vector<std::exception_ptr> m_Exceptions;
 	Timer::Ptr m_StatusTimer;
 	double m_StatusTimerTimeout;
 	LogSeverity m_StatsLogLevel;

--- a/lib/cli/consolecommand.cpp
+++ b/lib/cli/consolecommand.cpp
@@ -438,7 +438,7 @@ incomplete:
 					result = ExecuteScript(l_Session, command, scriptFrame.Sandboxed);
 				} catch (const ScriptError&) {
 					/* Re-throw the exception for the outside try-catch block. */
-					boost::rethrow_exception(boost::current_exception());
+					throw;
 				} catch (const std::exception& ex) {
 					Log(LogCritical, "ConsoleCommand")
 						<< "HTTP query failed: " << ex.what();

--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -89,7 +89,7 @@ void IdoMysqlConnection::Resume()
 
 	SetConnected(false);
 
-	m_QueryQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_QueryQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	/* Immediately try to connect on Resume() without timer. */
 	m_QueryQueue.Enqueue([this]() { Reconnect(); }, PriorityImmediate);
@@ -130,7 +130,7 @@ void IdoMysqlConnection::Pause()
 
 }
 
-void IdoMysqlConnection::ExceptionHandler(boost::exception_ptr exp)
+void IdoMysqlConnection::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogCritical, "IdoMysqlConnection", "Exception during database operation: Verify that your database is operational!");
 

--- a/lib/db_ido_mysql/idomysqlconnection.hpp
+++ b/lib/db_ido_mysql/idomysqlconnection.hpp
@@ -107,7 +107,7 @@ private:
 	void ClearTableBySession(const String& table);
 	void ClearTablesBySession();
 
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 
 	void FinishConnect(double startTime);
 };

--- a/lib/db_ido_pgsql/idopgsqlconnection.cpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.cpp
@@ -97,7 +97,7 @@ void IdoPgsqlConnection::Resume()
 
 	SetConnected(false);
 
-	m_QueryQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_QueryQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	/* Immediately try to connect on Resume() without timer. */
 	m_QueryQueue.Enqueue([this]() { Reconnect(); }, PriorityImmediate);
@@ -129,7 +129,7 @@ void IdoPgsqlConnection::Pause()
 		<< "'" << GetName() << "' paused.";
 }
 
-void IdoPgsqlConnection::ExceptionHandler(boost::exception_ptr exp)
+void IdoPgsqlConnection::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogWarning, "IdoPgsqlConnection", "Exception during database operation: Verify that your database is operational!");
 

--- a/lib/db_ido_pgsql/idopgsqlconnection.hpp
+++ b/lib/db_ido_pgsql/idopgsqlconnection.hpp
@@ -91,7 +91,7 @@ private:
 	void ClearTableBySession(const String& table);
 	void ClearTablesBySession();
 
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 
 	void FinishConnect(double startTime);
 };

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -369,9 +369,9 @@ void IcingaDB::UpdateAllConfigObjects()
 		upqObjectType.Join();
 
 		if (upqObjectType.HasExceptions()) {
-			for (boost::exception_ptr exc : upqObjectType.GetExceptions()) {
+			for (std::exception_ptr exc : upqObjectType.GetExceptions()) {
 				if (exc) {
-					boost::rethrow_exception(exc);
+					std::rethrow_exception(exc);
 				}
 			}
 		}
@@ -512,10 +512,10 @@ void IcingaDB::UpdateAllConfigObjects()
 	upq.Join();
 
 	if (upq.HasExceptions()) {
-		for (boost::exception_ptr exc : upq.GetExceptions()) {
+		for (std::exception_ptr exc : upq.GetExceptions()) {
 			try {
 				if (exc) {
-					boost::rethrow_exception(exc);
+					std::rethrow_exception(exc);
 			}
 			} catch(const std::exception& e) {
 				Log(LogCritical, "IcingaDB")

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -76,7 +76,7 @@ void IcingaDB::Start(bool runtimeCreated)
 	m_ConfigDumpInProgress = false;
 	m_ConfigDumpDone = false;
 
-	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	RedisConnInfo::ConstPtr connInfo = GetRedisConnInfo();
 
@@ -130,7 +130,7 @@ void IcingaDB::Start(bool runtimeCreated)
 	m_PendingItemsThread = std::thread([this, keepAlive] { PendingItemsThreadProc(); });
 }
 
-void IcingaDB::ExceptionHandler(boost::exception_ptr exp)
+void IcingaDB::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogCritical, "IcingaDB", "Exception during redis query. Verify that Redis is operational.");
 

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -414,7 +414,7 @@ private:
 
 	void AssertOnWorkQueue();
 
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 
 	using SyncableTypeInfo = std::pair<const Type::Ptr, QueryArgPair>;
 	static std::vector<SyncableTypeInfo> GetSyncableTypes();

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -93,7 +93,7 @@ void ElasticsearchWriter::Resume()
 	Log(LogInformation, "ElasticsearchWriter")
 		<< "'" << GetName() << "' resumed.";
 
-	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	/* Setup timer for periodically flushing m_DataBuffer */
 	m_FlushTimer = Timer::Create();
@@ -576,7 +576,7 @@ void ElasticsearchWriter::AssertOnWorkQueue()
 	ASSERT(m_WorkQueue.IsWorkerThread());
 }
 
-void ElasticsearchWriter::ExceptionHandler(boost::exception_ptr exp)
+void ElasticsearchWriter::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogCritical, "ElasticsearchWriter", "Exception during Elastic operation: Verify that your backend is operational!");
 

--- a/lib/perfdata/elasticsearchwriter.hpp
+++ b/lib/perfdata/elasticsearchwriter.hpp
@@ -54,7 +54,7 @@ private:
 		const Dictionary::Ptr& fields, double ts);
 
 	void AssertOnWorkQueue();
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 	void FlushTimeout();
 	void Flush();
 	void SendRequest(const String& body);

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -89,7 +89,7 @@ void GelfWriter::Resume()
 		<< "'" << GetName() << "' resumed.";
 
 	/* Register exception handler for WQ tasks. */
-	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort(), m_SslContext, !GetInsecureNoverify()};
 	m_LockedConnection.store(m_Connection);
@@ -139,7 +139,7 @@ void GelfWriter::AssertOnWorkQueue()
 	ASSERT(m_WorkQueue.IsWorkerThread());
 }
 
-void GelfWriter::ExceptionHandler(boost::exception_ptr exp)
+void GelfWriter::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogCritical, "GelfWriter") << "Exception during Graylog Gelf operation: " << DiagnosticInformation(exp, false);
 	Log(LogDebug, "GelfWriter") << "Exception during Graylog Gelf operation: " << DiagnosticInformation(exp, true);

--- a/lib/perfdata/gelfwriter.hpp
+++ b/lib/perfdata/gelfwriter.hpp
@@ -50,7 +50,7 @@ private:
 
 	void AssertOnWorkQueue();
 
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 };
 
 }

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -84,7 +84,7 @@ void GraphiteWriter::Resume()
 		<< "'" << GetName() << "' resumed.";
 
 	/* Register exception handler for WQ tasks. */
-	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	m_Connection = new PerfdataWriterConnection{this, GetHost(), GetPort()};
 	m_LockedConnection.store(m_Connection);
@@ -135,7 +135,7 @@ void GraphiteWriter::AssertOnWorkQueue()
  *
  * @param exp Exception pointer
  */
-void GraphiteWriter::ExceptionHandler(boost::exception_ptr exp)
+void GraphiteWriter::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogCritical, "GraphiteWriter", "Exception during Graphite operation: Verify that your backend is operational!");
 

--- a/lib/perfdata/graphitewriter.hpp
+++ b/lib/perfdata/graphitewriter.hpp
@@ -50,7 +50,7 @@ private:
 
 	void AssertOnWorkQueue();
 
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 };
 
 }

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -83,7 +83,7 @@ void InfluxdbCommonWriter::Resume()
 		<< "'" << GetName() << "' resumed.";
 
 	/* Register exception handler for WQ tasks. */
-	m_WorkQueue.SetExceptionCallback([this](boost::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
+	m_WorkQueue.SetExceptionCallback([this](std::exception_ptr exp) { ExceptionHandler(std::move(exp)); });
 
 	/* Setup timer for periodically flushing m_DataBuffer */
 	m_FlushTimer = Timer::Create();
@@ -135,7 +135,7 @@ void InfluxdbCommonWriter::AssertOnWorkQueue()
 	ASSERT(m_WorkQueue.IsWorkerThread());
 }
 
-void InfluxdbCommonWriter::ExceptionHandler(boost::exception_ptr exp)
+void InfluxdbCommonWriter::ExceptionHandler(std::exception_ptr exp)
 {
 	Log(LogCritical, GetReflectionType()->GetName(), "Exception during InfluxDB operation: Verify that your backend is operational!");
 

--- a/lib/perfdata/influxdbcommonwriter.hpp
+++ b/lib/perfdata/influxdbcommonwriter.hpp
@@ -64,7 +64,7 @@ private:
 
 	void AssertOnWorkQueue();
 
-	void ExceptionHandler(boost::exception_ptr exp);
+	void ExceptionHandler(std::exception_ptr exp);
 };
 
 template<class InfluxWriter>

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -84,7 +84,7 @@ void OpenTsdbWriter::Resume()
 	Log(LogInformation, "OpentsdbWriter")
 		<< "'" << GetName() << "' resumed.";
 
-	m_WorkQueue.SetExceptionCallback([](const boost::exception_ptr& exp) {
+	m_WorkQueue.SetExceptionCallback([](const std::exception_ptr& exp) {
 		Log(LogDebug, "OpenTsdbWriter")
 			<< "Exception during OpenTsdb operation: " << DiagnosticInformation(exp);
 	});

--- a/lib/perfdata/otlpmetricswriter.cpp
+++ b/lib/perfdata/otlpmetricswriter.cpp
@@ -99,7 +99,7 @@ void OTLPMetricsWriter::Resume()
 	Log(LogInformation, "OTLPMetricsWriter")
 		<< "'" << GetName() << "' resumed.";
 
-	m_WorkQueue.SetExceptionCallback([](boost::exception_ptr exp) {
+	m_WorkQueue.SetExceptionCallback([](std::exception_ptr exp) {
 		Log(LogCritical, "OTLPMetricsWriter")
 			<< "Exception while producing OTel metric: " << DiagnosticInformation(exp);
 	});

--- a/lib/remote/actionshandler.cpp
+++ b/lib/remote/actionshandler.cpp
@@ -57,10 +57,8 @@ bool ActionsHandler::HandleRequest(
 		} catch (const MissingPermissionError& ex) {
 			HttpUtility::SendJsonError(response, params, 403, ex.what());
 			return true;
-		} catch (const std::exception& ex) {
-			HttpUtility::SendJsonError(response, params, 404,
-				"No objects found.",
-				DiagnosticInformation(ex));
+		} catch (const std::exception&) {
+			HttpUtility::SendJsonError(response, params, 404, "No objects found.", std::current_exception());
 			return true;
 		}
 

--- a/lib/remote/configfileshandler.cpp
+++ b/lib/remote/configfileshandler.cpp
@@ -81,12 +81,12 @@ bool ConfigFilesHandler::HandleRequest(
 		response.result(http::status::ok);
 		response.set(http::field::content_type, "application/octet-stream");
 		response.SendFile(path, yc);
-	} catch (const std::ios_base::failure& ex) {
+	} catch (const std::ios_base::failure&) {
 		if (response.HasSerializationStarted()) {
 			throw;
 		}
 
-		HttpUtility::SendJsonError(response, params, 500, "Could not read file.", DiagnosticInformation(ex));
+		HttpUtility::SendJsonError(response, params, 500, "Could not read file.", std::current_exception());
 	}
 
 	return true;

--- a/lib/remote/configobjectutility.cpp
+++ b/lib/remote/configobjectutility.cpp
@@ -235,7 +235,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 				Log(LogNotice, "ConfigObjectUtility")
 					<< "Failed to commit config item '" << fullName << "'. Aborting and removing config path '" << path << "'.";
 
-				for (const boost::exception_ptr& ex : upq.GetExceptions()) {
+				for (const std::exception_ptr& ex : upq.GetExceptions()) {
 					errors->Add(DiagnosticInformation(ex, false));
 
 					if (diagnosticInformation)
@@ -256,7 +256,7 @@ bool ConfigObjectUtility::CreateObject(const Type::Ptr& type, const String& full
 				Log(LogNotice, "ConfigObjectUtility")
 					<< "Failed to activate config object '" << fullName << "'. Aborting and removing config path '" << path << "'.";
 
-				for (const boost::exception_ptr& ex : upq.GetExceptions()) {
+				for (const std::exception_ptr& ex : upq.GetExceptions()) {
 					errors->Add(DiagnosticInformation(ex, false));
 
 					if (diagnosticInformation)

--- a/lib/remote/configpackageshandler.cpp
+++ b/lib/remote/configpackageshandler.cpp
@@ -54,9 +54,8 @@ void ConfigPackagesHandler::HandleGet(const HttpApiRequest& request, HttpApiResp
 
 	try {
 		packages = ConfigPackageUtility::GetPackages();
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 500, "Could not retrieve packages.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 500, "Could not retrieve packages.", std::current_exception());
 		return;
 	}
 
@@ -120,9 +119,8 @@ void ConfigPackagesHandler::HandlePost(const HttpApiRequest& request, HttpApiRes
 		std::unique_lock<std::mutex> lock(ConfigPackageUtility::GetStaticPackageMutex());
 
 		ConfigPackageUtility::CreatePackage(packageName);
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 500, "Could not create package '" + packageName + "'.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 500, "Could not create package '" + packageName + "'.", std::current_exception());
 		return;
 	}
 
@@ -168,9 +166,8 @@ void ConfigPackagesHandler::HandleDelete(const HttpApiRequest& request, HttpApiR
 
 	try {
 		ConfigPackageUtility::DeletePackage(packageName);
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 500, "Failed to delete package '" + packageName + "'.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 500, "Failed to delete package '" + packageName + "'.", std::current_exception());
 		return;
 	}
 

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -172,10 +172,9 @@ void ConfigStagesHandler::HandlePost(const HttpApiRequest& request, HttpApiRespo
 
 		/* validate the config. on success, activate stage and reload */
 		ConfigPackageUtility::AsyncTryActivateStage(packageName, stageName, activate, reload, resetPackageUpdates);
-	} catch (const std::exception& ex) {
-		return HttpUtility::SendJsonError(response, params, 500,
-			"Stage creation failed.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 500, "Stage creation failed.", std::current_exception());
+		return;
 	}
 
 
@@ -234,10 +233,11 @@ void ConfigStagesHandler::HandleDelete(const HttpApiRequest& request, HttpApiRes
 
 	try {
 		ConfigPackageUtility::DeleteStage(packageName, stageName);
-	} catch (const std::exception& ex) {
-		return HttpUtility::SendJsonError(response, params, 500,
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 500,
 			"Failed to delete stage '" + stageName + "' in package '" + packageName + "'.",
-			DiagnosticInformation(ex));
+			std::current_exception());
+		return;
 	}
 
 	Dictionary::Ptr result1 = new Dictionary({

--- a/lib/remote/deleteobjecthandler.cpp
+++ b/lib/remote/deleteobjecthandler.cpp
@@ -61,10 +61,8 @@ bool DeleteObjectHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No objects found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No objects found.", std::current_exception());
 		return true;
 	}
 

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -430,7 +430,7 @@ void ProcessRequest(
 
 		HttpHandler::ProcessRequest(waitGroup, request, response, yc);
 		response.body().Finish();
-	} catch (const std::exception& ex) {
+	} catch (const std::exception&) {
 		/* Since we don't know the state the stream is in, we can't send an error response and
 		 * have to just cause a disconnect here.
 		 */
@@ -438,7 +438,7 @@ void ProcessRequest(
 			throw;
 		}
 
-		HttpUtility::SendJsonError(response, request.Params(), 500, "Unhandled exception", DiagnosticInformation(ex));
+		HttpUtility::SendJsonError(response, request.Params(), 500, "Unhandled exception", std::current_exception());
 	}
 
 	response.Flush(yc);

--- a/lib/remote/httputility.cpp
+++ b/lib/remote/httputility.cpp
@@ -84,14 +84,14 @@ void HttpUtility::SendJsonBody(HttpApiResponse& response, const Dictionary::Ptr&
 }
 
 void HttpUtility::SendJsonError(HttpApiResponse& response,
-	const Dictionary::Ptr& params, int code, const String& info, const String& diagnosticInformation)
+	const Dictionary::Ptr& params, int code, const String& info, const std::exception_ptr& ex)
 {
 	if (response.HasSerializationStarted()) {
 		std::ostringstream err;
 		err << "Impossible to send error response after streaming has started: error: '" << code << "', status: '"
 			<< info << "'";
-		if (!diagnosticInformation.IsEmpty()) {
-			err << ", diagnostic_information: '" << diagnosticInformation << "'";
+		if (ex) {
+			err << ", diagnostic_information: '" << DiagnosticInformation(ex) << "'";
 		}
 		BOOST_THROW_EXCEPTION(std::logic_error{err.str()});
 	}
@@ -102,8 +102,8 @@ void HttpUtility::SendJsonError(HttpApiResponse& response,
 		result->Set("status", info);
 	}
 
-	if (params && HttpUtility::GetLastParameter(params, "verbose") && !diagnosticInformation.IsEmpty()) {
-		result->Set("diagnostic_information", diagnosticInformation);
+	if (params && HttpUtility::GetLastParameter(params, "verbose") && ex) {
+		result->Set("diagnostic_information", DiagnosticInformation(ex));
 	}
 
 	response.Clear();

--- a/lib/remote/httputility.hpp
+++ b/lib/remote/httputility.hpp
@@ -28,7 +28,7 @@ public:
 	static void SendJsonBody(HttpApiResponse& response, const Dictionary::Ptr& params, const Value& val, boost::asio::yield_context& yc);
 	static void SendJsonBody(HttpApiResponse& response, const Dictionary::Ptr& params, const Value& val);
 	static void SendJsonError(HttpApiResponse& response, const Dictionary::Ptr& params, const int code,
-		const String& info = {}, const String& diagnosticInformation = {});
+		const String& info = {}, const std::exception_ptr& ex = nullptr);
 
 	static bool IsValidHeaderName(std::string_view name);
 	static bool IsValidHeaderValue(std::string_view value);

--- a/lib/remote/modifyobjecthandler.cpp
+++ b/lib/remote/modifyobjecthandler.cpp
@@ -59,10 +59,8 @@ bool ModifyObjectHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No objects found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No objects found.", std::current_exception());
 		return true;
 	}
 

--- a/lib/remote/objectqueryhandler.cpp
+++ b/lib/remote/objectqueryhandler.cpp
@@ -181,10 +181,8 @@ bool ObjectQueryHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No objects found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No objects found.", std::current_exception());
 		return true;
 	}
 

--- a/lib/remote/statushandler.cpp
+++ b/lib/remote/statushandler.cpp
@@ -105,10 +105,8 @@ bool StatusHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No objects found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No objects found.", std::current_exception());
 		return true;
 	}
 

--- a/lib/remote/templatequeryhandler.cpp
+++ b/lib/remote/templatequeryhandler.cpp
@@ -122,10 +122,8 @@ bool TemplateQueryHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No templates found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No templates found.", std::current_exception());
 		return true;
 	}
 

--- a/lib/remote/typequeryhandler.cpp
+++ b/lib/remote/typequeryhandler.cpp
@@ -84,10 +84,8 @@ bool TypeQueryHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No objects found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No objects found.", std::current_exception());
 		return true;
 	}
 

--- a/lib/remote/variablequeryhandler.cpp
+++ b/lib/remote/variablequeryhandler.cpp
@@ -94,10 +94,8 @@ bool VariableQueryHandler::HandleRequest(
 	} catch (const MissingPermissionError& ex) {
 		HttpUtility::SendJsonError(response, params, 403, ex.what());
 		return true;
-	} catch (const std::exception& ex) {
-		HttpUtility::SendJsonError(response, params, 404,
-			"No variables found.",
-			DiagnosticInformation(ex));
+	} catch (const std::exception&) {
+		HttpUtility::SendJsonError(response, params, 404, "No variables found.", std::current_exception());
 		return true;
 	}
 


### PR DESCRIPTION
This fixes the high response latency observed in #10875 when multiple requests target non-existent hosts in parallel. The reason is that for almost all API endpoints that target config objects diagnostic information including a stack trace is generated, regardless if it is actually returned (which only happens when the "verbose" parameter is given). The solution is to pass the `exception_ptr` into `SendJsonError()` and only generate the `DiagnosticInformation` from it when needed.

### Solution

`SendJsonError()` now takes a `std::exception_ptr` argument instead of a `dagnosticInformation` string that is generated at the call site. This is cheap and doesn't cause any copies. Then, where the actual decision is made to include the `diagnostic_information` (i.e. dependent on the "verbose" parameter), `DiagnosticInformation(<eptr>)` is run. The overload already existed, so there wasn't even a need to rethrow the exception and process the string from the result.

This is a clean solution, and the change makes sense even without the latency amplification in mind, since pointless work is avoided in any case.

However, some yak-shaving was required to feed `SendJsonError()` with an exception pointer gathered with `std::current_exception()` at the call-site. I had to make the entire code-base use `std::exception_ptr` instead of `boost::exception_ptr`. On the newest boost version, this is just a typedef, on previous versions the boost one could be constructed from the std one, but there's also old versions we still support which didn't have that conversion. And that refactor in turn uncovered a small bug in the `DiagnosticInformation(<eptr>)` which had a dead-code fallback that then failed to compile and is now fixed.

### Testing

Using the test-script that was provided in #10875, the improvement is clearly observable:

#### Before
With existent host/service:
```
$ ulimit -n 100000 && python3 wp.py --host https://localhost:5665 --user root --password icinga --total 5000 --parallel 200 --target-host master-1 --target-service procs --no-verify-ssl
Sending 5000 requests to https://localhost:5665
Max in-flight: 200
Press Ctrl+C to stop.

Progress: 3097/5000 sent (3097 ok, 0 errors) (host: master-1) (service: procs) — min: 0.001s, avg: 0.312s, p95: 1.758s, max: 2.564s

Total test duration: 7.200s
Done: 5000 ok, 0 errors out of 5000 total requests.
Request duration — min: 0.001s, max: 2.564s, avg: 0.282s, p95: 0.904s
```
With non-existent host/service:
```
$ ulimit -n 100000 && python3 wp.py --host https://localhost:5665 --user root --password icinga --total 5000 --parallel 200 --target-host master-1 --target-service procsasdf --no-verify-ssl
Sending 5000 requests to https://localhost:5665
Max in-flight: 200
Press Ctrl+C to stop.

Progress: 566/5000 sent (566 ok, 0 errors) (host: master-1) (service: procsasdf) — min: 0.116s, avg: 0.864s, p95: 2.527s, max: 4.867s
Progress: 1496/5000 sent (1496 ok, 0 errors) (host: master-1) (service: procsasdf) — min: 0.012s, avg: 1.046s, p95: 5.539s, max: 9.837s
Progress: 2419/5000 sent (2419 ok, 0 errors) (host: master-1) (service: procsasdf) — min: 0.012s, avg: 0.998s, p95: 4.867s, max: 13.447s
Progress: 3336/5000 sent (3336 ok, 0 errors) (host: master-1) (service: procsasdf) — min: 0.012s, avg: 1.015s, p95: 4.797s, max: 18.046s
Progress: 4198/5000 sent (4198 ok, 0 errors) (host: master-1) (service: procsasdf) — min: 0.012s, avg: 1.075s, p95: 5.001s, max: 22.430s

Total test duration: 29.636s
Done: 5000 ok, 0 errors out of 5000 total requests.
Request duration — min: 0.012s, max: 22.430s, avg: 1.160s, p95: 5.629s
jschmidt@ws-jschmidt:~/Projects/dev-docker$ ulimit -n 100000 && python3 wp.py --host https://localhost:5665 --user root --password icinga --total 5000 --parallel 200 --target-host master-1 --target-service procsasdf --no-verify-ssl
```
#### After
With existent host/service:
```
$ ulimit -n 100000 && python3 wp.py --host https://localhost:5665 --user root --password icinga --total 5000 --parallel 200 --target-host master-1 --target-service procs --no-verify-ssl
Sending 5000 requests to https://localhost:5665
Max in-flight: 200
Press Ctrl+C to stop.

Progress: 3161/5000 sent (3161 ok, 0 errors) (host: master-1) (service: procs) — min: 0.002s, avg: 0.304s, p95: 1.796s, max: 2.792s

Total test duration: 6.844s
Done: 5000 ok, 0 errors out of 5000 total requests.
Request duration — min: 0.002s, max: 2.792s, avg: 0.269s, p95: 0.799s
```
With non-existent host/service:
```
$ ulimit -n 100000 && python3 wp.py --host https://localhost:5665 --user root --password icinga --total 5000 --parallel 200 --target-host master-1 --target-service procsasdf --no-verify-ssl
Sending 5000 requests to https://localhost:5665
Sending 5000 requests to https://localhost:5665
Max in-flight: 200
Press Ctrl+C to stop.


Total test duration: 2.545s
Done: 5000 ok, 0 errors out of 5000 total requests.
Request duration — min: 0.002s, max: 2.126s, avg: 0.096s, p95: 0.212s
Sending: command not found
```
You can see that the error responses for non-existant targets are now actually much faster than successful requests, as one would expect.

Fixes #10875.