### PR TITLE
Reject cross-site state-changing API requests (Sec-Fetch-Site)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -294,6 +294,7 @@ Sven Wegener <swegener@gentoo.org>
 sysadt <sysadt@protonmail.com>
 T. Mulyana <nothinux@gmail.com>
 teclogi <27726999+teclogi@users.noreply.github.com>
+Tejashgupta <tejash5489@gmail.com>
 Theo Buehler <tb@openbsd.org>
 Thomas Forrer <thomas.forrer@wuerth-phoenix.com>
 Thomas Gelf <thomas.gelf@icinga.com>

--- a/doc/09-object-types.md
+++ b/doc/09-object-types.md
@@ -1115,6 +1115,11 @@ Configuration Attributes:
 The attributes `access_control_allow_credentials`, `access_control_allow_headers` and `access_control_allow_methods`
 are controlled by Icinga 2 and are not changeable by config any more.
 
+Icinga 2 rejects state-changing API requests (`POST`, `PUT`, `DELETE`) that a browser marks as cross-site via the
+`Sec-Fetch-Site` request header, unless their `Origin` is listed in `access_control_allow_origin`. This protects
+against cross-site request forgery using credentials a browser attaches automatically (e.g. cached HTTP Basic Auth).
+Non-browser clients, which never send `Sec-Fetch-*` headers, are unaffected.
+
 
 The ApiListener type expects its certificate files to be in the following locations:
 

--- a/lib/remote/httpserverconnection.cpp
+++ b/lib/remote/httpserverconnection.cpp
@@ -274,6 +274,71 @@ bool HandleAccessControl(
 	return true;
 }
 
+/**
+ * Rejects state-changing requests (POST/PUT/DELETE) that a browser has flagged as cross-site.
+ *
+ * Browsers set the "Sec-Fetch-Site" request header to "cross-site" for requests originating from
+ * a different site, including ones carrying credentials the browser attaches automatically (such as
+ * cached HTTP Basic Auth credentials). Non-browser clients (icinga2 CLI, cluster nodes, Icinga Web's
+ * backend, curl, ...) never send Sec-Fetch-* headers, so they are unaffected by this check. Read-only
+ * GET requests are also left alone here, as forging them can't change state on the receiving end.
+ *
+ * Origins explicitly allow-listed via the "access_control_allow_origin" attribute are exempt, as the
+ * administrator has already declared them trusted for cross-origin browser access.
+ */
+static inline
+bool EnsureNotForgedCrossSiteRequest(
+	const HttpApiRequest& request,
+	HttpApiResponse& response,
+	boost::asio::yield_context& yc
+)
+{
+	namespace http = boost::beast::http;
+
+	auto method (request.method());
+
+	if (method != http::verb::post && method != http::verb::put && method != http::verb::delete_) {
+		return true;
+	}
+
+	if (request["Sec-Fetch-Site"] != "cross-site") {
+		return true;
+	}
+
+	auto listener (ApiListener::GetInstance());
+
+	if (listener) {
+		auto headerAllowOrigin (listener->GetAccessControlAllowOrigin());
+
+		if (headerAllowOrigin) {
+			auto allowedOrigins (headerAllowOrigin->ToSet<String>());
+			auto& origin (request[http::field::origin]);
+
+			if (allowedOrigins.find(std::string(origin)) != allowedOrigins.end()) {
+				return true;
+			}
+		}
+	}
+
+	Log(LogWarning, "HttpServerConnection")
+		<< "Rejecting likely forged cross-site request: " << request.method_string() << ' ' << request.target();
+
+	if (request[http::field::accept] == "application/json") {
+		HttpUtility::SendJsonError(response, nullptr, 403, "Forbidden: Cross-site request rejected. "
+			"Set the Origin to an address listed in 'access_control_allow_origin' if this request is legitimate.");
+	} else {
+		response.result(http::status::forbidden);
+		response.set(http::field::content_type, "text/html");
+		response.body() << "<h1>Forbidden: Cross-site request rejected.</h1>";
+	}
+
+	response.set(http::field::connection, "close");
+
+	response.Flush(yc);
+
+	return false;
+}
+
 static inline
 bool EnsureAcceptHeader(
 	const HttpApiRequest& request,
@@ -521,6 +586,10 @@ void HttpServerConnection::ProcessMessages(boost::asio::yield_context yc)
 			});
 
 			if (!HandleAccessControl(request, response, yc)) {
+				break;
+			}
+
+			if (!EnsureNotForgedCrossSiteRequest(request, response, yc)) {
 				break;
 			}
 

--- a/test/remote-httpserverconnection.cpp
+++ b/test/remote-httpserverconnection.cpp
@@ -196,6 +196,113 @@ BOOST_AUTO_TEST_CASE(error_access_control)
 	BOOST_REQUIRE(Shutdown(client));
 }
 
