### PR TITLE
ssl_cert: Allow forcing IPv4 or IPv6

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -122,6 +122,7 @@ Henrik Triem <henrik.triem@icinga.com>
 Ian Kelling <ian@iankelling.org>
 Ildar Hizbulin <hizel@vyborg.ru>
 Irina Kaprizkina <ikapriz@gmail.com>
+Ishan Ajwani <94868152+IshanA2007@users.noreply.github.com>
 Iustin Pop <iustin@k1024.org>
 Jaap Marcus <9754650+jaapmarcus@users.noreply.github.com>
 Jack <jackdev@mailbox.org>

--- a/doc/10-icinga-template-library.md
+++ b/doc/10-icinga-template-library.md
@@ -6167,6 +6167,8 @@ ssl_cert_ignore_sct                     | **Optional.** Do not check for signed 
 ssl_cert_ignore_tls_renegotiation       | **Optional.** Do not check for renegotiation.
 ssl_cert_dane                           | **Optional.** Verify that valid DANE records exist ({211,301,302,311,312} or empty string).
 ssl_cert_long_output                    | **Optional.** Append the specified comma separated (no spaces) list of attributes to the plugin output on additional lines.
+ssl_cert_ipv4                           | **Optional.** Force IPv4. Defaults to false.
+ssl_cert_ipv6                           | **Optional.** Force IPv6. Defaults to false.
 
 
 #### jmx4perl <a id="plugin-contrib-command-jmx4perl"></a>

--- a/itl/plugins-contrib.d/web.conf
+++ b/itl/plugins-contrib.d/web.conf
@@ -596,11 +596,21 @@ object CheckCommand "ssl_cert" {
 			description = "Append the specified comma separated (no spaces) list of attributes to the plugin output on additional lines"
 			value = "$ssl_cert_long_output$"
 		}
+		"-4" = {
+			set_if = "$ssl_cert_ipv4$"
+			description = "Force IPv4"
+		}
+		"-6" = {
+			set_if = "$ssl_cert_ipv6$"
+			description = "Force IPv6"
+		}
 	}
 
 	vars.ssl_cert_address = "$check_address$"
 	vars.ssl_cert_port = 443
 	vars.ssl_cert_cn = "$ssl_cert_altnames$"
+	vars.check_ipv4 = "$ssl_cert_ipv4$"
+	vars.check_ipv6 = "$ssl_cert_ipv6$"
 }
 
 object CheckCommand "varnish" {


### PR DESCRIPTION
The `check_ssl_cert` plugin supports `-4`/`-6` to force IPv4 or IPv6, but the
`ssl_cert` CheckCommand had no way to pass them through.

As pointed out in the issue thread, the established pattern in the ITL is that
commands wrapping dual-stack-capable plugins provide their **own documented
switches** on top of `vars.check_ipv4`/`check_ipv6` (see `dig`, `ssh`, `tcp`).
This follows the `dig` CheckCommand exactly:

* `ssl_cert_ipv4` / `ssl_cert_ipv6` map to the plugin's `-4` / `-6` flags.
* Both also feed `vars.check_ipv4` / `vars.check_ipv6`, so the `ipv4-or-ipv6`
  template that `ssl_cert` already imports picks the matching address family
  instead of handing the plugin an address of the other family.
* Both are documented in `doc/10-icinga-template-library.md`.

This supersedes #9978, which used an `ssl_`-prefixed variable name, added no
documentation, and did not set `vars.check_ipv[46]`.

Verified with `icinga2 daemon -C` and by running the daemon against a stub
plugin; the rendered command lines are:

    check_ssl_cert -4 -H 127.0.0.1 -p 443     # ssl_cert_ipv4 = true
    check_ssl_cert -6 -H ::1 -p 443           # ssl_cert_ipv6 = true
    check_ssl_cert -H 127.0.0.1 -p 443        # neither set (unchanged)

fixes #9979
