### PR TITLE
[Backport support/2.16] Freeze perfdata arrays and remove locks in code using them

### DIFF
--- a/lib/icinga/checkresult.cpp
+++ b/lib/icinga/checkresult.cpp
@@ -33,3 +33,11 @@ double CheckResult::CalculateLatency() const
 
 	return latency;
 }
+
+void CheckResult::SetPerformanceData(const Array::Ptr& value, bool suppress_events, const Value& cookie)
+{
+	if (value) {
+		value->Freeze();
+	}
+	ObjectImpl<CheckResult>::SetPerformanceData(value, suppress_events, cookie);
+}

--- a/lib/icinga/checkresult.hpp
+++ b/lib/icinga/checkresult.hpp
@@ -22,6 +22,7 @@ public:
 
 	double CalculateExecutionTime() const;
 	double CalculateLatency() const;
+	void SetPerformanceData(const Array::Ptr& value, bool suppress_events = false, const Value& cookie = Empty) override;
 };
 
 }

--- a/lib/icinga/checkresult.ti
+++ b/lib/icinga/checkresult.ti
@@ -60,7 +60,7 @@ class CheckResult
 	[state, enum] ServiceState "state";
 	[state, enum] ServiceState previous_hard_state;
 	[state] String output;
-	[state] Array::Ptr performance_data;
+	[state, set_virtual] Array::Ptr performance_data;
 
 	[state] bool active {
 		default {{{ return true; }}}

--- a/lib/icinga/pluginutility.cpp
+++ b/lib/icinga/pluginutility.cpp
@@ -185,8 +185,6 @@ String PluginUtility::FormatPerfdata(const Array::Ptr& perfdata, bool normalize)
 
 	std::ostringstream result;
 
-	ObjectLock olock(perfdata);
-
 	bool first = true;
 	for (const Value& pdv : perfdata) {
 		if (!first)

--- a/lib/perfdata/elasticsearchwriter.cpp
+++ b/lib/perfdata/elasticsearchwriter.cpp
@@ -197,7 +197,6 @@ void ElasticsearchWriter::AddCheckResult(const Dictionary::Ptr& fields, const Ch
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
 	if (perfdata) {
-		ObjectLock olock(perfdata);
 		for (const Value& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/gelfwriter.cpp
+++ b/lib/perfdata/gelfwriter.cpp
@@ -313,7 +313,6 @@ void GelfWriter::CheckResultHandler(const Checkable::Ptr& checkable, const Check
 			Array::Ptr perfdata = cr->GetPerformanceData();
 
 			if (perfdata) {
-				ObjectLock olock(perfdata);
 				for (const Value& val : perfdata) {
 					PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/graphitewriter.cpp
+++ b/lib/perfdata/graphitewriter.cpp
@@ -334,7 +334,6 @@ void GraphiteWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
-	ObjectLock olock(perfdata);
 	for (const Value& val : perfdata) {
 		PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/influxdbcommonwriter.cpp
+++ b/lib/perfdata/influxdbcommonwriter.cpp
@@ -266,7 +266,6 @@ void InfluxdbCommonWriter::CheckResultHandler(const Checkable::Ptr& checkable, c
 		double ts = cr->GetExecutionEnd();
 
 		if (Array::Ptr perfdata = cr->GetPerformanceData()) {
-			ObjectLock olock(perfdata);
 			for (const Value& val : perfdata) {
 				PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/opentsdbwriter.cpp
+++ b/lib/perfdata/opentsdbwriter.cpp
@@ -317,7 +317,6 @@ void OpenTsdbWriter::SendPerfdata(const Checkable::Ptr& checkable, const String&
 
 	CheckCommand::Ptr checkCommand = checkable->GetCheckCommand();
 
-	ObjectLock olock(perfdata);
 	for (const Value& val : perfdata) {
 		PerfdataValue::Ptr pdv;
 

--- a/lib/perfdata/otlpmetricswriter.cpp
+++ b/lib/perfdata/otlpmetricswriter.cpp
@@ -181,7 +181,6 @@ void OTLPMetricsWriter::CheckResultHandler(const Checkable::Ptr& checkable, cons
 		auto endTime = cr->GetExecutionEnd();
 
 		Array::Ptr perfdata = cr->GetPerformanceData();
-		ObjectLock olock(perfdata);
 		for (const Value& val : perfdata) {
 			PerfdataValue::Ptr pdv;
 			if (val.IsObjectType<PerfdataValue>()) {

--- a/test/icinga-perfdata.cpp
+++ b/test/icinga-perfdata.cpp
@@ -38,6 +38,7 @@ BOOST_AUTO_TEST_CASE(quotes)
 BOOST_AUTO_TEST_CASE(multiple)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=123456 testB=123456");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd);
@@ -47,12 +48,14 @@ BOOST_AUTO_TEST_CASE(multiple)
 BOOST_AUTO_TEST_CASE(multiline)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata(" 'testA'=123456  'testB'=123456");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd);
 	BOOST_CHECK_EQUAL(str, "testA=123456 testB=123456");
 
 	pd = PluginUtility::SplitPerfdata(" 'testA'=123456  \n'testB'=123456");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	str = PluginUtility::FormatPerfdata(pd);
@@ -62,6 +65,7 @@ BOOST_AUTO_TEST_CASE(multiline)
 BOOST_AUTO_TEST_CASE(normalize)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=2m;3;4;1;5 testB=2foobar");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 2);
 
 	String str = PluginUtility::FormatPerfdata(pd, true);
@@ -333,6 +337,7 @@ BOOST_AUTO_TEST_CASE(ignore_warn_crit_ranges)
 BOOST_AUTO_TEST_CASE(empty_warn_crit_min_max)
 {
 	Array::Ptr pd = PluginUtility::SplitPerfdata("testA=5;;7;1;9 testB=5;7;;1;9 testC=5;;;1;9 testD=2m;;;1 testE=5;;7;;");
+	pd->Freeze();
 	BOOST_CHECK_EQUAL(pd->GetLength(), 5);
 
 	String str = PluginUtility::FormatPerfdata(pd, true);


### PR DESCRIPTION
Manual backport of #10857 to `support/2.16`, due to a merge conflict due to `test/perfdata-perfdatawriterfixture.hpp` missing `support/2.16`.