### PR TITLE
Remove unused `EventQueue` class

### DIFF
--- a/lib/icinga/apievents.cpp
+++ b/lib/icinga/apievents.cpp
@@ -37,10 +37,9 @@ void ApiEvents::StaticInitialize()
 
 void ApiEvents::CheckResultHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, const MessageOrigin::Ptr&)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("CheckResult");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::CheckResult));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'CheckResult'.");
@@ -62,19 +61,14 @@ void ApiEvents::CheckResultHandler(const Checkable::Ptr& checkable, const CheckR
 	result->Set("downtime_depth", checkable->GetDowntimeDepth());
 	result->Set("acknowledgement", checkable->IsAcknowledged());
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::StateChangeHandler(const Checkable::Ptr& checkable, const CheckResult::Ptr& cr, StateType, const MessageOrigin::Ptr&)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("StateChange");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::StateChange));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'StateChange'.");
@@ -98,10 +92,6 @@ void ApiEvents::StateChangeHandler(const Checkable::Ptr& checkable, const CheckR
 	result->Set("downtime_depth", checkable->GetDowntimeDepth());
 	result->Set("acknowledgement", checkable->IsAcknowledged());
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
@@ -109,10 +99,9 @@ void ApiEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& notif
 	const Checkable::Ptr& checkable, const std::set<User::Ptr>& users, NotificationType type,
 	const CheckResult::Ptr& cr, const String& author, const String& text, const MessageOrigin::Ptr&)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("Notification");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::Notification));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'Notification'.");
@@ -146,19 +135,14 @@ void ApiEvents::NotificationSentToAllUsersHandler(const Notification::Ptr& notif
 	result->Set("text", text);
 	result->Set("check_result", Serialize(cr));
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::FlappingChangedHandler(const Checkable::Ptr& checkable, const MessageOrigin::Ptr&)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("Flapping");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::Flapping));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'Flapping'.");
@@ -182,10 +166,6 @@ void ApiEvents::FlappingChangedHandler(const Checkable::Ptr& checkable, const Me
 	result->Set("threshold_low", checkable->GetFlappingThresholdLow());
 	result->Set("threshold_high", checkable->GetFlappingThresholdHigh());
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
@@ -193,10 +173,9 @@ void ApiEvents::AcknowledgementSetHandler(const Checkable::Ptr& checkable,
 	const String& author, const String& comment, AcknowledgementType type,
 	bool notify, bool persistent, double, double expiry, const MessageOrigin::Ptr&)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("AcknowledgementSet");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::AcknowledgementSet));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'AcknowledgementSet'.");
@@ -223,19 +202,14 @@ void ApiEvents::AcknowledgementSetHandler(const Checkable::Ptr& checkable,
 	result->Set("persistent", persistent);
 	result->Set("expiry", expiry);
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::AcknowledgementClearedHandler(const Checkable::Ptr& checkable, [[maybe_unused]] const String& removedBy, double, const MessageOrigin::Ptr&)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("AcknowledgementCleared");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::AcknowledgementCleared));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'AcknowledgementCleared'.");
@@ -256,19 +230,14 @@ void ApiEvents::AcknowledgementClearedHandler(const Checkable::Ptr& checkable, [
 	result->Set("state_type", checkable->GetStateType());
 	result->Set("acknowledgement_type", AcknowledgementNone);
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::CommentAddedHandler(const Comment::Ptr& comment)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("CommentAdded");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::CommentAdded));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'CommentAdded'.");
@@ -279,19 +248,14 @@ void ApiEvents::CommentAddedHandler(const Comment::Ptr& comment)
 		{ "comment", Serialize(comment, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::CommentRemovedHandler(const Comment::Ptr& comment)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("CommentRemoved");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::CommentRemoved));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'CommentRemoved'.");
@@ -302,19 +266,14 @@ void ApiEvents::CommentRemovedHandler(const Comment::Ptr& comment)
 		{ "comment", Serialize(comment, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::DowntimeAddedHandler(const Downtime::Ptr& downtime)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("DowntimeAdded");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::DowntimeAdded));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeAdded'.");
