### PR TITLE
Icinga DB: Fix inconsistent state_type for volatile checks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Aaron Bishop <erroneous@gmail.com>
 Adam Bolte <abolte@systemsaviour.com>
 Adam James <atj@pulsewidth.org.uk>
 akrus <akrus@flygroup.st>
+Akulbanxal <25ucs022@lnmiit.ac.in>
 Alan Jenkins <alan.christopher.jenkins@gmail.com>
 Alan Litster <alan.litster@twentyci.co.uk>
 Alex <alexp710@hotmail.com>

--- a/lib/icingadb/icingadb-objects.cpp
+++ b/lib/icingadb/icingadb-objects.cpp
@@ -2815,7 +2815,19 @@ Dictionary::Ptr IcingaDB::SerializeState(const Checkable::Ptr& checkable)
 	 */
 	attrs->Set("id", id);
 	attrs->Set("environment_id", m_EnvironmentId);
-	attrs->Set("state_type", Checkable::StateTypeToString(checkable->HasBeenChecked() ? checkable->GetStateType() : StateTypeHard).ToLower());
+	StateType stateType;
+
+	if (checkable->HasBeenChecked()) {
+		if (checkable->GetVolatile() && !checkable->IsStateOK(checkable->GetStateRaw())) {
+			stateType = StateTypeHard;
+		} else {
+			stateType = checkable->GetStateType();
+		}
+	} else {
+		stateType = StateTypeHard;
+	}
+
+	attrs->Set("state_type", Checkable::StateTypeToString(stateType).ToLower());
 
 	// TODO: last_hard/soft_state should be "previous".
 	if (service) {


### PR DESCRIPTION
When a checkable is configured as volatile, every state change is treated as hard. However, its internal state type in the core remains soft. This change ensures that the serialized state_type in Icinga DB's runtime state is set to hard for volatile checkables in a non-OK state, matching the history stream behavior.

fixes #10879