### PR TITLE
win-dev.ps1: prevent merge conflicts during backports

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -11,9 +11,14 @@ function ThrowOnNativeFailure {
 }
 
 
+# Keep the empty lines below to prevent merge conflicts during backports!
+
 $VsVersion = 2022
+
 $MsvcVersion = '14.3'
+
 $BoostVersion = @(1, 91, 0)
+
 $OpensslVersion = '3_5_7'
 
 switch ($Env:BITS) {


### PR DESCRIPTION
by adding empty lines between variables for the Boost/OpenSSL/... versions.

This way, individual versions are separated from each other and don't produce conflicts if e.g. only the OpenSSL version is backported.