### PR TITLE
Add GitLab CI/CD configuration

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
+        # NOTE: Keep the build jobs in sync with `.gitlab-ci.yml`.
         distro:
           # Alpine Linux to build Icinga 2 with LibreSSL, OpenBSD's default.
           # The "alpine:bash" image will be built below based on "alpine:3".
@@ -86,4 +87,4 @@ jobs:
       - name: Build Icinga
         run: >-
           docker run --rm -v "$(pwd):/icinga2" -e DISTRO=${{ matrix.distro }}
-          --platform ${{ matrix.platform }} ${{ matrix.distro }} /icinga2/.github/workflows/linux.bash
+          --platform ${{ matrix.platform }} ${{ matrix.distro }} /icinga2/tools/linux/ci-build.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,60 @@
+linux-build:
+  stage: build
+  script:
+    - case "$IMAGE_NAME" in alpine:*) apk add bash ;; esac
+    - DISTRO="$IMAGE_NAME" ICINGA2_SOURCE_DIR="$CI_PROJECT_DIR" tools/linux/ci-build.sh
+  image:
+    name: "$IMAGE_NAME"
+    docker:
+      platform: "$DOCKER_PLATFORM"
+  tags:
+    - "$OS_ARCH"
+  parallel:
+    # NOTE: Keep the build jobs in sync with `.github/workflows/linux.yml`.
+    matrix:
+      # x86_64 / amd64
+      - IMAGE_NAME:
+          - debian:11
+          - debian:12
+          - debian:13
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - ubuntu:25.04
+          - ubuntu:25.10
+          - ubuntu:26.04
+        OS_ARCH: amd64
+        DOCKER_PLATFORM: linux/amd64
+      - IMAGE_NAME:
+          - alpine:latest
+          - amazonlinux:2023
+          - fedora:42
+          - fedora:43
+          - fedora:44
+          - fedora:45
+          - rockylinux:8
+          - rockylinux:9
+          - rockylinux/rockylinux:10
+          - registry.suse.com/suse/sle15:15.6
+          - registry.suse.com/suse/sle15:15.7
+          - registry.suse.com/bci/bci-base:16.0
+        OS_ARCH: x86_64
+        DOCKER_PLATFORM: linux/amd64
+
+      # x86 / i386
+      - IMAGE_NAME:
+          - debian:11
+          - debian:12
+        OS_ARCH: i386
+        DOCKER_PLATFORM: linux/386
+
+      # aarch64 / arm64
+      # These are in addition to the Linux build jobs on GitHub Actions.
+      # This covers the ARM architecture, which is done by the container image builds on GitHub.
+      - IMAGE_NAME:
+          - debian:13
+        OS_ARCH: arm64
+        DOCKER_PLATFORM: linux/arm64
+      - IMAGE_NAME:
+          - rockylinux:8
+        OS_ARCH: aarch64
+        DOCKER_PLATFORM: linux/arm64

--- a/tools/linux/ci-build.sh
+++ b/tools/linux/ci-build.sh
@@ -11,6 +11,7 @@
 #  - ICINGA2_BUILD_DIR: Path where to place the CMake build directory.
 #  - CCACHE_DIR: Path where to keep a ccache cache directory.
 #  - DISTRO: Container image name, this is used to automatically detect build dependencies and compile flags.
+#  - ICINGA2_CI_BUILD_JOBS_RUNNER_${CI_RUNNER_ID} (dynamic name): number of parallel build jobs, see below for details.
 
 set -exo pipefail
 
@@ -158,7 +159,20 @@ cd "$ICINGA2_BUILD_DIR"
   "${CMAKE_OPTS[@]}" \
   "$ICINGA2_SOURCE_DIR"
 
