### PR TITLE
Enforce filter-expression permission by default in v2.17

### DIFF
--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -346,15 +346,6 @@ Run the following command to:
 icinga2 api setup
 ```
 
-For new installations, it is recommended to set the following additional attribute inside the `ApiListener` object
-definition in `/etc/icinga2/features-enabled/api.conf`. This will already enforce stricter permissions as they will
-become the default with v2.17 (see the [upgrading documentation](16-upgrading-icinga-2.md#upgrading-to-2-16-2) for the
-version that introduced that setting for more details):
-
-```
-enforce_filter_expression_permission = true
-```
-
 Restart Icinga 2 for these changes to take effect.
 
 ```bash

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1110,7 +1110,7 @@ Configuration Attributes:
   access\_control\_allow\_methods         | String     | **Deprecated.** Used in response to a preflight request to indicate which HTTP methods can be used when making the actual request. Defaults to `GET, POST, PUT, DELETE`. [(MDN docs)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Methods)
   environment                             | String     | **Optional.** Used as suffix in TLS SNI extension name; default from constant `ApiEnvironment`, which is empty.
   http\_response\_headers                 | Dictionary | **Optional.** Additional headers to add to HTTP responses, for example `{"Strict-Transport-Security" = "max-age=31536000"}`. Defaults to none.
-  enforce\_filter\_expression\_permission | Boolean    | **Optional.** Enforce the `filter-expression` permission. Defaults to `false` until v2.17 for compatibility.
+  enforce\_filter\_expression\_permission | Boolean    | **Optional.** Enforce the `filter-expression` permission. Defaults to `true`.
 
 The attributes `access_control_allow_credentials`, `access_control_allow_headers` and `access_control_allow_methods`
 are controlled by Icinga 2 and are not changeable by config any more.

--- a/doc/12-icinga2-api.md
+++ b/doc/12-icinga2-api.md
@@ -305,12 +305,6 @@ Available permissions that are not bound to specific URL endpoints:
   ------------------------------|------------
   filter-expression             | Allows the user to provide their own [advanced filter expressions](12-icinga2-api.md#icinga2-api-advanced-filters).
 
-!!! warning
-
-    The `filter-expression` permission was introduced in v2.16.2 and is only enforced if the
-    [`enforce_filter_expression_permission` attribute of `ApiListener`](09-object-types.md#objecttype-apilistener)
-    is set to `true`. For compatibility reasons, this will not be enforced by default until v2.17.
-
 The required actions or types can be replaced by using a wildcard match ("\*").
 
 
@@ -452,10 +446,6 @@ be defined once in the provided string value.
     In order to use these advanced filters, the `ApiUser` must be granted the `filter-expression` permission,
     which should only be done for trusted users. The evaluation happens in the main Icinga 2 worker process and may be
     abused for denial-of-service attacks, potentially crashing the Icinga 2 daemon.
-
-    Note that before v2.17, this permission is not enforced by default but only if the
-    [`enforce_filter_expression_permission` attribute of `ApiListener`](09-object-types.md#objecttype-apilistener)
-    is set accordingly.
 
 > **Note**
 >

--- a/lib/remote/apilistener.ti
+++ b/lib/remote/apilistener.ti
@@ -64,8 +64,8 @@ class ApiListener : ConfigObject
 
 	[state, no_user_modify] Dictionary::Ptr last_failed_zones_stage_validation;
 
-	[config, no_user_modify] bool enforce_filter_expression_permission {
-		default {{{ return false; }}}
+	[config, no_user_modify, deprecated] bool enforce_filter_expression_permission {
+		default {{{ return true; }}}
 	};
 
 	[state, no_user_modify] Dictionary::Ptr deleted_runtime_objects {


### PR DESCRIPTION
This is a followup change for #10909, which was included in the [v2.16.2](https://github.com/Icinga/icinga2/releases/tag/v2.16.2), [v2.15.4](https://github.com/Icinga/icinga2/releases/tag/v2.15.4), and [v2.14.9](https://github.com/Icinga/icinga2/releases/tag/v2.14.9) releases and adds a new `filter-expression` permission to Icinga 2. As that's an incompatible change, this permission is not enforced by default yet (users need to opt-in), but the documentation and log messages already announce that this will change in v2.17.

This PR now adds exactly those changes: it changes the default of the (also newly added in #10909) `enforce_filter_expression_permission` config option to `true` and marks it as deprecated so that users are disencouraged from disabling it, but rather add the `filter-expression` to `ApiUser` objects instead. The documentation is also updated accordingly.

Our own API consumers should not be affected by this. I've asked about this (also in internal chats), and only Icinga DB, which - according to https://github.com/Icinga/icinga2/pull/10919#pullrequestreview-4692934259 - does not use filter expression, and Icinga Director, which [asks for a wildcard permission](https://icinga.com/docs/icinga-director/latest/doc/04-Getting-started/#create-an-api-user), came up.