### PR TITLE
[GHSA-vj39-ww8j-vvx5] Checking if certificate update request comes from a valid endpoint

### DIFF
--- a/lib/remote/jsonrpcconnection-pki.cpp
+++ b/lib/remote/jsonrpcconnection-pki.cpp
@@ -344,7 +344,7 @@ void JsonRpcConnection::SendCertificateRequest(const JsonRpcConnection::Ptr& acl
 
 Value UpdateCertificateHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
-	if (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone)) {
+	if (!origin->FromClient->GetEndpoint() || (origin->FromZone && !Zone::GetLocalZone()->IsChildOf(origin->FromZone))) {
 		Log(LogWarning, "ClusterEvents")
 			<< "Discarding 'update certificate' message from '" << origin->FromClient->GetIdentity() << "': Invalid endpoint origin (client not allowed).";
 


### PR DESCRIPTION
> [!NOTE]
> This is the fix for [GHSA-vj39-ww8j-vvx5](https://github.com/Icinga/icinga2/security/advisories/GHSA-vj39-ww8j-vvx5) as it was already released in [v2.16.2](https://github.com/Icinga/icinga2/releases/tag/v2.16.2), [v2.15.4](https://github.com/Icinga/icinga2/releases/tag/v2.15.4), and [v2.14.9](https://github.com/Icinga/icinga2/releases/tag/v2.14.9).

As described in the [GHSA](https://github.com/Icinga/icinga2/security/advisories/GHSA-vj39-ww8j-vvx5), unlike other handlers, `UpdateCertificateHandler` doesn't check if the request comes from a valid endpoint. This PR adds that check to bring it in line with these other handlers.