### PR TITLE
Restore single-argument Json.decode() in the DSL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -83,6 +83,7 @@ Dirk Goetz <dirk.goetz@icinga.com>
 Dirk Wening <dirk.wening@netways.de>
 Dirk Melchers <dirk@dirk-melchers.de>
 Dolf Schimmel <dolf@transip.nl>
+Dominik Bay <dominik@bay.sh>
 Dominik Riva <driva@protonmail.com>
 dominik-r-s <43005480+dominik-r-s@users.noreply.github.com>
 Edgar Fuß <ef@math.uni-bonn.de>

--- a/lib/base/json-script.cpp
+++ b/lib/base/json-script.cpp
@@ -15,12 +15,22 @@ static String JsonEncodeShim(const Value& value)
 	return JsonEncode(value);
 }
 
+static Value JsonDecodeShim(const String& data)
+{
+	/* Wrap JsonDecode() so that the DSL function keeps its single-argument
+	 * signature. JsonDecode()'s depthLimit parameter has a default value, but
+	 * function pointers don't carry defaults, so binding it directly would make
+	 * depthLimit a required argument and break Json.decode("..."). See #10913.
+	 */
+	return JsonDecode(data);
+}
+
 INITIALIZE_ONCE([]() {
 	Namespace::Ptr jsonNS = new Namespace(true);
 
 	/* Methods */
 	jsonNS->Set("encode", new Function("Json#encode", JsonEncodeShim, { "value" }, true));
-	jsonNS->Set("decode", new Function("Json#decode", JsonDecode, { "value" }, true));
+	jsonNS->Set("decode", new Function("Json#decode", JsonDecodeShim, { "value" }, true));
 
 	jsonNS->Freeze();
 

--- a/test/base-json.cpp
+++ b/test/base-json.cpp
@@ -10,6 +10,7 @@
 #include "base/io-engine.hpp"
 #include "base/objectlock.hpp"
 #include "base/json.hpp"
+#include "base/scriptglobal.hpp"
 #include "test/utils.hpp"
 #include <boost/algorithm/string/replace.hpp>
 #include <BoostTestTargetConfig.h>
@@ -145,6 +146,20 @@ BOOST_AUTO_TEST_CASE(decode)
 
 	auto uint (output->Get("uint"));
 	BOOST_CHECK(uint.IsNumber() && uint.Get<double>() == 23.0);
+}
+
+BOOST_AUTO_TEST_CASE(decode_dsl_single_argument)
+{
+	/* Regression test for #10913: the Json.decode() DSL function must accept a
+	 * single argument. JsonDecode()'s optional depthLimit parameter must not
+	 * leak into the function binding as a required argument.
+	 */
+	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
+	Namespace::Ptr jsonNS = systemNS->Get("Json");
+	Function::Ptr decode = jsonNS->Get("decode");
+
+	BOOST_REQUIRE(decode);
+	BOOST_CHECK_EQUAL(decode->Invoke({ "2" }), Value(2));
 }
 
 BOOST_AUTO_TEST_CASE(invalid1)


### PR DESCRIPTION
Please note: I based this against support/2.16 as the security fix isn't on master yet (also explained below). Also this is my first contribution to the Icinga code base. But as we are a heavy Icinga user and discovered the bug I took the chance.

Since 2.16.2, `Json.decode("...")` fails with `Too few arguments for function`, an undocumented breaking change in a patch release (reported in #10913).

### Cause
The recursion depth limit added to `JsonDecode()` in 2.16.2 (ed163a8aa9d296820dd2ad14c47bf3f6a3fcce7d) gave the C++ function a second parameter with a default value:

`Value JsonDecode(const String& data, size_t depthLimit = JsonDecodeDefaultDepthLimit);`

The DSL binding in `json-script.cpp` passed this function pointer directly to `Function`. Required-argument count is deduced from the function-pointer arity via `boost::function_types::function_arity`, and function pointers do not carry default arguments — so the arity became 2 and `Json.decode()` started requiring two arguments.

### Fix
Wrap `JsonDecode()` in a single-argument shim (mirroring the existing `JsonEncodeShim`) so the registered function keeps its one-parameter contract while still applying the default depth limit internally. The 2.16.2 security hardening is fully preserved.

Adds a regression test that invokes the registered `Json.decode` function with a single argument (it fails against the unfixed binding with the exact `Too few arguments` error).

### Notes
- Targets `support/2.16`: the regression exists only there. `master` never received the depth-limit change, so it is unaffected. When the depth limit is forward-ported to `master`, this shim should accompany it.

fixes #10913