### PR TITLE
Replace legacy strand with executor-templated strand

### DIFF
--- a/lib/base/io-engine.cpp
+++ b/lib/base/io-engine.cpp
@@ -27,7 +27,7 @@ using namespace icinga;
  * @param yc Needed to asynchronously wait for the condition variable.
  * @param strand Where to post the wake-up of the condition variable.
  */
-CpuBoundWork::CpuBoundWork(boost::asio::yield_context yc, boost::asio::io_context::strand& strand)
+CpuBoundWork::CpuBoundWork(boost::asio::yield_context yc, IoStrand& strand)
 	: m_Done(false)
 {
 	VERIFY(IoEngine::IsStrandRunningOnThisThread(strand));

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -22,7 +22,6 @@
 #include <boost/exception/all.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/steady_timer.hpp>
 
@@ -33,6 +32,8 @@
 namespace icinga
 {
 
+using IoStrand = boost::asio::strand<boost::asio::io_context::executor_type>;
+
 /**
  * Scope lock for CPU-bound work done in an I/O thread
  *
@@ -41,7 +42,7 @@ namespace icinga
 class CpuBoundWork
 {
 public:
-	CpuBoundWork(boost::asio::yield_context yc, boost::asio::io_context::strand&);
+	CpuBoundWork(boost::asio::yield_context yc, IoStrand&);
 	CpuBoundWork(const CpuBoundWork&) = delete;
 	CpuBoundWork(CpuBoundWork&&) = delete;
 	CpuBoundWork& operator=(const CpuBoundWork&) = delete;
@@ -112,7 +113,7 @@ public:
 	 * [^2]: https://bugs.llvm.org/show_bug.cgi?id=19177
 	 * [^3]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26461
 	 */
-	BOOST_NOINLINE static bool IsStrandRunningOnThisThread(const boost::asio::io_context::strand& strand)
+	BOOST_NOINLINE static bool IsStrandRunningOnThisThread(const IoStrand& strand)
 	{
 		return strand.running_in_this_thread();
 	}
@@ -175,7 +176,7 @@ private:
 
 	std::atomic_uint_fast32_t m_CpuBoundSemaphore;
 	std::mutex m_CpuBoundWaitingMutex;
-	std::vector<std::pair<boost::asio::io_context::strand, Shared<AsioConditionVariable>::Ptr>> m_CpuBoundWaiting;
+	std::vector<std::pair<IoStrand, Shared<AsioConditionVariable>::Ptr>> m_CpuBoundWaiting;
 };
 
 class TerminateIoThread : public std::exception
@@ -255,8 +256,8 @@ public:
 	 * @param onTimeout The callback to invoke when the timeout occurs.
 	 */
 	template<class OnTimeout>
-	Timeout(boost::asio::io_context::strand& strand, const Timer::duration_type& timeoutFromNow, OnTimeout onTimeout)
-		: m_Timer(strand.context(), timeoutFromNow), m_Cancelled(Shared<Atomic<bool>>::Make(false))
+	Timeout(IoStrand& strand, const Timer::duration_type& timeoutFromNow, OnTimeout onTimeout)
+		: m_Timer(strand.get_inner_executor().context(), timeoutFromNow), m_Cancelled(Shared<Atomic<bool>>::Make(false))
 	{
 		ASSERT(IoEngine::IsStrandRunningOnThisThread(strand));
 

--- a/lib/base/io-engine.hpp
+++ b/lib/base/io-engine.hpp
@@ -21,7 +21,6 @@
 #include <boost/context/protected_fixedsize_stack.hpp>
 #include <boost/exception/all.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/steady_timer.hpp>
 
@@ -32,6 +31,8 @@
 namespace icinga
 {
 
+using IoStrand = boost::asio::strand<boost::asio::io_context::executor_type>;
+
 /**
  * Scope lock for CPU-bound work done in an I/O thread
  *
@@ -40,7 +41,7 @@ namespace icinga
 class CpuBoundWork
 {
 public:
-	CpuBoundWork(boost::asio::yield_context yc, boost::asio::io_context::strand&);
+	CpuBoundWork(boost::asio::yield_context yc, IoStrand&);
 	CpuBoundWork(const CpuBoundWork&) = delete;
 	CpuBoundWork(CpuBoundWork&&) = delete;
 	CpuBoundWork& operator=(const CpuBoundWork&) = delete;
@@ -111,7 +112,7 @@ public:
 	 * [^2]: https://bugs.llvm.org/show_bug.cgi?id=19177
 	 * [^3]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=26461
 	 */
-	BOOST_NOINLINE static bool IsStrandRunningOnThisThread(const boost::asio::io_context::strand& strand)
+	BOOST_NOINLINE static bool IsStrandRunningOnThisThread(const IoStrand& strand)
 	{
 		return strand.running_in_this_thread();
 	}
@@ -174,7 +175,7 @@ private:
 
 	std::atomic_uint_fast32_t m_CpuBoundSemaphore;
 	std::mutex m_CpuBoundWaitingMutex;
-	std::vector<std::pair<boost::asio::io_context::strand, Shared<AsioConditionVariable>::Ptr>> m_CpuBoundWaiting;
+	std::vector<std::pair<IoStrand, Shared<AsioConditionVariable>::Ptr>> m_CpuBoundWaiting;
 };
 
 class TerminateIoThread : public std::exception
@@ -255,11 +256,11 @@ public:
 	 */
 	template<class OnTimeout, class Rep, class Period>
 	Timeout(
-		boost::asio::io_context::strand& strand,
+		IoStrand& strand,
 		const std::chrono::duration<Rep, Period>& timeoutFromNow,
 		OnTimeout onTimeout
 	)
-		: m_Timer(strand.context(), std::chrono::duration_cast<Timer::duration>(timeoutFromNow)),
+		: m_Timer(strand.get_inner_executor().context(), std::chrono::duration_cast<Timer::duration>(timeoutFromNow)),
 		  m_Cancelled(Shared<Atomic<bool>>::Make(false))
 	{
 		ASSERT(IoEngine::IsStrandRunningOnThisThread(strand));

--- a/lib/base/tlsstream.cpp
+++ b/lib/base/tlsstream.cpp
@@ -133,7 +133,7 @@ void AsioTlsStream::ForceDisconnect()
  * @param strand Asio strand used for other operations on this connection.
  * @param yc Yield context for Asio coroutines
  */
-void AsioTlsStream::GracefulDisconnect(boost::asio::io_context::strand& strand, boost::asio::yield_context& yc)
+void AsioTlsStream::GracefulDisconnect(IoStrand& strand, boost::asio::yield_context& yc)
 {
 	if (!lowest_layer().is_open()) {
 		// Already disconnected, nothing to do.

--- a/lib/base/tlsstream.hpp
+++ b/lib/base/tlsstream.hpp
@@ -5,6 +5,7 @@
 #define TLSSTREAM_H
 
 #include "base/i2-base.hpp"
+#include "base/io-engine.hpp"
 #include "base/shared.hpp"
 #include "base/socket.hpp"
 #include "base/stream.hpp"
@@ -114,7 +115,7 @@ public:
 	}
 
 	void ForceDisconnect();
-	void GracefulDisconnect(boost::asio::io_context::strand& strand, boost::asio::yield_context& yc);
+	void GracefulDisconnect(IoStrand& strand, boost::asio::yield_context& yc);
 
 private:
 	inline

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -40,7 +40,7 @@ RedisConnection::RedisConnection(
 	bool trackOwnPendingQueries
 )
 	: m_ConnInfo{connInfo},
-	  m_Strand(io),
+	  m_Strand(io.get_executor()),
 	  m_Connecting(false),
 	  m_Connected(false),
 	  m_Started(false),
@@ -285,7 +285,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 {
 	Defer notConnecting ([this]() { m_Connecting.store(m_Connected.load()); });
 
-	boost::asio::deadline_timer timer (m_Strand.context());
+	boost::asio::deadline_timer timer (m_Strand.get_inner_executor().context());
 
 	for (;;) {
 		try {
@@ -294,7 +294,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB")
 						<< "Trying to connect to Redis server (async, TLS) on host '" << m_ConnInfo->Host << ":" << m_ConnInfo->Port << "'";
 
-					auto conn (Shared<AsioTlsStream>::Make(m_Strand.context(), *m_TLSContext, m_ConnInfo->Host));
+					auto conn (Shared<AsioTlsStream>::Make(m_Strand.get_inner_executor().context(), *m_TLSContext, m_ConnInfo->Host));
 					auto& tlsConn (conn->next_layer());
 					auto connectTimeout (MakeTimeout(conn));
 
@@ -324,7 +324,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB")
 						<< "Trying to connect to Redis server (async) on host '" << m_ConnInfo->Host << ":" << m_ConnInfo->Port << "'";
 
-					auto conn (Shared<TcpConn>::Make(m_Strand.context()));
+					auto conn (Shared<TcpConn>::Make(m_Strand.get_inner_executor().context()));
 					auto connectTimeout (MakeTimeout(conn));
 
 					icinga::Connect(conn->next_layer(), m_ConnInfo->Host, Convert::ToString(m_ConnInfo->Port), yc);
@@ -336,7 +336,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 				Log(LogInformation, "IcingaDB")
 					<< "Trying to connect to Redis server (async) on unix socket path '" << m_ConnInfo->Path << "'";
 
-				auto conn (Shared<UnixConn>::Make(m_Strand.context()));
+				auto conn (Shared<UnixConn>::Make(m_Strand.get_inner_executor().context()));
 				auto connectTimeout (MakeTimeout(conn));
 
 				conn->next_layer().async_connect(Unix::endpoint(m_ConnInfo->Path.CStr()), yc);

--- a/lib/icingadb/redisconnection.cpp
+++ b/lib/icingadb/redisconnection.cpp
@@ -40,7 +40,7 @@ RedisConnection::RedisConnection(
 	bool trackOwnPendingQueries
 )
 	: m_ConnInfo{connInfo},
-	  m_Strand(io),
+	  m_Strand(io.get_executor()),
 	  m_Connecting(false),
 	  m_Connected(false),
 	  m_Started(false),
@@ -285,7 +285,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 {
 	Defer notConnecting ([this]() { m_Connecting.store(m_Connected.load()); });
 
-	boost::asio::steady_timer timer (m_Strand.context());
+	boost::asio::steady_timer timer (m_Strand.get_inner_executor().context());
 
 	for (;;) {
 		try {
@@ -294,7 +294,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB")
 						<< "Trying to connect to Redis server (async, TLS) on host '" << m_ConnInfo->Host << ":" << m_ConnInfo->Port << "'";
 
-					auto conn (Shared<AsioTlsStream>::Make(m_Strand.context(), *m_TLSContext, m_ConnInfo->Host));
+					auto conn (Shared<AsioTlsStream>::Make(m_Strand.get_inner_executor().context(), *m_TLSContext, m_ConnInfo->Host));
 					auto& tlsConn (conn->next_layer());
 					auto connectTimeout (MakeTimeout(conn));
 
@@ -324,7 +324,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 					Log(m_Parent ? LogNotice : LogInformation, "IcingaDB")
 						<< "Trying to connect to Redis server (async) on host '" << m_ConnInfo->Host << ":" << m_ConnInfo->Port << "'";
 
-					auto conn (Shared<TcpConn>::Make(m_Strand.context()));
+					auto conn (Shared<TcpConn>::Make(m_Strand.get_inner_executor().context()));
 					auto connectTimeout (MakeTimeout(conn));
 
 					icinga::Connect(conn->next_layer(), m_ConnInfo->Host, Convert::ToString(m_ConnInfo->Port), yc);
@@ -336,7 +336,7 @@ void RedisConnection::Connect(asio::yield_context& yc)
 				Log(LogInformation, "IcingaDB")
 					<< "Trying to connect to Redis server (async) on unix socket path '" << m_ConnInfo->Path << "'";
 
-				auto conn (Shared<UnixConn>::Make(m_Strand.context()));
+				auto conn (Shared<UnixConn>::Make(m_Strand.get_inner_executor().context()));
 				auto connectTimeout (MakeTimeout(conn));
 
 				conn->next_layer().async_connect(Unix::endpoint(m_ConnInfo->Path.CStr()), yc);

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -19,7 +19,6 @@
 #include <boost/asio/buffered_stream.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/read.hpp>
@@ -289,7 +288,7 @@ struct RedisConnInfo final : SharedObject
 
 		RedisConnInfo::ConstPtr m_ConnInfo; // Redis connection info (immutable)
 
-		boost::asio::io_context::strand m_Strand;
+		IoStrand m_Strand;
 		Shared<TcpConn>::Ptr m_TcpConn;
 		Shared<UnixConn>::Ptr m_UnixConn;
 		Shared<AsioTlsStream>::Ptr m_TlsConn;

--- a/lib/icingadb/redisconnection.hpp
+++ b/lib/icingadb/redisconnection.hpp
@@ -19,7 +19,6 @@
 #include <boost/asio/buffered_stream.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/local/stream_protocol.hpp>
 #include <boost/asio/read.hpp>
@@ -289,7 +288,7 @@ struct RedisConnInfo final : SharedObject
 
 		RedisConnInfo::ConstPtr m_ConnInfo; // Redis connection info (immutable)
 
-		boost::asio::io_context::strand m_Strand;
+		IoStrand m_Strand;
 		Shared<TcpConn>::Ptr m_TcpConn;
 		Shared<UnixConn>::Ptr m_UnixConn;
 		Shared<AsioTlsStream>::Ptr m_TlsConn;

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -434,7 +434,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	}
 
 	auto& io (IoEngine::Get().GetIoContext());
-	auto strand (Shared<asio::io_context::strand>::Make(io));
+	auto strand (std::make_shared<IoStrand>(io.get_executor()));
 	Shared<asio::ssl::context>::Ptr ctx;
 
 	cr->SetExecutionStart(Utility::GetTime());

--- a/lib/methods/ifwapichecktask.cpp
+++ b/lib/methods/ifwapichecktask.cpp
@@ -436,7 +436,7 @@ void IfwApiCheckTask::ScriptFunc(const Checkable::Ptr& checkable, const CheckRes
 	}
 
 	auto& io (IoEngine::Get().GetIoContext());
-	auto strand (Shared<asio::io_context::strand>::Make(io));
+	auto strand (std::make_shared<IoStrand>(io.get_executor()));
 	Shared<asio::ssl::context>::Ptr ctx;
 
 	cr->SetExecutionStart(Utility::GetTime());

--- a/lib/otel/otel.cpp
+++ b/lib/otel/otel.cpp
@@ -62,7 +62,7 @@ OTel::OTel(OTelConnInfo& connInfo): OTel{connInfo, IoEngine::Get().GetIoContext(
 
 OTel::OTel(OTelConnInfo& connInfo, boost::asio::io_context& io)
 	: m_ConnInfo{std::move(connInfo)},
-	  m_Strand{io},
+	  m_Strand{io.get_executor()},
 	  m_ExportAsioCV{io},
 	  m_RetryExportAndConnTimer{io},
 	  m_Exporting{false},
@@ -241,9 +241,9 @@ void OTel::Connect(boost::asio::yield_context& yc)
 		try {
 			decltype(m_Stream) stream;
 			if (m_ConnInfo.EnableTls) {
-				stream = Shared<AsioTlsStream>::Make(m_Strand.context(), *m_TlsContext, m_ConnInfo.Host);
+				stream = Shared<AsioTlsStream>::Make(m_Strand.get_inner_executor().context(), *m_TlsContext, m_ConnInfo.Host);
 			} else {
-				stream = Shared<AsioTcpStream>::Make(m_Strand.context());
+				stream = Shared<AsioTcpStream>::Make(m_Strand.get_inner_executor().context());
 			}
 
 			Timeout timeout{m_Strand, boost::posix_time::seconds(10), [this, stream] {

--- a/lib/otel/otel.cpp
+++ b/lib/otel/otel.cpp
@@ -62,7 +62,7 @@ OTel::OTel(OTelConnInfo& connInfo): OTel{connInfo, IoEngine::Get().GetIoContext(
 
 OTel::OTel(OTelConnInfo& connInfo, boost::asio::io_context& io)
 	: m_ConnInfo{std::move(connInfo)},
-	  m_Strand{io},
+	  m_Strand{io.get_executor()},
 	  m_ExportAsioCV{io},
 	  m_RetryExportAndConnTimer{io},
 	  m_Exporting{false},
@@ -241,9 +241,9 @@ void OTel::Connect(boost::asio::yield_context& yc)
 		try {
 			decltype(m_Stream) stream;
 			if (m_ConnInfo.EnableTls) {
-				stream = Shared<AsioTlsStream>::Make(m_Strand.context(), *m_TlsContext, m_ConnInfo.Host);
+				stream = Shared<AsioTlsStream>::Make(m_Strand.get_inner_executor().context(), *m_TlsContext, m_ConnInfo.Host);
 			} else {
-				stream = Shared<AsioTcpStream>::Make(m_Strand.context());
+				stream = Shared<AsioTcpStream>::Make(m_Strand.get_inner_executor().context());
 			}
 
 			Timeout timeout{m_Strand, 10s, [this, stream] {

--- a/lib/otel/otel.hpp
+++ b/lib/otel/otel.hpp
@@ -111,7 +111,7 @@ private:
 	const OTelConnInfo m_ConnInfo;
 	std::optional<AsioTlsOrTcpStream> m_Stream;
 	Shared<boost::asio::ssl::context>::Ptr m_TlsContext;
-	boost::asio::io_context::strand m_Strand;
+	IoStrand m_Strand;
 
 	AsioConditionVariable m_ExportAsioCV; // Event to signal when a new export request is available.
 	// Timer for scheduling retries of failed exports and reconnection attempts.

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -42,7 +42,7 @@ PerfdataWriterConnection::PerfdataWriterConnection(
 	  m_Host(std::move(host)),
 	  m_Port(std::move(port)),
 	  m_ReconnectTimer(IoEngine::Get().GetIoContext()),
-	  m_Strand(IoEngine::Get().GetIoContext()),
+	  m_Strand(IoEngine::Get().GetIoContext().get_executor()),
 	  m_Stream(MakeStream())
 {
 }

--- a/lib/perfdata/perfdatawriterconnection.cpp
+++ b/lib/perfdata/perfdatawriterconnection.cpp
@@ -43,7 +43,7 @@ PerfdataWriterConnection::PerfdataWriterConnection(
 	  m_Host(std::move(host)),
 	  m_Port(std::move(port)),
 	  m_ReconnectTimer(IoEngine::Get().GetIoContext()),
-	  m_Strand(IoEngine::Get().GetIoContext()),
+	  m_Strand(IoEngine::Get().GetIoContext().get_executor()),
 	  m_Stream(MakeStream())
 {
 }

--- a/lib/perfdata/perfdatawriterconnection.hpp
+++ b/lib/perfdata/perfdatawriterconnection.hpp
@@ -150,7 +150,7 @@ private:
 
 	std::chrono::milliseconds m_RetryTimeout{InitialRetryWait};
 	boost::asio::steady_timer m_ReconnectTimer;
-	boost::asio::io_context::strand m_Strand;
+	IoStrand m_Strand;
 	AsioTlsOrTcpStream m_Stream;
 };
 

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -27,7 +27,6 @@
 #include "base/exception.hpp"
 #include "base/tcpsocket.hpp"
 #include <boost/asio/buffer.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/ssl/context.hpp>
@@ -493,7 +492,7 @@ bool ApiListener::AddListener(const String& node, const String& service)
 	Log(LogInformation, "ApiListener")
 		<< "Started new listener on '[" << localEndpoint.address() << "]:" << localEndpoint.port() << "'";
 
-	auto strand = Shared<asio::io_context::strand>::Make(io);
+	auto strand = std::make_shared<IoStrand>(io.get_executor());
 
 	boost::signals2::scoped_connection closeSignal = m_OnListenerShutdown.connect([strand, acceptor]() {
 		boost::asio::post(*strand, [acceptor] {
@@ -569,7 +568,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 			lock.unlock();
 			sslConn->lowest_layer() = std::move(socket);
 
-			auto strand (Shared<asio::io_context::strand>::Make(io));
+			auto strand = std::make_shared<IoStrand>(io.get_executor());
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
 				Timeout timeout (*strand, boost::posix_time::microseconds(int64_t(GetConnectTimeout() * 1e6)),
@@ -613,7 +612,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 	}
 
 	auto& io (IoEngine::Get().GetIoContext());
-	auto strand (Shared<asio::io_context::strand>::Make(io));
+	auto strand = std::make_shared<IoStrand>(io.get_executor());
 
 	IoEngine::SpawnCoroutine(*strand, [this, strand, endpoint, &io](asio::yield_context yc) {
 		String host = endpoint->GetHost();
@@ -656,7 +655,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 }
 
 void ApiListener::NewClientHandler(
-	boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+	boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {
@@ -691,7 +690,7 @@ static const auto l_AppVersionInt (([]() -> unsigned long {
  * @param client The new client.
  */
 void ApiListener::NewClientHandlerInternal(
-	boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+	boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -27,7 +27,6 @@
 #include "base/exception.hpp"
 #include "base/tcpsocket.hpp"
 #include <boost/asio/buffer.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/spawn.hpp>
 #include <boost/asio/ssl/context.hpp>
@@ -512,7 +511,7 @@ bool ApiListener::AddListener(const String& node, const String& service)
 	Log(LogInformation, "ApiListener")
 		<< "Started new listener on '[" << localEndpoint.address() << "]:" << localEndpoint.port() << "'";
 
-	auto strand = Shared<asio::io_context::strand>::Make(io);
+	auto strand = std::make_shared<IoStrand>(io.get_executor());
 
 	boost::signals2::scoped_connection closeSignal = m_OnListenerShutdown.connect([strand, acceptor]() {
 		boost::asio::post(*strand, [acceptor] {
@@ -588,7 +587,7 @@ void ApiListener::ListenerCoroutineProc(boost::asio::yield_context yc, const Sha
 			lock.unlock();
 			sslConn->lowest_layer() = std::move(socket);
 
-			auto strand (Shared<asio::io_context::strand>::Make(io));
+			auto strand = std::make_shared<IoStrand>(io.get_executor());
 
 			IoEngine::SpawnCoroutine(*strand, [this, strand, sslConn, remoteEndpoint](asio::yield_context yc) {
 				Timeout timeout (*strand, std::chrono::duration<double>{GetConnectTimeout()},
@@ -632,7 +631,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 	}
 
 	auto& io (IoEngine::Get().GetIoContext());
-	auto strand (Shared<asio::io_context::strand>::Make(io));
+	auto strand = std::make_shared<IoStrand>(io.get_executor());
 
 	IoEngine::SpawnCoroutine(*strand, [this, strand, endpoint, &io](asio::yield_context yc) {
 		String host = endpoint->GetHost();
@@ -675,7 +674,7 @@ void ApiListener::AddConnection(const Endpoint::Ptr& endpoint)
 }
 
 void ApiListener::NewClientHandler(
-	boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+	boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {
@@ -710,7 +709,7 @@ static const auto l_AppVersionInt (([]() -> unsigned long {
  * @param client The new client.
  */
 void ApiListener::NewClientHandlerInternal(
-	boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+	boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 	const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 )
 {

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -26,6 +26,7 @@
 #include <boost/asio/ssl/context.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <set>
 
@@ -209,11 +210,11 @@ private:
 	void AddConnection(const Endpoint::Ptr& endpoint);
 
 	void NewClientHandler(
-		boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+		boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void NewClientHandlerInternal(
-		boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+		boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server);

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -26,6 +26,7 @@
 #include <boost/asio/ssl/context.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <set>
 
@@ -214,11 +215,11 @@ private:
 	void AddConnection(const Endpoint::Ptr& endpoint);
 
 	void NewClientHandler(
-		boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+		boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void NewClientHandlerInternal(
-		boost::asio::yield_context yc, const Shared<boost::asio::io_context::strand>::Ptr& strand,
+		boost::asio::yield_context yc, const std::shared_ptr<IoStrand>& strand,
 		const Shared<AsioTlsStream>::Ptr& client, const String& hostname, ConnectionRole role
 	);
 	void ListenerCoroutineProc(boost::asio::yield_context yc, const Shared<boost::asio::ip::tcp::acceptor>::Ptr& server);

--- a/lib/remote/httpmessage.hpp
+++ b/lib/remote/httpmessage.hpp
@@ -291,7 +291,7 @@ public:
 	 * @param yc Yield context that is used for waiting.
 	 * @param strand Strand the caller is running on, used for synchronization.
 	 */
-	void StartCpuBoundWork(boost::asio::yield_context yc, boost::asio::io_context::strand& strand)
+	void StartCpuBoundWork(boost::asio::yield_context yc, IoStrand& strand)
 	{
 		m_CpuBoundWork.emplace(yc, strand);
 	}

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -41,7 +41,7 @@ HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, cons
 }
 
 HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io)
-	: m_WaitGroup(waitGroup), m_Stream(stream), m_IoStrand(io), m_ShuttingDown(false), m_ConnectionReusable(true), m_CheckLivenessTimer(io)
+	: m_WaitGroup(waitGroup), m_Stream(stream), m_IoStrand(io.get_executor()), m_ShuttingDown(false), m_ConnectionReusable(true), m_CheckLivenessTimer(io)
 {
 	if (authenticated) {
 		m_ApiUser = ApiUser::GetByClientCN(identity);
@@ -419,7 +419,7 @@ void ProcessRequest(
 	const WaitGroup::Ptr& waitGroup,
 	std::chrono::steady_clock::duration& cpuBoundWorkTime,
 	boost::asio::yield_context& yc,
-	boost::asio::io_context::strand& strand
+	IoStrand& strand
 )
 {
 	try {

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -41,7 +41,7 @@ HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, cons
 }
 
 HttpServerConnection::HttpServerConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated, const Shared<AsioTlsStream>::Ptr& stream, boost::asio::io_context& io)
-	: m_WaitGroup(waitGroup), m_Stream(stream), m_IoStrand(io), m_ShuttingDown(false), m_ConnectionReusable(true), m_CheckLivenessTimer(io)
+	: m_WaitGroup(waitGroup), m_Stream(stream), m_IoStrand(io.get_executor()), m_ShuttingDown(false), m_ConnectionReusable(true), m_CheckLivenessTimer(io)
 {
 	if (authenticated) {
 		m_ApiUser = ApiUser::GetByClientCN(identity);
@@ -420,7 +420,7 @@ void ProcessRequest(
 	const WaitGroup::Ptr& waitGroup,
 	std::chrono::steady_clock::duration& cpuBoundWorkTime,
 	boost::asio::yield_context& yc,
-	boost::asio::io_context::strand& strand
+	IoStrand& strand
 )
 {
 	try {

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -5,13 +5,13 @@
 #define HTTPSERVERCONNECTION_H
 
 #include "remote/apiuser.hpp"
+#include "base/io-engine.hpp"
 #include "base/string.hpp"
 #include "base/tlsstream.hpp"
 #include "base/wait-group.hpp"
 #include <memory>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/spawn.hpp>
 #include <chrono>
 
@@ -55,7 +55,7 @@ private:
 	std::chrono::steady_clock::time_point m_Seen{std::chrono::steady_clock::now()};
 	std::chrono::milliseconds m_LivenessTimeout{10s};
 	String m_PeerAddress;
-	boost::asio::io_context::strand m_IoStrand;
+	IoStrand m_IoStrand;
 	bool m_ShuttingDown;
 	bool m_ConnectionReusable;
 	boost::asio::deadline_timer m_CheckLivenessTimer;

--- a/lib/remote/httpserverconnection.hpp
+++ b/lib/remote/httpserverconnection.hpp
@@ -5,13 +5,13 @@
 #define HTTPSERVERCONNECTION_H
 
 #include "remote/apiuser.hpp"
+#include "base/io-engine.hpp"
 #include "base/string.hpp"
 #include "base/tlsstream.hpp"
 #include "base/wait-group.hpp"
 #include <memory>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/spawn.hpp>
 #include <chrono>
 
@@ -55,7 +55,7 @@ private:
 	std::chrono::steady_clock::time_point m_Seen{std::chrono::steady_clock::now()};
 	std::chrono::milliseconds m_LivenessTimeout{10s};
 	String m_PeerAddress;
-	boost::asio::io_context::strand m_IoStrand;
+	IoStrand m_IoStrand;
 	bool m_ShuttingDown;
 	bool m_ConnectionReusable;
 	boost::asio::steady_timer m_CheckLivenessTimer;

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -39,7 +39,7 @@ JsonRpcConnection::JsonRpcConnection(const WaitGroup::Ptr& waitGroup, const Stri
 JsonRpcConnection::JsonRpcConnection(const WaitGroup::Ptr& waitGroup, const String& identity, bool authenticated,
 	const Shared<AsioTlsStream>::Ptr& stream, ConnectionRole role, boost::asio::io_context& io)
 	: m_Identity(identity), m_Authenticated(authenticated), m_Stream(stream), m_Role(role),
-	m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_IoStrand(io),
+	m_Timestamp(Utility::GetTime()), m_Seen(Utility::GetTime()), m_IoStrand(io.get_executor()),
 	m_OutgoingMessagesQueued(io), m_WriterDone(io), m_ShuttingDown(false), m_WaitGroup(waitGroup),
 	m_CheckLivenessTimer(io), m_HeartbeatTimer(io)
 {

--- a/lib/remote/jsonrpcconnection.hpp
+++ b/lib/remote/jsonrpcconnection.hpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <vector>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/io_context_strand.hpp>
 #include <boost/asio/spawn.hpp>
 
 namespace icinga
@@ -76,7 +75,7 @@ private:
 	ConnectionRole m_Role;
 	double m_Timestamp;
 	double m_Seen;
-	boost::asio::io_context::strand m_IoStrand;
+	IoStrand m_IoStrand;
 	std::vector<String> m_OutgoingMessagesQueue;
 	AsioEvent m_OutgoingMessagesQueued;
 	AsioEvent m_WriterDone;

--- a/test/base-io-engine.cpp
+++ b/test/base-io-engine.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_SUITE(base_io_engine)
 BOOST_AUTO_TEST_CASE(timeout_run)
 {
 	boost::asio::io_context io;
-	boost::asio::io_context::strand strand (io);
+	IoStrand strand (io.get_executor());
 	int called = 0;
 
 	IoEngine::SpawnCoroutine(strand, [&](boost::asio::yield_context yc) {
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(timeout_run)
 BOOST_AUTO_TEST_CASE(timeout_cancelled)
 {
 	boost::asio::io_context io;
-	boost::asio::io_context::strand strand (io);
+	IoStrand strand (io.get_executor());
 	int called = 0;
 
 	IoEngine::SpawnCoroutine(strand, [&](boost::asio::yield_context yc) {
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(timeout_cancelled)
 BOOST_AUTO_TEST_CASE(timeout_scope)
 {
 	boost::asio::io_context io;
-	boost::asio::io_context::strand strand (io);
+	IoStrand strand (io.get_executor());
 	int called = 0;
 
 	IoEngine::SpawnCoroutine(strand, [&](boost::asio::yield_context yc) {
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(timeout_scope)
 BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
 {
 	boost::asio::io_context io;
-	boost::asio::io_context::strand strand (io);
+	IoStrand strand (io.get_executor());
 	int called = 0;
 
 	IoEngine::SpawnCoroutine(strand, [&](boost::asio::yield_context yc) {
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(timeout_due_cancelled)
 BOOST_AUTO_TEST_CASE(timeout_due_scope)
 {
 	boost::asio::io_context io;
-	boost::asio::io_context::strand strand (io);
+	IoStrand strand (io.get_executor());
 	int called = 0;
 
 	IoEngine::SpawnCoroutine(strand, [&](boost::asio::yield_context yc) {


### PR DESCRIPTION
This replaces `boost::asio::io_context::strand` with the executor-templated `boost::asio::strand<boost::asio::io_context_executor_type>`. This should prevent issues like #10825 to occur in the future, because the modern strand does not share implementation pointers between individual strand objects.

### Detailed Description

The issue with the previously used strand was that there is a chance for two strand users (like a `PerfdataWriterConnection` and a `JsonRpcConnection`) to share an implementation object. This means that even though both objects hold distinct strand objects, one can block the execution of the other. So when one objects holds a lock, waits on an IO-Operation on that strand and the other object resumes on the strand and tries to acquire the same lock, both objects are deadlocked.

The executor-templated strand type is never shared between users and so should never run into this kind of deadlock. It's available for all boost versions we currently support and I've checked the changelog and git history carefully to see if there are any critical bugs that have been fixed since it was introduced. Technically boost-1.66 was the version this new strand has been introduced, but it seems there have been relatively few changes outside of some refactoring since then.

Currently this is all in one commit, because it's hard to switch this over gradually with some critical pieces (`Timeout` and `GracefulDisconnect` most notably) using the strand type explicitly and make incompatible calls on it which can't easily be generalized. And I didn't want to go through the effort of adding an overload either, just so it becomes pointless after switching everything over.

### Notes
#### Use of `std::shared_ptr<strand>` instead of `Shared<strand>::Ptr`

When a `Shared<Foo>::Ptr` is dereferenced, the object is of type `Shared` that inherits from `Foo`. When passed to `SpawnCoroutine()`, this keeps older boost versions from using their dedicated [`boost::asio::spawn(const strand< Executor > & ex, ...)`](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/spawn/overload5.html) overloads and falls back to the generic Executor based overloads, which then fail somewhere in the machinery (the reason the overload exists).

Newer boost versions don't have this problem and the strand can just be treated as a generic executor, but for now we'll have to use `std::shared_ptr<strand>` for shared strands, because that correctly dereferences to the original type. The alternative would have been explicit object slicing with `static_cast<strand&>` at each call-site.

Honestly, I hadn't looked that closely at `Shared<>::Ptr`, but this makes it a giant ball of anti-patterns in my eyes. Most egregious of all, unconstrained deriving from arbitrary types isn't a good idea and might break all kinds of things. In my opinion we should consider deprecating it and just use `std::shared_ptr` with `std::make_shared` and `std::shared_from_this` in new code.

Closes #10861.