### PR TITLE
Relax timer test tolerance on all platforms, not just Windows

### DIFF
--- a/test/base-timer.cpp
+++ b/test/base-timer.cpp
@@ -6,15 +6,6 @@
 #include "base/application.hpp"
 #include <BoostTestTargetConfig.h>
 
-/**
- * Windows needs a special handicap to keep up with the other OSs.
- */
-#ifdef _WIN32
-static constexpr double timeMultiplier = 10;
-#else //_WIN32
-static constexpr double timeMultiplier = 1;
-#endif //_WIN32
-
 using namespace icinga;
 
 BOOST_AUTO_TEST_SUITE(base_timer)
@@ -38,10 +29,10 @@ BOOST_AUTO_TEST_CASE(invoke)
 
 	Timer::Ptr timer = Timer::Create();
 	timer->OnTimerExpired.connect([&counter](const Timer* const&) { counter++; });
-	timer->SetInterval(.1 * timeMultiplier);
+	timer->SetInterval(1);
 
 	timer->Start();
-	Utility::Sleep(.55 * timeMultiplier);
+	Utility::Sleep(5.5);
 	timer->Stop();
 
 	// At this point, the timer should have fired exactly 5 times (0.5 / 0.1) and the sixth time
@@ -55,12 +46,12 @@ BOOST_AUTO_TEST_CASE(scope)
 
 	Timer::Ptr timer = Timer::Create();
 	timer->OnTimerExpired.connect([&counter](const Timer* const&) { counter++; });
-	timer->SetInterval(.1 * timeMultiplier);
+	timer->SetInterval(1);
 
 	timer->Start();
-	Utility::Sleep(.55 * timeMultiplier);
+	Utility::Sleep(5.5);
 	timer.reset();
-	Utility::Sleep(.1 * timeMultiplier);
+	Utility::Sleep(1);
 
 	// At this point, the timer should have fired exactly 5 times (0.5 / 0.1) and the sixth time
 	// should not have fired yet as we destroyed the timer after 0.55 seconds (0.6 would be needed),


### PR DESCRIPTION
macOS ARM64 GitHub and Linux ARM64 GitLab runners are similarly slow/jittery as Windows, causing flaky failures in base-timer tests. Apply the same 10x timeMultiplier handicap everywhere instead of gating it behind _WIN32.