### PR TITLE
GHA: Windows: run on Windows Server 2022

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         bits: [32, 64]
 
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     env:
       BITS: '${{ matrix.bits }}'


### PR DESCRIPTION
Recently, the Windows Server 2025 image upgraded Visual Studio from v2022 to v2026. Our build setup is not prepared for this, so we must pin the OS image.

closes #10881