### PR TITLE
Use STL random generation instead of C-style functions

### DIFF
--- a/lib/base/math-script.cpp
+++ b/lib/base/math-script.cpp
@@ -9,6 +9,8 @@
 #include "base/namespace.hpp"
 #include <boost/math/special_functions/round.hpp>
 #include <cmath>
+#include <random>
+#include <mutex>
 
 using namespace icinga;
 
@@ -99,7 +101,13 @@ static double MathPow(double x, double y)
 
 static double MathRandom()
 {
-	return (double)std::rand() / RAND_MAX;
+	static std::mutex genMutex;
+	static std::mt19937 gen{std::random_device{}()};
+
+	std::uniform_real_distribution<double> dist{0, 1};
+
+	std::lock_guard lock{genMutex};
+	return dist(gen);
 }
 
 static double MathRound(double x)

--- a/lib/base/utility.cpp
+++ b/lib/base/utility.cpp
@@ -29,8 +29,9 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
-#include <stdlib.h>
-#include <future>
+#include <cstdlib>
+#include <random>
+#include <mutex>
 #include <set>
 #include <utf8.h>
 #include <vector>
@@ -63,7 +64,6 @@
 using namespace icinga;
 
 boost::thread_specific_ptr<String> Utility::m_ThreadName;
-boost::thread_specific_ptr<unsigned int> Utility::m_RandSeed;
 
 #ifdef I2_DEBUG
 double Utility::m_DebugTime = -1;
@@ -1464,18 +1464,13 @@ String Utility::GetFQDN()
 
 int Utility::Random()
 {
-#ifdef _WIN32
-	return rand();
-#else /* _WIN32 */
-	unsigned int *seed = m_RandSeed.get();
+	static std::mutex genMutex;
+	static std::mt19937 gen{std::random_device{}()};
 
-	if (!seed) {
-		seed = new unsigned int(Utility::GetTime());
-		m_RandSeed.reset(seed);
-	}
+	std::uniform_int_distribution<int> dist{0, std::numeric_limits<int>::max()};
 
-	return rand_r(seed);
-#endif /* _WIN32 */
+	std::lock_guard lock{genMutex};
+	return dist(gen);
 }
 
 tm Utility::LocalTime(time_t ts)

--- a/lib/base/utility.hpp
+++ b/lib/base/utility.hpp
@@ -197,7 +197,6 @@ private:
 #endif /* I2_DEBUG */
 
 	static boost::thread_specific_ptr<String> m_ThreadName;
-	static boost::thread_specific_ptr<unsigned int> m_RandSeed;
 };
 
 }

--- a/lib/icinga/checkable.cpp
+++ b/lib/icinga/checkable.cpp
@@ -11,6 +11,8 @@
 #include "base/timer.hpp"
 #include <boost/range/algorithm/find.hpp>
 #include <boost/thread/once.hpp>
+#include <random>
+#include <mutex>
 
 using namespace icinga;
 
@@ -128,7 +130,15 @@ void Checkable::Start(bool runtimeCreated)
 
 	if (GetNextCheck() < now + 60) {
 		double delta = std::min(GetCheckInterval(), 60.0);
-		delta *= (double)std::rand() / RAND_MAX;
+
+		static std::mutex genMutex;
+		static std::mt19937 gen{std::random_device{}()};
+		std::uniform_real_distribution<double> dist{0, 1};
+
+		{
+			std::lock_guard lock{genMutex};
+			delta *= dist(gen);
+		}
 		SetNextCheck(now + delta);
 	}
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -74,10 +74,11 @@ GlobalTimezoneFixture::~GlobalTimezoneFixture()
 
 std::string GetRandomString(std::string prefix, std::size_t length)
 {
-	std::random_device rd;
-	std::mt19937 gen(rd());
+	static std::mutex genMutex;
+	static std::mt19937 gen(std::random_device{}());
 	std::uniform_int_distribution<int> distribution('!', '~');
 
+	std::lock_guard lock{genMutex};
 	for (auto i = 0U; i < length; i++) {
 		prefix += static_cast<char>(distribution(gen));
 	}


### PR DESCRIPTION
This replaces the C-style random number generation (`rand()` and `rand_r()`) used in three places in our code with the C++ equivalent. It also protects access to the generators with mutexes.

### Reasoning

In the case of `Utility::Random()` this primarily had poor entropy because it was seeded with the timestamp at the time of initialization. While this was already thread-safe on Linux, since the seed was stored in a tread_local pointer, that could potentially lead to problems with compiler optimizations in conjunction with boost coroutine suspension points, which we've faced numerous issues with in the past and I'm very wary of by now.

And on Windows it used the same non-thread-safe `rand()` function as the other examples below. This PR gets rid of the OS-specific preprocessor branches and uses the same standard functions everywhere, which still might be inferior on Windows, but much less so than before.

In the case of the DSL-facing `MathRandom()` and `Checkable::Start()` this had outright concurrent access to non-thread-safe global state via the `rand()` function, which technically is a data-race and undefined behavior, even though it didn't seem to affect us much in practice (but who knows).

I also adjusted the prior `std::mt19937` usage in `test/utils.cpp` to use the same mutex-guarded static generator pattern for consistency, even though this wasn't facing any of the issues above.

### Caveats

- `std::uniform_real_distribution` is a half-open range, meaning in the cases where we want it to return values from 0 to 1 it will never actually return 1.0. Shouldn't matter in practice, but if we want to replicate the exact behavior as before, we can always fall back to generating integer and divide them by the max value.
- `std::mt19937` can be seeded with more than one 32bit value for full entropy using `std::seed_seq`. Or alternatively we could use `boost::mt19937` instead which can be passed the `random_device` directly so it can take as much entropy as it needs. But both of those options would IMHO over-complicate things, clutter initialization and be a bit slower, so I left it at *good enough*, which is still much much better than what we had before. If a reviewer explicitly requests either option, I'm happy to add it.