@@ -325,19 +284,14 @@ void ApiEvents::DowntimeAddedHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::DowntimeRemovedHandler(const Downtime::Ptr& downtime)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("DowntimeRemoved");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::DowntimeRemoved));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeRemoved'.");
@@ -348,19 +302,14 @@ void ApiEvents::DowntimeRemovedHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::DowntimeStartedHandler(const Downtime::Ptr& downtime)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("DowntimeStarted");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::DowntimeStarted));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeStarted'.");
@@ -371,19 +320,14 @@ void ApiEvents::DowntimeStartedHandler(const Downtime::Ptr& downtime)
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
 
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
-
 	inboxes.Push(std::move(result));
 }
 
 void ApiEvents::DowntimeTriggeredHandler(const Downtime::Ptr& downtime)
 {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType("DowntimeTriggered");
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(EventType::DowntimeTriggered));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents", "Processing event type 'DowntimeTriggered'.");
@@ -393,10 +337,6 @@ void ApiEvents::DowntimeTriggeredHandler(const Downtime::Ptr& downtime)
 		{ "timestamp", Utility::GetTime() },
 		{ "downtime", Serialize(downtime, FAConfig | FAState) }
 	});
-
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
 
 	inboxes.Push(std::move(result));
 }
@@ -416,10 +356,9 @@ void ApiEvents::OnVersionChangedHandler(const ConfigObject::Ptr& object, const V
 }
 
 void ApiEvents::SendObjectChangeEvent(const ConfigObject::Ptr& object, const EventType& eventType, const String& eventQueue) {
-	std::vector<EventQueue::Ptr> queues = EventQueue::GetQueuesForType(eventQueue);
 	auto inboxes (EventsRouter::GetInstance().GetInboxes(eventType));
 
-	if (queues.empty() && !inboxes)
+	if (!inboxes)
 		return;
 
 	Log(LogDebug, "ApiEvents") << "Processing event type '" + eventQueue + "'.";
@@ -430,10 +369,6 @@ void ApiEvents::SendObjectChangeEvent(const ConfigObject::Ptr& object, const Eve
 		{"object_type", object->GetReflectionType()->GetName()},
 		{"object_name", object->GetName()},
 	});
-
-	for (const EventQueue::Ptr& queue : queues) {
-		queue->ProcessEvent(result);
-	}
 
 	inboxes.Push(std::move(result));
 }

--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -6,120 +6,13 @@
 #include "remote/filterutility.hpp"
 #include "base/io-engine.hpp"
 #include "base/logger.hpp"
-#include "base/utility.hpp"
 #include <boost/asio/spawn.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/system/error_code.hpp>
-#include <chrono>
 #include <utility>
 
 using namespace icinga;
-
-bool EventQueue::CanProcessEvent(const String& type) const
-{
-	std::unique_lock<std::mutex> lock(m_Mutex);
-
-	return m_Types.find(type) != m_Types.end();
-}
-
-void EventQueue::ProcessEvent(const Dictionary::Ptr& event)
-{
-	Namespace::Ptr frameNS = new Namespace();
-	ScriptFrame frame(true, frameNS);
-	frame.Sandboxed = true;
-
-	try {
-		if (!FilterUtility::EvaluateFilter(frame, m_Filter.get(), event, "event"))
-			return;
-	} catch (const std::exception& ex) {
-		Log(LogWarning, "EventQueue")
-			<< "Error occurred while evaluating event filter for queue '" << m_Name << "': " << DiagnosticInformation(ex);
-		return;
-	}
-
-	std::unique_lock<std::mutex> lock(m_Mutex);
-
-	for (auto& kv : m_Events) {
-		kv.second.push_back(event);
-	}
-
-	m_CV.notify_all();
-}
-
-void EventQueue::AddClient(void *client)
-{
-	std::unique_lock<std::mutex> lock(m_Mutex);
-
-	auto result = m_Events.insert(std::make_pair(client, std::deque<Dictionary::Ptr>()));
-	ASSERT(result.second);
-
-#ifndef I2_DEBUG
-	(void)result;
-#endif /* I2_DEBUG */
-}
-
-void EventQueue::RemoveClient(void *client)
-{
-	std::unique_lock<std::mutex> lock(m_Mutex);
-
-	m_Events.erase(client);
-}
-
-void EventQueue::SetTypes(const std::set<String>& types)
-{
-	std::unique_lock<std::mutex> lock(m_Mutex);
-	m_Types = types;
-}
-
-void EventQueue::SetFilter(std::unique_ptr<Expression> filter)
-{
-	std::unique_lock<std::mutex> lock(m_Mutex);
-	m_Filter.swap(filter);
-}
-
-Dictionary::Ptr EventQueue::WaitForEvent(void *client, double timeout)
-{
-	std::unique_lock<std::mutex> lock(m_Mutex);
-
-	for (;;) {
-		auto it = m_Events.find(client);
-		ASSERT(it != m_Events.end());
-
-		if (!it->second.empty()) {
-			Dictionary::Ptr result = *it->second.begin();
-			it->second.pop_front();
-			return result;
-		}
-
-		if (m_CV.wait_for(lock, std::chrono::duration<double>(timeout)) == std::cv_status::timeout)
-			return nullptr;
-	}
-}
-
-std::vector<EventQueue::Ptr> EventQueue::GetQueuesForType(const String& type)
-{
-	EventQueueRegistry::ItemMap queues = EventQueueRegistry::GetInstance()->GetItems();
-
-	std::vector<EventQueue::Ptr> availQueues;
-
-	for (auto& kv : queues) {
-		if (kv.second->CanProcessEvent(type))
-			availQueues.push_back(kv.second);
-	}
-
-	return availQueues;
-}
-
-EventQueue::Ptr EventQueue::GetByName(const String& name)
-{
-	return EventQueueRegistry::GetInstance()->GetItem(name);
-}
-
-void EventQueue::Register(const String& name, const EventQueue::Ptr& function)
-{
-	EventQueueRegistry::GetInstance()->Register(name, function);
-}
 
 std::mutex EventsInbox::m_FiltersMutex;
 std::map<String, EventsInbox::Filter> EventsInbox::m_Filters ({{"", EventsInbox::Filter{1, Expression::Ptr()}}});

