### PR TITLE
IcingaDB: Fix multiple potential race-conditions during initial config dump

### DIFF
--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -210,6 +210,11 @@ void IcingaDB::ConfigStaticInitialize()
 
 void IcingaDB::UpdateAllConfigObjects()
 {
+	// Snapshot the current number of reconnections made by any of the RedisConnections.
+	// This is compared to the current value at the end of the function to verify that no
+	// reconnects occurred.
+	auto snapReconnectCount = m_ReconnectCount->load(std::memory_order_acquire);
+
 	// This function performs an initial dump of all configuration objects into Redis, thus there are no
 	// previously enqueued queries on m_RconWorker that we need to wait for. So, no Sync() call is necessary here.
 	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:schema", "MAXLEN", "1", "*", "version", "6"}, {}, true);
@@ -513,13 +518,8 @@ void IcingaDB::UpdateAllConfigObjects()
 
 	if (upq.HasExceptions()) {
 		for (std::exception_ptr exc : upq.GetExceptions()) {
-			try {
-				if (exc) {
-					std::rethrow_exception(exc);
-			}
-			} catch(const std::exception& e) {
-				Log(LogCritical, "IcingaDB")
-						<< "Exception during ConfigDump: " << e.what();
+			if (exc) {
+				std::rethrow_exception(exc);
 			}
 		}
 	}
@@ -530,10 +530,21 @@ void IcingaDB::UpdateAllConfigObjects()
 
 	m_RconWorker->FireAndForgetQuery({"XADD", "icinga:dump", "*", "key", "*", "state", "done"});
 
-	// enqueue a callback that will notify us once all previous queries were executed and wait for this event
-	std::promise<void> p;
-	m_RconWorker->EnqueueCallback([&p](boost::asio::yield_context&) { p.set_value(); });
-	p.get_future().wait();
+	/* The other connections already get a final sync in their workqueue above, so we sync just
+	 * the `m_RconWorker` here, to ensure that all requests have made it through the queue.
+	 * This also puts a final check to the connection, since it would throw if the connection
+	 * went down in the meantime.
+	 */
+	m_RconWorker->Sync();
+
+	/* Since now all connections were synced after all transactions have completed, we can now compare
+	 * the current reconnect count to the snapshot we made at the start of this function. If the count
+	 * matches we know for sure that no reconnects on any of the connections lead to an inconsistent
+	 * sync. If reconnects did occur, this throws and the update is repeated again.
+	 */
+	if (m_ReconnectCount->load(std::memory_order_acquire) != snapReconnectCount) {
+		BOOST_THROW_EXCEPTION(std::runtime_error{"Lost connection to Redis during ConfigDump"});
+	}
 
 	auto endTime (Utility::GetTime());
 	auto took (endTime - startTime);

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -102,12 +102,15 @@ void IcingaDB::Start(bool runtimeCreated)
 
 	for (auto & conn : childConns) {
 		conn->SetConnectedCallback([this, pendingConns, conn](boost::asio::yield_context&) {
+			conn->SetConnectedCallback([reconnectCount = m_ReconnectCount](boost::asio::yield_context&) {
+				reconnectCount->fetch_add(1, std::memory_order_release);
+			});
+
 			auto pending = --*pendingConns;
 			Log(LogDebug, "IcingaDB") << pending << " pending child connections remaining";
 			if (pending == 0) {
 				m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
 			}
-			conn->SetConnectedCallback(nullptr);
 		});
 	}
 
@@ -152,7 +155,15 @@ void IcingaDB::OnConnectedHandler()
 	m_ConfigDumpInProgress = true;
 	PublishStats();
 
-	UpdateAllConfigObjects();
+	while (true) {
+		try {
+			UpdateAllConfigObjects();
+			break;
+		} catch (const std::exception& ex) {
+			Log(LogCritical, "IcingaDB") << "Exception during ConfigDump: " << ex.what();
+		}
+		Utility::Sleep(10);
+	}
 
 	m_ConfigDumpDone.store(true);
 	m_ConfigDumpInProgress = false;

--- a/lib/icingadb/icingadb.cpp
+++ b/lib/icingadb/icingadb.cpp
@@ -84,6 +84,8 @@ void IcingaDB::Start(bool runtimeCreated)
 	m_RconLocked.store(m_Rcon);
 
 	m_RconWorker = new RedisConnection(connInfo, m_Rcon);
+	std::vector<RedisConnection::Ptr> childConns;
+	childConns.push_back(m_RconWorker);
 
 	for (const auto& [type, _] : GetSyncableTypes()) {
 		auto ctype (dynamic_cast<ConfigType*>(type.get()));
@@ -91,28 +93,29 @@ void IcingaDB::Start(bool runtimeCreated)
 			continue;
 
 		RedisConnection::Ptr con = new RedisConnection(connInfo, m_Rcon);
-
-		con->SetConnectedCallback([this, con](boost::asio::yield_context&) {
-			con->SetConnectedCallback(nullptr);
-
-			size_t pending = --m_PendingRcons;
-			Log(LogDebug, "IcingaDB") << pending << " pending child connections remaining";
-			if (pending == 0) {
-				m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
-			}
-		});
+		childConns.push_back(con);
 
 		m_Rcons[ctype] = std::move(con);
 	}
 
-	m_PendingRcons = m_Rcons.size();
+	auto pendingConns = std::make_shared<std::atomic_size_t>(childConns.size());
 
-	m_Rcon->SetConnectedCallback([this](boost::asio::yield_context&) {
+	for (auto & conn : childConns) {
+		conn->SetConnectedCallback([this, pendingConns, conn](boost::asio::yield_context&) {
+			auto pending = --*pendingConns;
+			Log(LogDebug, "IcingaDB") << pending << " pending child connections remaining";
+			if (pending == 0) {
+				m_WorkQueue.Enqueue([this]() { OnConnectedHandler(); });
+			}
+			conn->SetConnectedCallback(nullptr);
+		});
+	}
+
+	m_Rcon->SetConnectedCallback([this, childConns = std::move(childConns)](boost::asio::yield_context&) {
 		m_Rcon->SetConnectedCallback(nullptr);
 
-		m_RconWorker->Start();
-		for (auto& kv : m_Rcons) {
-			kv.second->Start();
+		for (const auto& conn : childConns) {
+			conn->Start();
 		}
 	});
 	m_Rcon->Start();

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -456,7 +456,6 @@ private:
 	 */
 	RedisConnection::Ptr m_RconWorker;
 	std::unordered_map<ConfigType*, RedisConnection::Ptr> m_Rcons;
-	std::atomic_size_t m_PendingRcons;
 
 	struct {
 		DumpedGlobals CustomVar, ActionUrl, NotesUrl, IconImage, DependencyGroup;

--- a/lib/icingadb/icingadb.hpp
+++ b/lib/icingadb/icingadb.hpp
@@ -456,6 +456,7 @@ private:
 	 */
 	RedisConnection::Ptr m_RconWorker;
 	std::unordered_map<ConfigType*, RedisConnection::Ptr> m_Rcons;
+	std::shared_ptr<std::atomic_uint> m_ReconnectCount = std::make_shared<std::atomic_uint>(0);
 
 	struct {
 		DumpedGlobals CustomVar, ActionUrl, NotesUrl, IconImage, DependencyGroup;


### PR DESCRIPTION
This fixes a regression from 2.16.0 onwards where Start() doesn't wait for all `RedisConnections` to finish connecting before attempting the initial config dump. It also adds a robust error detection and retry logic for the initial config dump.

This goes beyond the patch linked in the original issue, because even when catching the exceptions out of `UpdateAllConfigObjects()`, there are still numerous scenarios where a connection drops and causes silent inconsistencies in the state dumped to Redis, but then reconnects in time before the next throwing synchronization point.

The fix this PR attempts for that issue is to count all reconnections on all connections occurring after the initial connections have been established. Then, we take a snapshot of that count at the start of `UpdateAllConfigObjects()` and then compare it to the current value at the end of the function, after all connections have a final synchronization point. If the count didn't change, that means no connection errors happened.

## Caveats

+ There is a pre-existing lifetime issue I discovered while fixing these bugs in `IcingaDB::Start()`: When the initial callbacks set with `SetConnectedCallback()` all the lambdas capture the `this` pointer of the `IcingaDB` object. But since the coroutines in RedisConnection hold a keepalive pointer, they may outlive IcingaDB's destructor. And if the initial connection fails the entire time, but then succeeds in that exact moment when `RedisConnection` is kept alive by its coroutines, that could result in a segmentation fault. However that's very unlikely and probably wouldn't affect anything critical.
+ This doesn't properly handle any Redis Errors that might be returned since most Queries are the fire and forget kind. But that seems to be the intention with that code, so I didn't touch it.

Fixes #10941.