### PR TITLE
Containerfile: Install missing dependency for check_ssl_cert & check_dns

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -148,6 +148,7 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --no-install-suggests \
         bc \
+        bind9-dnsutils \
         ca-certificates \
         curl \
         dumb-init \


### PR DESCRIPTION
The check `check_ssl_cert` requires the `host` command, which is provided by the `bind9-host` package.
`check_dns` requires `nslookup`, which is part of `bind9-dnsutils`, which in turn depends on `bind9-host`.