### PR TITLE
Security Release v2.16.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga2/milestones?state=closed).
 
+## 2.16.5 (2026-08-18)
+
+This release contains a bugfix for a regression in the `IcingaDB` feature that was introduced in v2.16.0 and some
+security enhancements that fix a couple of minor vulnerabilities.
+
+One vulnerability allowed an authenticated `ApiUser` with the `events/*` permission to obtain information about
+objects through crafted filter expressions, without holding the relevant `objects/query/*` permission. The fix is to
+correctly apply permissions to filter expressions on `/v1/events`.
+
+The other vulnerability allowed an authenticated Icinga 2 node to use the ~1 GB message limit to possibly crash another
+node through memory exhaustion. Depending on available memory, multiple compromised nodes may be required for
+a successful attack since a node can only make one connection. The fix applies a 16 MiB limit to messages from nodes
+lower in the hierarchy.
+
+### Security Enhancements
+
+* Apply user permissions to filter expressions for `/v1/events` similarly to `/v1/objects`
+([GHSA-v265-w3gm-99vg](https://github.com/Icinga/icinga2/security/advisories/GHSA-v265-w3gm-99vg))
+* Introduce an additional 16 MiB message size limit on all child-zone connections
+([GHSA-wm63-p2jg-5665](https://github.com/Icinga/icinga2/security/advisories/GHSA-wm63-p2jg-5665))
+* Don't include sensitive certificate request tickets in log messages (#10960)
+* Don't log full object config containing potentially sensitive information (#10988)
+
+### Bugfixes
+
+* IcingaDB: Fix multiple potential race conditions during initial config dump (#10981)
+
 ## 2.16.4 (2026-07-16)
 
 This release contains a number of fixes for various smaller but annoying bugs, including one regression regarding API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ lower in the hierarchy.
 ### Security Enhancements
 
 * Apply user permissions to filter expressions for `/v1/events` similarly to `/v1/objects`
-([GHSA-v265-w3gm-99vg](https://github.com/Icinga/icinga2/security/advisories/GHSA-v265-w3gm-99vg))
+  ([GHSA-v265-w3gm-99vg](https://github.com/Icinga/icinga2/security/advisories/GHSA-v265-w3gm-99vg))
 * Introduce an additional 16 MiB message size limit on all child-zone connections
-([GHSA-wm63-p2jg-5665](https://github.com/Icinga/icinga2/security/advisories/GHSA-wm63-p2jg-5665))
+  ([GHSA-wm63-p2jg-5665](https://github.com/Icinga/icinga2/security/advisories/GHSA-wm63-p2jg-5665))
 * Don't include sensitive certificate request tickets in log messages (#10960)
 * Don't log full object config containing potentially sensitive information (#10988)
 

--- a/ICINGA2_VERSION
+++ b/ICINGA2_VERSION
@@ -1,2 +1,2 @@
-Version: 2.16.4
+Version: 2.16.5
 Revision: 1

--- a/lib/remote/endpoint.cpp
+++ b/lib/remote/endpoint.cpp
@@ -182,3 +182,14 @@ double Endpoint::GetSecondsProcessingMessages() const
 {
 	return m_InputProcessingTime;
 }
+
+ssize_t Endpoint::GetMessageReceiveSizeLimit() const
+{
+	// Parent and sibling nodes are trusted
+	// to send messages of unbounded size, e.g. config syncs
+	if (Zone::GetLocalZone()->IsChildOf(m_Zone)) {
+		return -1;
+	}
+
+	return 16L * 1024 * 1024;
+}

--- a/lib/remote/endpoint.hpp
+++ b/lib/remote/endpoint.hpp
@@ -62,6 +62,8 @@ public:
 
 	double GetSecondsProcessingMessages() const override;
 
+	ssize_t GetMessageReceiveSizeLimit() const;
+
 protected:
 	void OnAllConfigLoaded() override;
 

--- a/lib/remote/eventqueue.cpp
+++ b/lib/remote/eventqueue.cpp
@@ -130,8 +130,8 @@ std::map<String, EventsInbox::Filter> EventsInbox::m_Filters ({{"", EventsInbox:
 
 EventsRouter EventsRouter::m_Instance;
 
-EventsInbox::EventsInbox(String filter, const String& filterSource)
-	: m_Timer(IoEngine::Get().GetIoContext())
+EventsInbox::EventsInbox(String filter, const String& filterSource, ApiUser::Ptr user)
+	: m_User(std::move(user)), m_Timer(IoEngine::Get().GetIoContext())
 {
 	std::unique_lock<std::mutex> lock (m_FiltersMutex);
 	m_Filter = m_Filters.find(filter);
@@ -167,6 +167,11 @@ EventsInbox::~EventsInbox()
 const Expression::Ptr& EventsInbox::GetFilter()
 {
 	return m_Filter->second.Expr;
+}
+
+const ApiUser::Ptr& EventsInbox::GetUser() const noexcept
+{
+	return m_User;
 }
 
 void EventsInbox::Push(Dictionary::Ptr event)
@@ -214,8 +219,8 @@ Dictionary::Ptr EventsInbox::Shift(boost::asio::yield_context yc, double timeout
 	return event;
 }
 
-EventsSubscriber::EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource)
-	: m_Types(std::move(types)), m_Inbox(new EventsInbox(std::move(filter), filterSource))
+EventsSubscriber::EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource, ApiUser::Ptr user)
+	: m_Types(std::move(types)), m_Inbox(new EventsInbox(std::move(filter), filterSource, std::move(user)))
 {
 	EventsRouter::GetInstance().Subscribe(m_Types, m_Inbox);
 }
@@ -244,22 +249,32 @@ void EventsFilter::Push(Dictionary::Ptr event)
 {
 	for (auto& perFilter : m_Inboxes) {
 		if (perFilter.first) {
-			ScriptFrame frame(true, new Namespace());
-			frame.Sandboxed = true;
+			/* Each subscriber may hold different permissions, so the filter has to be evaluated
+			 * separately per inbox using a checker bound to that inbox's own user, even though
+			 * several inboxes here share the same compiled filter expression. A fresh checker is
+			 * created per evaluation since inboxes are shared across concurrently dispatching
+			 * threads and the checker's internal permission cache is not thread-safe.
+			 */
+			for (auto& inbox : perFilter.second) {
+				ScriptFrame frame(true, new Namespace());
 
-			try {
-				if (!FilterUtility::EvaluateFilter(frame, perFilter.first.get(), event, "event")) {
-					continue;
+				frame.Sandboxed = true;
+				frame.PermChecker = new FilterExprPermissionChecker(inbox->GetUser());
+
+				try {
+					if (FilterUtility::EvaluateFilter(frame, perFilter.first.get(), event, "event")) {
+						inbox->Push(event);
+					}
+				} catch (const std::exception& ex) {
+					Log(LogWarning, "EventQueue")
+						<< "Error occurred while evaluating event filter for queue of user '"
+						<< inbox->GetUser()->GetName() << "': " << DiagnosticInformation(ex);
 				}
-			} catch (const std::exception& ex) {
-				Log(LogWarning, "EventQueue")
-					<< "Error occurred while evaluating event filter for queue: " << DiagnosticInformation(ex);
-				continue;
 			}
-		}
-
-		for (auto& inbox : perFilter.second) {
-			inbox->Push(event);
+		} else {
+			for (auto& inbox : perFilter.second) {
+				inbox->Push(event);
+			}
 		}
 	}
 }

--- a/lib/remote/eventqueue.hpp
+++ b/lib/remote/eventqueue.hpp
@@ -86,7 +86,7 @@ class EventsInbox : public Object
 public:
 	DECLARE_PTR_TYPEDEFS(EventsInbox);
 
-	EventsInbox(String filter, const String& filterSource);
+	EventsInbox(String filter, const String& filterSource, ApiUser::Ptr user);
 	EventsInbox(const EventsInbox&) = delete;
 	EventsInbox(EventsInbox&&) = delete;
 	EventsInbox& operator=(const EventsInbox&) = delete;
@@ -94,6 +94,7 @@ public:
 	~EventsInbox();
 
 	const Expression::Ptr& GetFilter();
+	const ApiUser::Ptr& GetUser() const noexcept;
 
 	void Push(Dictionary::Ptr event);
 	Dictionary::Ptr Shift(boost::asio::yield_context yc, double timeout = 5);
@@ -110,6 +111,7 @@ private:
 
 	std::mutex m_Mutex;
 	decltype(m_Filters.begin()) m_Filter;
+	ApiUser::Ptr m_User;
 	std::queue<Dictionary::Ptr> m_Queue;
 	boost::asio::deadline_timer m_Timer;
 };
@@ -117,7 +119,7 @@ private:
 class EventsSubscriber
 {
 public:
-	EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource);
+	EventsSubscriber(std::set<EventType> types, String filter, const String& filterSource, ApiUser::Ptr user);
 	EventsSubscriber(const EventsSubscriber&) = delete;
 	EventsSubscriber(EventsSubscriber&&) = delete;
 	EventsSubscriber& operator=(const EventsSubscriber&) = delete;

--- a/lib/remote/eventshandler.cpp
+++ b/lib/remote/eventshandler.cpp
@@ -103,7 +103,7 @@ bool EventsHandler::HandleRequest(
 		filter = HttpUtility::GetLastParameter(params, "filter");
 	}
 
-	EventsSubscriber subscriber (std::move(eventTypes), std::move(filter), l_ApiQuery);
+	EventsSubscriber subscriber (std::move(eventTypes), std::move(filter), l_ApiQuery, user);
 
 	response.result(http::status::ok);
 	response.set(http::field::content_type, "application/json");

--- a/lib/remote/filterutility.cpp
+++ b/lib/remote/filterutility.cpp
@@ -26,110 +26,95 @@ Dictionary::Ptr FilterUtility::GetTargetForVar(const String& name, const Value& 
 	});
 }
 
-/**
- * Controls access to an object or variable based on an ApiUser's permissions.
- *
- * This is accomplished by caching the generated filter expressions so they don't have to be
- * regenerated again and again when access is repeatedly checked in script functions and when
- * evaluating expressions.
- */
-class FilterExprPermissionChecker : public ScriptPermissionChecker
+FilterExprPermissionChecker::FilterExprPermissionChecker(ApiUser::Ptr user) : m_User(std::move(user))
 {
-public:
-	DECLARE_PTR_TYPEDEFS(FilterExprPermissionChecker);
+}
 
-	explicit FilterExprPermissionChecker(ApiUser::Ptr user) : m_User(std::move(user)) {}
+/**
+ * Check if the user has the given permission and cache the result if they do.
+ *
+ * This is a wrapper around FilterUtility::CheckPermission() that caches the generated
+ * filter expression for later use when checking permissions inside sandboxed ScriptFrames.
+ *
+ * Like FilterUtility::CheckPermission() an exception is thrown if the user does not have
+ * the requested permission.
+ *
+ * If the user has permission and there is a filter for the given permission, the filter
+ * expression  is generated, cached and then a pointer to it is returned, otherwise a
+ * nullptr will be returned.
+ *
+ * Since the optionally returned pointer is a raw-pointer and this class retains ownership
+ * over the expression it is only valid for the lifetime of the @c FilterExprPermissionChecker
+ * object that returned it.
+ *
+ * @param permissionString The permission string to check against the ApiUser member of this class.
+ *
+ * @return a pointer to the generated permission expression if the permission has a filter, or nullptr if not.
+ */
+Expression* FilterExprPermissionChecker::CheckPermission(const String& permissionString)
+{
+	auto [it, inserted] = m_PermCache.try_emplace(permissionString);
+	auto& [hasPermission, permissionExpr] = it->second;
 
-	/**
-	 * Check if the user has the given permission and cache the result if they do.
-	 *
-	 * This is a wrapper around FilterUtility::CheckPermission() that caches the generated
-	 * filter expression for later use when checking permissions inside sandboxed ScriptFrames.
-	 *
-	 * Like FilterUtility::CheckPermission() an exception is thrown if the user does not have
-	 * the requested permission.
-	 *
-	 * If the user has permission and there is a filter for the given permission, the filter
-	 * expression  is generated, cached and then a pointer to it is returned, otherwise a
-	 * nullptr will be returned.
-	 *
-	 * Since the optionally returned pointer is a raw-pointer and this class retains ownership
-	 * over the expression it is only valid for the lifetime of the @c FilterExprPermissionChecker
-	 * object that returned it.
-	 *
-	 * @param permissionString The permission string to check against the ApiUser member of this class.
-	 *
-	 * @return a pointer to the generated permission expression if the permission has a filter, or nullptr if not.
-	 */
-	Expression* CheckPermission(const String& permissionString)
-	{
-		auto [it, inserted] = m_PermCache.try_emplace(permissionString);
-		auto& [hasPermission, permissionExpr] = it->second;
-
-		if (inserted) {
-			FilterUtility::CheckPermission(m_User, permissionString, &permissionExpr);
-		} else if (!hasPermission) {
-			BOOST_THROW_EXCEPTION(ScriptError("Missing permission: " + permissionString.ToLower()));
-		}
-
-		hasPermission = true;
-		return permissionExpr.get();
+	if (inserted) {
+		FilterUtility::CheckPermission(m_User, permissionString, &permissionExpr);
+	} else if (!hasPermission) {
+		BOOST_THROW_EXCEPTION(ScriptError("Missing permission: " + permissionString.ToLower()));
 	}
 
-	/**
-	 * Checks if this object's ApiUser has permissions to access variable `varName`.
-	 *
-	 * @param varName The name of the variable to check for access
-	 *
-	 * @return 'true' if the variable can be accessed, 'false' if it can't.
-	 */
-	bool CanAccessGlobalVariable(const String& varName) override
-	{
-		auto obj = FilterUtility::GetTargetForVar(varName, ScriptGlobal::Get(varName));
-		return CheckPermissionAndEvalFilter("variables", obj, "variable");
+	hasPermission = true;
+	return permissionExpr.get();
+}
+
+/**
+ * Checks if this object's ApiUser has permissions to access variable `varName`.
+ *
+ * @param varName The name of the variable to check for access
+ *
+ * @return 'true' if the variable can be accessed, 'false' if it can't.
+ */
+bool FilterExprPermissionChecker::CanAccessGlobalVariable(const String& varName)
+{
+	auto obj = FilterUtility::GetTargetForVar(varName, ScriptGlobal::Get(varName));
+	return CheckPermissionAndEvalFilter("variables", obj, "variable");
+}
+
+/**
+ * Checks if this object's ApiUser has permissions to access ConfigObject `obj`.
+ *
+ * @param obj A pointer to the ConfigObject to check for access
+ *
+ * @return 'true' if the object can be accessed, 'false' if it can't.
+ */
+bool FilterExprPermissionChecker::CanAccessConfigObject(const ConfigObject::Ptr& obj)
+{
+	ASSERT(obj);
+
+	String perm = "objects/query/" + obj->GetReflectionType()->GetName();
+	String varName = obj->GetReflectionType()->GetName().ToLower();
+
+	return CheckPermissionAndEvalFilter(perm, obj, varName);
+}
+
+bool FilterExprPermissionChecker::CheckPermissionAndEvalFilter(const String& permissionString, const Object::Ptr& obj, const String& varName)
+{
+	auto [it, inserted] = m_PermCache.try_emplace(permissionString);
+	auto& [hasPermission, permissionExpr] = it->second;
+
+	if (inserted) {
+		hasPermission = FilterUtility::HasPermission(m_User, permissionString, &permissionExpr);
 	}
 
-	/**
-	 * Checks if this object's ApiUser has permissions to access ConfigObject `obj`.
-	 *
-	 * @param obj A pointer to the ConfigObject to check for access
-	 *
-	 * @return 'true' if the object can be accessed, 'false' if it can't.
-	 */
-	bool CanAccessConfigObject(const ConfigObject::Ptr& obj) override
-	{
-		ASSERT(obj);
-
-		String perm = "objects/query/" + obj->GetReflectionType()->GetName();
-		String varName = obj->GetReflectionType()->GetName().ToLower();
-
-		return CheckPermissionAndEvalFilter(perm, obj, varName);
+	if (hasPermission && permissionExpr) {
+		ScriptFrame permissionFrame(false, new Namespace());
+		// Sandboxing is lifted because this only evaluates the function from the
+		// ApiUser->permissions->filter
+		permissionFrame.Sandboxed = false;
+		return FilterUtility::EvaluateFilter(permissionFrame, permissionExpr.get(), obj, varName);
 	}
 
-private:
-	bool CheckPermissionAndEvalFilter(const String& permissionString, const Object::Ptr& obj, const String& varName)
-	{
-		auto [it, inserted] = m_PermCache.try_emplace(permissionString);
-		auto& [hasPermission, permissionExpr] = it->second;
-
-		if (inserted) {
-			hasPermission = FilterUtility::HasPermission(m_User, permissionString, &permissionExpr);
-		}
-
-		if (hasPermission && permissionExpr) {
-			ScriptFrame permissionFrame(false, new Namespace());
-			// Sandboxing is lifted because this only evaluates the function from the
-			// ApiUser->permissions->filter
-			permissionFrame.Sandboxed = false;
-			return FilterUtility::EvaluateFilter(permissionFrame, permissionExpr.get(), obj, varName);
-		}
-
-		return hasPermission;
-	}
-
-	std::unordered_map<String, std::pair<bool, std::unique_ptr<Expression>>> m_PermCache;
-	ApiUser::Ptr m_User;
-};
+	return hasPermission;
+}
 
 Type::Ptr FilterUtility::TypeFromPluralName(const String& pluralName)
 {

--- a/lib/remote/filterutility.hpp
+++ b/lib/remote/filterutility.hpp
@@ -75,6 +75,31 @@ class MissingPermissionError : public ScriptError
 	using ScriptError::ScriptError;
 };
 
+/**
+ * Controls access to an object or variable based on an ApiUser's permissions.
+ *
+ * This is accomplished by caching the generated filter expressions so they don't have to be
+ * regenerated again and again when access is repeatedly checked in script functions and when
+ * evaluating expressions.
+ */
+class FilterExprPermissionChecker : public ScriptPermissionChecker
+{
+public:
+	DECLARE_PTR_TYPEDEFS(FilterExprPermissionChecker);
+
+	explicit FilterExprPermissionChecker(ApiUser::Ptr user);
+
+	Expression* CheckPermission(const String& permissionString);
+	bool CanAccessGlobalVariable(const String& varName) override;
+	bool CanAccessConfigObject(const ConfigObject::Ptr& obj) override;
+
+private:
+	bool CheckPermissionAndEvalFilter(const String& permissionString, const Object::Ptr& obj, const String& varName);
+
+	std::unordered_map<String, std::pair<bool, std::unique_ptr<Expression>>> m_PermCache;
+	ApiUser::Ptr m_User;
+};
+
 }
 
 #endif /* FILTERUTILITY_H */

--- a/lib/remote/jsonrpc.hpp
+++ b/lib/remote/jsonrpc.hpp
@@ -26,8 +26,8 @@ public:
 	static size_t SendMessage(const Shared<AsioTlsStream>::Ptr& stream, const Dictionary::Ptr& message, boost::asio::yield_context yc);
 	static size_t SendRawMessage(const Shared<AsioTlsStream>::Ptr& stream, const String& json, boost::asio::yield_context yc);
 
-	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, ssize_t maxMessageLength = -1);
-	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, boost::asio::yield_context yc, ssize_t maxMessageLength = -1);
+	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, ssize_t maxMessageLength);
+	static String ReadMessage(const Shared<AsioTlsStream>::Ptr& stream, boost::asio::yield_context yc, ssize_t maxMessageLength);
 
 	static Dictionary::Ptr DecodeMessage(const String& message);
 

--- a/lib/remote/jsonrpcconnection.cpp
+++ b/lib/remote/jsonrpcconnection.cpp
@@ -73,7 +73,10 @@ void JsonRpcConnection::HandleIncomingMessages(boost::asio::yield_context yc)
 		String jsonString;
 
 		try {
-			jsonString = JsonRpc::ReadMessage(m_Stream, yc, m_Endpoint ? -1 : 1024 * 1024);
+			// Unauthenticated connections are limited to 1MB messages
+			jsonString = JsonRpc::ReadMessage(
+				m_Stream, yc, m_Endpoint ? m_Endpoint->GetMessageReceiveSizeLimit() : 1024L * 1024
+			);
 		} catch (const std::exception& ex) {
 			Log(m_ShuttingDown ? LogDebug : LogNotice, "JsonRpcConnection")
 				<< "Error while reading JSON-RPC message for identity '" << m_Identity

--- a/lib/remote/pkiutility.cpp
+++ b/lib/remote/pkiutility.cpp
@@ -215,7 +215,8 @@ int PkiUtility::RequestCertificate(const String& host, const String& port, const
 		stream->flush();
 
 		for (;;) {
-			response = JsonRpc::DecodeMessage(JsonRpc::ReadMessage(stream));
+			// Parent nodes are trusted to send messages of unbounded size
+			response = JsonRpc::DecodeMessage(JsonRpc::ReadMessage(stream, -1));
 
 			if (response && response->Contains("error")) {
 				Log(LogCritical, "cli", "Could not fetch valid response. Please check the master log (notice or debug).");


### PR DESCRIPTION
This PR adds the changes included in the security release [v2.16.5](https://github.com/Icinga/icinga2/releases/tag/v2.16.5) to the public `support/2.16` branch. It includes:

- Backport of #10998, fix for https://github.com/Icinga/icinga2/security/advisories/GHSA-v265-w3gm-99vg
- Backport of #10999, fix for https://github.com/Icinga/icinga2/security/advisories/GHSA-wm63-p2jg-5665
- Changelog and version bump

The head of the PR branch is the tagged release commit.