### PR TITLE
Forward-port missing v2.15.1 upgrading docs to master branch

### DIFF
--- a/doc/16-upgrading-icinga-2.md
+++ b/doc/16-upgrading-icinga-2.md
@@ -37,6 +37,17 @@ alternatives:
 * `ExternalCommandListener` and `LivestatusListener`: Please use the [Icinga 2 API](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/) instead.
 * Windows check-plugins (`check_*.exe`) and `CheckCommand`s: Please use our [PowerShell plugins](https://github.com/Icinga/icinga-powershell-plugins) instead.
 
+## Upgrading to v2.15.1, v2.14.7, or v2.13.13 <a id="upgrading-to-2-15-1"></a>
+
+These three versions include the same fix to the logrotate configuration in `/etc/logrotate.d/icinga2`. As this file is
+tracked as a configuration file by package managers, it may not be updated automatically if it was modified locally.
+After upgrading, make sure to check if there are any files with an extension like `.dpkg-dist` or `.rpmnew` next to it.
+If so, you need to incorporate the changes into your configuration manually.
+
+To verify that the fix was applied correctly, check the contents of `/etc/logrotate.d/icinga2`: If the file uses the
+command `"$DAEMON" internal signal --sig SIGHUP --pid "$pid"` (instead of `kill -HUP "$pid"`), it was upgraded
+correctly.
+
 ## Upgrading to v2.15 <a id="upgrading-to-2-15"></a>
 
 ### Icinga DB <a id="upgrading-to-2-15-icingadb"></a>


### PR DESCRIPTION
During the preparation of the v2.16.2 (and more) releases, I noticed that older support branches contained upgrading docs that are missing from the `master` branch.

In particular, the [Upgrading to v2.15.1, v2.14.7, or v2.13.13](https://github.com/Icinga/icinga2/blob/support/2.15/doc/16-upgrading-icinga-2.md#upgrading-to-2-15-1) section is missing in both the [`support/2.16` branch](https://github.com/Icinga/icinga2/blob/support/2.16/doc/16-upgrading-icinga-2.md#upgrading-to-2-15-1) (which is used to render https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/), and the [`master` branch](https://github.com/Icinga/icinga2/blob/support/2.16/doc/16-upgrading-icinga-2.md#upgrading-to-2-15-1) (which will be used to create future `support/*` branches from).

This PR forward-ports the changes to that everything is on master, so that it's not lost. It's also supposed to be backported so that it appears on https://icinga.com/docs/icinga-2/latest/doc/16-upgrading-icinga-2/ again (where it was lost with the v2.16.0 release).

Quick and dirty shell script to verify what's missing (note that "Upgrading to v2.13.13" and "Upgrading to v2.14.7" are the same as added here, just with a different heading, and "Upgrading to v2.16.2, v2.15.4, or v2.14.9" will be added by #10909):

```bash
for branch in origin/support/2.{8..16}; do
  git show "$branch":doc/16-upgrading-icinga-2.md | grep '^#.*Upgrading to'
done | sort -u | while read -r heading; do
  grep -Fe "$heading" doc/16-upgrading-icinga-2.md || echo "MISSING: $heading"
done
```