### PR TITLE
[Backport support/2.16] GitHub actions, doc/: drop EOL Amazon Linux 2

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -22,27 +22,6 @@ case "$DISTRO" in
     ln -vs /usr/lib/ninja-build/bin/ninja /usr/local/bin/ninja
     ;;
 
-  amazonlinux:2)
-    amazon-linux-extras install -y epel
-    yum install -y bison ccache cmake3 gcc-c++ flex ninja-build system-rpm-config \
-      {libedit,mariadb,ncurses,openssl,postgresql,systemd}-devel
-
-    yum install -y bzip2 tar wget
-    wget https://archives.boost.io/release/1.69.0/source/boost_1_69_0.tar.bz2
-    tar -xjf boost_1_69_0.tar.bz2
-
-    (
-      cd boost_1_69_0
-      ./bootstrap.sh --with-libraries=context,coroutine,date_time,filesystem,iostreams,program_options,regex,system,test,thread
-      ./b2 define=BOOST_COROUTINES_NO_DEPRECATION_WARNING
-    )
-
-    ln -vs /usr/bin/cmake3 /usr/local/bin/cmake
-    ln -vs /usr/bin/ninja-build /usr/local/bin/ninja
-    CMAKE_OPTS+=(-DBOOST_{INCLUDEDIR=/boost_1_69_0,LIBRARYDIR=/boost_1_69_0/stage/lib})
-    export LD_LIBRARY_PATH=/boost_1_69_0/stage/lib
-    ;;
-
   amazonlinux:20*)
     dnf install -y amazon-rpm-config bison cmake flex gcc-c++ ninja-build \
       {boost,libedit,mariadb-connector-c,ncurses,openssl,postgresql,systemd,protobuf-lite}-devel
@@ -131,10 +110,6 @@ case "$DISTRO" in
     esac
     ;;
   *)
-    # Turn off with OTel on Amazon Linux 2 as the default Protobuf compiler is way too old.
-    if [ "$DISTRO" = "amazonlinux:2" ]; then
-      CMAKE_OPTS+=(-DICINGA2_WITH_OPENTELEMETRY=OFF)
-    fi
     CMAKE_OPTS+=(-DCMAKE_{C,CXX}_FLAGS="$(rpm -E '%{optflags} %{?march_flag}') ${WARN_FLAGS}")
     export LDFLAGS="$(rpm -E '%{?build_ldflags}')"
     ;;

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,6 @@ jobs:
           # The "alpine:bash" image will be built below based on "alpine:3".
           - alpine:bash
 
-          - amazonlinux:2
           - amazonlinux:2023
 
           # Raspberry Pi OS is close enough to Debian to test just one of them.

--- a/doc/02-installation.md
+++ b/doc/02-installation.md
@@ -158,15 +158,6 @@ zypper ref
 ```bash
 wget https://packages.icinga.com/subscription/amazon/ICINGA-release.repo -O /etc/yum.repos.d/ICINGA-release.repo
 ```
-
-The packages for **Amazon Linux 2** depend on other packages which are distributed
-as part of the [EPEL repository](https://fedoraproject.org/wiki/EPEL).
-
-```bash
-yum install epel-release
-```
-
-The packages for newer versions of Amazon Linux don't require additional repositories.
 <!-- {% endif %} -->
 
 <!-- {% if windows %} -->
@@ -327,14 +318,6 @@ zypper install --recommends monitoring-plugins-all
 <!-- {% if not icingaDocs %} -->
 #### Amazon Linux
 <!-- {% endif %} -->
-The packages for **Amazon Linux 2** depend on other packages which are distributed as part of the EPEL repository.
-
-```bash
-amazon-linux-extras install epel
-
-yum install nagios-plugins-all
-```
-
 Unfortunately newer versions of Amazon Linux don't provide those plugins, yet.
 <!-- {% endif %} -->
 

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1875,7 +1875,7 @@ on the [OpenTelemetry website](https://opentelemetry.io/).
 
 !!! info
 
-    The official package builds for Debian 11, Ubuntu 22.04 and Amazon Linux 2 do not include this object type.
+    The official package builds for Debian 11 and Ubuntu 22.04 do not include this object type.
     These builds disable OpenTelemetry support (`ICINGA2_WITH_OPENTELEMETRY=OFF`) because the
     default Protobuf compiler version is too old for the required code generation.
 

--- a/doc/14-features.md
+++ b/doc/14-features.md
@@ -665,8 +665,8 @@ icinga2 feature enable otlpmetrics
 
 !!! info
 
-    **Package availability note (Debian 11 / Ubuntu 22.04 / Amazon Linux 2):**
-    The official Icinga 2 packages for Debian 11, Ubuntu 22.04 and Amazon Linux 2 are built with
+    **Package availability note (Debian 11 / Ubuntu 22.04):**
+    The official Icinga 2 packages for Debian 11 and Ubuntu 22.04 are built with
     `-DICINGA2_WITH_OPENTELEMETRY=OFF`, because the default Protobuf compiler in these
     distributions is too old for the OpenTelemetry code generation used by Icinga 2.
     As a result, the `otlpmetrics` feature (and `OTLPMetricsWriter` type) is not available


### PR DESCRIPTION
Manual backport of #10931 as [it was decided that there won't be further Icinga package builds for Amazon Linux 2](https://github.com/Icinga/icinga2/pull/10931#issuecomment-4913719851), so v2.16.4 won't be built for Amazon Linux 2. Needed to be done manually as there were some conflicts as code was removed again before it ever made it into a release, see https://github.com/Icinga/icinga2/pull/10931#pullrequestreview-4625378473.