### PR TITLE
fixes #7217

### DIFF
--- a/lib/base/string-script.cpp
+++ b/lib/base/string-script.cpp
@@ -32,7 +32,7 @@ static String StringSubstr(const std::vector<Value>& args)
 	if (args.empty())
 		BOOST_THROW_EXCEPTION(std::invalid_argument("Too few arguments"));
 
-	if (static_cast<double>(args[0]) < 0 || static_cast<double>(args[0]) >= self.GetLength())
+	if (static_cast<double>(args[0]) < 0 || static_cast<double>(args[0]) > self.GetLength())
 		BOOST_THROW_EXCEPTION(std::invalid_argument("String index is out of range"));
 
 	if (args.size() > 1)

--- a/test/config-ops.cpp
+++ b/test/config-ops.cpp
@@ -289,4 +289,26 @@ BOOST_AUTO_TEST_CASE(sandboxed_ticket_salt)
 	BOOST_CHECK_THROW(expr->Evaluate(frame), ScriptError);
 }
 
+BOOST_AUTO_TEST_CASE(substr_bounds)
+{
+	ScriptFrame frame(true);
+	std::unique_ptr<Expression> expr;
+
+	// Normal substring.
+	expr = ConfigCompiler::CompileText("<test>", "\"hamburger\".substr(0, 7)");
+	BOOST_CHECK(expr->Evaluate(frame).GetValue() == "hamburg");
+
+	// Start at the end of the string with zero length.
+	expr = ConfigCompiler::CompileText("<test>", "\"something\".substr(9, 0)");
+	BOOST_CHECK(expr->Evaluate(frame).GetValue() == "");
+
+	// Empty string.
+	expr = ConfigCompiler::CompileText("<test>", "\"\".substr(0, 0)");
+	BOOST_CHECK(expr->Evaluate(frame).GetValue() == "");
+
+	// Out of bounds must still throw.
+	expr = ConfigCompiler::CompileText("<test>", "\"something\".substr(10, 0)");
+	BOOST_CHECK_THROW(expr->Evaluate(frame).GetValue(), ScriptError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Allow substr() with a start index equal to the string length to return an empty string instead of throwing, consistent with std::string::substr.

Added regression tests in `test/config-ops.cpp` covering the boundary cases.

refs #7217