### PR TITLE
Work around a compiler segfault on SLES 15.7 aarch64

### DIFF
--- a/lib/base/dictionary.cpp
+++ b/lib/base/dictionary.cpp
@@ -155,9 +155,8 @@ Dictionary::Iterator Dictionary::End()
  * Removes the item specified by the iterator from the dictionary.
  *
  * @param it The iterator.
- * @return an iterator to the element after the removed element.
  */
-Dictionary::Iterator Dictionary::Remove(Dictionary::Iterator it)
+void Dictionary::Remove(Dictionary::Iterator it)
 {
 	ASSERT(OwnsLock());
 	std::unique_lock<std::shared_timed_mutex> lock (m_DataMutex);
@@ -165,7 +164,7 @@ Dictionary::Iterator Dictionary::Remove(Dictionary::Iterator it)
 	if (m_Frozen)
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Dictionary must not be modified."));
 
-	return m_Data.erase(it);
+	m_Data.erase(it);
 }
 
 /**

--- a/lib/base/dictionary.hpp
+++ b/lib/base/dictionary.hpp
@@ -56,7 +56,7 @@ public:
 
 	void Remove(const String& key);
 
-	Iterator Remove(Iterator it);
+	void Remove(Iterator it);
 
 	void Clear();
 

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -580,10 +580,10 @@ void ApiListener::PruneDeletedRuntimeObjects()
 
 	for (auto it = deletedRuntimeObjects->Begin(); it != deletedRuntimeObjects->End();) {
 		if (it->second < cutoff) {
-			it = deletedRuntimeObjects->Remove(it);
+			deletedRuntimeObjects->Remove(it++);
 		} else {
-			it++;
-		};
+			++it;
+		}
 	}
 }
 


### PR DESCRIPTION
Revert "Make `Dictionary::Remove(Iterator)` return the next iterator" and change the one location that now made use of that return value to increment the iterator itself beforehand. I don't see anything that would be wrong with the previous code and I'm pretty certain this is a compiler bug. While at it, I've also removed a stray semicolon and changed the increment in the other branch to the prefix operator as the value is discarded.

    [35/151] Building CXX object lib/base/CMakeFiles/base.dir/base_unity.cpp.o
    FAILED: lib/base/CMakeFiles/base.dir/base_unity.cpp.o
    /usr/bin/c++ -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT -DBOOST_COROUTINES_NO_DEPRECATION_WARNING -DBOOST_FILESYSTEM_NO_DEPRECATED -DOPENSSL_SUPPRESS_DEPRECATED -D_GNU_SOURCE -I/builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f -I/builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib -isystem /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/third-party/nlohmann_json -isystem /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/third-party/utf8cpp/source -isystem /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/third-party/mmatch -isystem /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/third-party/socketpair -O2 -g -Wsuggest-override -g -pthread -Winvalid-pch -O2 -g -DNDEBUG -std=c++1z -MD -MT lib/base/CMakeFiles/base.dir/base_unity.cpp.o -MF lib/base/CMakeFiles/base.dir/base_unity.cpp.o.d -o lib/base/CMakeFiles/base.dir/base_unity.cpp.o -c /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/base_unity.cpp
    In file included from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/configobject.cpp:8:0,
                     from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/base_unity.cpp:9:
    /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/serializer.hpp:20:14: warning: 'virtual const char* icinga::CircularReferenceError::what() const' can be marked override [-Wsuggest-override]
      const char *what(void) const throw() final;
                  ^~~~
    In file included from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/filelogger-ti.hpp:12:0,
                     from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/filelogger.hpp:8,
                     from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/filelogger.cpp:4,
                     from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/base_unity.cpp:25:
    /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/streamlogger.hpp:33:7: warning: 'virtual void icinga::StreamLogger::ProcessLogEntry(const icinga::LogEntry&)' can be marked override [-Wsuggest-override]
      void ProcessLogEntry(const LogEntry& entry) final;
           ^~~~~~~~~~~~~~~
    /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/streamlogger.hpp:34:7: warning: 'virtual void icinga::StreamLogger::Flush()' can be marked override [-Wsuggest-override]
      void Flush() final;
           ^~~~~
    In file included from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/config/configitem.hpp:8:0,
                     from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/scriptutils.cpp:17,
                     from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/base_unity.cpp:56:
    /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/config/expression.hpp:264:19: warning: 'virtual const icinga::DebugInfo& icinga::DebuggableExpression::GetDebugInfo() const' can be marked override [-Wsuggest-override]
      const DebugInfo& GetDebugInfo() const final;
                       ^~~~~~~~~~~~
    In file included from /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/base_unity.cpp:78:0:
    /builds/packages/icinga2/packaging/sles/15.7/BUILD/icinga2-2.16.3+111.g8ff3d586f/lib/base/workqueue.cpp:80:1: internal compiler error: Segmentation fault
     }
     ^
    Please submit a full bug report,
    with preprocessed source if appropriate.
    See <https://bugs.opensuse.org/> for instructions.

Yes, this is pretty stupid, I just tried individually reverting what individual changes might have triggered this and found the changed return type of `Dictionary::Remove()` the minimal thing I could revert to make that buggy compiler happy again. I then looked if any of it's uses might be problematic and found a different use of that method that just did it in a way that's still correct but doesn't need iterator returned from `std::map::erase()`:

https://github.com/Icinga/icinga2/blob/8ff3d586f975fa4ce3cfd9887d2b3950e617f334/lib/icingadb/icingadb-utility.cpp#L356

Undoing the change to `Dictionary::Remove()` and adjusting the single caller that cared about the return value to use the same pattern as in `icingadb-utility.cpp` made the compiler happy, so I guess we'll just go with that. That compiler already has shown to be funky in #10795 before.

According to [cppreference](https://en.cppreference.com/cpp/container/map/erase), `erase()` only invalidates the iterator that is passed to it, so incrementing it after the call wouldn't work, but the postfix increment operator first increments it and then passes the old value to the function, so `it` remains valid:

> References and iterators to the erased elements are invalidated. Other references and iterators are not affected.

## Tests

As the problem only specifically happens with SLES 15.7 and ARM, the issue does not show up in our GitHub Actions jobs. The following two (not publicly accessible) pipelines from our packaging tooling show the fix:

- [41003](https://git.icinga.com/packages/icinga2/-/pipelines/41003) (this week's snapshot pipeline for commit 8ff3d586f975fa4ce3cfd9887d2b3950e617f334) failed with the above error for SLES 15.7 aarch64, every other package built successfully.
- [41025](https://git.icinga.com/packages/icinga2/-/pipelines/41025) (test pipeline for commit 4d6f63dcb7bac2905bfd0e54b6d4d37d719e7530 from this PR) built all packages successfully again.

This reverts commit 3cb6e5a15212d43491d58c7696c32b5ed0f23675 from #10830.