### PR TITLE
Fix `ccache` usage in GitHub Actions

### DIFF
--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -144,6 +144,15 @@ fi
 mkdir /icinga2/build
 cd /icinga2/build
 
+# Disable the addtion of debug symbols to the objects to reduce ccache size.
+# Several targets will also add '-g' to the regular compiler flags, and adding
+# -g0 to the build-type specific variable is the only way to reliably override
+# it.
+CMAKE_OPTS+=(
+  -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG -g0"
+  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG -g0"
+)
+
 "${SCL_ENABLE_GCC[@]}" cmake \
   -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -37,8 +37,9 @@ case "$DISTRO" in
     ;;
 
   amazonlinux:20*)
-    dnf install -y amazon-rpm-config bison cmake flex gcc-c++ ninja-build \
+    dnf install -y amazon-rpm-config spal-release bison cmake flex gcc-c++ ninja-build \
       {boost,libedit,mariadb-connector-c,ncurses,openssl,postgresql,systemd,protobuf-lite}-devel
+    dnf install -y ccache
     ;;
 
   debian:*|ubuntu:*)

--- a/.github/workflows/linux.bash
+++ b/.github/workflows/linux.bash
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -exo pipefail
 
-export PATH="/usr/lib/ccache/bin:/usr/lib/ccache:/usr/lib64/ccache:$PATH"
 export CCACHE_DIR=/icinga2/ccache
+# Limit ccache so all targets together don't ever get over the 10 GiB limit
+# that would cause the cache of the first action to be evicted.
+export CCACHE_MAXSIZE=400M
 export CTEST_OUTPUT_ON_FAILURE=1
 CMAKE_OPTS=()
 SCL_ENABLE_GCC=()
@@ -127,6 +129,18 @@ case "$DISTRO" in
     ;;
 esac
 
+# ccache isn't packaged for every distro (currently only amazonlinux).
+# We add it at the CMake layer because that's more compatible with distros
+# that use their own compiler wrappers.
+if command -v ccache >/dev/null; then
+  CMAKE_OPTS+=(
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+  )
+  # Zero the stats so the summary below reflects only this run.
+  ccache -z
+fi
+
 mkdir /icinga2/build
 cd /icinga2/build
 
@@ -140,6 +154,17 @@ cd /icinga2/build
   "${CMAKE_OPTS[@]}" ..
 
 ninja -v
+
+# Print ccache stats
+if command -v ccache >/dev/null; then
+  ccache -s
+  # Not all distros have a ccache version that prints precise cache size values.
+  # Some have ccache --print-stats but others don't. This just prints the size
+  # of the cache directory in MiB.
+  ccache_kib=$(du -sk "$CCACHE_DIR" | cut -f1)
+  printf 'exact ccache size (du): %s KiB (%d.%02d MiB)\n' \
+    "$ccache_kib" "$((ccache_kib / 1024))" "$((ccache_kib * 100 / 1024 % 100))"
+fi
 
 ninja test
 ninja install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,11 +71,15 @@ jobs:
       - name: Turn on Problem Matcher
         run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
-      - name: Restore/backup ccache
-        uses: actions/cache@v6
+      - name: Restore ccache
+        uses: actions/cache/restore@v6
         with:
           path: ccache
-          key: ccache/${{ matrix.distro }}
+          # The exact key is only ever written by the Save step below, so on any
+          # run it won't pre-exist and restore falls through restore-keys to the
+          # newest saved snapshot — i.e. the latest push to a base branch.
+          key: ccache/${{ matrix.distro }}-${{ matrix.platform }}-${{ github.run_id }}
+          restore-keys: ccache/${{ matrix.distro }}-${{ matrix.platform }}-
 
       - name: Build Alpine Docker Image
         if: "matrix.distro == 'alpine:bash'"
@@ -87,3 +91,12 @@ jobs:
         run: >-
           docker run --rm -v "$(pwd):/icinga2" -e DISTRO=${{ matrix.distro }}
           --platform ${{ matrix.platform }} ${{ matrix.distro }} /icinga2/.github/workflows/linux.bash
