### PR TITLE
Fix rockylinux GHA by updating before installing dependencies

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -89,6 +89,7 @@ case "$DISTRO" in
 
   *rockylinux:*)
     dnf install -y 'dnf-command(config-manager)' epel-release
+    dnf update -y
 
     case "$DISTRO" in
       *:8)


### PR DESCRIPTION
Rockylinux seems to be one of those distros that need to be fully updateed before you can reliably install stuff. This led to the `mariadb-devel` package failing to install in [recent CI-runs](https://github.com/Icinga/icinga2/actions/runs/28797817987/job/85392844081). This PR adds a `dnf update -y` before we install the dependencies.