### PR TITLE
More efficient and movable `Defer`

### DIFF
--- a/lib/base/defer.hpp
+++ b/lib/base/defer.hpp
@@ -1,62 +1,103 @@
 // SPDX-FileCopyrightText: 2012 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#ifndef DEFER
-#define DEFER
+#pragma once
 
-#include <functional>
+#include <optional>
+#include <type_traits>
 #include <utility>
 
 namespace icinga
 {
+
+template<typename T, typename Enable = void>
+struct is_deferrable : std::false_type {};
+
+template<typename T>
+struct is_deferrable<std::optional<T>, std::enable_if_t<std::is_invocable_r_v<void, T>>> : std::true_type {};
+
+template<typename T>
+struct is_deferrable<T, std::enable_if_t<std::is_invocable_r_v<void, T>>> : std::true_type {};
 
 /**
  * An action to be executed at end of scope.
  *
  * @ingroup base
  */
-class Defer
-{
+template<typename DeferredFn, typename = std::enable_if_t<is_deferrable<DeferredFn>::value, int>>
+class Defer {
 public:
-	inline
-	Defer(std::function<void()> func) : m_Func(std::move(func))
+	/**
+	 * Construct from either a lambda, a `void(*)()` function pointer or a `std::function<void()>`.
+	 *
+	 * The type the function gets stored as depends on whether it is explicitly specified or deduced by the CTAD guide
+	 * for this constructor.
+	 */
+	template<typename Fn, std::enable_if_t<std::is_constructible_v<DeferredFn, Fn> && std::is_invocable_r_v<void, Fn>, int> = 0>
+	explicit Defer(Fn&& func) : m_Func(std::forward<Fn>(func))
 	{
 	}
 
 	Defer() = default;
 
+	/**
+	 * Move constructor.
+	 *
+	 * The exception guarantee is due to move construction of all three supported types also giving the same guarantee.
+	 * For lambdas specifically this is guaranteed by the move constructor getting deleted if any of the captured types
+	 * move constructors aren't noexcept.
+	 */
+	Defer(Defer&& other, std::enable_if_t<std::is_nothrow_move_constructible_v<DeferredFn>, int> = 0) noexcept
+		: m_Func(std::move(other.m_Func))
+	{
+		other.Cancel();
+	}
+
 	Defer(const Defer&) = delete;
-	Defer(Defer&&) = delete;
 	Defer& operator=(const Defer&) = delete;
 	Defer& operator=(Defer&&) = delete;
 
-	inline
 	~Defer()
 	{
 		if (m_Func) {
 			try {
-				m_Func();
+				if constexpr (std::is_convertible_v<std::nullopt_t, DeferredFn>) {
+					(*m_Func)();
+				} else {
+					m_Func();
+				}
 			} catch (...) {
 				// https://stackoverflow.com/questions/130117/throwing-exceptions-out-of-a-destructor
 			}
 		}
 	}
 
-	inline void SetFunc(std::function<void()> func)
+	/**
+	 * Replace the function executed at the end of the scope with a different one.
+	 *
+	 * This requires `Defer` to be explicitly templated with a type-erased function type, like `std::function<void()>`
+	 * or a `void(*)()` function pointers and won't work with deduced lambda types.
+	 */
+	template<typename Fn, std::enable_if_t<std::is_constructible_v<DeferredFn, Fn> && std::is_invocable_r_v<void, Fn>, int> = 0>
+	void SetFunc(Fn&& fn)
 	{
-		m_Func = std::move(func);
+		m_Func = std::forward<Fn>(fn);
 	}
 
-	inline
-	void Cancel()
+	void Cancel() noexcept
 	{
-		m_Func = nullptr;
+		if constexpr (std::is_convertible_v<std::nullopt_t, DeferredFn>) {
+			m_Func.reset();
+		} else {
+			m_Func = nullptr;
+		}
 	}
 
 private:
-	std::function<void()> m_Func;
+	DeferredFn m_Func;
 };
 
-}
+template<typename Fn, std::enable_if_t<std::is_invocable_r_v<void, Fn>, int> = 0>
+Defer(Fn&&) -> Defer<std::optional<std::decay_t<Fn>>>;
 
-#endif /* DEFER */
+} // namespace icinga

--- a/lib/remote/apilistener.cpp
+++ b/lib/remote/apilistener.cpp
@@ -1540,7 +1540,7 @@ void ApiListener::ReplayLog(const JsonRpcConnection::Ptr& client)
 		std::unique_lock<std::mutex> lock(m_LogLock);
 
 		CloseLogFile();
