### PR TITLE
Forward-port the change logs for v2.16.3, v2.15.5, and v2.14.10 to master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,16 @@ We will also no longer provide 32bit Windows MSIs via Chocolatey (#10757).
 * OpenSSL shipped on Windows updated to 3.5.6: #10786
 * Boost version shipped on Windows updated to 1.90: #10669
 
+## 2.15.5 (2026-07-01)
+
+This is a hotfix release that fixes a regression with the `Json.decode()` DSL function that was introduced in v2.15.4:
+The addition of a second argument to the internal `JsonDecode()` function unintentionally leaked into the DSL as a
+required argument. This version restores the old and intended behavior of `Json.decode()`.
+
+### Changes
+
+* Restore single-argument `Json.decode()` in the DSL (#10920)
+
 ## 2.15.4 (2026-06-29)
 
 This release fixes some critical security vulnerabilities in Icinga 2. Users are advised to upgrade immediately, as two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga2/milestones?state=closed).
 
+## 2.16.3 (2026-07-01)
+
+This is a hotfix release that fixes a regression with the `Json.decode()` DSL function that was introduced in v2.16.2:
+The addition of a second argument to the internal `JsonDecode()` function unintentionally leaked into the DSL as a
+required argument. This version restores the old and intended behavior of `Json.decode()`.
+
+### Changes
+
+* Restore single-argument `Json.decode()` in the DSL (#10921)
+* Add the upgrading documentation for v2.15.1 again, which went missing with the v2.16.0 release (#10916)
+
 ## 2.16.2 (2026-06-29)
 
 This release fixes some critical security vulnerabilities in Icinga 2. Users are advised to upgrade immediately, as two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,6 +412,16 @@ Thanks to all contributors:
 * Reduce task function allocation overhead by using a per-thread created lambda in `WorkQueue`. #9575
 * Remove redundant trailing empty lines and add missing newlines in some files. #7799
 
+## 2.14.10 (2026-07-01)
+
+This is a hotfix release that fixes a regression with the `Json.decode()` DSL function that was introduced in v2.14.9:
+The addition of a second argument to the internal `JsonDecode()` function unintentionally leaked into the DSL as a
+required argument. This version restores the old and intended behavior of `Json.decode()`.
+
+### Changes
+
+* Restore single-argument `Json.decode()` in the DSL (#10922)
+
 ## 2.14.9 (2026-06-29)
 
 This release fixes some critical security vulnerabilities in Icinga 2. Users are advised to upgrade immediately, as two


### PR DESCRIPTION
This PR ensures that the change logs for all Icinga 2 versions are available in the `master` branch.