### PR TITLE
GHA: Linux: test only one architecture per Debian version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,8 +29,6 @@ jobs:
 
           # Raspberry Pi OS is close enough to Debian to test just one of them.
           # Its architecture is different, though, and covered by the Docker job.
-          - debian:11
-          - debian:12
           - debian:13
 
           - fedora:41

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,8 +30,6 @@ jobs:
 
           # Raspberry Pi OS is close enough to Debian to test just one of them.
           # Its architecture is different, though, and covered by the Docker job.
-          - debian:11
-          - debian:12
           - debian:13
 
           - fedora:42

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,8 +14,6 @@ linux-build:
     matrix:
       # x86_64 / amd64
       - IMAGE_NAME:
-          - debian:11
-          - debian:12
           - debian:13
           - ubuntu:22.04
           - ubuntu:24.04


### PR DESCRIPTION
You complained about too many stuff in the GHA. Here's my peace offer.