### PR TITLE
Replace manual memory management with RAII containers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Aaron Bishop <erroneous@gmail.com>
 Adam Bolte <abolte@systemsaviour.com>
 Adam James <atj@pulsewidth.org.uk>
+Aditya <imadityaprasad@gmail.com>
 akrus <akrus@flygroup.st>
 Alan Jenkins <alan.christopher.jenkins@gmail.com>
 Alan Litster <alan.litster@twentyci.co.uk>

--- a/lib/base/process.cpp
+++ b/lib/base/process.cpp
@@ -597,10 +597,10 @@ bool Process::GetAdjustPriority() const
 void Process::IOThreadProc(int tid)
 {
 #ifdef _WIN32
-	HANDLE *handles = nullptr;
-	HANDLE *fhandles = nullptr;
+	std::vector<HANDLE> handles;
+	std::vector<HANDLE> fhandles;
 #else /* _WIN32 */
-	pollfd *pfds = nullptr;
+	std::vector<pollfd> pfds;
 #endif /* _WIN32 */
 	int count = 0;
 	double now;
@@ -617,13 +617,13 @@ void Process::IOThreadProc(int tid)
 
 			count = 1 + l_Processes[tid].size();
 #ifdef _WIN32
-			handles = reinterpret_cast<HANDLE *>(realloc(handles, sizeof(HANDLE) * count));
-			fhandles = reinterpret_cast<HANDLE *>(realloc(fhandles, sizeof(HANDLE) * count));
+			handles.resize(count);
+			fhandles.resize(count);
 
 			fhandles[0] = l_Events[tid];
 
 #else /* _WIN32 */
-			pfds = reinterpret_cast<pollfd *>(realloc(pfds, sizeof(pollfd) * count));
+			pfds.resize(count);
 
 			pfds[0].fd = l_EventFDs[tid][0];
 			pfds[0].events = POLLIN;
@@ -670,9 +670,9 @@ void Process::IOThreadProc(int tid)
 		timeout *= 1000;
 
 #ifdef _WIN32
-		DWORD rc = WaitForMultipleObjects(count, fhandles, FALSE, timeout == -1 ? INFINITE : static_cast<DWORD>(timeout));
+		DWORD rc = WaitForMultipleObjects(count, fhandles.data(), FALSE, timeout == -1 ? INFINITE : static_cast<DWORD>(timeout));
 #else /* _WIN32 */
-		int rc = poll(pfds, count, timeout);
+		int rc = poll(pfds.data(), count, timeout);
 
 		if (rc < 0)
 			continue;

--- a/lib/db_ido_mysql/idomysqlconnection.cpp
+++ b/lib/db_ido_mysql/idomysqlconnection.cpp
@@ -722,15 +722,15 @@ String IdoMysqlConnection::Escape(const String& s)
 	String utf8s = Utility::ValidateUTF8(s);
 
 	size_t length = utf8s.GetLength();
-	auto *to = new char[utf8s.GetLength() * 2 + 1];
 
-	m_Mysql->real_escape_string(&m_Connection, to, utf8s.CStr(), length);
+	String to;
+	to.GetData().resize(length * 2 + 1);
 
-	String result = String(to);
+	size_t escapedLength = m_Mysql->real_escape_string(&m_Connection, to.GetData().data(), utf8s.CStr(), length);
 
-	delete [] to;
+	to.GetData().resize(escapedLength);
 
-	return result;
+	return to;
 }
 
 Dictionary::Ptr IdoMysqlConnection::FetchRow(const IdoMysqlResult& result)


### PR DESCRIPTION
Replaced manual temporary buffer management with `std::vector` in:
- `Process::IOThreadProc()`
- `IdoMysqlConnection::Escape()`

This removes explicit allocation/deallocation and relies on RAII while preserving existing behavior.

Closes #10813.