### PR TITLE
[Backport support/2.14] Restore single-argument Json.decode() in the DSL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,6 +78,7 @@ Dinesh Majrekar <dinesh.majrekar@serverchoice.com>
 Dirk Goetz <dirk.goetz@icinga.com>
 Dirk Melchers <dirk@dirk-melchers.de>
 Dolf Schimmel <dolf@transip.nl>
+Dominik Bay <dominik@bay.sh>
 Dominik Riva <driva@protonmail.com>
 dominik-r-s <43005480+dominik-r-s@users.noreply.github.com>
 Edgar Fuß <ef@math.uni-bonn.de>

--- a/lib/base/json-script.cpp
+++ b/lib/base/json-script.cpp
@@ -14,12 +14,22 @@ static String JsonEncodeShim(const Value& value)
 	return JsonEncode(value);
 }
 
+static Value JsonDecodeShim(const String& data)
+{
+	/* Wrap JsonDecode() so that the DSL function keeps its single-argument
+	 * signature. JsonDecode()'s depthLimit parameter has a default value, but
+	 * function pointers don't carry defaults, so binding it directly would make
+	 * depthLimit a required argument and break Json.decode("..."). See #10913.
+	 */
+	return JsonDecode(data);
+}
+
 INITIALIZE_ONCE([]() {
 	Namespace::Ptr jsonNS = new Namespace(true);
 
 	/* Methods */
 	jsonNS->Set("encode", new Function("Json#encode", JsonEncodeShim, { "value" }, true));
-	jsonNS->Set("decode", new Function("Json#decode", JsonDecode, { "value" }, true));
+	jsonNS->Set("decode", new Function("Json#decode", JsonDecodeShim, { "value" }, true));
 
 	jsonNS->Freeze();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -85,6 +85,7 @@ add_boost_test(base
     base_io_engine/timeout_due_scope
     base_json/encode
     base_json/decode
+    base_json/decode_dsl_single_argument
     base_json/invalid1
     base_json/decode_depth_limit
     base_json/stack_size_coroutine

--- a/test/base-json.cpp
+++ b/test/base-json.cpp
@@ -8,6 +8,7 @@
 #include "base/io-engine.hpp"
 #include "base/objectlock.hpp"
 #include "base/json.hpp"
+#include "base/scriptglobal.hpp"
 #include <functional>
 #include <future>
 #include <boost/algorithm/string/replace.hpp>
@@ -121,6 +122,20 @@ BOOST_AUTO_TEST_CASE(decode)
 
 	auto uint (output->Get("uint"));
 	BOOST_CHECK(uint.IsNumber() && uint.Get<double>() == 23.0);
+}
+
+BOOST_AUTO_TEST_CASE(decode_dsl_single_argument)
+{
+	/* Regression test for #10913: the Json.decode() DSL function must accept a
+	 * single argument. JsonDecode()'s optional depthLimit parameter must not
+	 * leak into the function binding as a required argument.
+	 */
+	Namespace::Ptr systemNS = ScriptGlobal::Get("System");
+	Namespace::Ptr jsonNS = systemNS->Get("Json");
+	Function::Ptr decode = jsonNS->Get("decode");
+
+	BOOST_REQUIRE(decode);
+	BOOST_CHECK_EQUAL(decode->Invoke({ "2" }), Value(2));
 }
 
 BOOST_AUTO_TEST_CASE(invalid1)


### PR DESCRIPTION
Manual backport of #10914 to `support/2.14` due to a merge conflict in `test/base-json.cpp`. Additionally, I've added the newly introduced test case to `test/CMakeLists.txt` as that's still necessary for this older support branch.