### PR TITLE
Remove Debian 11 from CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,7 +30,6 @@ jobs:
 
           # Raspberry Pi OS is close enough to Debian to test just one of them.
           # Its architecture is different, though, and covered by the Docker job.
-          - debian:11
           - debian:12
           - debian:13
 
@@ -60,8 +59,6 @@ jobs:
           - linux/amd64
 
         include:
-          - distro: debian:11
-            platform: linux/386
           - distro: debian:12
             platform: linux/386
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,6 @@ linux-build:
     matrix:
       # x86_64 / amd64
       - IMAGE_NAME:
-          - debian:11
           - debian:12
           - debian:13
           - ubuntu:22.04
@@ -42,7 +41,6 @@ linux-build:
 
       # x86 / i386
       - IMAGE_NAME:
-          - debian:11
           - debian:12
         OS_ARCH: i386
         DOCKER_PLATFORM: linux/386


### PR DESCRIPTION
Removed Debian 11 from both GitHub and GitLab CI because it's EOL since end of August[^1].

[^1]: https://endoflife.date/debian