### PR TITLE
Bump Boost shipped for Windows to v1.92

### DIFF
--- a/doc/win-dev.ps1
+++ b/doc/win-dev.ps1
@@ -17,7 +17,7 @@ $VsVersion = 2022
 
 $MsvcVersion = '14.3'
 
-$BoostVersion = @(1, 91, 0)
+$BoostVersion = @(1, 92, 0)
 
 $OpensslVersion = '3_5_7'
 

--- a/tools/win32/configure-dev.ps1
+++ b/tools/win32/configure-dev.ps1
@@ -34,10 +34,10 @@ if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
   $env:OPENSSL_ROOT_DIR = 'c:\local\OpenSSL-Win64'
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = 'c:\local\boost_1_91_0'
+  $env:BOOST_ROOT = 'c:\local\boost_1_92_0'
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_91_0\lib64-msvc-14.3'
+  $env:BOOST_LIBRARYDIR = 'c:\local\boost_1_92_0\lib64-msvc-14.3'
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'

--- a/tools/win32/configure.ps1
+++ b/tools/win32/configure.ps1
@@ -36,10 +36,10 @@ if (-not (Test-Path env:OPENSSL_ROOT_DIR)) {
   $env:OPENSSL_ROOT_DIR = "c:\local\OpenSSL_3_5_7-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_ROOT)) {
-  $env:BOOST_ROOT = "c:\local\boost_1_91_0-Win${env:BITS}"
+  $env:BOOST_ROOT = "c:\local\boost_1_92_0-Win${env:BITS}"
 }
 if (-not (Test-Path env:BOOST_LIBRARYDIR)) {
-  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_91_0-Win${env:BITS}\lib${env:BITS}-msvc-14.3"
+  $env:BOOST_LIBRARYDIR = "c:\local\boost_1_92_0-Win${env:BITS}\lib${env:BITS}-msvc-14.3"
 }
 if (-not (Test-Path env:FLEX_BINARY)) {
   $env:FLEX_BINARY = 'C:\ProgramData\chocolatey\bin\win_flex.exe'


### PR DESCRIPTION
Update the default Boost version from 1.91.0 to 1.92.0 across all Windows build configuration scripts.

**This is important for all other PRs being tested against v1.92 compatibility from day one!**

## Test

Tested with `nix-build i2boost192.nix`. I use NixOS btw.

<details>
  <summary>cat i2boost192.nix</summary>

```nix
with import <nixpkgs> { };
(icinga2.override {
  boost = boost191.overrideAttrs (old: {
    src = fetchurl {
      urls = [
        "https://archives.boost.io/release/1.92.0/source/boost_1_92_0.tar.bz2"
      ];
      hash = "sha256-XB1Ay44Zrb90Ck7C2jWz5Y8/WASx3ORN61Pfchk8vGw=";
    };
  });
})
.overrideAttrs (old: {
  cmakeFlags = old.cmakeFlags ++ ["-DICINGA2_UNITY_BUILD=OFF"];
})
```
</details>

ldd(1) proves the correct Boost version.

<details>
  <summary>ldd $(nix-build i2boost192.nix)/lib/icinga2/sbin/icinga2</summary>

```
	linux-vdso.so.1 (0x000075a72cc28000)
	libdl.so.2 => /nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67/lib/libdl.so.2 (0x000075a72cc1b000)
	libboost_coroutine.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_coroutine.so.1.92.0 (0x000075a72cc14000)
	libboost_context.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_context.so.1.92.0 (0x000075a72cc0f000)
	libboost_filesystem.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_filesystem.so.1.92.0 (0x000075a72cbe2000)
	libboost_iostreams.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_iostreams.so.1.92.0 (0x000075a72b3e7000)
	libboost_thread.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_thread.so.1.92.0 (0x000075a72b3c7000)
	libboost_program_options.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_program_options.so.1.92.0 (0x000075a72b358000)
	libssl.so.3 => /nix/store/39jzpf9ray7mxjnlmqbrxlyz0dsz0448-openssl-3.6.3/lib/libssl.so.3 (0x000075a72b23e000)
	libcrypto.so.3 => /nix/store/39jzpf9ray7mxjnlmqbrxlyz0dsz0448-openssl-3.6.3/lib/libcrypto.so.3 (0x000075a72aa00000)
	libprotobuf-lite.so.35.1.0 => /nix/store/627hivwhnbmkgj71z5af0gfqdm03s408-protobuf-35.1/lib/libprotobuf-lite.so.35.1.0 (0x000075a72b194000)
	libsystemd.so.0 => /nix/store/hbg7ib0c60pn7hi8sx7w5yvs8yfahwgw-systemd-261.1/lib/libsystemd.so.0 (0x000075a72a600000)
	libedit.so.0 => /nix/store/54y8r4srwlgwyjm55zz3zlaq4bgd3344-libedit-20260508-3.1/lib/libedit.so.0 (0x000075a72b155000)
	libncursesw.so.6 => /nix/store/w11kc8r5ixj3ir37q8ndrv82gimr5vjd-ncurses-6.6/lib/libncursesw.so.6 (0x000075a72b0d9000)
	libboost_random.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_random.so.1.92.0 (0x000075a72cbd5000)
	libboost_date_time.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_date_time.so.1.92.0 (0x000075a72cbd0000)
	libboost_atomic.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_atomic.so.1.92.0 (0x000075a72b0cf000)
	libboost_chrono.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_chrono.so.1.92.0 (0x000075a72b0c5000)
	libboost_container.so.1.92.0 => /nix/store/wfj55gph0firnpvjilyj4fnvacyslawa-boost-1.91.0/lib/libboost_container.so.1.92.0 (0x000075a72b0ad000)
	libabsl_log_internal_check_op.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_check_op.so.2601.0.0 (0x000075a72b0a4000)
	libabsl_die_if_null.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_die_if_null.so.2601.0.0 (0x000075a72b09e000)
	libabsl_log_internal_conditions.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_conditions.so.2601.0.0 (0x000075a72b099000)
	libabsl_log_internal_message.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_message.so.2601.0.0 (0x000075a72b08a000)
	libabsl_log_internal_nullguard.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_nullguard.so.2601.0.0 (0x000075a72b085000)
	libabsl_examine_stack.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_examine_stack.so.2601.0.0 (0x000075a72a9fb000)
	libabsl_log_internal_format.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_format.so.2601.0.0 (0x000075a72a9f5000)
	libabsl_log_internal_structured_proto.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_structured_proto.so.2601.0.0 (0x000075a72a9f0000)
	libabsl_log_internal_log_sink_set.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_log_sink_set.so.2601.0.0 (0x000075a72a9e9000)
	libabsl_log_sink.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_sink.so.2601.0.0 (0x000075a72a9e4000)
	libabsl_log_entry.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_entry.so.2601.0.0 (0x000075a72a9de000)
	libabsl_log_internal_proto.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_proto.so.2601.0.0 (0x000075a72a9d9000)
	libabsl_flags_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_internal.so.2601.0.0 (0x000075a72a9cd000)
	libabsl_flags_marshalling.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_marshalling.so.2601.0.0 (0x000075a72a9c1000)
	libabsl_flags_reflection.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_reflection.so.2601.0.0 (0x000075a72a9b5000)
	libabsl_flags_config.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_config.so.2601.0.0 (0x000075a72a9ad000)
	libabsl_flags_program_name.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_program_name.so.2601.0.0 (0x000075a72a9a7000)
	libabsl_flags_private_handle_accessor.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_private_handle_accessor.so.2601.0.0 (0x000075a72a9a2000)
	libabsl_flags_commandlineflag.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_commandlineflag.so.2601.0.0 (0x000075a72a99d000)
	libabsl_flags_commandlineflag_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_flags_commandlineflag_internal.so.2601.0.0 (0x000075a72a998000)
	libabsl_log_initialize.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_initialize.so.2601.0.0 (0x000075a72a991000)
	libabsl_log_internal_globals.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_globals.so.2601.0.0 (0x000075a72a98c000)
	libabsl_log_globals.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_globals.so.2601.0.0 (0x000075a72a986000)
	libabsl_vlog_config_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_vlog_config_internal.so.2601.0.0 (0x000075a72a97d000)
	libabsl_log_internal_fnmatch.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_internal_fnmatch.so.2601.0.0 (0x000075a72a978000)
	libabsl_raw_hash_set.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_raw_hash_set.so.2601.0.0 (0x000075a72a96c000)
	libabsl_hashtablez_sampler.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_hashtablez_sampler.so.2601.0.0 (0x000075a72a966000)
	libabsl_random_distributions.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_distributions.so.2601.0.0 (0x000075a72a961000)
	libabsl_random_seed_sequences.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_seed_sequences.so.2601.0.0 (0x000075a72a95c000)
	libabsl_random_internal_entropy_pool.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_entropy_pool.so.2601.0.0 (0x000075a72a956000)
	libabsl_random_internal_randen.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_randen.so.2601.0.0 (0x000075a72a94f000)
	libabsl_random_internal_randen_hwaes.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_randen_hwaes.so.2601.0.0 (0x000075a72a94a000)
	libabsl_random_internal_randen_hwaes_impl.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_randen_hwaes_impl.so.2601.0.0 (0x000075a72a945000)
	libabsl_random_internal_randen_slow.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_randen_slow.so.2601.0.0 (0x000075a72a93f000)
	libabsl_random_internal_platform.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_platform.so.2601.0.0 (0x000075a72a939000)
	libabsl_random_internal_seed_material.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_internal_seed_material.so.2601.0.0 (0x000075a72a932000)
	libabsl_random_seed_gen_exception.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_random_seed_gen_exception.so.2601.0.0 (0x000075a72a92d000)
	libabsl_statusor.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_statusor.so.2601.0.0 (0x000075a72a927000)
	libabsl_status.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_status.so.2601.0.0 (0x000075a72a91b000)
	libabsl_cord.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_cord.so.2601.0.0 (0x000075a72a8f7000)
	libabsl_cordz_info.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_cordz_info.so.2601.0.0 (0x000075a72a8ee000)
	libabsl_cord_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_cord_internal.so.2601.0.0 (0x000075a72a8d8000)
	libabsl_cordz_functions.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_cordz_functions.so.2601.0.0 (0x000075a72a8d3000)
	libabsl_exponential_biased.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_exponential_biased.so.2601.0.0 (0x000075a72a8ce000)
	libabsl_cordz_handle.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_cordz_handle.so.2601.0.0 (0x000075a72a8c8000)
	libabsl_crc_cord_state.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_crc_cord_state.so.2601.0.0 (0x000075a72a8bd000)
	libabsl_crc32c.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_crc32c.so.2601.0.0 (0x000075a72a8b7000)
	libabsl_crc_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_crc_internal.so.2601.0.0 (0x000075a72a8b0000)
	libabsl_crc_cpu_detect.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_crc_cpu_detect.so.2601.0.0 (0x000075a72a8ab000)
	libabsl_leak_check.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_leak_check.so.2601.0.0 (0x000075a72a8a6000)
	libabsl_strerror.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_strerror.so.2601.0.0 (0x000075a72a89f000)
	libabsl_str_format_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_str_format_internal.so.2601.0.0 (0x000075a72a87c000)
	libabsl_synchronization.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_synchronization.so.2601.0.0 (0x000075a72a869000)
	libabsl_stacktrace.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_stacktrace.so.2601.0.0 (0x000075a72a863000)
	libabsl_borrowed_fixup_buffer.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_borrowed_fixup_buffer.so.2601.0.0 (0x000075a72a846000)
	libabsl_hash.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_hash.so.2601.0.0 (0x000075a72a83f000)
	libabsl_city.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_city.so.2601.0.0 (0x000075a72a83a000)
	libabsl_symbolize.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_symbolize.so.2601.0.0 (0x000075a72a831000)
	libabsl_debugging_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_debugging_internal.so.2601.0.0 (0x000075a72a82a000)
	libabsl_demangle_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_demangle_internal.so.2601.0.0 (0x000075a72a5ef000)
	libabsl_demangle_rust.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_demangle_rust.so.2601.0.0 (0x000075a72a5e7000)
	libabsl_decode_rust_punycode.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_decode_rust_punycode.so.2601.0.0 (0x000075a72a823000)
	libabsl_utf8_for_code_point.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_utf8_for_code_point.so.2601.0.0 (0x000075a72a5e2000)
	libabsl_graphcycles_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_graphcycles_internal.so.2601.0.0 (0x000075a72a5d8000)
	libabsl_kernel_timeout_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_kernel_timeout_internal.so.2601.0.0 (0x000075a72a5d2000)
	libabsl_malloc_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_malloc_internal.so.2601.0.0 (0x000075a72a5c9000)
	libabsl_tracing_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_tracing_internal.so.2601.0.0 (0x000075a72a5c4000)
	libabsl_time.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_time.so.2601.0.0 (0x000075a72a5ac000)
	libabsl_civil_time.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_civil_time.so.2601.0.0 (0x000075a72a5a4000)
	libabsl_time_zone.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_time_zone.so.2601.0.0 (0x000075a72a583000)
	libabsl_strings.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_strings.so.2601.0.0 (0x000075a72a559000)
	libabsl_int128.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_int128.so.2601.0.0 (0x000075a72a552000)
	libabsl_strings_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_strings_internal.so.2601.0.0 (0x000075a72a54c000)
	libabsl_base.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_base.so.2601.0.0 (0x000075a72a545000)
	libabsl_spinlock_wait.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_spinlock_wait.so.2601.0.0 (0x000075a72a540000)
	libabsl_throw_delegate.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_throw_delegate.so.2601.0.0 (0x000075a72a537000)
	libabsl_raw_logging_internal.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_raw_logging_internal.so.2601.0.0 (0x000075a72a532000)
	libabsl_log_severity.so.2601.0.0 => /nix/store/dimhfx22q23ca2pqfwqr26r0siqx5v2i-abseil-cpp-20260107.1/lib/libabsl_log_severity.so.2601.0.0 (0x000075a72a52d000)
	libstdc++.so.6 => /nix/store/w2nk3f7prwzpm6h13rfxh8lh46yfdysj-gcc-15.3.0-lib/lib/libstdc++.so.6 (0x000075a72a200000)
	libm.so.6 => /nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67/lib/libm.so.6 (0x000075a72a108000)
	libgcc_s.so.1 => /nix/store/w2nk3f7prwzpm6h13rfxh8lh46yfdysj-gcc-15.3.0-lib/lib/libgcc_s.so.1 (0x000075a72a4fe000)
	libpthread.so.0 => /nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67/lib/libpthread.so.0 (0x000075a72a4f9000)
	libc.so.6 => /nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67/lib/libc.so.6 (0x000075a729e00000)
	librt.so.1 => /nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67/lib/librt.so.1 (0x000075a72a4f4000)
	libz.so.1 => /nix/store/fkcbg2c1w29jr5yp9awai9w3v1wvxdk9-zlib-1.3.2/lib/libz.so.1 (0x000075a72a4d3000)
	libbz2.so.1 => /nix/store/5ip9nvln2q56cqwxc4ijmpvnmj5vfxlb-bzip2-1.0.8/lib/libbz2.so.1 (0x000075a72a4be000)
	liblzma.so.5 => /nix/store/bybssc25s0zbp9iz0b0k9cb3ysgcjpyj-xz-5.8.3/lib/liblzma.so.5 (0x000075a72a48c000)
	libzstd.so.1 => /nix/store/9nizcmvz2699nkrbzxx8xsp5d8jp686w-zstd-1.5.7/lib/libzstd.so.1 (0x000075a72a033000)
	libutf8_validity.so.35.1.0 => /nix/store/627hivwhnbmkgj71z5af0gfqdm03s408-protobuf-35.1/lib/libutf8_validity.so.35.1.0 (0x000075a72a487000)
	/nix/store/qqiqd3ah10x8hzsif4j1y4xc1miw23nx-glibc-2.42-67/lib/ld-linux-x86-64.so.2 => /nix/store/0d8g8n0a11v6f5m2h416ajyxmnkwc3md-glibc-2.42-67/lib64/ld-linux-x86-64.so.2 (0x000075a72cc2a000)
```
</details>