### PR TITLE
CLI: Fix duplicate zones generation when Local zone == Parent zone

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Aaron Bishop <erroneous@gmail.com>
 Adam Bolte <abolte@systemsaviour.com>
 Adam James <atj@pulsewidth.org.uk>
 akrus <akrus@flygroup.st>
+Akulbanxal <25ucs022@lnmiit.ac.in>
 Alan Jenkins <alan.christopher.jenkins@gmail.com>
 Alan Litster <alan.litster@twentyci.co.uk>
 Alex <alexp710@hotmail.com>

--- a/lib/cli/nodeutility.cpp
+++ b/lib/cli/nodeutility.cpp
@@ -78,25 +78,42 @@ int NodeUtility::GenerateNodeIcingaConfig(const String& endpointName, const Stri
 		config->Add(myParentEndpoint);
 	}
 
-	/* add the parent zone to the config */
-	config->Add(new Dictionary({
-		{ "__name", parentZoneName },
-		{ "__type", "Zone" },
-		{ "endpoints", myParentZoneMembers }
-	}));
+	if (zoneName == parentZoneName) {
+		/* store the local generated node configuration */
+		config->Add(new Dictionary({
+			{ "__name", endpointName },
+			{ "__type", "Endpoint" }
+		}));
 
-	/* store the local generated node configuration */
-	config->Add(new Dictionary({
-		{ "__name", endpointName },
-		{ "__type", "Endpoint" }
-	}));
+		myParentZoneMembers->Add(endpointName);
 
-	config->Add(new Dictionary({
-		{ "__name", zoneName },
-		{ "__type", "Zone" },
-		{ "parent", parentZoneName },
-		{ "endpoints", new Array({ endpointName }) }
-	}));
+		/* add the single zone to the config */
+		config->Add(new Dictionary({
+			{ "__name", zoneName },
+			{ "__type", "Zone" },
+			{ "endpoints", myParentZoneMembers }
+		}));
+	} else {
+		/* add the parent zone to the config */
+		config->Add(new Dictionary({
+			{ "__name", parentZoneName },
+			{ "__type", "Zone" },
+			{ "endpoints", myParentZoneMembers }
+		}));
+
+		/* store the local generated node configuration */
+		config->Add(new Dictionary({
+			{ "__name", endpointName },
+			{ "__type", "Endpoint" }
+		}));
+
+		config->Add(new Dictionary({
+			{ "__name", zoneName },
+			{ "__type", "Zone" },
+			{ "parent", parentZoneName },
+			{ "endpoints", new Array({ endpointName }) }
+		}));
+	}
 
 	for (const String& globalzone : globalZones) {
 		config->Add(new Dictionary({


### PR DESCRIPTION
When configuring a node via the wizard/setup where the Local zone name is identical to the Parent zone name (e.g. for high-availability secondary master setups), GenerateNodeIcingaConfig created two duplicate Zone objects. This change ensures a single Zone object is generated containing all parent and local endpoints.

fixes #10270