+
+      - name: Save ccache
+        # Only update ccache on a push to master to preserve as much useful
+        # artefacts as possible while staying under GitHub's 10GB size limit.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v6
+        with:
+          path: ccache
+          key: ccache/${{ matrix.distro }}-${{ matrix.platform }}-${{ github.run_id }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,11 +66,15 @@ jobs:
       - name: Turn on Problem Matcher
         run: echo "::add-matcher::.github/problem-matchers/gcc.json"
 
-      - name: Restore/backup ccache
-        uses: actions/cache@v6
+      - name: Restore ccache
+        uses: actions/cache/restore@v6
         with:
           path: ccache
-          key: ccache/${{ matrix.distro }}
+          # The exact key is only ever written by the Save step below, so on any
+          # run it won't pre-exist and restore falls through restore-keys to the
+          # newest saved snapshot — i.e. the latest push to a base branch.
+          key: ccache/${{ matrix.distro }}-${{ matrix.platform }}-${{ github.run_id }}
+          restore-keys: ccache/${{ matrix.distro }}-${{ matrix.platform }}-
 
       - name: Build Alpine Docker Image
         if: "matrix.distro == 'alpine:bash'"
@@ -82,3 +86,12 @@ jobs:
         run: >-
           docker run --rm -v "$(pwd):/icinga2" -e DISTRO=${{ matrix.distro }}
           --platform ${{ matrix.platform }} ${{ matrix.distro }} /icinga2/tools/linux/ci-build.sh
+
+      - name: Save ccache
+        # Only update ccache on a push to master to preserve as much useful
+        # artefacts as possible while staying under GitHub's 10GB size limit.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v6
+        with:
+          path: ccache
+          key: ccache/${{ matrix.distro }}-${{ matrix.platform }}-${{ github.run_id }}

--- a/tools/linux/ci-build.sh
+++ b/tools/linux/ci-build.sh
@@ -19,7 +19,9 @@ set -exo pipefail
 : "${ICINGA2_BUILD_DIR:=${ICINGA2_SOURCE_DIR}/build}"
 : "${CCACHE_DIR:=${ICINGA2_SOURCE_DIR}/ccache}"
 
-export PATH="/usr/lib/ccache/bin:/usr/lib/ccache:/usr/lib64/ccache:$PATH"
+# Limit ccache so all targets together don't ever get over the 10 GiB limit
+# that would cause the cache of the first action to be evicted.
+export CCACHE_MAXSIZE=400M
 export CTEST_OUTPUT_ON_FAILURE=1
 export CCACHE_DIR
 
@@ -146,6 +148,18 @@ case "$DISTRO" in
     ;;
 esac
 
+# ccache isn't packaged for every distro (currently only amazonlinux).
+# We add it at the CMake layer because that's more compatible with distros
+# that use their own compiler wrappers.
+if command -v ccache >/dev/null; then
+  CMAKE_OPTS+=(
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+  )
+  # Zero the stats so the summary below reflects only this run.
+  ccache -z
+fi
+
 mkdir -p "$ICINGA2_BUILD_DIR"
 cd "$ICINGA2_BUILD_DIR"
 
@@ -173,6 +187,17 @@ if [[ -v CI_RUNNER_ID ]]; then
 fi
 
 ninja "${NINJA_OPTS[@]}"
+
+# Print ccache stats
+if command -v ccache >/dev/null; then
+  ccache -s
+  # Not all distros have a ccache version that prints precise cache size values.
+  # Some have ccache --print-stats but others don't. This just prints the size
+  # of the cache directory in MiB.
+  ccache_kib=$(du -sk "$CCACHE_DIR" | cut -f1)
+  printf 'exact ccache size (du): %s KiB (%d.%02d MiB)\n' \
+    "$ccache_kib" "$((ccache_kib / 1024))" "$((ccache_kib * 100 / 1024 % 100))"
+fi
 
 ninja test
 ninja install

--- a/tools/linux/ci-build.sh
+++ b/tools/linux/ci-build.sh
@@ -163,6 +163,15 @@ fi
 mkdir -p "$ICINGA2_BUILD_DIR"
 cd "$ICINGA2_BUILD_DIR"
 
+# Disable the addtion of debug symbols to the objects to reduce ccache size.
+# Several targets will also add '-g' to the regular compiler flags, and adding
+# -g0 to the build-type specific variable is the only way to reliably override
+# it.
+CMAKE_OPTS+=(
+  -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG -g0"
+  -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -DNDEBUG -g0"
+)
+
 "${SCL_ENABLE_GCC[@]}" cmake \
   -GNinja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/tools/linux/ci-build.sh
+++ b/tools/linux/ci-build.sh
@@ -56,8 +56,9 @@ case "$DISTRO" in
     ;;
 
   amazonlinux:20*)
