### PR TITLE
[Backport support/2.16] Bump OpenSSL shipped for Windows to v3.5.7

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -14,7 +14,7 @@ function ThrowOnNativeFailure {
 $VsVersion = 2022
 $MsvcVersion = '14.3'
 $BoostVersion = @(1, 90, 0)
-$OpensslVersion = '3_5_6'
+$OpensslVersion = '3_5_7'
 
 switch ($Env:BITS) {
 	32 { }

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -33,7 +33,7 @@ if (-not (Test-Path env:CMAKE_ARGS)) {
   $env:CMAKE_ARGS = '[]'
 }
 if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
-  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_5_6-Win${env:BITS}"
+  $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_5_7-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
   $env:BOOST_ROOT = "c:\local\boost_1_90_0-Win${env:BITS}"


### PR DESCRIPTION
Manual backport of #10874 ([due to merge conflicts](https://github.com/Icinga/icinga2/pull/10874#issuecomment-4776598652))