### PR TITLE
GHA: Remove Fedora 42, Debian 11, Ubuntu 25.04 and Ubuntu 25.10

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,6 @@ jobs:
 
           - ubuntu:22.04
           - ubuntu:24.04
-          - ubuntu:25.04
           - ubuntu:25.10
           - ubuntu:26.04
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,6 @@ jobs:
 
           # Raspberry Pi OS is close enough to Debian to test just one of them.
           # Its architecture is different, though, and covered by the Docker job.
-          - debian:11
           - debian:12
           - debian:13
 
@@ -59,8 +58,6 @@ jobs:
           - linux/amd64
 
         include:
-          - distro: debian:11
-            platform: linux/386
           - distro: debian:12
             platform: linux/386
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -50,7 +50,6 @@ jobs:
 
           - ubuntu:22.04
           - ubuntu:24.04
-          - ubuntu:25.10
           - ubuntu:26.04
 
         platform:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,6 @@ jobs:
           - debian:12
           - debian:13
 
-          - fedora:42
           - fedora:43
           - fedora:44
           - fedora:45

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ linux-build:
           - debian:13
           - ubuntu:22.04
           - ubuntu:24.04
-          - ubuntu:25.04
           - ubuntu:25.10
           - ubuntu:26.04
         OS_ARCH: amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,6 @@ linux-build:
     matrix:
       # x86_64 / amd64
       - IMAGE_NAME:
-          - debian:11
           - debian:12
           - debian:13
           - ubuntu:22.04
@@ -41,7 +40,6 @@ linux-build:
 
       # x86 / i386
       - IMAGE_NAME:
-          - debian:11
           - debian:12
         OS_ARCH: i386
         DOCKER_PLATFORM: linux/386

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ linux-build:
           - debian:13
           - ubuntu:22.04
           - ubuntu:24.04
-          - ubuntu:25.10
           - ubuntu:26.04
         OS_ARCH: amd64
         DOCKER_PLATFORM: linux/amd64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,6 @@ linux-build:
       - IMAGE_NAME:
           - alpine:latest
           - amazonlinux:2023
-          - fedora:42
           - fedora:43
           - fedora:44
           - fedora:45


### PR DESCRIPTION
They're EOL: https://git.icinga.com/packages/tooling/ci-templates/-/merge_requests/164