-		Defer reopenLog;
+		Defer<std::function<void()>> reopenLog;
 
 		if (count == -1 || count > 50000) {
 			OpenLogFile();

--- a/lib/remote/configpackageutility.cpp
+++ b/lib/remote/configpackageutility.cpp
@@ -164,7 +164,7 @@ void ConfigPackageUtility::ActivateStage(const String& packageName, const String
 }
 
 void ConfigPackageUtility::TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName,
-	bool activate, bool reload, const Shared<Defer>::Ptr& resetPackageUpdates)
+	bool activate, bool reload, const Shared<Defer<void(*)()>>::Ptr& resetPackageUpdates)
 {
 	String logFile = GetPackageDir() + "/" + packageName + "/" + stageName + "/startup.log";
 	std::ofstream fpLog(logFile.CStr(), std::ofstream::out | std::ostream::binary | std::ostream::trunc);
@@ -205,7 +205,7 @@ void ConfigPackageUtility::TryActivateStageCallback(const ProcessResult& pr, con
 }
 
 void ConfigPackageUtility::AsyncTryActivateStage(const String& packageName, const String& stageName, bool activate, bool reload,
-	const Shared<Defer>::Ptr& resetPackageUpdates)
+	const Shared<Defer<void(*)()>>::Ptr& resetPackageUpdates)
 {
 	VERIFY(Application::GetArgC() >= 1);
 

--- a/lib/remote/configpackageutility.hpp
+++ b/lib/remote/configpackageutility.hpp
@@ -41,7 +41,7 @@ public:
 	static void SetActiveStageToFile(const String& packageName, const String& stageName);
 	static void ActivateStage(const String& packageName, const String& stageName);
 	static void AsyncTryActivateStage(const String& packageName, const String& stageName, bool activate, bool reload,
-		const Shared<Defer>::Ptr& resetPackageUpdates);
+		const Shared<Defer<void(*)()>>::Ptr& resetPackageUpdates);
 
 	static std::vector<std::pair<String, bool> > GetFiles(const String& packageName, const String& stageName);
 
@@ -64,7 +64,7 @@ private:
 	static void WriteStageConfig(const String& packageName, const String& stageName);
 
 	static void TryActivateStageCallback(const ProcessResult& pr, const String& packageName, const String& stageName, bool activate,
-		bool reload, const Shared<Defer>::Ptr& resetPackageUpdates);
+		bool reload, const Shared<Defer<void(*)()>>::Ptr& resetPackageUpdates);
 
 	static bool ValidateFreshName(const String& name);
 };

--- a/lib/remote/configstageshandler.cpp
+++ b/lib/remote/configstageshandler.cpp
@@ -161,7 +161,7 @@ void ConfigStagesHandler::HandlePost(const HttpApiRequest& request, HttpApiRespo
 			l_LastReloadFailedTime = currentReloadFailedTime;
 		}
 
-		auto resetPackageUpdates (Shared<Defer>::Make([]() {
+		auto resetPackageUpdates (Shared<Defer<void(*)()>>::Make([]() {
 			std::lock_guard lock(l_RunningPackageUpdatesMutex);
 			l_RunningPackageUpdates = false;
 		}));


### PR DESCRIPTION
This refactor makes `Defer` work without `std::function` by default and thus without all the overhead (like allocation and type erasure) that comes with it. It also makes `Defer`-objects movable. `std::function<void()>` is still supported by explicit instantiation along with `void(*)()` pointers when a fixed function type is needed with and without capture.

### Other Changes

There are only two call-sites that needed to be adapted, `ApiListener::ReplayLog()` gets an explicitly instantiated `Defer<std::function<void()>>` so the code can keep using `Defer::SetFunc()`. And the use around `ConfigPackageUtility` gets an explicit `Defer<void(*)()>` because the type needs to be available in the header and thus can't be deduced.

### Reasoning

Aside from the obvious efficiency gains the reason I started on this refactor was because I wanted to move a `Defer` object into a lambda-capture and noticed that it had the move constructor disabled. I then looked into what possible reason there could be for the disabled move constructor and didn't find any, but then noticed that by templating `Defer` and adding a deduction guide to a `std::optional<lambda>`, `std::function` could be avoided entirely. So this is a little more than the bare minimum I needed, but still it's a nice improvement, I think.

### Additional Options

The changes in `ConfigPackageUtility` currently minimize the diff, but the `Shared<Defer>::Ptr` there could easily be avoided as well. This would however mean slight changes in the potential lifetime of the defer which should be evaluated carefully. I can do that in this PR if anyone wants me to.