### PR TITLE
JsonRpcConnection: cap message size for child endpoints

### DIFF
--- a/lib/remote/endpoint.cpp
+++ b/lib/remote/endpoint.cpp
@@ -182,3 +182,14 @@ double Endpoint::GetSecondsProcessingMessages() const
 {
 	return m_InputProcessingTime;
 }
+
+ssize_t Endpoint::GetMessageReceiveSizeLimit() const
+{
+	// Parent and sibling nodes are trusted
+	// to send messages of unbounded size, e.g. config syncs
+	if (Zone::GetLocalZone()->IsChildOf(m_Zone)) {
+		return -1;
+	}
+
+	return 16L * 1024 * 1024;
+}

--- a/lib/remote/endpoint.hpp
+++ b/lib/remote/endpoint.hpp
@@ -62,6 +62,8 @@ public:
 
 	double GetSecondsProcessingMessages() const override;
 
+	ssize_t GetMessageReceiveSizeLimit() const;
+
 protected:
 	void OnAllConfigLoaded() override;
 

--- a/lib/remote/jsonrpc.hpp
+++ b/lib/remote/jsonrpc.hpp
@@ -26,8 +26,8 @@ public:
 	static size_t SendMessage(const Shared<AsioTlsStream>::Ptr& stream, const Dictionary::Ptr& message, boost::asio::yield_context yc);
 	static size_t SendRawMessage(const Shared<AsioTlsStream>::Ptr& stream, const String& json, boost::asio::yield_context yc);
 
-	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, ssize_t maxMessageLength = -1);
-	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, boost::asio::yield_context yc, ssize_t maxMessageLength = -1);
+	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, ssize_t maxMessageLength);
+	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, boost::asio::yield_context yc, ssize_t maxMessageLength);
 
 	static Dictionary::Ptr DecodeMessage(const String& message);
 

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -73,7 +73,10 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 		String jsonString;
 
 		try {
-			jsonString = JsonRpc::ReadMessage(m_Stream, yc, m_Endpoint ? -1 : 1024 * 1024);
+			// Unauthenticated connections are limited to 1MB messages
+			jsonString = JsonRpc::ReadMessage(
+				m_Stream, yc, m_Endpoint ? m_Endpoint->GetMessageReceiveSizeLimit() : 1024L * 1024
+			);
 		} catch (const std::exception& ex) {
 			Log(m_ShuttingDown ? LogDebug : LogNotice, "JsonRpcConnection")
 				<< "Error while reading JSON-RPC message for identity '" << m_Identity

--- a/lib/remote/pkiutility.cpp
+++ b/lib/remote/pkiutility.cpp
@@ -215,7 +215,8 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 		stream->flush();
 
 		for (;;) {
-			response = JsonRpc::DecodeMessage(JsonRpc::ReadMessage(stream));
+			// Parent nodes are trusted to send messages of unbounded size
+			response = JsonRpc::DecodeMessage(JsonRpc::ReadMessage(stream, -1));
 
 			if (response && response->Contains("error")) {
 				Log(LogCritical, "cli", "Could not fetch valid response. Please check the master log (notice or debug).");


### PR DESCRIPTION
Only parent/sibling zones are trusted to send (e.g. config sync)
unbounded JSON-RPC messages. Other authenticated endpoints
previously had no size limit at all, allowing a malicious or
compromised child/unrelated endpoint to exhaust memory with an
oversized message; they are now capped at 16 MB like
unauthenticated connections are already capped at 1 MB.

fixes https://github.com/Icinga/icinga2/security/advisories/GHSA-wm63-p2jg-5665