### PR TITLE
Fix missing -o argument in snmp-interface CheckCommand

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -98,6 +98,7 @@ Evgeni Golov <evgeni@golov.de>
 Ewoud Kohl van Wijngaarden <ewoud@kohlvanwijngaarden.nl>
 Fabian Röhl <mail@fabian-roehl.de>
 Fabian Werner <47595490+fabieins@users.noreply.github.com>
+Farhan <farhan900720@gmail.com>
 fbachmann <bachmann.f@gmail.com>
 Federico Cuello <federico.cuello@sociomantic.com>
 Federico Pires <federico.pires@upsight.com>

--- a/itl/command-plugins-manubulon.conf
+++ b/itl/command-plugins-manubulon.conf
@@ -302,6 +302,10 @@ object CheckCommand "snmp-interface" {
 			set_if = "$snmp_interface_admin$"
 			description = "Use administrative status instead of operational"
 		}
+		"-o" = {
+            value = "$snmp_interface_olength$"
+            description = "Max-size of the SNMP message, usefull in case of Too Long responses."
+        }
 	}
 
 	vars.snmp_interface = "eth0"


### PR DESCRIPTION
refs #9578 

This PR adds the missing `-o` (`$snmp_interface_olength$`) parameter to the `snmp-interface` CheckCommand definition in the Manubulon template (`itl/command-plugins-manubulon.conf`). 

This matches the equivalent definition found in `snmp-storage`, allowing users to define the max-size of the SNMP message to handle "Too Long" responses. I have also added myself to the AUTHORS file.