-ninja -v
+NINJA_OPTS=(-v)
+
+# Allow to customize the number of parallel build jobs to scale the jobs to the available resources provided by
+# different GitLab runners. Setting `ICINGA2_CI_BUILD_JOBS_RUNNER_23=4` and `ICINGA2_CI_BUILD_JOBS_RUNNER_42=8` in the
+# CI variables of the project causes the runners with ID 23 and 42 to use `-j 4` and `-j 8` respectively.
+# If not set, ninja uses its default.
+if [[ -v CI_RUNNER_ID ]]; then
+  jobs_var_name="ICINGA2_CI_BUILD_JOBS_RUNNER_${CI_RUNNER_ID}"
+  if [[ -v "$jobs_var_name" ]]; then
+    NINJA_OPTS+=(-j "${!jobs_var_name}")
+  fi
+fi
+
+ninja "${NINJA_OPTS[@]}"
 
 ninja test
 ninja install

--- a/tools/linux/ci-build.sh
+++ b/tools/linux/ci-build.sh
@@ -1,9 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Helper script for quickly building Icinga 2 in a container.
+#
+# CAUTION: This modifies the system by automatically installing required dependencies and should
+# only be used on test systems that will be thrown away afterwards, like in a CI environment.
+#
+# The behavior can be tweaked by setting the following environment variables:
+#
+#  - ICINGA2_SOURCE_DIR: Path where to find the Icinga 2 source tree.
+#  - ICINGA2_BUILD_DIR: Path where to place the CMake build directory.
+#  - CCACHE_DIR: Path where to keep a ccache cache directory.
+#  - DISTRO: Container image name, this is used to automatically detect build dependencies and compile flags.
+
 set -exo pipefail
 
+: "${ICINGA2_SOURCE_DIR:=/icinga2}"
+: "${ICINGA2_BUILD_DIR:=${ICINGA2_SOURCE_DIR}/build}"
+: "${CCACHE_DIR:=${ICINGA2_SOURCE_DIR}/ccache}"
+
 export PATH="/usr/lib/ccache/bin:/usr/lib/ccache:/usr/lib64/ccache:$PATH"
-export CCACHE_DIR=/icinga2/ccache
 export CTEST_OUTPUT_ON_FAILURE=1
+export CCACHE_DIR
+
 CMAKE_OPTS=()
 SCL_ENABLE_GCC=()
 # -Wstringop-overflow is notorious for false positives and has been a problem for years.
@@ -127,8 +145,8 @@ case "$DISTRO" in
     ;;
 esac
 
-mkdir /icinga2/build
-cd /icinga2/build
+mkdir -p "$ICINGA2_BUILD_DIR"
+cd "$ICINGA2_BUILD_DIR"
 
 "${SCL_ENABLE_GCC[@]}" cmake \
   -GNinja \
@@ -137,7 +155,8 @@ cd /icinga2/build
   -DUSE_SYSTEMD=ON \
   -DICINGA2_USER=$(id -un) \
   -DICINGA2_GROUP=$(id -gn) \
-  "${CMAKE_OPTS[@]}" ..
+  "${CMAKE_OPTS[@]}" \
+  "$ICINGA2_SOURCE_DIR"
 
 ninja -v
 


### PR DESCRIPTION
Development of Icinga 2 mainly happens on GitHub and that isn't supposed to change, but for our past security updates, we have switched from developing the fixes in private forks provided by the GHSA to doing it in our own private GitLab instance. This has the advantage that we can merge fixes there and easily build packages before pushing everything out to the public at GitHub and the GHSA forks come with the limitation that they don't run GitHub Actions, meaning no CI. Doing the development on GitLab allows us to use its CI/CD functionality, which requires a configuration that this PR adds. Maybe it's even useful for someone else as I've tried to keep things that are specific to our GitLab instance to an absolute minimum (what remains are that tag names that are used to pin jobs to runners with the matching architecture).

The already existing `.github/workflows/linux.bash` build script was generalized a bit so that some more environment variables can be provided to customize the paths it uses, making it more suitable for use in GitLab as well. It was also moved to the `tools/linux/` directory (similar to how `tools/win32/` already exists with other build scripts), as it is no longer specific to GitHub Actions.

### Tests

This was already tested successfully on our GitLab instance. Given that the script is also in use by GitHub Actions, these are the final test and they still worked for this PR just fine.