### PR TITLE
Fix ssl_cert root certificate variable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -180,6 +180,7 @@ Malte Rabenseifner <mail@malte-rabenseifner.de>
 Manas Singh <00manassingh00@gmail.com>
 Manuel Reiter <reiter@csc.uni-frankfurt.de>
 Marc Rupprecht <marc.rupprecht@netways.de>
+Marcel Hoffmann <marcel.hoffmann@netways.de>
 Marcus van Dam <marcus@marcusvandam.nl>
 MarcusCaepio <MarcusCaepio@users.noreply.github.com>
 Marianne Spiller <github@spiller.me>

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -462,7 +462,7 @@ object CheckCommand "ssl_cert" {
 			description = "Forces a new check by SSL Labs"
 		}
 		"-r" = {
-			value = "$ssl_cert_rootssl_cert$"
+			value = "$ssl_cert_rootcert$"
 			description = "Root certificate or directory to be used for certificate validation"
 		}
 		"--ssl2" = {


### PR DESCRIPTION
Use the documented ssl_cert_rootcert variable for the -r argument.

Fixes #10954