### PR TITLE
(WIP) Optimize runtime object update

### DIFF
--- a/lib/checker/checkercomponent.cpp
+++ b/lib/checker/checkercomponent.cpp
@@ -182,7 +182,7 @@ void CheckerComponent::CheckThreadProc()
 //#endif /* I2_DEBUG */
 
 		if (Checkable::GetPendingChecks() >= icingaApp->GetMaxConcurrentChecks())
-			wait = 0.5;
+			wait = 0.1;
 
 		if (wait > 0) {
 			/* Wait for the next check. */

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -538,6 +538,8 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 	Log(LogInformation, "ApiListener")
 		<< "Syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
 
+	auto start = std::chrono::steady_clock::now();
+
 	std::unordered_set<ConfigObject*> syncedObjects;
 	for (const Type::Ptr& type : Type::GetAllTypes()) {
 		if (auto *ctype = dynamic_cast<ConfigType *>(type.get())) {
@@ -552,8 +554,9 @@ void ApiListener::SendRuntimeConfigObjects(const JsonRpcConnection::Ptr& aclient
 		}
 	}
 
+	auto took = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
 	Log(LogInformation, "ApiListener")
-		<< "Finished syncing runtime objects to endpoint '" << endpoint->GetName() << "'.";
+		<< "Finished syncing runtime objects to endpoint '" << endpoint->GetName() << "' in " << took.count() << "ms.";
 }
 
 /**

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -442,6 +442,9 @@ void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const Mess
 void ApiListener::UpdateConfigObjectWithParents(const ConfigObject::Ptr& object, const Zone::Ptr& azone,
 	const JsonRpcConnection::Ptr& client, std::unordered_set<ConfigObject*>& syncedObjects)
 {
+	if (object->GetPackage() != "_api" && object->GetVersion() == 0)
+		return;
+
 	if (syncedObjects.find(object.get()) != syncedObjects.end()) {
 		return;
 	}

--- a/lib/remote/apilistener-configsync.cpp
+++ b/lib/remote/apilistener-configsync.cpp
@@ -339,13 +339,13 @@ Value ApiListener::ConfigDeleteObjectAPIHandler(const MessageOrigin::Ptr& origin
 }
 
 void ApiListener::UpdateConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,
-	const JsonRpcConnection::Ptr& client)
+	const JsonRpcConnection::Ptr& client, bool skipZoneCheck)
 {
 	/* only send objects to zones which have access to the object */
 	if (client) {
 		Zone::Ptr target_zone = client->GetEndpoint()->GetZone();
 
-		if (target_zone && !target_zone->CanAccessObject(object)) {
+		if (!skipZoneCheck && target_zone && !target_zone->CanAccessObject(object)) {
 			Log(LogDebug, "ApiListener")
 				<< "Not sending 'update config' message to unauthorized zone '" << target_zone->GetName() << "'"
 				<< " for object: '" << object->GetName() << "'.";
@@ -460,7 +460,7 @@ void ApiListener::UpdateConfigObjectWithParents(const ConfigObject::Ptr& object,
 	}
 
 	/* send the config object to the connected client */
-	UpdateConfigObject(object, nullptr, client);
+	UpdateConfigObject(object, nullptr, client, true);
 }
 
 void ApiListener::DeleteConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,

--- a/lib/remote/apilistener.hpp
+++ b/lib/remote/apilistener.hpp
@@ -270,7 +270,7 @@ private:
 
 	/* configsync */
 	void UpdateConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,
-		const JsonRpcConnection::Ptr& client = nullptr);
+		const JsonRpcConnection::Ptr& client = nullptr, bool skipZoneCheck = false);
 	void UpdateConfigObjectWithParents(const ConfigObject::Ptr& object, const Zone::Ptr& azone,
 		const JsonRpcConnection::Ptr& client, std::unordered_set<ConfigObject*>& syncedObjects);
 	void DeleteConfigObject(const ConfigObject::Ptr& object, const MessageOrigin::Ptr& origin,

--- a/lib/remote/zone.cpp
+++ b/lib/remote/zone.cpp
@@ -108,13 +108,14 @@ bool Zone::CanAccessObject(const ConfigObject::Ptr& object)
 
 bool Zone::IsChildOf(const Zone::Ptr& zone)
 {
-	Zone::Ptr azone = this;
+	if (this == zone.get()) {
+		return true;
+	}
 
-	while (azone) {
-		if (azone == zone)
+	for (const Zone::Ptr& parent : m_AllParents) {
+		if (parent == zone) {
 			return true;
-
-		azone = azone->GetParent();
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Micro-optimize a couple of places in the runtime config update. This can make a critical difference when a cluster has multiple hundred thousands of checkables, especially in cases where endpoints sync repeatedly due to some kinds of configuration mistakes.

This also contains a commit that makes runtime config syncs that are going on in the background less impactful to check scheduling. That and the early abort in `UpdateConfigObjectWithParents` are probably the most impactful changes, but the others are essentially free optimizations to a hot path, so still worth taking.

I will back this up with a few graphs and stats before I make this ready for review.