+BOOST_AUTO_TEST_CASE(error_cross_site_state_change)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::post);
+	request.target("/v1/test");
+	request.set(http::field::host, "localhost:5665");
+	request.set(http::field::accept, "application/json");
+	request.set("Sec-Fetch-Site", "cross-site");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	BOOST_REQUIRE_NO_THROW(http::read(*client, buf, response));
+
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::forbidden);
+	Dictionary::Ptr body = JsonDecode(response.body());
+	BOOST_REQUIRE(body);
+	BOOST_REQUIRE_EQUAL(body->Get("error"), 403);
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(cross_site_state_change_allowed_for_configured_origin)
+{
+	CreateTestUsers();
+	CreateApiListener("example.org");
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::post);
+	request.target("/v1/test");
+	request.set(http::field::origin, "example.org");
+	request.set(http::field::host, "localhost:5665");
+	request.set(http::field::accept, "application/json");
+	request.set("Sec-Fetch-Site", "cross-site");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	BOOST_REQUIRE_NO_THROW(http::read(*client, buf, response));
+
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(cross_site_get_not_rejected)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::get);
+	request.target("/v1/test");
+	request.set(http::field::host, "localhost:5665");
+	request.set(http::field::accept, "application/json");
+	request.set("Sec-Fetch-Site", "cross-site");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	BOOST_REQUIRE_NO_THROW(http::read(*client, buf, response));
+
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
+BOOST_AUTO_TEST_CASE(cross_site_header_absent_state_change_allowed)
+{
+	CreateTestUsers();
+	SetupHttpServerConnection(true);
+
+	http::request<boost::beast::http::string_body> request;
+	request.method(http::verb::post);
+	request.target("/v1/test");
+	request.set(http::field::host, "localhost:5665");
+	request.set(http::field::accept, "application/json");
+	request.set(http::field::connection, "close");
+	request.content_length(0);
+	http::write(*client, request);
+	client->flush();
+
+	flat_buffer buf;
+	http::response<http::string_body> response;
+	BOOST_REQUIRE_NO_THROW(http::read(*client, buf, response));
+
+	BOOST_REQUIRE_EQUAL(response.result(), http::status::ok);
+	BOOST_REQUIRE_EQUAL(response.body(), "test");
+
+	BOOST_REQUIRE(Shutdown(client));
+}
+
 BOOST_AUTO_TEST_CASE(error_accept_header)
 {
 	CreateTestUsers();


### PR DESCRIPTION
## Context

Opening this as a **draft**, deliberately narrow-scoped, to invite feedback on the approach given #10431 wasn't fully resolved in discussion - @julianbrost questioned whether CSRF applies here at all since Icinga 2 has no cookie-based sessions, while @Al2Klimov argued the API is explicitly used from browsers (Chrome support, Icinga Web on the same host) and raised a separate DoS-via-expensive-GET-filter concern.

I think there's a concrete, uncontested angle here worth fixing regardless of how that debate settles: **HTTP Basic Auth credentials are cached by the browser per-origin and re-attached automatically**, including to "simple" cross-origin `POST` requests that JavaScript can send without triggering a CORS preflight (by using a CORS-safelisted `Content-Type` and setting `Accept: application/json`, which is enough to satisfy the existing `EnsureAcceptHeader` check). Such a request can reach action/config-modifying endpoints using a logged-in admin's cached credentials, triggered by simply visiting an unrelated malicious page - without the admin's consent or knowledge.

## What this PR does

- Rejects `POST`/`PUT`/`DELETE` API requests carrying `Sec-Fetch-Site: cross-site` (a header browsers set and scripts cannot spoof or override), unless the request's `Origin` is explicitly allow-listed via the existing `access_control_allow_origin` attribute.
- Leaves `GET` alone - forging a read doesn't change state, and this deliberately avoids the disputed DoS-via-filter part of the issue.
- Non-browser clients (cluster nodes, `icinga2` CLI, Icinga Web's PHP backend, curl, ...) never send `Sec-Fetch-*` headers and are completely unaffected.
- Adds tests in `test/remote-httpserverconnection.cpp` covering: rejection with no allow-listed origin, pass-through when the origin is allow-listed, GET being unaffected, and requests without the header (non-browser clients) being unaffected.
- Documents the new behavior next to `access_control_allow_origin` in `doc/09-object-types.md`.

## Open questions for maintainers

- Is scoping this to `POST`/`PUT`/`DELETE` only (leaving GET/DoS-via-filter out) the right cut, or should this be folded into a broader design that also addresses the GET concern?
- Is reusing `access_control_allow_origin` as the trust boundary the right call, or should this have its own opt-in/opt-out toggle given the disagreement about whether it's needed at all?

I have not been able to build/run the full test suite locally in my environment (no local Boost/CMake toolchain set up) - relying on CI and review to catch anything my manual reasoning missed.

refs #10431