### PR TITLE
Avoid inconsistent modified attributes state after object updates were rejected due to validation errors

### DIFF
--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -92,6 +92,7 @@ public:
 void ConfigObject::ModifyAttribute(const String& attr, const Value& value, bool updateVersion)
 {
 	Dictionary::Ptr original_attributes = GetOriginalAttributes();
+	std::vector<std::pair<String, Value>> orig_attr_updates;
 	bool updated_original_attributes = false;
 
 	Type::Ptr type = GetReflectionType();
@@ -161,15 +162,11 @@ void ConfigObject::ModifyAttribute(const String& attr, const Value& value, bool 
 		oldValue = dict->Get(key).Clone();
 
 		if (field.Attributes & FAConfig) {
-			updated_original_attributes = true;
-
 			if (oldValue.IsObjectType<Dictionary>()) {
 				Dictionary::Ptr oldDict = oldValue;
 				ObjectLock olock(oldDict);
 				for (const auto& kv : oldDict) {
-					String key = prefix + "." + kv.first;
-					if (!original_attributes->Contains(key))
-						original_attributes->Set(key, kv.second);
+					orig_attr_updates.emplace_back(prefix + "." + kv.first, kv.second);
 				}
 
 				/* store the new value as null */
@@ -177,13 +174,12 @@ void ConfigObject::ModifyAttribute(const String& attr, const Value& value, bool 
 					Dictionary::Ptr valueDict = value;
 					ObjectLock olock(valueDict);
 					for (const auto& kv : valueDict) {
-						String key = attr + "." + kv.first;
-						if (!original_attributes->Contains(key))
-							original_attributes->Set(key, Empty);
+						orig_attr_updates.emplace_back(attr + "." + kv.first, Empty);
 					}
 				}
-			} else if (!original_attributes->Contains(attr))
-				original_attributes->Set(attr, oldValue);
+			} else {
+				orig_attr_updates.emplace_back(attr, oldValue);
+			}
 		}
 
 		dict->Set(key, value);
@@ -191,15 +187,19 @@ void ConfigObject::ModifyAttribute(const String& attr, const Value& value, bool 
 		newValue = value;
 
 		if (field.Attributes & FAConfig) {
-			if (!original_attributes->Contains(attr)) {
-				updated_original_attributes = true;
-				original_attributes->Set(attr, oldValue);
-			}
+			orig_attr_updates.emplace_back(attr, oldValue);
 		}
 	}
 
 	ModAttrValidationUtils utils;
 	ValidateField(fid, Lazy<Value>{newValue}, utils);
+
+	for (auto &[key, val] : orig_attr_updates) {
+		if (!original_attributes->Contains(key)) {
+			updated_original_attributes = true;
+			original_attributes->Set(key, std::move(val));
+		}
+	}
 
 	SetField(fid, newValue);
 


### PR DESCRIPTION
Update `original_attributes` only after validation of the new value. Otherwise, the value may be rejected, leaving original_attributes in the already changed but now inconsistent state.

I noticed that issue while working on #10940, but I've created this as a separate PR as this can also be viewed as an independent issue. As shown by the tests below, this can already be triggered even without that PR.

## Tests

The following test creates an object, then tries to modify a custom variable with an invalid value and then observes the resulting behavior.

### Before (master as of 8ff3d586f975fa4ce3cfd9887d2b3950e617f334)

Create an object for testing (having non-empty `vars` seems to be important for reproducing this):

```console
$ curl -Ssku root:icinga https://127.0.0.1:5665/v1/objects/hosts/inconsistent-attrs \
    -X PUT --json '{"attrs": {"check_command": "dummy", "vars.location": "Earth"}, "pretty": true}'
{
    "results": [
        {
            "code": 200,
            "status": "Object was created"
        }
    ]
}

```

Attempt to modify its custom variables without success (as expected, it fails):

```console
$ curl -Ssku root:icinga https://127.0.0.1:5665/v1/objects/hosts/inconsistent-attrs \
    -X POST --json '{"attrs": {"vars.oops": "$invalid_macro_string"}, "pretty": true}'
{
    "results": [
        {
            "code": 500,
            "name": "inconsistent-attrs",
            "status": "Attribute 'vars.oops' could not be set: Error: Validation failed for object 'inconsistent-attrs' of type 'Host'; Attribute 'vars' -> 'oops': Closing $ not found in macro format string '$invalid_macro_string'.\nLocation: in /data/var/lib/icinga2/api/packages/_api/77e78991-06d4-4589-aa0c-ee60e1d7724e/conf.d/hosts/inconsistent-attrs.conf: 1:0-1:31\n/data/var/lib/icinga2/api/packages/_api/77e78991-06d4-4589-aa0c-ee60e1d7724e/conf.d/hosts/inconsistent-attrs.conf(1): object Host \"inconsistent-attrs\" {\n                                                                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n/data/var/lib/icinga2/api/packages/_api/77e78991-06d4-4589-aa0c-ee60e1d7724e/conf.d/hosts/inconsistent-attrs.conf(2):  check_command = \"dummy\"\n/data/var/lib/icinga2/api/packages/_api/77e78991-06d4-4589-aa0c-ee60e1d7724e/conf.d/hosts/inconsistent-attrs.conf(3):  vars[\"location\"] = \"Earth\"\n",
            "type": "Host"
        }
    ]
}
```

Now query the object, in particular the `original_attributes`, you'll see that even though the update was rejected, `vars.oops` was added there:

```console
$ curl -Ssku root:icinga https://127.0.0.1:5665/v1/objects/hosts/inconsistent-attrs \
    -X GET --json '{"attrs": ["vars", "original_attributes"], "pretty": true}' 
{
    "results": [
        {
            "attrs": {
                "original_attributes": {
                    "vars.oops": null
                },
                "vars": {
                    "location": "Earth"
                }
            },
            "joins": {},
            "meta": {},
            "name": "inconsistent-attrs",
            "type": "Host"
        }
    ]
}
```

Now restart Icinga 2:

```console
$ curl -Ssku root:icinga https://127.0.0.1:5665/v1/actions/restart-process \
    -X POST --json '{"pretty": true}'                                                   
{
    "results": [
        {
            "code": 200,
            "status": "Restarting Icinga 2."
        }
    ]
}
```

And perform the very same query again, where you can observe, that now the object has a mysterious `vars.oops` with value `null`:

```console
% curl -Ssku root:icinga https://127.0.0.1:5665/v1/objects/hosts/inconsistent-attrs \
    -X GET --json '{"attrs": ["vars", "original_attributes"], "pretty": true}' 
{
    "results": [
        {
            "attrs": {
                "original_attributes": {
                    "vars.oops": null
                },
                "vars": {
                    "location": "Earth",
                    "oops": null
                }
            },
            "joins": {},
            "meta": {},
            "name": "inconsistent-attrs",
            "type": "Host"
        }
    ]
}
```

### This PR (as of 0332ead94bc5e18775cc394ba6255b2fec37d74b)

If the object is still there from the previous test, make sure to delete it.

Creating (PUT) and attempting to update (POST) produces the same responses, the difference only starts to show with the following GET request, where nothing was added to `original_attributes`:

```console
$ curl -Ssku root:icinga https://127.0.0.1:5665/v1/objects/hosts/inconsistent-attrs \
    -X GET --json '{"attrs": ["vars", "original_attributes"], "pretty": true}'

{
    "results": [
        {
            "attrs": {
                "original_attributes": {},
                "vars": {
                    "location": "Earth"
                }
            },
            "joins": {},
            "meta": {},
            "name": "inconsistent-attrs",
            "type": "Host"
        }
    ]
}
```

Which - in contrast to the previous behavior - also stays the same across a restart of Icinga 2.

## Additional Information

The value of `original_attributes` is important here as this is used to create `/var/lib/icinga2/modified-attributes.conf` which then contains something like this with the unfixed version, explaining why this suddenly appears within `vars` after the restart:

```
var obj = get_object("Host", "inconsistent-attrs")
if (obj) {
	obj.modify_attribute("vars.oops", null)
	obj.version = 1783613466.662146
}
```