### PR TITLE
docs: Remove blog post reference for jq in icinga2-api.md

### DIFF
--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -119,8 +119,6 @@ curl ... | jq
 curl ... | python -m json.tool
 ```
 
-jq also has additional filter capabilities, as shown in [this blogpost](https://www.netways.de/blog/2018/08/24/json-in-bequem/).
-
 ```bash
 curl ... |jq '{name: .results[].name}'
 ```


### PR DESCRIPTION
Remove a reference to a blog post about jq filter capabilities, due to the post being depublished