### PR TITLE
Clarify tcp CheckCommand -E argument documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -294,6 +294,7 @@ Sven Wegener <swegener@gentoo.org>
 sysadt <sysadt@protonmail.com>
 T. Mulyana <nothinux@gmail.com>
 teclogi <27726999+teclogi@users.noreply.github.com>
+Tejashgupta <tejash5489@gmail.com>
 Theo Buehler <tb@openbsd.org>
 Thomas Forrer <thomas.forrer@wuerth-phoenix.com>
 Thomas Gelf <thomas.gelf@icinga.com>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -1644,9 +1644,9 @@ tcp_address     | **Optional.** The host's address. Defaults to "$address$" if t
 tcp_port        | **Required.** The port that should be checked.
 tcp_expect      | **Optional.** String to expect in server response. Multiple strings must be defined as array.
 tcp_all         | **Optional.** All expect strings need to occur in server response. Defaults to false.
-tcp_escape_send | **Optional.** Enable usage of \\n, \\r, \\t or \\\\ in send string.
+tcp_escape_send | **Optional.** Enable usage of \\n, \\r, \\t or \\\\ in send string. Default is nothing.
 tcp_send        | **Optional.** String to send to the server.
-tcp_escape_quit | **Optional.** Enable usage of \\n, \\r, \\t or \\\\ in quit string.
+tcp_escape_quit | **Optional.** Enable usage of \\n, \\r, \\t or \\\\ in quit string. Default is \\r\\n added to end of quit.
 tcp_quit        | **Optional.** String to send server to initiate a clean close of the connection.
 tcp_refuse      | **Optional.** Accept TCP refusals with states ok, warn, crit. Defaults to crit.
 tcp_mismatch    | **Optional.** Accept expected string mismatches with states ok, warn, crit. Defaults to warn.

--- a/itl/command-plugins.conf
+++ b/itl/command-plugins.conf
@@ -201,11 +201,14 @@ object CheckCommand "tcp" {
 			set_if = "$tcp_all$"
 			description = "All expect strings need to occur in server response. Defaults to false."
 		}
+		/* check_tcp only applies "-E" to send/quit strings parsed after it, so each
+		 * occurrence must be ordered directly before the argument it escapes.
+		 */
 		"-E_send" = {
 			key = "-E"
 			order = 1
 			set_if = "$tcp_escape_send$"
-			description = "Enable usage of \n, \r, \t or \\ in send string."
+			description = "Enable usage of \n, \r, \t or \\ in send string. Default is nothing."
 		}
 		"-s" = {
 			order = 2
@@ -216,7 +219,7 @@ object CheckCommand "tcp" {
 			key = "-E"
 			order = 3
 			set_if = "$tcp_escape_quit$"
-			description = "Enable usage of \n, \r, \t or \\ in quit string."
+			description = "Can use \n, \r, \t or \\ in quit string. Default is \r\n added to end of quit."
 		}
 		"-q" = {
 			order = 4


### PR DESCRIPTION
## Context

Issue #6168 reports that the ordering of `-s`/`-e`/`-E` in the `tcp` CheckCommand seems wrong, and that `-E` isn't "just a flag" because check_tcp appends `\r\n` to the quit string by default.

Looking at this closely (including the `check_tcp.c` source in monitoring-plugins):

- The `-E` ordering issue described in the report already appears to be fixed. The `tcp` CheckCommand's `-E_send`/`-s`/`-E_quit`/`-q` arguments have had explicit `order` values (1/2/3/4) since 2015, which correctly guarantees `-E` precedes the `-s`/`-q` it's meant to affect — matching check_tcp's documented requirement ("Must come before send or quit option"). The `-e` (expect) argument has no ordering requirement at all in check_tcp — it just accumulates match strings regardless of position, so its lack of an explicit `order` is harmless.
- The default `\r\n`-appended-to-quit behavior is real, but it's baked into the external `check_tcp` binary (monitoring-plugins), not something the ITL wrapper can change. It's undocumented in the `tcp` CheckCommand's own descriptions though — while the equivalent `ftp` and `clamd` CheckCommands (same `-E_send`/`-E_quit` pattern) already document it.

## What this PR does

A small, doc-only consistency fix:
- Brings the `tcp` CheckCommand's `-E_send`/`-E_quit` argument `description`s in `itl/command-plugins.conf` in line with the wording already used by `ftp`/`clamd` (mentioning the default `\r\n`-on-quit behavior).
- Adds a short comment explaining why `-E_send`/`-E_quit` need their explicit `order` values.
- Mirrors the same clarification in `doc/10-icinga-template-library.md`'s `tcp_escape_send`/`tcp_escape_quit` rows.

No functional/behavioral change — the ordering was already correct.

refs #6168