### PR TITLE
Base, DB IDO: Optimize object retrieval by caching types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Aaron Bishop <erroneous@gmail.com>
 Adam Bolte <abolte@systemsaviour.com>
 Adam James <atj@pulsewidth.org.uk>
 akrus <akrus@flygroup.st>
+Akulbanxal <25ucs022@lnmiit.ac.in>
 Alan Jenkins <alan.christopher.jenkins@gmail.com>
 Alan Litster <alan.litster@twentyci.co.uk>
 Alex <alexp710@hotmail.com>

--- a/lib/base/configobject.cpp
+++ b/lib/base/configobject.cpp
@@ -687,6 +687,12 @@ ConfigObject::Ptr ConfigObject::GetObject(const String& type, const String& name
 	return ctype->GetObject(name);
 }
 
+ConfigObject::Ptr ConfigObject::GetZone(const String& name)
+{
+	static ConfigType *ctype = dynamic_cast<ConfigType *>(Type::GetByName("Zone").get());
+	return ctype->GetObject(name);
+}
+
 ConfigObject::Ptr ConfigObject::GetZone() const
 {
 	return m_Zone;

--- a/lib/base/configobject.hpp
+++ b/lib/base/configobject.hpp
@@ -73,6 +73,7 @@ public:
 	}
 
 	static ConfigObject::Ptr GetObject(const String& type, const String& name);
+	static ConfigObject::Ptr GetZone(const String& name);
 
 	static void DumpObjects(const String& filename, int attributeTypes = FAState);
 	static void RestoreObjects(const String& filename, int attributeTypes = FAState);

--- a/lib/db_ido/dbtype.cpp
+++ b/lib/db_ido/dbtype.cpp
@@ -3,6 +3,8 @@
 
 #include "db_ido/dbtype.hpp"
 #include "db_ido/dbconnection.hpp"
+#include "base/configtype.hpp"
+#include "base/type.hpp"
 #include "base/objectlock.hpp"
 #include "base/debug.hpp"
 #include <boost/thread/once.hpp>
@@ -86,22 +88,34 @@ DbObject::Ptr DbType::GetOrCreateObjectByName(const String& name1, const String&
 	if (!name2.IsEmpty())
 		objName += "!" + name2;
 
-	String objType = m_Name;
+	ConfigType *type = nullptr;
 
 	if (m_TypeID == DbObjectTypeCommand) {
 		if (objName.SubStr(0, 6) == "check_") {
-			objType = "CheckCommand";
+			static ConfigType *checkCommandType = dynamic_cast<ConfigType *>(Type::GetByName("CheckCommand").get());
+			type = checkCommandType;
 			objName = objName.SubStr(6);
 		} else if (objName.SubStr(0, 13) == "notification_") {
-			objType = "NotificationCommand";
+			static ConfigType *notificationCommandType = dynamic_cast<ConfigType *>(Type::GetByName("NotificationCommand").get());
+			type = notificationCommandType;
 			objName = objName.SubStr(13);
 		} else if (objName.SubStr(0, 6) == "event_") {
-			objType = "EventCommand";
+			static ConfigType *eventCommandType = dynamic_cast<ConfigType *>(Type::GetByName("EventCommand").get());
+			type = eventCommandType;
 			objName = objName.SubStr(6);
+		} else {
+			if (!m_ConfigType)
+				m_ConfigType = dynamic_cast<ConfigType *>(Type::GetByName(m_Name).get());
+			type = m_ConfigType;
 		}
+	} else {
+		if (!m_ConfigType)
+			m_ConfigType = dynamic_cast<ConfigType *>(Type::GetByName(m_Name).get());
+		type = m_ConfigType;
 	}
 
-	dbobj->SetObject(ConfigObject::GetObject(objType, objName));
+	if (type)
+		dbobj->SetObject(type->GetObject(objName));
 
 	return dbobj;
 }

--- a/lib/db_ido/dbtype.hpp
+++ b/lib/db_ido/dbtype.hpp
@@ -13,6 +13,7 @@ namespace icinga
 {
 
 class DbObject;
+class ConfigType;
 
 /**
  * A database object type.
@@ -50,6 +51,8 @@ private:
 	long m_TypeID;
 	String m_IDColumn;
 	ObjectFactory m_ObjectFactory;
+
+	mutable ConfigType* m_ConfigType = nullptr;
 
 	static std::mutex& GetStaticMutex();
 	static TypeMap& GetTypes();

--- a/tools/mkclass/classcompiler.cpp
+++ b/tools/mkclass/classcompiler.cpp
@@ -908,7 +908,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 					/* Ew */
 					if (field.Type.TypeName == "Zone" && m_Library == "base")
-						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetObject(\"Zone\", ";
+						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetZone(";
 					else
 						m_Impl << "this, ConfigObject::GetObject<" << field.Type.TypeName << ">(";
 
@@ -922,7 +922,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 					/* Ew */
 					if (field.Type.TypeName == "Zone" && m_Library == "base")
-						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetObject(\"Zone\", ";
+						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetZone(";
 					else
 						m_Impl << "this, ConfigObject::GetObject<" << field.Type.TypeName << ">(";
 
@@ -935,7 +935,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 					/* Ew */
 					if (field.Type.TypeName == "Zone" && m_Library == "base")
-						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetObject(\"Zone\", ";
+						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetZone(";
 					else
 						m_Impl << "this, ConfigObject::GetObject<" << field.Type.TypeName << ">(";
 
@@ -945,7 +945,7 @@ void ClassCompiler::HandleClass(const Klass& klass, const ClassDebugInfo&)
 
 					/* Ew */
 					if (field.Type.TypeName == "Zone" && m_Library == "base")
-						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetObject(\"Zone\", ";
+						m_Impl << "dynamic_cast<ConfigObject*>(this), ConfigObject::GetZone(";
 					else
 						m_Impl << "this, ConfigObject::GetObject<" << field.Type.TypeName << ">(";
 


### PR DESCRIPTION
Avoid string-based lookups in ConfigObject::GetObject(type, name) by introducing a cached ConfigObject::GetZone(name) helper for the base library, and caching ConfigType pointers in DbType for the IDO database library.

fixes #10274