### PR TITLE
Fix sporadic failures in test cases

### DIFF
--- a/test/notification-notificationcomponent.cpp
+++ b/test/notification-notificationcomponent.cpp
@@ -25,14 +25,14 @@ namespace {
  * This isn't actually an issue here because the name is very specific to the single use-case of
  * obtaining access to NotificationTimerHandler().
  */
-template<auto privateMemberFnPtr>
-struct InvokeTimerHandlerImpl
+template<auto privateMemberPtr>
+struct GetNotificationTimerImpl
 {
-	friend void InvokeTimerHandler(const NotificationComponent::Ptr& nc) { (*nc.*privateMemberFnPtr)(); }
+	friend Timer::Ptr GetNotificationTimer(const NotificationComponent::Ptr& nc) { return *nc.*privateMemberPtr; }
 };
-void InvokeTimerHandler(const NotificationComponent::Ptr& nc);
+Timer::Ptr GetNotificationTimer(const NotificationComponent::Ptr& nc);
 
-template struct InvokeTimerHandlerImpl<&NotificationComponent::NotificationTimerHandler>;
+template struct GetNotificationTimerImpl<&NotificationComponent::m_NotificationTimer>;
 
 } // namespace
 
@@ -86,6 +86,8 @@ object NotificationComponent "nc" {}
 
 		auto ret = ConfigItem::RunWithActivationContext(new Function("CreateTestObjects", createObjects));
 		BOOST_REQUIRE(ret);
+
+		GetNotificationTimer(NotificationComponent::GetByName("nc"))->Stop(true);
 
 		m_Host = Host::GetByName("h1");
 		BOOST_REQUIRE(m_Host);
@@ -190,7 +192,8 @@ object NotificationComponent "nc" {}
 	static void NotificationTimerHandler()
 	{
 		auto nc = NotificationComponent::GetByName("nc");
-		InvokeTimerHandler(nc);
+		auto timer = GetNotificationTimer(nc);
+		timer->OnTimerExpired(&*timer);
 	}
 
 	void ReceiveCheckResults(std::size_t num, ServiceState state)

--- a/test/notification-notificationcomponent.cpp
+++ b/test/notification-notificationcomponent.cpp
@@ -189,6 +189,13 @@ object NotificationComponent "nc" {}
 		BOOST_REQUIRE_LE(m_Notification->GetNextNotification(), Utility::GetTime());
 	}
 
+	void ElapseNotificationDelay(double timesBegin)
+	{
+		auto now = Utility::GetTime();
+		m_Host->SetLastHardStateChange(now - timesBegin - 1);
+		m_Notification->SetNextNotification(now - 1);
+	}
+
 	static void NotificationTimerHandler()
 	{
 		auto nc = NotificationComponent::GetByName("nc");
@@ -204,7 +211,6 @@ object NotificationComponent "nc" {}
 	double GetLastNotificationTimestamp() { return m_Notification->GetLastNotification(); }
 
 	double GetNextNotificationTimestamp() { return m_Notification->GetNextNotification(); }
-	void SetNextNotificationTimestamp(double val) { m_Notification->SetNextNotification(val); }
 
 	std::uint8_t GetSuppressedNotifications() { return m_Notification->GetSuppressedNotifications(); }
 
@@ -278,7 +284,13 @@ BOOST_AUTO_TEST_CASE(notify_send_reminders)
  */
 BOOST_AUTO_TEST_CASE(notify_delayed)
 {
-	constexpr double timesBegin = 0.01;
+	/* The times.begin delay window.
+	 * It has to be comfortably larger than the time it can take to get from recording the hard state change to
+	 * evaluating the delay condition in BeginExecuteNotification() during ReceiveCheckResults() below. Otherwise, on a
+	 * slow machine, the notification would be sent out immediately instead of being delayed, and the assertions on the
+	 * scheduled next notification would fail sporadically.
+	 */
+	constexpr double timesBegin = 10.0;
 
 	/* We're always inside a time-period for this test-case.
 	 */
@@ -312,11 +324,10 @@ BOOST_AUTO_TEST_CASE(notify_delayed)
 	BOOST_REQUIRE_EQUAL(GetLastNotification(), 0);
 	BOOST_REQUIRE_EQUAL(GetNotificationCount(), 0);
 
-	/* Now we reset the next scheduled timer run to the past. Since we have verified above
-	 * that it was in fact set correctly, this is fine to do here so we don't have to wait.
+	/* Now we simulate that the delay has elapsed. Since we have verified above that the next
+	 * notification was scheduled correctly, this is fine to do here so we don't have to wait.
 	 */
-	SetNextNotificationTimestamp(Utility::GetTime() + timesBegin);
-	WaitUntilNextReminderScheduled();
+	ElapseNotificationDelay(timesBegin);
 	NotificationTimerHandler();
 	BOOST_REQUIRE(WaitForExpectedNotificationCount(1));
 	BOOST_REQUIRE_EQUAL(GetLastNotification(), NotificationProblem);
@@ -341,8 +352,7 @@ BOOST_AUTO_TEST_CASE(notify_delayed)
 
 	/* Again, after the delay has "elapsed", the "reminder" should be sent out.
 	 */
-	SetNextNotificationTimestamp(Utility::GetTime() + timesBegin);
-	WaitUntilNextReminderScheduled();
+	ElapseNotificationDelay(timesBegin);
 	NotificationTimerHandler();
 	BOOST_REQUIRE(WaitForExpectedNotificationCount(3));
 	BOOST_REQUIRE_EQUAL(GetLastNotification(), NotificationProblem);

--- a/test/remote-httpserverconnection.cpp
+++ b/test/remote-httpserverconnection.cpp
@@ -557,8 +557,8 @@ BOOST_AUTO_TEST_CASE(liveness_disconnect)
 	SetupHttpServerConnection(false, std::chrono::milliseconds(300)); // 300ms liveness timeout is more than enough!
 
 	BOOST_REQUIRE(AssertServerDisconnected(std::chrono::milliseconds(450))); // Give some leeway to Asio's timers
-	BOOST_REQUIRE(ExpectLogPattern("HTTP client disconnected .*"));
-	BOOST_REQUIRE(ExpectLogPattern("No messages for HTTP connection have been received in the last \\d+ seconds, disconnecting .*"));
+	REQUIRE_LOG_MESSAGE("HTTP client disconnected .*", 1s);
+	REQUIRE_LOG_MESSAGE("No messages for HTTP connection have been received in the last \\d+ seconds, disconnecting .*", 1s);
 	BOOST_REQUIRE(Shutdown(client));
 }
 


### PR DESCRIPTION
This (hopefully) fixes sporadic failures in the following test-cases:
+ `remote_httpserverconnection/liveness_disconnect`: by giving the log messages each a 1s timeout to appear.
+ `notificationcomponent/notify_delayed`: By changing the mechanism for elapsing the `times.begin` delay from waiting it out to setting the last state change into the past.

Additionally I've closed a potential change for a race condition if a `notificationcomponent/` test ends up taking longer than 5s by disabling the timer inside `NotificationComponent` since the `NotificationTimerHandler()` is called manually in a deterministic way by these test-cases.