-    dnf install -y amazon-rpm-config bison cmake flex gcc-c++ ninja-build \
+    dnf install -y amazon-rpm-config spal-release bison cmake flex gcc-c++ ninja-build \
       {boost,libedit,mariadb-connector-c,ncurses,openssl,postgresql,systemd,protobuf-lite}-devel
+    dnf install -y ccache
     ;;
 
   debian:*|ubuntu:*)


### PR DESCRIPTION
This fixes the `actions/cache` GitHub action we use to save and restore ccache for faster builds in PRs that change little or no code.

As a rough estimate, the Linux workflow on this PR, when rebuilt with a warm cache went down from 2h 17m to 1h 25m.

### What was broken?

The default cache action only saves to a key when it didn't find an exact match. On current master the save and restore keys are identical and depend on just the `matrix.distro` string. This effectively means one cache entry per distro got written (probably a long time ago), that old entry always gets restored again and again, only ever leads to cache misses and no new entry gets saved because the keys matched exactly. This is the reason we weren't seeing any benefits, even when force-pushing to a PR with zero code changes.

To solve this we now save to a key in the format `ccache-<distro>-<platform>-<runid>` with the runid being the critical part, and we use the `restore-keys` attribute of the action to do a prefix-matched restore from any key that matches just the distro and platform. This means that a new cache entry gets stored for each run.

### Why save only on pushes to master

GitHub `actions/cache` has a total limit of 10 GiB across all cache entries per repo. The eviction for old entries past this limit is LRU. Meanwhile `ccache`'s limits are controlled via the `CCACHE_MAXSIZE` environment variable or otherwise defaults to 5 GiB. Lets assume for a moment we left it at the default and each distro accumulated more and more cached objects. At some point, the total objects cached between `alpine:bash` and `debian:12 (linux/386)` (the first and last jobs at the time of writing) will weigh enough that they will go over the GHA's maximum of 10 GiB and `alpine:bash`'s cache of the same run will already be evicted by GitHub causing full rebuilds on their next run. Then `amazonlinux:2023` gets evicted and so on.

So we set `CCACHE_MAXSIZE` to a reasonable limit for all distros. I've chosen `400 MiB`, which fits around four full rebuilds for the average distro (each weighing around 100 MiB), which currently gives us 8 GiB if all distros fully use it, so a bit of headroom remains for other things or additions to the matrix. This avoids any individual run evicting caches of earlier jobs. But there is still a problem when CI jobs for multiple PRs run concurrently, which is very common in this repo. There is no sane way to cap this either, without restricting the max size further into uselessness.

So the idea is to always restore the cache from the last master build and save it only on a push to master after a PR has been merged. Since those don't run concurrently, we ensure that there is always a cache that can be read for PR jobs. Obviously how useful that cache is will depend on how much that PR changes (more on that further down).

### Invoking `ccache` through CMake

Previously we were using (or trying to anyway) `ccache`'s compiler wrapper scripts by prioritizing them in `$PATH`. This has some issues with compatibility that we can afford to avoid because CMake has native support for launchers like `ccache` since version 3.17. By setting `CMAKE_<lang>_COMPILER_LAUNCHER=ccache` it just works. The build scripts will now just preface every compiler invocation with the `ccache` command.

### Other changes

+ Amazonlinux doesn't have `ccache` in its regular repos, but it does have it in its SPAL repos, which can be installed through the `spal-release` package, so we do that now.
+ I've disabled the debug symbols that get added through some of the distros' flags by appending `-g0` to the very end of the compiler flags. This about halves the cache space required by each run. I don't think debug symbols add anything in the GitHub CI, so that's a good trade-off in my eyes.

### Future improvements

My idea for the future, once #10936 gets merged is to look into enabling precompiled headers in a separate PR. That would allow us reasonably fast non-unity builds, which would synergize much better with the cache action, because it would be more efficient with the cache size and rebuilds would only ever be what the PR directly touches, making it less of a hassle that we only ever restore the cache from master.