### PR TITLE
[GHSA-jgqj-x5j9-vgcm] ConfigWriter::EmitScope: Escape import

### DIFF
--- a/lib/base/configwriter.cpp
+++ b/lib/base/configwriter.cpp
@@ -64,7 +64,8 @@ void ConfigWriter::EmitScope(std::ostream& fp, int indentLevel, const Dictionary
 		for (const Value& import : imports) {
 			fp << "\n";
 			EmitIndent(fp, indentLevel);
-			fp << "import \"" << import << "\"";
+			fp << "import ";
+			EmitString(fp, import.Get<String>());
 		}
 
 		fp << "\n";
@@ -173,11 +174,6 @@ void ConfigWriter::EmitConfigItem(std::ostream& fp, const String& type, const St
 
 	fp << " ";
 	EmitScope(fp, 1, attrs, imports, true);
-}
-
-void ConfigWriter::EmitComment(std::ostream& fp, const String& text)
-{
-	fp << "/* " << text << " */\n";
 }
 
 void ConfigWriter::EmitFunctionCall(std::ostream& fp, const String& name, const Array::Ptr& arguments)

--- a/lib/base/configwriter.hpp
+++ b/lib/base/configwriter.hpp
@@ -54,7 +54,6 @@ public:
 	static void EmitConfigItem(std::ostream& fp, const String& type, const String& name, bool isTemplate,
 		bool ignoreOnError, const Array::Ptr& imports, const Dictionary::Ptr& attrs);
 
-	static void EmitComment(std::ostream& fp, const String& text);
 	static void EmitFunctionCall(std::ostream& fp, const String& name, const Array::Ptr& arguments);
 
 	static const std::vector<String>& GetKeywords();


### PR DESCRIPTION
Escape all user-supplied template imports when creating an Icinga 2 DSL configuration object. Without the escape, a `"` within the template name would allow escaping the created object and create other Icinga 2 DSL objects, exceeding potential user privileges.

The same bug was present in ConfigWriter::EmitComment, but as this method is dead code, it could just be removed.