### PR TITLE
ApiListener: don't log config/attributes on config sync

### DIFF
--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -42,9 +42,6 @@ void ApiListener::ConfigUpdateObjectHandler(const ConfigObject::Ptr& object, con
 
 Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin, const Dictionary::Ptr& params)
 {
-	Log(LogNotice, "ApiListener")
-		<< "Received config update for object: " << JsonEncode(params);
-
 	/* check permissions */
 	ApiListener::Ptr listener = ApiListener::GetInstance();
 
@@ -107,6 +104,10 @@ Value ApiListener::ConfigUpdateObjectAPIHandler(const MessageOrigin::Ptr& origin
 			<< std::fixed << deletedVersion << ".";
 		return Empty;
 	}
+
+	Log(LogNotice, "ApiListener")
+		<< "Received config update for object '" << objName << "' of type " << objType
+		<< ", version: " << std::fixed << objVersion;
 
 	Type::Ptr ptype = Type::GetByName(objType);
 	auto *ctype = dynamic_cast<ConfigType *>(ptype.get());


### PR DESCRIPTION
Config sync debug/notice logs serialized the full "config::UpdateObject" params, including the object's rendered config text and modified attributes. For ApiUser, that means the plaintext password ends up in debug.log (and notice-level logs) whenever an API user is created, updated or the cluster re-connects, since password isn't excluded from this path the way it is from the GET /v1/objects API.

Skip the payload dump and only log name/type/version instead.