### PR TITLE
EventsHandler: enforce per-user permission checks in event filters

### DIFF
--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -19,8 +19,8 @@ std::map<String, EventsInbox::Filter> EventsInbox::m_Filters ({{"", EventsInbox:
 
 EventsRouter EventsRouter::m_Instance;
 
-EventsInbox::EventsInbox(String filter, const String& filterSource)
-	: m_Timer(IoEngine::Get().GetIoContext())
+EventsInbox::EventsInbox(String filter, const String& filterSource, ApiUser::Ptr user)
+	: m_User(std::move(user)), m_Timer(IoEngine::Get().GetIoContext())
 {
 	std::unique_lock<std::mutex> lock (m_FiltersMutex);
 	m_Filter = m_Filters.find(filter);
@@ -56,6 +56,11 @@ EventsInbox::~EventsInbox()
 const Expression::Ptr& EventsInbox::GetFilter()
 {
 	return m_Filter->second.Expr;
+}
+
+const ApiUser::Ptr& EventsInbox::GetUser() const noexcept
+{
+	return m_User;
 }
 
 void EventsInbox::Push(Dictionary::Ptr event)
@@ -103,8 +108,8 @@ Dictionary::Ptr EventsInbox::Shift(boost::asio::yield_context yc, std::chrono::m
 	return event;
 }
 
-EventsSubscriber::EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource)
-	: m_Types(std::move(types)), m_Inbox(new EventsInbox(std::move(filter), filterSource))
+EventsSubscriber::EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource, ApiUser::Ptr user)
+	: m_Types(std::move(types)), m_Inbox(new EventsInbox(std::move(filter), filterSource, std::move(user)))
 {
 	EventsRouter::GetInstance().Subscribe(m_Types, m_Inbox);
 }
@@ -133,22 +138,32 @@ void EventsFilter::Push(Dictionary::Ptr event)
 {
 	for (auto& perFilter : m_Inboxes) {
 		if (perFilter.first) {
-			ScriptFrame frame(true, new Namespace());
-			frame.Sandboxed = true;
+			/* Each subscriber may hold different permissions, so the filter has to be evaluated
+			 * separately per inbox using a checker bound to that inbox's own user, even though
+			 * several inboxes here share the same compiled filter expression. A fresh checker is
+			 * created per evaluation since inboxes are shared across concurrently dispatching
+			 * threads and the checker's internal permission cache is not thread-safe.
+			 */
+			for (auto& inbox : perFilter.second) {
+				ScriptFrame frame(true, new Namespace());
 
-			try {
-				if (!FilterUtility::EvaluateFilter(frame, perFilter.first.get(), event, "event")) {
-					continue;
+				frame.Sandboxed = true;
+				frame.PermChecker = new FilterExprPermissionChecker(inbox->GetUser());
+
+				try {
+					if (FilterUtility::EvaluateFilter(frame, perFilter.first.get(), event, "event")) {
+						inbox->Push(event);
+					}
+				} catch (const std::exception& ex) {
+					Log(LogWarning, "EventQueue")
+						<< "Error occurred while evaluating event filter for queue of user '"
+						<< inbox->GetUser()->GetName() << "': " << DiagnosticInformation(ex);
 				}
-			} catch (const std::exception& ex) {
-				Log(LogWarning, "EventQueue")
-					<< "Error occurred while evaluating event filter for queue: " << DiagnosticInformation(ex);
-				continue;
 			}
-		}
-
-		for (auto& inbox : perFilter.second) {
-			inbox->Push(event);
+		} else {
+			for (auto& inbox : perFilter.second) {
+				inbox->Push(event);
+			}
 		}
 	}
 }

--- a/lib/remote/eventqueue.hpp
+++ b/lib/remote/eventqueue.hpp
@@ -43,7 +43,7 @@ class EventsInbox : public Object
 public:
 	DECLARE_PTR_TYPEDEFS(EventsInbox);
 
-	EventsInbox(String filter, const String& filterSource);
+	EventsInbox(String filter, const String& filterSource, ApiUser::Ptr user);
 	EventsInbox(const EventsInbox&) = delete;
 	EventsInbox(EventsInbox&&) = delete;
 	EventsInbox& operator=(const EventsInbox&) = delete;
@@ -51,6 +51,7 @@ public:
 	~EventsInbox();
 
 	const Expression::Ptr& GetFilter();
+	const ApiUser::Ptr& GetUser() const noexcept;
 
 	void Push(Dictionary::Ptr event);
 	Dictionary::Ptr Shift(boost::asio::yield_context yc, std::chrono::milliseconds timeout = 5s);
@@ -67,6 +68,7 @@ private:
 
 	std::mutex m_Mutex;
 	decltype(m_Filters.begin()) m_Filter;
+	ApiUser::Ptr m_User;
 	std::queue<Dictionary::Ptr> m_Queue;
 	boost::asio::steady_timer m_Timer;
 };
@@ -74,7 +76,7 @@ private:
 class EventsSubscriber
 {
 public:
-	EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource);
+	EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource, ApiUser::Ptr user);
 	EventsSubscriber(const EventsSubscriber&) = delete;
 	EventsSubscriber(EventsSubscriber&&) = delete;
 	EventsSubscriber& operator=(const EventsSubscriber&) = delete;

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -103,7 +103,7 @@ bool EventsHandler::HandleRequest(
 		filter = HttpUtility::GetLastParameter(params, "filter");
 	}
 
-	EventsSubscriber subscriber (std::move(eventTypes), std::move(filter), l_ApiQuery);
+	EventsSubscriber subscriber (std::move(eventTypes), std::move(filter), l_ApiQuery, user);
 
 	response.result(http::status::ok);
 	response.set(http::field::content_type, "application/json");

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -26,110 +26,95 @@ Dictionary::Ptr FilterUtility::GetTargetForVar(const String& name, const Value& 
 	});
 }
 