--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -16,10 +16,6 @@
 
 using namespace icinga;
 
-EventQueue::EventQueue(String name)
-	: m_Name(std::move(name))
-{ }
-
 bool EventQueue::CanProcessEvent(const String& type) const
 {
 	std::unique_lock<std::mutex> lock(m_Mutex);

--- a/lib/remote/eventqueue.hpp
+++ b/lib/remote/eventqueue.hpp
@@ -9,58 +9,15 @@
 #include "config/expression.hpp"
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/spawn.hpp>
-#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <set>
 #include <map>
-#include <deque>
 #include <queue>
 
 namespace icinga
 {
-
-class EventQueue final : public Object
-{
-public:
-	DECLARE_PTR_TYPEDEFS(EventQueue);
-
-	EventQueue() = delete;
-
-	bool CanProcessEvent(const String& type) const;
-	void ProcessEvent(const Dictionary::Ptr& event);
-	void AddClient(void *client);
-	void RemoveClient(void *client);
-
-	void SetTypes(const std::set<String>& types);
-	void SetFilter(std::unique_ptr<Expression> filter);
-
-	Dictionary::Ptr WaitForEvent(void *client, double timeout = 5);
-
-	static std::vector<EventQueue::Ptr> GetQueuesForType(const String& type);
-
-	static EventQueue::Ptr GetByName(const String& name);
-	static void Register(const String& name, const EventQueue::Ptr& function);
-
-private:
-	String m_Name;
-
-	mutable std::mutex m_Mutex;
-	std::condition_variable m_CV;
-
-	std::set<String> m_Types;
-	std::unique_ptr<Expression> m_Filter;
-
-	std::map<void *, std::deque<Dictionary::Ptr> > m_Events;
-};
-
-/**
- * A registry for API event queues.
- *
- * @ingroup base
- */
-using EventQueueRegistry = Registry<EventQueue::Ptr>;
 
 enum class EventType : uint_fast8_t
 {

--- a/lib/remote/eventqueue.hpp
+++ b/lib/remote/eventqueue.hpp
@@ -26,7 +26,7 @@ class EventQueue final : public Object
 public:
 	DECLARE_PTR_TYPEDEFS(EventQueue);
 
-	EventQueue(String name);
+	EventQueue() = delete;
 
 	bool CanProcessEvent(const String& type) const;
 	void ProcessEvent(const Dictionary::Ptr& event);


### PR DESCRIPTION
   Successfully compiling with only `EventQueue#EventQueue()` removed (619865f14fd79da6ff6c0ab5ce77dc1c8f9a1983, for GHA see f1d5e3b19bff52c8f03eaaf0c6e5a8b4e62948e1) proves that:

   - EventQueue's non-static methods are never called due to the lack of an instance
   - EventQueue's static methods which take an instance are never called
   - EventQueue's static methods which return instances are no-op

Less code = shorter build time, also fewer things made up by AI.

Apropos, latter was my motivation for this – my AI made things up which won't exist anymore with this PR merged.