### PR TITLE
GHA: Linux: remove EOL Fedora 41

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -33,7 +33,6 @@ jobs:
           - debian:12
           - debian:13
 
-          - fedora:41
           - fedora:42
           - fedora:43
           - fedora:44


### PR DESCRIPTION
See https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/156#note_33471