-/**
- * Controls access to an object or variable based on an ApiUser's permissions.
- *
- * This is accomplished by caching the generated filter expressions so they don't have to be
- * regenerated again and again when access is repeatedly checked in script functions and when
- * evaluating expressions.
- */
-class FilterExprPermissionChecker : public ScriptPermissionChecker
+FilterExprPermissionChecker::FilterExprPermissionChecker(ApiUser::Ptr user) : m_User(std::move(user))
 {
-public:
-	DECLARE_PTR_TYPEDEFS(FilterExprPermissionChecker);
+}
 
-	explicit FilterExprPermissionChecker(ApiUser::Ptr user) : m_User(std::move(user)) {}
+/**
+ * Check if the user has the given permission and cache the result if they do.
+ *
+ * This is a wrapper around FilterUtility::CheckPermission() that caches the generated
+ * filter expression for later use when checking permissions inside sandboxed ScriptFrames.
+ *
+ * Like FilterUtility::CheckPermission() an exception is thrown if the user does not have
+ * the requested permission.
+ *
+ * If the user has permission and there is a filter for the given permission, the filter
+ * expression  is generated, cached and then a pointer to it is returned, otherwise a
+ * nullptr will be returned.
+ *
+ * Since the optionally returned pointer is a raw-pointer and this class retains ownership
+ * over the expression it is only valid for the lifetime of the @c FilterExprPermissionChecker
+ * object that returned it.
+ *
+ * @param permissionString The permission string to check against the ApiUser member of this class.
+ *
+ * @return a pointer to the generated permission expression if the permission has a filter, or nullptr if not.
+ */
+Expression* FilterExprPermissionChecker::CheckPermission(const String& permissionString)
+{
+	auto [it, inserted] = m_PermCache.try_emplace(permissionString);
+	auto& [hasPermission, permissionExpr] = it->second;
 
-	/**
-	 * Check if the user has the given permission and cache the result if they do.
-	 *
-	 * This is a wrapper around FilterUtility::CheckPermission() that caches the generated
-	 * filter expression for later use when checking permissions inside sandboxed ScriptFrames.
-	 *
-	 * Like FilterUtility::CheckPermission() an exception is thrown if the user does not have
-	 * the requested permission.
-	 *
-	 * If the user has permission and there is a filter for the given permission, the filter
-	 * expression  is generated, cached and then a pointer to it is returned, otherwise a
-	 * nullptr will be returned.
-	 *
-	 * Since the optionally returned pointer is a raw-pointer and this class retains ownership
-	 * over the expression it is only valid for the lifetime of the @c FilterExprPermissionChecker
-	 * object that returned it.
-	 *
-	 * @param permissionString The permission string to check against the ApiUser member of this class.
-	 *
-	 * @return a pointer to the generated permission expression if the permission has a filter, or nullptr if not.
-	 */
-	Expression* CheckPermission(const String& permissionString)
-	{
-		auto [it, inserted] = m_PermCache.try_emplace(permissionString);
-		auto& [hasPermission, permissionExpr] = it->second;
-
-		if (inserted) {
-			FilterUtility::CheckPermission(m_User, permissionString, &permissionExpr);
-		} else if (!hasPermission) {
-			BOOST_THROW_EXCEPTION(ScriptError("Missing permission: " + permissionString.ToLower()));
-		}
-
-		hasPermission = true;
-		return permissionExpr.get();
+	if (inserted) {
+		FilterUtility::CheckPermission(m_User, permissionString, &permissionExpr);
+	} else if (!hasPermission) {
+		BOOST_THROW_EXCEPTION(ScriptError("Missing permission: " + permissionString.ToLower()));
 	}
 
-	/**
-	 * Checks if this object's ApiUser has permissions to access variable `varName`.
-	 *
-	 * @param varName The name of the variable to check for access
-	 *
-	 * @return 'true' if the variable can be accessed, 'false' if it can't.
-	 */
-	bool CanAccessGlobalVariable(const String& varName) override
-	{
-		auto obj = FilterUtility::GetTargetForVar(varName, ScriptGlobal::Get(varName));
-		return CheckPermissionAndEvalFilter("variables", obj, "variable");
+	hasPermission = true;
+	return permissionExpr.get();
+}
+
+/**
+ * Checks if this object's ApiUser has permissions to access variable `varName`.
+ *
+ * @param varName The name of the variable to check for access
+ *
+ * @return 'true' if the variable can be accessed, 'false' if it can't.
+ */
+bool FilterExprPermissionChecker::CanAccessGlobalVariable(const String& varName)
+{
+	auto obj = FilterUtility::GetTargetForVar(varName, ScriptGlobal::Get(varName));
+	return CheckPermissionAndEvalFilter("variables", obj, "variable");
+}
+
+/**
+ * Checks if this object's ApiUser has permissions to access ConfigObject `obj`.
+ *
+ * @param obj A pointer to the ConfigObject to check for access
+ *
+ * @return 'true' if the object can be accessed, 'false' if it can't.
+ */
+bool FilterExprPermissionChecker::CanAccessConfigObject(const ConfigObject::Ptr& obj)
+{
+	ASSERT(obj);
+
+	String perm = "objects/query/" + obj->GetReflectionType()->GetName();
+	String varName = obj->GetReflectionType()->GetName().ToLower();
+
+	return CheckPermissionAndEvalFilter(perm, obj, varName);
+}
+
+bool FilterExprPermissionChecker::CheckPermissionAndEvalFilter(const String& permissionString, const Object::Ptr& obj, const String& varName)
+{
+	auto [it, inserted] = m_PermCache.try_emplace(permissionString);
+	auto& [hasPermission, permissionExpr] = it->second;
+
+	if (inserted) {
+		hasPermission = FilterUtility::HasPermission(m_User, permissionString, &permissionExpr);
 	}
 
-	/**
-	 * Checks if this object's ApiUser has permissions to access ConfigObject `obj`.
-	 *
-	 * @param obj A pointer to the ConfigObject to check for access
-	 *
-	 * @return 'true' if the object can be accessed, 'false' if it can't.
-	 */
-	bool CanAccessConfigObject(const ConfigObject::Ptr& obj) override
-	{
-		ASSERT(obj);
-
-		String perm = "objects/query/" + obj->GetReflectionType()->GetName();
-		String varName = obj->GetReflectionType()->GetName().ToLower();
-
-		return CheckPermissionAndEvalFilter(perm, obj, varName);
+	if (hasPermission && permissionExpr) {
+		ScriptFrame permissionFrame(false, new Namespace());
+		// Sandboxing is lifted because this only evaluates the function from the
+		// ApiUser->permissions->filter
+		permissionFrame.Sandboxed = false;
+		return FilterUtility::EvaluateFilter(permissionFrame, permissionExpr.get(), obj, varName);
 	}
 
-private:
-	bool CheckPermissionAndEvalFilter(const String& permissionString, const Object::Ptr& obj, const String& varName)
-	{
-		auto [it, inserted] = m_PermCache.try_emplace(permissionString);
-		auto& [hasPermission, permissionExpr] = it->second;
-
-		if (inserted) {
-			hasPermission = FilterUtility::HasPermission(m_User, permissionString, &permissionExpr);
-		}
-
-		if (hasPermission && permissionExpr) {
-			ScriptFrame permissionFrame(false, new Namespace());
-			// Sandboxing is lifted because this only evaluates the function from the
-			// ApiUser->permissions->filter
-			permissionFrame.Sandboxed = false;
-			return FilterUtility::EvaluateFilter(permissionFrame, permissionExpr.get(), obj, varName);
-		}
-
-		return hasPermission;
-	}
-
-	std::unordered_map<String, std::pair<bool, std::unique_ptr<Expression>>> m_PermCache;
-	ApiUser::Ptr m_User;
-};
+	return hasPermission;
+}
 
 Type::Ptr FilterUtility::TypeFromPluralName(const String& pluralName)
 {

--- a/lib/remote/filterutility.hpp
+++ b/lib/remote/filterutility.hpp
@@ -75,6 +75,31 @@ class MissingPermissionError : public ScriptError
 	using ScriptError::ScriptError;
 };
 
+/**
+ * Controls access to an object or variable based on an ApiUser's permissions.
+ *
+ * This is accomplished by caching the generated filter expressions so they don't have to be
+ * regenerated again and again when access is repeatedly checked in script functions and when
+ * evaluating expressions.
+ */
+class FilterExprPermissionChecker : public ScriptPermissionChecker
+{
+public:
+	DECLARE_PTR_TYPEDEFS(FilterExprPermissionChecker);
+
+	explicit FilterExprPermissionChecker(ApiUser::Ptr user);
+
+	Expression* CheckPermission(const String& permissionString);
+	bool CanAccessGlobalVariable(const String& varName) override;
+	bool CanAccessConfigObject(const ConfigObject::Ptr& obj) override;
+
+private:
+	bool CheckPermissionAndEvalFilter(const String& permissionString, const Object::Ptr& obj, const String& varName);
+
+	std::unordered_map<String, std::pair<bool, std::unique_ptr<Expression>>> m_PermCache;
+	ApiUser::Ptr m_User;
+};
+
 }
 
 #endif /* FILTERUTILITY_H */


### PR DESCRIPTION
   `EventsFilter::Push()` evaluated user-supplied `/v1/events` filter
   expressions in a sandboxed `ScriptFrame` without ever assigning a
   `PermChecker`. With none set, `ScriptFrame` fell back to the
   constructor default `ScriptPermissionChecker`, which grants
   unconditional access to all config objects and global variables.

   An API user holding only `events/<Type>` permission could therefore
   call `System.get_object()` or `globals.<Type>.objects.get()` from
   within a filter expression and use event delivery as a binary oracle
   to read config object fields (custom vars, command `env`, etc.)
   without holding `objects/query/<Type>`.

fixes https://github.com/Icinga/icinga2/security/advisories/GHSA-v265-w3gm-99vg